### PR TITLE
#766 selected text condition @WIP

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -256,6 +256,31 @@ public abstract class Condition {
   }
 
   /**
+   * Checks for selected (highlighted) text on a given web element
+   *
+   * <p>Sample: {@code $("input").shouldHave(selectedText("Text"))}</p>
+   *
+   * <p>NB! Case sensitive</p>
+   *
+   * @param expectedText expected highlighted text of the element
+   */
+  public static Condition selectedText(final String expectedText) {
+    return new Condition("selectedText") {
+      @Override
+      public boolean apply(final Driver driver, final WebElement element) {
+        return driver.executeJavaScript("return arguments[0].value.substring(arguments[0].selectionStart, arguments[0].selectionEnd);", element)
+          .equals(expectedText);
+      }
+
+      @Override
+      public String toString() {
+        return name + " '" + expectedText + '\'';
+      }
+    };
+  }
+
+
+  /**
    * <p>Sample: <code>$("h1").shouldHave(textCaseSensitive("Hello\s*John"))</code></p>
    *
    * <p>NB! Ignores multiple whitespaces between words</p>

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -256,13 +256,13 @@ public abstract class Condition {
   }
 
   /**
-   * Checks for selected or highlighted text on a given input web element
+   * Checks for selected text on a given input web element
    *
    * <p>Sample: {@code $("input").shouldHave(selectedText("Text"))}</p>
    *
    * <p>NB! Case sensitive</p>
    *
-   * @param expectedText expected highlighted text of the element
+   * @param expectedText expected selected text of the element
    */
   public static Condition selectedText(final String expectedText) {
     return new Condition("selectedText") {

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -256,7 +256,7 @@ public abstract class Condition {
   }
 
   /**
-   * Checks for selected (highlighted) text on a given web element
+   * Checks for selected (highlighted) text on a given input web element
    *
    * <p>Sample: {@code $("input").shouldHave(selectedText("Text"))}</p>
    *
@@ -266,11 +266,18 @@ public abstract class Condition {
    */
   public static Condition selectedText(final String expectedText) {
     return new Condition("selectedText") {
+      String actualResult;
+
       @Override
       public boolean apply(final Driver driver, final WebElement element) {
-        return driver.executeJavaScript(
-          "return arguments[0].value.substring(arguments[0].selectionStart, arguments[0].selectionEnd);", element)
-          .equals(expectedText);
+        actualResult =  driver.executeJavaScript(
+          "return arguments[0].value.substring(arguments[0].selectionStart, arguments[0].selectionEnd);", element);
+        return actualResult.equals(expectedText);
+      }
+
+      @Override
+      public String actualValue(Driver driver, WebElement element) {
+        return "'" + actualResult + "'";
       }
 
       @Override

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -256,7 +256,7 @@ public abstract class Condition {
   }
 
   /**
-   * Checks for selected (highlighted) text on a given input web element
+   * Checks for selected or highlighted text on a given input web element
    *
    * <p>Sample: {@code $("input").shouldHave(selectedText("Text"))}</p>
    *
@@ -266,10 +266,10 @@ public abstract class Condition {
    */
   public static Condition selectedText(final String expectedText) {
     return new Condition("selectedText") {
-      String actualResult;
+      String actualResult = "";
 
       @Override
-      public boolean apply(final Driver driver, final WebElement element) {
+      public boolean apply(Driver driver, WebElement element) {
         actualResult =  driver.executeJavaScript(
           "return arguments[0].value.substring(arguments[0].selectionStart, arguments[0].selectionEnd);", element);
         return actualResult.equals(expectedText);

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -268,7 +268,8 @@ public abstract class Condition {
     return new Condition("selectedText") {
       @Override
       public boolean apply(final Driver driver, final WebElement element) {
-        return driver.executeJavaScript("return arguments[0].value.substring(arguments[0].selectionStart, arguments[0].selectionEnd);", element)
+        return driver.executeJavaScript(
+          "return arguments[0].value.substring(arguments[0].selectionStart, arguments[0].selectionEnd);", element)
           .equals(expectedText);
       }
 

--- a/src/test/java/integration/SelectedTextTest.java
+++ b/src/test/java/integration/SelectedTextTest.java
@@ -1,0 +1,40 @@
+package integration;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static com.codeborne.selenide.Condition.selectedText;
+
+
+class SelectedTextTest extends ITest {
+
+  @BeforeEach
+  void before() {
+    openFile("page_with_highlighting.html");
+    $(By.id("selected")).click();
+  }
+
+  @Test
+  void canRetrieveSelectedTextOfWebElementSuccessfully() {
+    $(By.id("selected")).shouldHave(selectedText("Select Me"));
+  }
+
+  @Test
+  void selectedTextIsOnlyCorrectOnExactCaseSensitiveMatch() {
+    $(By.id("selected")).shouldNotHave(selectedText("Select Me "));
+  }
+
+  @Test
+  void whenThereIsNoSelectionSelectedTextIsEmpty() {
+    clearSelection();
+    $(By.id("selected")).shouldHave(selectedText(""));
+  }
+
+  private void clearSelection() {
+    driver().executeJavaScript("window.getSelection().removeAllRanges();");
+  }
+
+
+}

--- a/src/test/java/integration/SelectedTextTest.java
+++ b/src/test/java/integration/SelectedTextTest.java
@@ -13,7 +13,7 @@ class SelectedTextTest extends ITest {
 
   @BeforeEach
   void before() {
-    openFile("page_with_highlighting.html");
+    openFile("page_with_selectable_text.html");
   }
 
   @Test
@@ -47,7 +47,7 @@ class SelectedTextTest extends ITest {
   private void makeSelection(final int start, final int tail) {
     $(By.id("start")).setValue(String.valueOf(start));
     $(By.id("tail")).setValue(String.valueOf(tail));
-    $(By.id("highlight")).click();
+    $(By.id("selectable")).click();
   }
 
 }

--- a/src/test/java/integration/SelectedTextTest.java
+++ b/src/test/java/integration/SelectedTextTest.java
@@ -17,24 +17,24 @@ class SelectedTextTest extends ITest {
   }
 
   @Test
-  void selectedTextOfInputIsConfirmedSuccessfully() {
+  void selectedTextIsCorrect() {
     makeSelection(0, 5);
     getSelectableElement().shouldHave(selectedText("this "));
   }
 
   @Test
-  void selectedTextOfInputIsCaseSensitive() {
+  void selectedTextIsCaseSensitive() {
     makeSelection(5, 10);
     getSelectableElement().shouldNotHave(selectedText("Is a "));
   }
 
   @Test
-  void noSelectedTextOnInputReturnsEmptyString() {
+  void selectedTextReturnsEmptyWhenNothingIsSelected() {
     getSelectableElement().shouldHave(selectedText(""));
   }
 
   @Test
-  void overwrittenSelectionIsDetectedSuccessfully() {
+  void reappliedSelectionsAreDetectedCorrectly() {
     makeSelection(2, 4);
     makeSelection(3, 13);
     getSelectableElement().shouldHave(selectedText("s is a lon"));

--- a/src/test/java/integration/SelectedTextTest.java
+++ b/src/test/java/integration/SelectedTextTest.java
@@ -1,6 +1,7 @@
 package integration;
 
 
+import com.codeborne.selenide.SelenideElement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -13,28 +14,40 @@ class SelectedTextTest extends ITest {
   @BeforeEach
   void before() {
     openFile("page_with_highlighting.html");
-    $(By.id("selected")).click();
   }
 
   @Test
-  void canRetrieveSelectedTextOfWebElementSuccessfully() {
-    $(By.id("selected")).shouldHave(selectedText("Select Me"));
+  void selectedTextOfInputIsConfirmedSuccessfully() {
+    makeSelection(0,5);
+    getSelectableElement().shouldHave(selectedText("this "));
   }
 
   @Test
-  void selectedTextIsOnlyCorrectOnExactCaseSensitiveMatch() {
-    $(By.id("selected")).shouldNotHave(selectedText("Select Me "));
+  void selectedTextOfInputIsCaseSensitive() {
+    makeSelection(5, 10);
+    getSelectableElement().shouldNotHave(selectedText("Is a "));
   }
 
   @Test
-  void whenThereIsNoSelectionSelectedTextIsEmpty() {
-    clearSelection();
-    $(By.id("selected")).shouldHave(selectedText(""));
+  void noSelectedTextOnInputReturnsEmptyString() {
+    getSelectableElement().shouldHave(selectedText(""));
   }
 
-  private void clearSelection() {
-    driver().executeJavaScript("window.getSelection().removeAllRanges();");
+  @Test
+  void overwrittenSelectionIsDetectedSuccessfully() {
+    makeSelection(2,4);
+    makeSelection(3, 13);
+    getSelectableElement().shouldHave(selectedText("s is a lon"));
   }
 
+  private SelenideElement getSelectableElement() {
+    return $(By.id("selected"));
+  }
+
+  private void makeSelection(final int start, final int tail) {
+    $(By.id("start")).setValue(String.valueOf(start));
+    $(By.id("tail")).setValue(String.valueOf(tail));
+    $(By.id("highlight")).click();
+  }
 
 }

--- a/src/test/java/integration/SelectedTextTest.java
+++ b/src/test/java/integration/SelectedTextTest.java
@@ -18,7 +18,7 @@ class SelectedTextTest extends ITest {
 
   @Test
   void selectedTextOfInputIsConfirmedSuccessfully() {
-    makeSelection(0,5);
+    makeSelection(0, 5);
     getSelectableElement().shouldHave(selectedText("this "));
   }
 
@@ -35,7 +35,7 @@ class SelectedTextTest extends ITest {
 
   @Test
   void overwrittenSelectionIsDetectedSuccessfully() {
-    makeSelection(2,4);
+    makeSelection(2, 4);
     makeSelection(3, 13);
     getSelectableElement().shouldHave(selectedText("s is a lon"));
   }

--- a/src/test/resources/page_with_highlighting.html
+++ b/src/test/resources/page_with_highlighting.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Highlighting elements</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <script type="text/javascript" src="jquery.min.js" language="JavaScript"></script>
+</head>
+<body>
+<input type="text" name="textbox" value="Select Me" id="selected" onfocus="this.select()">
+</body>
+</html>

--- a/src/test/resources/page_with_highlighting.html
+++ b/src/test/resources/page_with_highlighting.html
@@ -6,6 +6,28 @@
   <script type="text/javascript" src="jquery.min.js" language="JavaScript"></script>
 </head>
 <body>
-<input type="text" name="textbox" value="Select Me" id="selected" onfocus="this.select()">
+<input id="selected" type="text" value="this is a long piece of selectable text"><br>
+<input id="start" type="text" name="start"><br>
+<input id="tail" type="text" name="tail"><br>
+<input type="button" id="highlight" value="select!" onmousedown="highlight(getStart(), getTail()); return false">
+
+<script>
+
+  function getStart() {
+    return document.getElementById("start").value;
+  }
+
+  function getTail() {
+    return document.getElementById("tail").value;
+  }
+
+  function highlight(start, tail) {
+    var input = document.getElementById("selected");
+    input.setSelectionRange(start, tail);
+    input.focus();
+  }
+
+</script>
+
 </body>
 </html>

--- a/src/test/resources/page_with_selectable_text.html
+++ b/src/test/resources/page_with_selectable_text.html
@@ -1,15 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Highlighting elements</title>
+  <title>Selectable text on elements</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-  <script type="text/javascript" src="jquery.min.js" language="JavaScript"></script>
 </head>
 <body>
 <input id="selected" type="text" value="this is a long piece of selectable text"><br>
 <input id="start" type="text" name="start"><br>
 <input id="tail" type="text" name="tail"><br>
-<input type="button" id="highlight" value="select!" onmousedown="highlight(getStart(), getTail()); return false">
+<input type="button" id="selectable" value="select!" onclick="makeSelection(getStart(), getTail()); return false">
 
 <script>
 
@@ -21,7 +20,7 @@
     return document.getElementById("tail").value;
   }
 
-  function highlight(start, tail) {
+  function makeSelection(start, tail) {
     var input = document.getElementById("selected");
     input.setSelectionRange(start, tail);
     input.focus();


### PR DESCRIPTION
## Proposed changes
Provides capabilities for selenide to read and assert against the 'selected' or 'highlighted' text of a given input field as requested in #766.

By 'highlighted' or 'selected' we mean => The text on the element that if a user was to issue a copy command, would be copied to the clipboard.

Would like some feedback on this as an approach to this feature, this PR is a work in progress.  Example output where the selected text is not matching:

```
Element should have selectedText 't2his ' {By.id: selected}
Element: '<input id="selected" type="text" value="this is a long piece of selectable text"></input>'
Actual value: 'this '
```

Thoughts? thanks for your time.

## Checklist
- [X] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)