### PR TITLE
Don't change ElementCollection type on toArray

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -369,9 +369,8 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   public Object[] toArray() {
     List<WebElement> fetchedElements = collection.getElements();
     Object[] result = new Object[fetchedElements.size()];
-    Iterator<WebElement> it = fetchedElements.iterator();
     for (int i = 0; i < result.length; i++) {
-      result[i] = Describe.describe(driver(), it.next());
+      result[i] = CollectionElement.wrap(collection, i);
     }
     return result;
   }

--- a/src/test/java/com/codeborne/selenide/ElementsCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/ElementsCollectionTest.java
@@ -323,6 +323,13 @@ class ElementsCollectionTest implements WithAssertions {
       .hasToString("[WebDriverException: Failed to fetch elements]");
   }
 
+  @Test
+  void toArray() {
+    ElementsCollection collection = new ElementsCollection(source);
+    when(source.getElements()).thenReturn(asList(element1, element2));
+    assertThat(collection.toArray()).hasOnlyElementsOfType(SelenideElement.class);
+  }
+
   private WebElement element(String tag) {
     WebElement element = mock(WebElement.class);
     when(element.getTagName()).thenReturn(tag);


### PR DESCRIPTION
## Proposed changes
Don't change ElementCollection type on toArray

Fixed https://github.com/selenide/selenide/issues/844

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)