### PR TITLE
Enhanced chromeoptions arguments and preferences

### DIFF
--- a/src/main/java/com/codeborne/selenide/Config.java
+++ b/src/main/java/com/codeborne/selenide/Config.java
@@ -14,8 +14,6 @@ public interface Config {
   String browserBinary();
   String pageLoadStrategy();
   DesiredCapabilities browserCapabilities();
-  String chromeoptionsArgs();
-  String chromeoptionsPrefs();
 
   String baseUrl();
   long timeout();

--- a/src/main/java/com/codeborne/selenide/Config.java
+++ b/src/main/java/com/codeborne/selenide/Config.java
@@ -14,6 +14,8 @@ public interface Config {
   String browserBinary();
   String pageLoadStrategy();
   DesiredCapabilities browserCapabilities();
+  String chromeoptionsArgs();
+  String chromeoptionsPrefs();
 
   String baseUrl();
   long timeout();
@@ -33,4 +35,5 @@ public interface Config {
   boolean proxyEnabled();
   String proxyHost();
   int proxyPort();
+
 }

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -41,6 +41,9 @@ public class SelenideConfig implements Config {
   private String proxyHost = System.getProperty("selenide.proxyHost", "");
   private int proxyPort = Integer.parseInt(System.getProperty("selenide.proxyPort", "0"));
 
+  private String chromeoptionsArgs = System.getProperty("chromeoptions.args", "");
+  private String chromeoptionsPrefs = System.getProperty("chromeoptions.prefs", "");
+
   @Override
   public String baseUrl() {
     return baseUrl;
@@ -328,6 +331,26 @@ public class SelenideConfig implements Config {
 
   public SelenideConfig browserCapabilities(DesiredCapabilities browserCapabilities) {
     this.browserCapabilities = browserCapabilities;
+    return this;
+  }
+
+  @Override
+  public String chromeoptionsArgs() {
+    return chromeoptionsArgs;
+  }
+
+  public SelenideConfig chromeoptionsArgs(String chromeoptionsArgs) {
+    this.chromeoptionsArgs = chromeoptionsArgs;
+    return this;
+  }
+
+  @Override
+  public String chromeoptionsPrefs() {
+    return chromeoptionsPrefs;
+  }
+
+  public SelenideConfig chromeoptionsPrefs(String chromeoptionsPrefs) {
+    this.chromeoptionsPrefs = chromeoptionsPrefs;
     return this;
   }
 }

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -41,9 +41,6 @@ public class SelenideConfig implements Config {
   private String proxyHost = System.getProperty("selenide.proxyHost", "");
   private int proxyPort = Integer.parseInt(System.getProperty("selenide.proxyPort", "0"));
 
-  private String chromeoptionsArgs = System.getProperty("chromeoptions.args", "");
-  private String chromeoptionsPrefs = System.getProperty("chromeoptions.prefs", "");
-
   @Override
   public String baseUrl() {
     return baseUrl;
@@ -334,23 +331,4 @@ public class SelenideConfig implements Config {
     return this;
   }
 
-  @Override
-  public String chromeoptionsArgs() {
-    return chromeoptionsArgs;
-  }
-
-  public SelenideConfig chromeoptionsArgs(String chromeoptionsArgs) {
-    this.chromeoptionsArgs = chromeoptionsArgs;
-    return this;
-  }
-
-  @Override
-  public String chromeoptionsPrefs() {
-    return chromeoptionsPrefs;
-  }
-
-  public SelenideConfig chromeoptionsPrefs(String chromeoptionsPrefs) {
-    this.chromeoptionsPrefs = chromeoptionsPrefs;
-    return this;
-  }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -53,8 +53,7 @@ class ChromeDriverFactory extends AbstractDriverFactory {
    */
   private ChromeOptions transferChromeOptionsFromSystemProperties(ChromeOptions currentChromeOptions) {
     if (System.getProperty("chromeoptions.args") != null) {
-      // Regexp from https://stackoverflow.com/a/15739087/1110503 to handle commas in values
-      Stream<String> params = Arrays.stream(System.getProperty("chromeoptions.args").split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)"));
+      Stream<String> params = Arrays.stream(parseCSVhandlingQuotes(System.getProperty("chromeoptions.args")));
       List<String> args = params
         .map(s -> s.replace("\"", ""))
         .collect(Collectors.toList());
@@ -69,8 +68,7 @@ class ChromeDriverFactory extends AbstractDriverFactory {
 
   private Map<String, Object> parsePreferencesFromString(String preferencesString) {
     Map<String, Object> prefs = new HashMap<>();
-    // Regexp from https://stackoverflow.com/a/15739087/1110503 to handle commas in values
-    String[] allPrefs = preferencesString.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
+    String[] allPrefs = parseCSVhandlingQuotes(preferencesString);
     for (String pref : allPrefs) {
       String[] keyValue = pref
         .replace("\"", "")
@@ -92,6 +90,17 @@ class ChromeDriverFactory extends AbstractDriverFactory {
       prefs.put(keyValue[0], prefValue);
     }
     return prefs;
+  }
+
+  /**
+   * parse parameters which can come from command-line interface
+   * @param csvString comma-separated values, quotes can be used to mask spaces and commas
+   *                  Example: 123,"foo bar","bar,foo"
+   * @return values as array, quotes are preserved
+   */
+  private String[] parseCSVhandlingQuotes(String csvString) {
+    // Regexp from https://stackoverflow.com/a/15739087/1110503 to handle commas in values
+    return csvString.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -52,16 +52,16 @@ class ChromeDriverFactory extends AbstractDriverFactory {
    * @return
    */
   private ChromeOptions transferChromeOptionsFromSystemProperties(Config config, ChromeOptions currentChromeOptions) {
-    if (!config.chromeoptionsArgs().equals("")) {
+    if (System.getProperty("chromeoptions.args") != null) {
       // Regexp from https://stackoverflow.com/a/15739087/1110503 to handle commas in values
-      Stream<String> params = Arrays.stream(config.chromeoptionsArgs().split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)"));
+      Stream<String> params = Arrays.stream(System.getProperty("chromeoptions.args").split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)"));
       List<String> args = params
         .map(s -> s.replace("\"", ""))
         .collect(Collectors.toList());
       currentChromeOptions.addArguments(args);
     }
-    if (!config.chromeoptionsPrefs().equals("")) {
-      Map<String, Object> prefs = parsePreferencesFromString(config.chromeoptionsPrefs());
+    if (System.getProperty("chromeoptions.prefs") != null) {
+      Map<String, Object> prefs = parsePreferencesFromString(System.getProperty("chromeoptions.prefs"));
       currentChromeOptions.setExperimentalOption("prefs", prefs);
     }
     return currentChromeOptions;

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import java.util.stream.*;
 
 class ChromeDriverFactory extends AbstractDriverFactory {
   private static final Logger log = Logger.getLogger(ChromeDriverFactory.class.getName());
@@ -57,7 +58,11 @@ class ChromeDriverFactory extends AbstractDriverFactory {
         String value = System.getProperties().getProperty(key);
         switch (capability) {
           case "args": {
-            List<String> args = Arrays.asList(value.split(","));
+            // Regexp from https://stackoverflow.com/a/15739087/1110503 to handle commas in values
+            Stream<String> params = Arrays.stream(value.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)"));
+            List<String> args=params
+              .map(s -> s.replace("\"",""))
+              .collect(Collectors.toList());
             currentChromeOptions.addArguments(args);
             break;
           }
@@ -70,7 +75,7 @@ class ChromeDriverFactory extends AbstractDriverFactory {
             log.warning(capability + " is ignored." +
                     "Only so-called arguments (chromeoptions.args=<values comma separated>) " +
                     "and preferences (chromeoptions.prefs=<comma-separated dictionary of key=value> " +
-                    "are supported for the chromeoptions at the moment");
+                    "are supported for the chromeoptions at the moment.");
             break;
         }
       }
@@ -80,9 +85,12 @@ class ChromeDriverFactory extends AbstractDriverFactory {
 
   private Map<String, Object> parsePreferencesFromString(String preferencesString) {
     Map<String, Object> prefs = new HashMap<>();
-    String[] allPrefs = preferencesString.split(",");
+    // Regexp from https://stackoverflow.com/a/15739087/1110503 to handle commas in values
+    String[] allPrefs = preferencesString.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
     for (String pref : allPrefs) {
-      String[] keyValue = pref.split("=");
+      String[] keyValue = pref
+        .replace("\"","")
+        .split("=");
 
       if (keyValue.length == 1) {
         log.warning(String.format(

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -38,7 +38,7 @@ class ChromeDriverFactory extends AbstractDriverFactory {
       options.setBinary(config.browserBinary());
     }
     options.merge(createCommonCapabilities(config, proxy));
-    options = transferChromeOptionsFromSystemProperties(config, options);
+    options = transferChromeOptionsFromSystemProperties(options);
     log.config("Chrome options:" + options.toString());
     return options;
   }
@@ -49,9 +49,9 @@ class ChromeDriverFactory extends AbstractDriverFactory {
    * for ChromeOptions (there is also "Extensions" etc.)
    *
    * @param currentChromeOptions
-   * @return
+   * @return options updated with args & prefs parameters
    */
-  private ChromeOptions transferChromeOptionsFromSystemProperties(Config config, ChromeOptions currentChromeOptions) {
+  private ChromeOptions transferChromeOptionsFromSystemProperties(ChromeOptions currentChromeOptions) {
     if (System.getProperty("chromeoptions.args") != null) {
       // Regexp from https://stackoverflow.com/a/15739087/1110503 to handle commas in values
       Stream<String> params = Arrays.stream(System.getProperty("chromeoptions.args").split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)"));

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -21,7 +21,6 @@ class ChromeDriverFactoryTest implements WithAssertions {
   private final String CHROME_OPTIONS_PREFS = "chromeoptions.prefs";
   private final String CHROME_OPTIONS_ARGS = "chromeoptions.args";
   private Proxy proxy = mock(Proxy.class);
-  private SelenideConfig config = new SelenideConfig();
 
   @AfterEach
   void tearDown() {
@@ -32,7 +31,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionArgumentsFromSystemPropsToDriver() {
     System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,xcvcd=123");
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments).contains("abdd", "--abcd", "xcvcd=123");
@@ -41,7 +40,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriver() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true");
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap)
@@ -54,7 +53,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriverNoAssignmentStatement() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=1,key2");
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap).hasSize(1);
@@ -65,7 +64,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriverTwoAssignmentStatement() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=1,key2=1=false");
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap).hasSize(1);
@@ -77,12 +76,12 @@ class ChromeDriverFactoryTest implements WithAssertions {
     System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,\"snc,snc\",xcvcd=123");
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true,\"key5=abc,555\"");
 
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments)
-      .contains("abdd", "--abcd", "xcvcd=123","snc,snc");
+      .contains("abdd", "--abcd", "xcvcd=123", "snc,snc");
 
     assertThat(prefsMap)
       .containsEntry("key1", "stringval")
@@ -94,6 +93,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
   @Test
   void browserBinaryCanBeSet() {
+    SelenideConfig config = new SelenideConfig();
     config.browserBinary("c:/browser.exe");
     Capabilities caps = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map options = (Map) caps.asMap().get(ChromeOptions.CAPABILITY);
@@ -103,6 +103,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
   @Test
   void headlessCanBeSet() {
+    SelenideConfig config = new SelenideConfig();
     config.headless(true);
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -74,21 +74,22 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
   @Test
   void transferChromeOptionsAndPrefs() {
-    System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,xcvcd=123");
-    System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true");
+    System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,\"snc,snc\",xcvcd=123");
+    System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true,\"key5=abc,555\"");
 
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments)
-      .contains("abdd", "--abcd", "xcvcd=123");
+      .contains("abdd", "--abcd", "xcvcd=123","snc,snc");
 
     assertThat(prefsMap)
       .containsEntry("key1", "stringval")
       .containsEntry("key2", 1)
       .containsEntry("key3", false)
-      .containsEntry("key4", true);
+      .containsEntry("key4", true)
+      .containsEntry("key5", "abc,555");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -32,16 +32,20 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
   @Test
   void transferChromeOptionArgumentsFromSystemPropsToDriver() {
-    System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,xcvcd=123");
+    System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,\"snc,snc\",xcvcd=123,\"abc emd\"");
+
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 
-    assertThat(optionArguments).contains("abdd", "--abcd", "xcvcd=123");
+    assertThat(optionArguments)
+      .contains("abdd", "--abcd", "xcvcd=123", "snc,snc", "abc emd");
   }
 
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriver() {
-    System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true");
+    System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true," +
+      "\"key5=abc,555\",key6=\"555 abc\"");
+
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
@@ -49,12 +53,15 @@ class ChromeDriverFactoryTest implements WithAssertions {
       .containsEntry("key1", "stringval")
       .containsEntry("key2", 1)
       .containsEntry("key3", false)
-      .containsEntry("key4", true);
+      .containsEntry("key4", true)
+      .containsEntry("key5", "abc,555")
+      .containsEntry("key6", "555 abc");
   }
 
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriverNoAssignmentStatement() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=1,key2");
+
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
@@ -66,6 +73,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriverTwoAssignmentStatement() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=1,key2=1=false");
+
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
@@ -74,28 +82,9 @@ class ChromeDriverFactoryTest implements WithAssertions {
   }
 
   @Test
-  void transferChromeOptionsAndPrefs() {
-    System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,\"snc,snc\",xcvcd=123,\"abc emd\"");
-    System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true,\"key5=abc,555\"");
-
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
-    List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
-    Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
-
-    assertThat(optionArguments)
-      .contains("abdd", "--abcd", "xcvcd=123", "snc,snc", "abc emd");
-
-    assertThat(prefsMap)
-      .containsEntry("key1", "stringval")
-      .containsEntry("key2", 1)
-      .containsEntry("key3", false)
-      .containsEntry("key4", true)
-      .containsEntry("key5", "abc,555");
-  }
-
-  @Test
   void browserBinaryCanBeSet() {
     config.browserBinary("c:/browser.exe");
+
     Capabilities caps = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map options = (Map) caps.asMap().get(ChromeOptions.CAPABILITY);
 
@@ -105,6 +94,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void headlessCanBeSet() {
     config.headless(true);
+
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -75,7 +75,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
   @Test
   void transferChromeOptionsAndPrefs() {
-    System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,\"snc,snc\",xcvcd=123");
+    System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,\"snc,snc\",xcvcd=123,\"abc emd\"");
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true,\"key5=abc,555\"");
 
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
@@ -83,7 +83,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments)
-      .contains("abdd", "--abcd", "xcvcd=123", "snc,snc");
+      .contains("abdd", "--abcd", "xcvcd=123", "snc,snc", "abc emd");
 
     assertThat(prefsMap)
       .containsEntry("key1", "stringval")

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -20,7 +20,9 @@ import static org.mockito.Mockito.mock;
 class ChromeDriverFactoryTest implements WithAssertions {
   private final String CHROME_OPTIONS_PREFS = "chromeoptions.prefs";
   private final String CHROME_OPTIONS_ARGS = "chromeoptions.args";
+
   private Proxy proxy = mock(Proxy.class);
+  private SelenideConfig config = new SelenideConfig();
 
   @AfterEach
   void tearDown() {
@@ -31,7 +33,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionArgumentsFromSystemPropsToDriver() {
     System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,xcvcd=123");
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments).contains("abdd", "--abcd", "xcvcd=123");
@@ -40,7 +42,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriver() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true");
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap)
@@ -53,7 +55,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriverNoAssignmentStatement() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=1,key2");
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap).hasSize(1);
@@ -64,7 +66,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   @Test
   void transferChromeOptionPreferencesFromSystemPropsToDriverTwoAssignmentStatement() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=1,key2=1=false");
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap).hasSize(1);
@@ -76,7 +78,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
     System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,\"snc,snc\",xcvcd=123");
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true,\"key5=abc,555\"");
 
-    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(new SelenideConfig(), proxy);
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
@@ -93,7 +95,6 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
   @Test
   void browserBinaryCanBeSet() {
-    SelenideConfig config = new SelenideConfig();
     config.browserBinary("c:/browser.exe");
     Capabilities caps = new ChromeDriverFactory().createChromeOptions(config, proxy);
     Map options = (Map) caps.asMap().get(ChromeOptions.CAPABILITY);
@@ -103,7 +104,6 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
   @Test
   void headlessCanBeSet() {
-    SelenideConfig config = new SelenideConfig();
     config.headless(true);
     ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -3,12 +3,32 @@ package com.codeborne.selenide;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 /**
- * Settings for all Selenide functionality
+ * Configuration settings for Selenide default browser
  * <br>
  * This class is designed so that every setting can be set either via system property or programmatically.
  * <br>
  * Please note that all fields are static, meaning that
  * every change will immediately reflect in all threads (if you run tests in parallel).
+ *
+ * <p>
+ *   These system properties can be additonally used having effect on every new created browser in test.
+ *   For example as -D<property>=<value> in command-line
+ * </p>
+ * <p>
+ *  <b>chromeoptions.args</b> - Sets the arguments for chrome options, parameters are comma separated
+ *  If comma is a part of the value, use double quotes around the argument
+ *  Non-official list of parameters can be found at https://peter.sh/experiments/chromium-command-line-switches/
+ *
+ *  Example: --no-sandbox,--disable-3d-apis,"--user-agent=Firefox 45, Mozilla"
+ * </p>
+ * <p>
+ *  <b>chromeoptions.prefs</b> - ser the preferences for chrome options, which are comma separated
+ *   keyX=valueX preferences. If comma is a part of the value, use double quotes around the preference
+ *   List of preferences can be found at
+ *   https://chromium.googlesource.com/chromium/src/+/master/chrome/common/pref_names.cc
+ *
+ *   Example: homepage=http://google.com,"intl.allowed_languages=en,ru,es"
+ * </p>
  */
 public class Configuration {
   private static SelenideConfig defaults = new SelenideConfig();
@@ -282,24 +302,4 @@ public class Configuration {
    */
   public static String browserBinary = defaults.browserBinary();
 
-  /**
-   * Sets the arguments for chrome options, parameters are comma separated
-   * If comma is a part of the value, use double quotes around the argument
-   * Non-official list of parameters can be found
-   * at https://peter.sh/experiments/chromium-command-line-switches/
-   * Can be set by system property "chromeoptions.args" or programmatically
-   * Example: --no-sandbox,--disable-3d-apis,"--user-agent=Firefox 45, Mozilla"
-   */
-  public static String chromeoptionsArgs = defaults.chromeoptionsArgs();
-
-  /**
-   * Sets the preferences for chrome options, which are comma separated
-   * keyX=valueX preferences
-   * If comma is a part of the value, use double quotes around the preference
-   * List of preferences can be found at
-   * https://chromium.googlesource.com/chromium/src/+/master/chrome/common/pref_names.cc
-   * Can be set by system property "chromeoptions.prefs" or programmatically
-   * Example: homepage=http://google.com,"intl.allowed_languages=en,ru,es"
-   */
-  public static String chromeoptionsPrefs = defaults.chromeoptionsPrefs();
 }

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -281,4 +281,25 @@ public class Configuration {
    * Works only for Chrome, Firefox and Opera.
    */
   public static String browserBinary = defaults.browserBinary();
+
+  /**
+   * Sets the arguments for chrome options, parameters are comma separated
+   * If comma is a part of the value, use double quotes around the argument
+   * Non-official list of parameters can be found
+   * at https://peter.sh/experiments/chromium-command-line-switches/
+   * Can be set by system property "chromeoptions.args" or programmatically
+   * Example: --no-sandbox,--disable-3d-apis,"--user-agent=Firefox 45, Mozilla"
+   */
+  public static String chromeoptionsArgs = defaults.chromeoptionsArgs();
+
+  /**
+   * Sets the preferences for chrome options, which are comma separated
+   * keyX=valueX preferences
+   * If comma is a part of the value, use double quotes around the preference
+   * List of preferences can be found at
+   * https://chromium.googlesource.com/chromium/src/+/master/chrome/common/pref_names.cc
+   * Can be set by system property "chromeoptions.prefs" or programmatically
+   * Example: homepage=http://google.com,"intl.allowed_languages=en,ru,es"
+   */
+  public static String chromeoptionsPrefs = defaults.chromeoptionsPrefs();
 }

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
@@ -160,14 +160,4 @@ class StaticConfig implements Config {
   public DesiredCapabilities browserCapabilities() {
     return Configuration.browserCapabilities;
   }
-
-  @Override
-  public String chromeoptionsArgs() {
-    return Configuration.chromeoptionsArgs;
-  }
-
-  @Override
-  public String chromeoptionsPrefs() {
-    return Configuration.chromeoptionsPrefs;
-  }
 }

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
@@ -160,4 +160,14 @@ class StaticConfig implements Config {
   public DesiredCapabilities browserCapabilities() {
     return Configuration.browserCapabilities;
   }
+
+  @Override
+  public String chromeoptionsArgs() {
+    return Configuration.chromeoptionsArgs;
+  }
+
+  @Override
+  public String chromeoptionsPrefs() {
+    return Configuration.chromeoptionsPrefs;
+  }
 }


### PR DESCRIPTION
## Proposed changes
Chromeoptions arguments and preferences now allow to have commas in value, when parameter is masked with double quotes. see #836 
Also they are made available as Configuration to work smoothly with Selenide 5.+ versions, with multiple browser.
Usage is documented in javadoc and tests.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)