### PR TITLE
875 fix dependencies for it execution

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -31,7 +31,7 @@ dependencies {
   testImplementation("org.assertj:assertj-core:3.11.1")
   testImplementation("org.seleniumhq.selenium:htmlunit-driver:$htmlunitDriverVersion")
 
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+  testCompile("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testRuntimeOnly('org.slf4j:slf4j-simple:1.7.25')
   testRuntimeOnly('com.codeborne:phantomjsdriver:1.4.4') { transitive = false }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,8 +30,8 @@ dependencies {
   testImplementation('com.automation-remarks:video-recorder-junit5:1.8')
   testImplementation("org.assertj:assertj-core:3.11.1")
   testImplementation("org.seleniumhq.selenium:htmlunit-driver:$htmlunitDriverVersion")
+  testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
 
-  testCompile("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testRuntimeOnly('org.slf4j:slf4j-simple:1.7.25')
   testRuntimeOnly('com.codeborne:phantomjsdriver:1.4.4') { transitive = false }
 }


### PR DESCRIPTION
fixes the gradle dependencies for running a single integration test within IDEA.  Problem lies with gradle 5.

@rosolko should we move also phantomjsdriver and slf4j to the same?

I can confirm when using testImplementation for junit engine, that I can infact successfully run 1 IT