### PR TITLE
deprecated exist and replace it by existInDOM

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -49,7 +49,7 @@ public abstract class Condition {
    *
    * <p>Sample: {@code $("input[type=hidden]").should(existInDOM);}</p>
    */
-  public static final Condition existInDOM = new Condition("existInDOM") {
+  public static final Condition existInDOM = new Condition("exist in DOM") {
     @Override
     public boolean apply(Driver driver, WebElement element) {
       try {

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -25,10 +25,12 @@ public abstract class Condition {
   };
 
   /**
-   * Check if element exist. It can be visible or hidden.
+   * @deprecated use {@link #existInDOM} instead. Exist was often confused with visible.
+   * Check if element exists. It can be visible or hidden.
    *
    * <p>Sample: {@code $("input").should(exist);}</p>
    */
+  @Deprecated
   public static final Condition exist = new Condition("exist") {
     @Override
     public boolean apply(Driver driver, WebElement element) {
@@ -41,6 +43,25 @@ public abstract class Condition {
       }
     }
   };
+
+  /**
+   * Check if element exists in DOM. It can be visible or hidden.
+   *
+   * <p>Sample: {@code $("input[type=hidden]").should(existInDOM);}</p>
+   */
+  public static final Condition existInDOM = new Condition("existInDOM") {
+    @Override
+    public boolean apply(Driver driver, WebElement element) {
+      try {
+        element.isDisplayed();
+        return true;
+      } catch (StaleElementReferenceException e) {
+        return false;
+      }
+    }
+  };
+
+
 
   /**
    * Checks that element is not visible or does not exists.
@@ -479,7 +500,7 @@ public abstract class Condition {
   /**
    * Negate given condition.
    * <p>
-   * Used for methods like $.shouldNot(exist), $.shouldNotBe(visible)
+   * Used for methods like $.shouldNot(existInDOM), $.shouldNotBe(visible)
    * <p>
    * Typically you don't need to use it.
    */

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -277,7 +277,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * <p>Timeout is configurable via Configuration#timeout</p>
    *
    * <p>For example: {@code
-   *   $("#errorMessage").should(exist);
+   *   $("#errorMessage").should(existInDOM);
    * }</p>
    *
    * @see Configuration#timeout

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
@@ -7,7 +7,7 @@ import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.ui.Select;
 
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 
 public class SelectOptionByTextOrIndex implements Command<Void> {
   @Override
@@ -28,7 +28,8 @@ public class SelectOptionByTextOrIndex implements Command<Void> {
         select.selectByVisibleText(text);
       }
       catch (NoSuchElementException e) {
-        throw new ElementNotFound(selectField.driver(), selectField.getSearchCriteria() + "/option[text:" + text + ']', exist, e);
+        throw new ElementNotFound(selectField.driver(), selectField.getSearchCriteria() + "/option[text:" + text + ']',
+          existInDOM, e);
       }
     }
   }
@@ -40,7 +41,8 @@ public class SelectOptionByTextOrIndex implements Command<Void> {
         select.selectByIndex(index);
       }
       catch (NoSuchElementException e) {
-        throw new ElementNotFound(selectField.driver(), selectField.getSearchCriteria() + "/option[index:" + index + ']', exist, e);
+        throw new ElementNotFound(selectField.driver(), selectField.getSearchCriteria() + "/option[index:" + index + ']',
+          existInDOM, e);
       }
     }
   }

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
@@ -7,7 +7,7 @@ import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.ui.Select;
 
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 
 public class SelectOptionByValue implements Command {
   @Override
@@ -31,7 +31,7 @@ public class SelectOptionByValue implements Command {
       select.selectByValue(value);
     }
     catch (NoSuchElementException e) {
-      throw new ElementNotFound(selectField.driver(), selectField.getSearchCriteria() + "/option[value:" + value + ']', exist, e);
+      throw new ElementNotFound(selectField.driver(), selectField.getSearchCriteria() + "/option[value:" + value + ']', existInDOM, e);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
@@ -12,7 +12,7 @@ import org.openqa.selenium.WebElement;
 import java.lang.reflect.Proxy;
 import java.util.List;
 
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static java.lang.Thread.currentThread;
 
 public class ElementFinder extends WebElementSource {
@@ -91,10 +91,10 @@ public class ElementFinder extends WebElementSource {
   @Override
   public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
     if (parent instanceof SelenideElement) {
-      ((SelenideElement) parent).should(exist);
+      ((SelenideElement) parent).should(existInDOM);
     }
     else if (parent instanceof WebElement) {
-      WebElementWrapper.wrap(driver(), (WebElement) parent).should(exist);
+      WebElementWrapper.wrap(driver(), (WebElement) parent).should(existInDOM);
     }
     
     return super.createElementNotFoundError(condition, lastError);

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -22,7 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.codeborne.selenide.AssertionMode.SOFT;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.logevents.ErrorsCollector.validateAssertionMode;
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
 import static java.util.Arrays.asList;
@@ -128,7 +128,7 @@ class SelenideElementProxy implements InvocationHandler {
       throw new ElementIsNotClickableException(driver(), lastError);
     }
     else if (lastError instanceof WebDriverException) {
-      throw webElementSource.createElementNotFoundError(exist, lastError);
+      throw webElementSource.createElementNotFoundError(existInDOM, lastError);
     }
     throw lastError;
   }

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -137,15 +137,15 @@ class ConditionTest {
 
   @Test
   void elementExists() {
-    assertThat(exist.apply(driver, elementWithVisibility(true))).isTrue();
-    assertThat(exist.apply(driver, elementWithVisibility(false))).isTrue();
+    assertThat(existInDOM.apply(driver, elementWithVisibility(true))).isTrue();
+    assertThat(existInDOM.apply(driver, elementWithVisibility(false))).isTrue();
   }
 
   @Test
   void elementExists_returnsFalse_ifItThrowsException() {
     WebElement element = mock(WebElement.class);
     when(element.isDisplayed()).thenThrow(new StaleElementReferenceException("ups"));
-    assertThat(exist.apply(driver, element)).isFalse();
+    assertThat(existInDOM.apply(driver, element)).isFalse();
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndexCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndexCommandTest.java
@@ -53,7 +53,7 @@ class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
       selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new String[]{this.defaultElementText}});
     } catch (ElementNotFound exception) {
       assertThat(exception)
-        .hasMessage(String.format("Element not found {null/option[text:%s]}\nExpected: existInDOM", this.defaultElementText));
+        .hasMessage(String.format("Element not found {null/option[text:%s]}\nExpected: exist in DOM", this.defaultElementText));
     }
   }
 
@@ -66,7 +66,7 @@ class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
       selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new String[]{""}});
     } catch (ElementNotFound exception) {
       assertThat(exception)
-        .hasMessage("Element not found {null/option[text:]}\nExpected: existInDOM");
+        .hasMessage("Element not found {null/option[text:]}\nExpected: exist in DOM");
     }
   }
 
@@ -83,7 +83,7 @@ class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
       selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new int[]{defaultIndex}});
     } catch (ElementNotFound exception) {
       assertThat(exception)
-        .hasMessage(String.format("Element not found {null/option[index:%d]}\nExpected: existInDOM", defaultIndex));
+        .hasMessage(String.format("Element not found {null/option[index:%d]}\nExpected: exist in DOM", defaultIndex));
     }
   }
 

--- a/src/test/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndexCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndexCommandTest.java
@@ -53,7 +53,7 @@ class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
       selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new String[]{this.defaultElementText}});
     } catch (ElementNotFound exception) {
       assertThat(exception)
-        .hasMessage(String.format("Element not found {null/option[text:%s]}\nExpected: exist", this.defaultElementText));
+        .hasMessage(String.format("Element not found {null/option[text:%s]}\nExpected: existInDOM", this.defaultElementText));
     }
   }
 
@@ -66,7 +66,7 @@ class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
       selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new String[]{""}});
     } catch (ElementNotFound exception) {
       assertThat(exception)
-        .hasMessage("Element not found {null/option[text:]}\nExpected: exist");
+        .hasMessage("Element not found {null/option[text:]}\nExpected: existInDOM");
     }
   }
 
@@ -83,7 +83,7 @@ class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
       selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new int[]{defaultIndex}});
     } catch (ElementNotFound exception) {
       assertThat(exception)
-        .hasMessage(String.format("Element not found {null/option[index:%d]}\nExpected: exist", defaultIndex));
+        .hasMessage(String.format("Element not found {null/option[index:%d]}\nExpected: existInDOM", defaultIndex));
     }
   }
 

--- a/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
@@ -68,6 +68,7 @@ class SelectionOptionByValueCommandTest implements WithAssertions {
     assertThatThrownBy(() -> {
       selectOptionByValueCommand.execute(proxy, selectField, new Object[]{new String[]{defaultElementValue}});
     }).isInstanceOf(ElementNotFound.class)
-      .hasMessage(String.format("Element not found {By.tagName{select}/option[value:%s]}\nExpected: exist in DOM", defaultElementValue));
+      .hasMessage(String.format("Element not found {By.tagName{select}/option[value:%s]}\nExpected: exist in DOM",
+        defaultElementValue));
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
@@ -68,6 +68,6 @@ class SelectionOptionByValueCommandTest implements WithAssertions {
     assertThatThrownBy(() -> {
       selectOptionByValueCommand.execute(proxy, selectField, new Object[]{new String[]{defaultElementValue}});
     }).isInstanceOf(ElementNotFound.class)
-      .hasMessage(String.format("Element not found {By.tagName{select}/option[value:%s]}\nExpected: exist", defaultElementValue));
+      .hasMessage(String.format("Element not found {By.tagName{select}/option[value:%s]}\nExpected: existInDOM", defaultElementValue));
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
@@ -68,6 +68,6 @@ class SelectionOptionByValueCommandTest implements WithAssertions {
     assertThatThrownBy(() -> {
       selectOptionByValueCommand.execute(proxy, selectField, new Object[]{new String[]{defaultElementValue}});
     }).isInstanceOf(ElementNotFound.class)
-      .hasMessage(String.format("Element not found {By.tagName{select}/option[value:%s]}\nExpected: existInDOM", defaultElementValue));
+      .hasMessage(String.format("Element not found {By.tagName{select}/option[value:%s]}\nExpected: exist in DOM", defaultElementValue));
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/UtilCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/UtilCommandTest.java
@@ -13,12 +13,12 @@ class UtilCommandTest implements WithAssertions {
   void testArgsToCondition() {
     List<Condition> conditions = Util.argsToConditions(new Object[]{
       Condition.enabled,
-      new Condition[]{Condition.appear, Condition.exist},
+      new Condition[]{Condition.appear, Condition.existInDOM},
       "hello",
       2L
     });
     assertThat(conditions)
-      .isEqualTo(asList(Condition.enabled, Condition.visible, Condition.exist));
+      .isEqualTo(asList(Condition.enabled, Condition.visible, Condition.existInDOM));
   }
 
   @Test
@@ -26,12 +26,12 @@ class UtilCommandTest implements WithAssertions {
     assertThatThrownBy(() -> {
       List<Condition> conditions = Util.argsToConditions(new Object[]{
         Condition.enabled,
-        new Condition[]{Condition.appear, Condition.exist},
+        new Condition[]{Condition.appear, Condition.existInDOM},
         1,
         2.0
       });
       assertThat(conditions)
-        .isEqualTo(asList(Condition.enabled, Condition.visible, Condition.exist));
+        .isEqualTo(asList(Condition.enabled, Condition.visible, Condition.existInDOM));
     }).isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/ElementNotFoundTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementNotFoundTest.java
@@ -19,9 +19,9 @@ class ElementNotFoundTest implements WithAssertions {
 
   @Test
   void testElementNotFoundWithByCriteria() {
-    ElementNotFound elementNotFoundById = new ElementNotFound(driver, By.id("Hello"), Condition.exist);
+    ElementNotFound elementNotFoundById = new ElementNotFound(driver, By.id("Hello"), Condition.existInDOM);
     String expectedMessage = "Element not found {By.id: Hello}\n" +
-      "Expected: exist\n" +
+      "Expected: existInDOM\n" +
       "Screenshot: null\n" +
       "Timeout: 0 ms.";
     assertThat(elementNotFoundById)
@@ -30,9 +30,9 @@ class ElementNotFoundTest implements WithAssertions {
 
   @Test
   void testElementNotFoundWithStringCriteria() {
-    ElementNotFound elementNotFoundById = new ElementNotFound(driver, "Hello", Condition.exist);
+    ElementNotFound elementNotFoundById = new ElementNotFound(driver, "Hello", Condition.existInDOM);
     String expectedMessage = "Element not found {Hello}\n" +
-      "Expected: exist\n" +
+      "Expected: existInDOM\n" +
       "Screenshot: null\n" +
       "Timeout: 0 ms.";
     assertThat(elementNotFoundById)
@@ -41,9 +41,9 @@ class ElementNotFoundTest implements WithAssertions {
 
   @Test
   void testElementNotFoundWithStringCriteriaAndThrowableError() {
-    ElementNotFound elementNotFoundById = new ElementNotFound(driver, "Hello", Condition.exist, new Throwable("Error message"));
+    ElementNotFound elementNotFoundById = new ElementNotFound(driver, "Hello", Condition.existInDOM, new Throwable("Error message"));
     String expectedMessage = "Element not found {Hello}\n" +
-      "Expected: exist\n" +
+      "Expected: existInDOM\n" +
       "Screenshot: null\n" +
       "Timeout: 0 ms.\n" +
       "Caused by: java.lang.Throwable: Error message";

--- a/src/test/java/com/codeborne/selenide/ex/ElementNotFoundTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementNotFoundTest.java
@@ -21,7 +21,7 @@ class ElementNotFoundTest implements WithAssertions {
   void testElementNotFoundWithByCriteria() {
     ElementNotFound elementNotFoundById = new ElementNotFound(driver, By.id("Hello"), Condition.existInDOM);
     String expectedMessage = "Element not found {By.id: Hello}\n" +
-      "Expected: existInDOM\n" +
+      "Expected: exist in DOM\n" +
       "Screenshot: null\n" +
       "Timeout: 0 ms.";
     assertThat(elementNotFoundById)
@@ -32,7 +32,7 @@ class ElementNotFoundTest implements WithAssertions {
   void testElementNotFoundWithStringCriteria() {
     ElementNotFound elementNotFoundById = new ElementNotFound(driver, "Hello", Condition.existInDOM);
     String expectedMessage = "Element not found {Hello}\n" +
-      "Expected: existInDOM\n" +
+      "Expected: exist in DOM\n" +
       "Screenshot: null\n" +
       "Timeout: 0 ms.";
     assertThat(elementNotFoundById)
@@ -43,7 +43,7 @@ class ElementNotFoundTest implements WithAssertions {
   void testElementNotFoundWithStringCriteriaAndThrowableError() {
     ElementNotFound elementNotFoundById = new ElementNotFound(driver, "Hello", Condition.existInDOM, new Throwable("Error message"));
     String expectedMessage = "Element not found {Hello}\n" +
-      "Expected: existInDOM\n" +
+      "Expected: exist in DOM\n" +
       "Screenshot: null\n" +
       "Timeout: 0 ms.\n" +
       "Caused by: java.lang.Throwable: Error message";

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
@@ -26,7 +26,7 @@ import java.util.logging.Logger;
 
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.enabled;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Condition.visible;
@@ -106,7 +106,7 @@ class SelenideElementProxyTest implements WithAssertions {
   @Test
   void elementNotFoundAsExpected() {
     when(webdriver.findElement(By.cssSelector("#firstName"))).thenReturn(null);
-    driver.find("#firstName").shouldNotBe(exist);
+    driver.find("#firstName").shouldNotBe(existInDOM);
     driver.find("#firstName").should(disappear);
     driver.find("#firstName").shouldNotBe(visible);
     driver.find("#firstName").shouldNotBe(enabled);
@@ -117,7 +117,7 @@ class SelenideElementProxyTest implements WithAssertions {
   void elementNotFoundAsExpected2() {
     when(webdriver.findElement(By.cssSelector("#firstName")))
       .thenThrow(new WebDriverException("element is not found and this is expected"));
-    driver.find("#firstName").shouldNot(exist);
+    driver.find("#firstName").shouldNot(existInDOM);
     driver.find("#firstName").should(disappear);
     driver.find("#firstName").shouldNotBe(visible);
     driver.find("#firstName").shouldNotBe(enabled);
@@ -136,7 +136,7 @@ class SelenideElementProxyTest implements WithAssertions {
   void webdriverReportsInvalidXpath_using_shouldNot() {
     when(webdriver.findElement(By.cssSelector("#firstName")))
       .thenThrow(new InvalidSelectorException("Error INVALID_EXPRESSION_ERR ups"));
-    assertThatThrownBy(() -> driver.find("#firstName").shouldNot(exist))
+    assertThatThrownBy(() -> driver.find("#firstName").shouldNot(existInDOM))
       .isInstanceOf(InvalidSelectorException.class);
   }
 

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -20,7 +20,7 @@ import static com.codeborne.selenide.CollectionCondition.exactTexts;
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Condition.cssClass;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Condition.visible;
@@ -169,7 +169,7 @@ class CollectionMethodsTest extends ITest {
   @Test
   void findWaitsUntilElementMatches() {
     $$("#dynamic-content-container span").findBy(text("dynamic content2")).shouldBe(visible);
-    $$("#dynamic-content-container span").findBy(text("unexisting")).shouldNot(exist);
+    $$("#dynamic-content-container span").findBy(text("unexisting")).shouldNot(existInDOM);
   }
 
   @Test

--- a/src/test/java/integration/ElementHiddenTest.java
+++ b/src/test/java/integration/ElementHiddenTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import static com.codeborne.selenide.Condition.appear;
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.disappears;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.visible;
 
@@ -39,7 +39,7 @@ class ElementHiddenTest extends ITest {
 
   @Test
   void shouldExist() {
-    $("#hide").should(exist);
+    $("#hide").should(existInDOM);
   }
 
   @Test

--- a/src/test/java/integration/ElementRemovedTest.java
+++ b/src/test/java/integration/ElementRemovedTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import static com.codeborne.selenide.Condition.appear;
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.disappears;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.visible;
 
@@ -42,7 +42,7 @@ class ElementRemovedTest extends ITest {
 
   @Test
   void shouldNotExist() {
-    $("#remove").shouldNot(exist);
+    $("#remove").shouldNot(existInDOM);
   }
 
   @Test

--- a/src/test/java/integration/InvalidXPathTest.java
+++ b/src/test/java/integration/InvalidXPathTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidSelectorException;
 
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 
 class InvalidXPathTest extends ITest {
   @BeforeEach
@@ -16,14 +16,14 @@ class InvalidXPathTest extends ITest {
 
   @Test
   void usingInvalidXPathShouldThrowInvalidSelectorException() {
-    assertThatThrownBy(() -> $(By.xpath("##[id")).shouldNot(exist))
+    assertThatThrownBy(() -> $(By.xpath("##[id")).shouldNot(existInDOM))
       .isInstanceOf(InvalidSelectorException.class);
   }
 
   @Test
   void lookingForMissingElementByXPathShouldFail() {
     try {
-      $(By.xpath("//tagga")).should(exist);
+      $(By.xpath("//tagga")).should(existInDOM);
       fail("Expected: ElementNotFound exception with cause");
     } catch (ElementNotFound expectedException) {
       assertThat(expectedException.toString())

--- a/src/test/java/integration/LongRunningAjaxRequestTest.java
+++ b/src/test/java/integration/LongRunningAjaxRequestTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.Condition.disappear;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
@@ -14,7 +14,7 @@ class LongRunningAjaxRequestTest extends ITest {
   @BeforeEach
   void openTestPage() {
     openFile("long_ajax_request.html");
-    $("#loading").shouldNot(exist);
+    $("#loading").shouldNot(existInDOM);
     $(byText("Run long request")).click();
   }
 
@@ -30,9 +30,9 @@ class LongRunningAjaxRequestTest extends ITest {
 
   @Test
   void dollarWaitsUntilElementDisappears() {
-    $(byText("Loading...")).should(exist);
+    $(byText("Loading...")).should(existInDOM);
     $(byText("Loading...")).should(disappear);
-    $(byText("Loading...")).shouldNot(exist);
+    $(byText("Loading...")).shouldNot(existInDOM);
   }
 
   @Test
@@ -43,20 +43,20 @@ class LongRunningAjaxRequestTest extends ITest {
 
   @Test
   void dollarWithParentWaitsUntilElementDisappears() {
-    $("#results").$("span#loading").should(exist);
-    $("#results").$("span#loading").shouldNot(exist);
+    $("#results").$("span#loading").should(existInDOM);
+    $("#results").$("span#loading").shouldNot(existInDOM);
   }
 
   @Test
   void dollarWithParentAndIndexWaitsUntilElementDisappears() {
-    $("#results").$("span#loading", 0).should(exist);
-    $("#results").$("span#loading", 0).shouldNot(exist);
-    $("#results").$("span#loading", 666).shouldNot(exist);
+    $("#results").$("span#loading", 0).should(existInDOM);
+    $("#results").$("span#loading", 0).shouldNot(existInDOM);
+    $("#results").$("span#loading", 666).shouldNot(existInDOM);
   }
 
   @Test
   void waitingTimeout() {
-    assertThatThrownBy(() -> $("#non-existing-element").should(exist))
+    assertThatThrownBy(() -> $("#non-existing-element").should(existInDOM))
       .isInstanceOf(AssertionError.class);
   }
 
@@ -72,25 +72,25 @@ class LongRunningAjaxRequestTest extends ITest {
 
   @Test
   void shouldNotExist() {
-    $("#non-existing-element").shouldNot(exist);
-    $("#non-existing-element", 7).shouldNot(exist);
-    $(By.linkText("non-existing-link")).shouldNot(exist);
-    $(By.linkText("non-existing-link"), 8).shouldNot(exist);
+    $("#non-existing-element").shouldNot(existInDOM);
+    $("#non-existing-element", 7).shouldNot(existInDOM);
+    $(By.linkText("non-existing-link")).shouldNot(existInDOM);
+    $(By.linkText("non-existing-link"), 8).shouldNot(existInDOM);
   }
 
   @Test
   void findWaitsForConditions() {
-    $("#results").find(byText("non-existing element")).shouldNot(exist);
-    $("#results").find(byText("non-existing element"), 3).shouldNot(exist);
+    $("#results").find(byText("non-existing element")).shouldNot(existInDOM);
+    $("#results").find(byText("non-existing element"), 3).shouldNot(existInDOM);
 
-    $("#results").find(byText("Loading...")).shouldNot(exist);
-    $("#results").find(byText("Loading..."), 0).shouldNot(exist);
+    $("#results").find(byText("Loading...")).shouldNot(existInDOM);
+    $("#results").find(byText("Loading..."), 0).shouldNot(existInDOM);
   }
 
   @Test
   void shouldNotExistWithinParentElement() {
-    $("body").$("#non-existing-element").shouldNot(exist);
-    $("body").$("#non-existing-element", 4).shouldNot(exist);
+    $("body").$("#non-existing-element").shouldNot(existInDOM);
+    $("body").$("#non-existing-element", 4).shouldNot(existInDOM);
   }
 
   @Test

--- a/src/test/java/integration/NotExistingElementTest.java
+++ b/src/test/java/integration/NotExistingElementTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.attribute;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
@@ -17,7 +17,7 @@ class NotExistingElementTest extends ITest {
 
   @Test
   void shouldNotExist() {
-    $("#not_exist").shouldNot(exist);
+    $("#not_exist").shouldNot(existInDOM);
   }
 
   @Test

--- a/src/test/java/integration/SelectorsTest.java
+++ b/src/test/java/integration/SelectorsTest.java
@@ -4,7 +4,7 @@ import com.codeborne.selenide.SelenideElement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byId;
@@ -21,7 +21,7 @@ class SelectorsTest extends ITest {
 
   @Test
   void canFindElementByName() {
-    $(byName("domain")).should(exist);
+    $(byName("domain")).should(existInDOM);
   }
 
   @Test

--- a/statics/src/test/java/integration/ElementsContainerWithManuallyInitializedFieldsTest.java
+++ b/statics/src/test/java/integration/ElementsContainerWithManuallyInitializedFieldsTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.support.FindBy;
 
 import static com.codeborne.selenide.CollectionCondition.texts;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
@@ -26,7 +26,7 @@ class ElementsContainerWithManuallyInitializedFieldsTest extends IntegrationTest
   void canInitializeElementsContainerFieldsWithoutFindByAnnotation() {
     MyPage page = page(MyPage.class);
 
-    page.container.getSelf().should(exist, visible);
+    page.container.getSelf().should(existInDOM, visible);
     page.container.headerLink.shouldHave(text("Options with 'apostrophes' and \"quotes\""));
     page.container.options.shouldHave(texts("-- Select your hero --", "John Mc'Lain", "Arnold \"Schwarzenegger\"",
       "Mickey \"Rock'n'Roll\" Rourke"));

--- a/statics/src/test/java/integration/ErrorMessagesForMissingElementTest.java
+++ b/statics/src/test/java/integration/ErrorMessagesForMissingElementTest.java
@@ -18,7 +18,7 @@ import org.openqa.selenium.support.FindBy;
 import java.util.regex.Pattern;
 
 import static com.codeborne.selenide.Condition.attribute;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
@@ -209,7 +209,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
   @Test
   void existingElementShouldNotExist() {
     try {
-      $("h2").shouldNot(exist);
+      $("h2").shouldNot(existInDOM);
       fail("Expected ElementFound");
     }
     catch (ElementShouldNot e) {

--- a/statics/src/test/java/integration/ErrorMessagesForMissingElementTest.java
+++ b/statics/src/test/java/integration/ErrorMessagesForMissingElementTest.java
@@ -213,7 +213,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
       fail("Expected ElementFound");
     }
     catch (ElementShouldNot e) {
-      assertThat(e.toString()).matches("Element should not exist \\{h2\\}\n" +
+      assertThat(e.toString()).matches("Element should not exist in DOM \\{h2\\}\n" +
         "Element: '<h2>Dropdown list</h2>'\n" +
         (supportsScreenshots() ? "Screenshot: http://ci.org/build/reports/tests/EMFMET" + png() + "\n" : "") +
         "Page source: http://ci.org/build/reports/tests/EMFMET" + html() + "\n" +

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -91,14 +91,14 @@ class SelectsTest extends IntegrationTest {
   void throwsElementNotFoundWithOptionsText() {
     assertThatThrownBy(() -> $x("//select[@name='domain']").selectOption("unexisting-option"))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessage("Element not found {By.xpath: //select[@name='domain']/option[text:unexisting-option]}\nExpected: exist");
+      .hasMessage("Element not found {By.xpath: //select[@name='domain']/option[text:unexisting-option]}\nExpected: exist in DOM");
   }
 
   @Test()
   void throwsElementNotFoundWithOptionsIndex() {
     assertThatThrownBy(() -> $x("//select[@name='domain']").selectOption(999))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessage("Element not found {By.xpath: //select[@name='domain']/option[index:999]}\nExpected: exist");
+      .hasMessage("Element not found {By.xpath: //select[@name='domain']/option[index:999]}\nExpected: exist in DOM");
   }
 
   @Test

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -21,7 +21,7 @@ import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.disappears;
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.exactText;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.focused;
 import static com.codeborne.selenide.Condition.have;
 import static com.codeborne.selenide.Condition.hidden;
@@ -89,16 +89,16 @@ class SelenideMethodsTest extends IntegrationTest {
     $("#theHiddenElement").shouldBe(hidden);
     $("#theHiddenElement").should(disappear);
     $("#theHiddenElement").waitUntil(disappears, 1000);
-    $("#theHiddenElement").should(exist);
+    $("#theHiddenElement").should(existInDOM);
 
-    $(".non-existing-element").should(Condition.not(exist));
-    $(".non-existing-element").shouldNot(exist);
+    $(".non-existing-element").should(Condition.not(existInDOM));
+    $(".non-existing-element").shouldNot(existInDOM);
   }
 
   @Test
   void userCanUseCustomPollingInterval() {
     $("#theHiddenElement").waitUntil(disappears, 1000, 10);
-    $(".non-existing-element").waitWhile(exist, 1000, 20);
+    $(".non-existing-element").waitWhile(existInDOM, 1000, 20);
   }
 
   @Test

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnElementFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnElementFailsOnTest.java
@@ -12,7 +12,7 @@ import org.openqa.selenium.NoSuchElementException;
 import static com.codeborne.selenide.Condition.appear;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.exactText;
-import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.existInDOM;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
@@ -136,7 +136,7 @@ class MethodCalledOnElementFailsOnTest extends IntegrationTest {
     SelenideElement element = $$(".nonexistent").findBy(cssClass("the-expanse"));
 
     try {
-      element.shouldBe(exist);
+      element.should(existInDOM);
       fail("Expected ElementNotFound");
     } catch (ElementNotFound expected) {
       assertThat(expected)

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest.java
@@ -125,7 +125,7 @@ class MethodCalledOnEntityWithInvalidLocatorFailsOnTest extends IntegrationTest 
     SelenideElement element = $$("##invalid-locator").findBy(cssClass("the-expanse"));
 
     try {
-      element.shouldBe(exist);
+      element.should(existInDOM);
       fail("Expected ElementNotFound");
     } catch (ElementNotFound expected) {
       assertThat(expected)
@@ -155,7 +155,7 @@ class MethodCalledOnEntityWithInvalidLocatorFailsOnTest extends IntegrationTest 
     SelenideElement element = $("ul").find("##invalid-locator");
 
     try {
-      element.shouldBe(exist);
+      element.should(existInDOM);
       fail("Expected ElementNotFound");
     } catch (ElementNotFound expected) {
       assertThat(expected)
@@ -351,7 +351,7 @@ class MethodCalledOnEntityWithInvalidLocatorFailsOnTest extends IntegrationTest 
     }
         /*
             Element not found {ul}
-            Expected: exist
+            Expected: existInDOM
 
             Screenshot: file:/E:/julia/QA/selenide/build/reports/tests/firefox/integration
             /errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest/

--- a/statics/src/test/java/integration/errormessages/package-info.java
+++ b/statics/src/test/java/integration/errormessages/package-info.java
@@ -39,7 +39,7 @@
  *                                             ...
  *                    without waiting
  *                                   isDisplayed()
- *                                   exist()
+ *                                   existInDOM()
  *
  *  fail options
  *             fail on getting element / elements


### PR DESCRIPTION
Exist is ambiguous and is often confused with Visible, causing flaky tests by design.

Typical example:

 ```
 alertBox.should(exist); // instead of alertBox.shouldBe(visible);
  // some actions which are okay, if alertBox is visible
```

Now, if alertBox is just hidden, but exist in DOM (very often the case), it will make test flaky.

The goal of this PR is to make very clear, that this condition is not the same as visible, and thus - reduce the use of it to only cases where it is really necessary (like checking some hidden fields to be present).

alertBox.should(exist) is an example of wrong usage. 
Typical usage for exist is for example

`  $("input[type=hidden][name=special_discount_field]").should(exist);
`