### PR TITLE
Test basic auth without proxy

### DIFF
--- a/statics/src/test/java/integration/BasicAuthTest.java
+++ b/statics/src/test/java/integration/BasicAuthTest.java
@@ -11,6 +11,7 @@ import static com.codeborne.selenide.Selenide.open;
 class BasicAuthTest extends IntegrationTest {
   @Test
   void canPassBasicAuth_via_URL() {
+    toggleProxy(false);
     open("/basic-auth/hello", "", "scott", "tiger");
     $("body").shouldHave(text("Hello, scott:tiger!"));
   }

--- a/statics/src/test/java/integration/BrowserPositionTest.java
+++ b/statics/src/test/java/integration/BrowserPositionTest.java
@@ -15,12 +15,12 @@ class BrowserPositionTest extends IntegrationTest {
   @BeforeEach
   @AfterEach
   void closeBrowser() {
+    assumeFalse(isHeadless());
     close();
   }
 
   @Test
   void ableToSetBrowserPosition() {
-    assumeFalse(isHeadless());
     Configuration.browserPosition = "30x60";
 
     openFile("start_page.html");

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -7,6 +7,7 @@ import com.codeborne.selenide.junit5.ScreenShooterExtension;
 import com.codeborne.selenide.junit5.TextReportExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -37,6 +38,11 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     }
   }
 
+  @BeforeAll
+  static void resetSettingsBeforeClass() {
+    resetSettings();
+  }
+
   @BeforeEach
   final void setUpEach() {
     resetSettings();
@@ -44,7 +50,7 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     rememberTimeout();
   }
 
-  private void resetSettings() {
+  private static void resetSettings() {
     Configuration.browser = System.getProperty("selenide.browser", CHROME);
     Configuration.baseUrl = getBaseUrl();
     Configuration.headless = Boolean.parseBoolean(System.getProperty("selenide.headless", "false"));
@@ -77,7 +83,7 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
       "&timeout=" + timeout, pageObjectClass);
   }
 
-  protected void toggleProxy(boolean proxyEnabled) {
+  protected static void toggleProxy(boolean proxyEnabled) {
     if (proxyEnabled) {
       assumeFalse(isPhantomjs()); // I don't know why, but PhantomJS seems to ignore proxy
     }


### PR DESCRIPTION
## Proposed changes
It's a technical change to improve Selenide own tests.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)