### PR TITLE
Fixes 2jdoc errs on #834, see HtmlUnitDriver in Interface Browsers

### DIFF
--- a/src/main/java/com/codeborne/selenide/Browsers.java
+++ b/src/main/java/com/codeborne/selenide/Browsers.java
@@ -19,20 +19,16 @@ public interface Browsers {
   public static final String SAFARI = "safari";
 
   /**
-   * To use HtmlUnitDriver, you need to include extra dependency to your project:
-   * <dependency org="org.seleniumhq.selenium" name="selenium-htmlunit-driver" rev="2.+" conf="test->default"/>
-   *
-   * It's also possible to run HtmlUnit driver emulating different browsers:
+   * To use the HtmlUnitDriver, you need to add the following dependency to your project:
    * <p>
-   * java -Dbrowser=htmlunit:firefox
+   * {@code <dependency org="org.seleniumhq.selenium" name="selenium-htmlunit-driver"
+   *                         rev="2.+" conf= "test->default"/>}
    * </p>
-   * <p>
-   * java -Dbrowser=htmlunit:chrome
-   * </p>
-   * <p>
-   * java -Dbrowser=htmlunit:internet explorer   (default)
-   * </p>
-   * etc.
+   * <p>It is also possible to run HtmlUnitDriver so that it emulates different browsers</p>
+   * <p>{@code java -Dbrowser=htmlunit:firefox}</p>
+   * <p>{@code java -Dbrowser=htmlunit:chrome}</p>
+   * <p>{@code java -Dbrowser=htmlunit:internet explorer   (default)}</p>
+   * <p>etc</p>
    */
   public static final String HTMLUNIT = "htmlunit";
 


### PR DESCRIPTION
## Proposed changes
JavaDoc errors are keeping documentation out of the generated JavaDocs

## Checklist
- [ /] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] I have added necessary documentation (if appropriate)
Here is full generated Java documentation for Browsers.java

![broswers_htmlunit_javadoc_screenshot_2018-10-09_23-17-47](https://user-images.githubusercontent.com/208059/46702582-9a514200-cc1b-11e8-9486-beac6a860ea4.png)
