### PR TITLE
#867 user can switch between custom webdrivers many times

### DIFF
--- a/src/main/java/com/codeborne/selenide/drivercommands/WebDriverWrapper.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/WebDriverWrapper.java
@@ -40,10 +40,11 @@ public class WebDriverWrapper implements Driver {
     return webDriver;
   }
 
+  /**
+   * Does not close webdriver.
+   * This class holds a webdriver created by user - in this case user is responsible for closing webdriver by himself.
+   */
   @Override
   public void close() {
-    if (!config().holdBrowserOpen()) {
-      new CloseDriverCommand(webDriver, null).run();
-    }
   }
 }

--- a/src/test/java/com/codeborne/selenide/drivercommands/WebDriverWrapperTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/WebDriverWrapperTest.java
@@ -1,0 +1,21 @@
+package com.codeborne.selenide.drivercommands;
+
+import com.codeborne.selenide.SelenideConfig;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+class WebDriverWrapperTest {
+
+  @Test
+  void name() {
+    WebDriver webDriver = mock(WebDriver.class);
+    WebDriverWrapper driver = new WebDriverWrapper(new SelenideConfig(), webDriver);
+
+    driver.close();
+
+    verifyNoMoreInteractions(webDriver);
+  }
+}

--- a/statics/src/test/java/integration/CustomWebdriverTest.java
+++ b/statics/src/test/java/integration/CustomWebdriverTest.java
@@ -1,0 +1,56 @@
+package integration;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.close;
+import static com.codeborne.selenide.WebDriverRunner.isChrome;
+import static com.codeborne.selenide.WebDriverRunner.isFirefox;
+import static com.codeborne.selenide.WebDriverRunner.setWebDriver;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+public class CustomWebdriverTest extends IntegrationTest {
+  private WebDriver browser1;
+  private WebDriver browser2;
+
+  @BeforeAll
+  static void setUp() {
+    assumeThat(isChrome() || isFirefox()).isTrue();
+
+    close();
+    if (isFirefox()) WebDriverManager.firefoxdriver().setup();
+    if (isChrome()) WebDriverManager.chromedriver().setup();
+  }
+
+  @Test
+  void userCanSwitchBetweenWebdrivers() {
+    toggleProxy(false);
+    browser1 = isFirefox() ? new FirefoxDriver() : new ChromeDriver();
+    browser2 = isFirefox() ? new FirefoxDriver() : new ChromeDriver();
+
+    setWebDriver(browser1);
+    openFile("page_with_selects_without_jquery.html");
+    $("h1").shouldBe(visible);
+
+    setWebDriver(browser2);
+    openFile("page_with_selects_without_jquery.html");
+    $("h2").shouldBe(visible);
+
+    setWebDriver(browser1);
+    openFile("page_with_selects_without_jquery.html");
+    $("h1").shouldBe(visible);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (browser1 != null) browser1.quit();
+    if (browser2 != null) browser2.quit();
+  }
+}


### PR DESCRIPTION
... and Selenide should not close them

Fix for issue #867

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)