### PR TITLE
Including condition explanation into CollectionCondition toString()

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -1,6 +1,14 @@
 package com.codeborne.selenide;
 
-import com.codeborne.selenide.collections.*;
+import com.codeborne.selenide.collections.ExactTexts;
+import com.codeborne.selenide.collections.ListSize;
+import com.codeborne.selenide.collections.SizeGreaterThan;
+import com.codeborne.selenide.collections.SizeGreaterThanOrEqual;
+import com.codeborne.selenide.collections.SizeLessThan;
+import com.codeborne.selenide.collections.SizeLessThanOrEqual;
+import com.codeborne.selenide.collections.SizeNotEqual;
+import com.codeborne.selenide.collections.Texts;
+import com.codeborne.selenide.collections.TextsInAnyOrder;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import com.google.common.base.Predicate;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
@@ -96,6 +104,10 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
     return new ExactTexts(expectedTexts);
   }
 
+  /**
+   * Wraps CollectionCondition without any changes except toString() method
+   * where explanation string (because) are being appended
+   */
   private static class ExplainedCollectionCondition extends CollectionCondition {
     private final CollectionCondition delegate;
     private final String message;

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -1,16 +1,9 @@
 package com.codeborne.selenide;
 
-import com.codeborne.selenide.collections.ExactTexts;
-import com.codeborne.selenide.collections.ListSize;
-import com.codeborne.selenide.collections.SizeGreaterThan;
-import com.codeborne.selenide.collections.SizeGreaterThanOrEqual;
-import com.codeborne.selenide.collections.SizeLessThan;
-import com.codeborne.selenide.collections.SizeLessThanOrEqual;
-import com.codeborne.selenide.collections.SizeNotEqual;
-import com.codeborne.selenide.collections.Texts;
-import com.codeborne.selenide.collections.TextsInAnyOrder;
+import com.codeborne.selenide.collections.*;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import com.google.common.base.Predicate;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
@@ -103,12 +96,42 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
     return new ExactTexts(expectedTexts);
   }
 
+  private static class ExplainedCollectionCondition extends CollectionCondition {
+    private final CollectionCondition delegate;
+    private final String message;
+
+    private ExplainedCollectionCondition(CollectionCondition delegate, String message) {
+      this.delegate = delegate;
+      this.message = message;
+    }
+
+    @Override
+    public String toString() {
+      return delegate.toString() + " (because " + message + ")";
+    }
+
+    @Override
+    public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
+      delegate.fail(collection, elements, lastError, timeoutMs);
+    }
+
+    @Override
+    public boolean applyNull() {
+      return delegate.applyNull();
+    }
+
+    @Override
+    public boolean apply(@NullableDecl List<WebElement> input) {
+      return delegate.apply(input);
+    }
+  }
+
   /**
    * Should be used for explaining the reason of condition
    */
   public CollectionCondition because(String explanation) {
     this.explanation = explanation;
-    return this;
+    return new ExplainedCollectionCondition(this, explanation);
   }
 
   public abstract boolean applyNull();

--- a/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
@@ -9,7 +9,6 @@ import com.codeborne.selenide.collections.SizeLessThanOrEqual;
 import com.codeborne.selenide.collections.SizeNotEqual;
 import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.collections.TextsInAnyOrder;
-import com.codeborne.selenide.impl.CollectionElement;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
@@ -9,6 +9,7 @@ import com.codeborne.selenide.collections.SizeLessThanOrEqual;
 import com.codeborne.selenide.collections.SizeNotEqual;
 import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.collections.TextsInAnyOrder;
+import com.codeborne.selenide.impl.CollectionElement;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -115,5 +116,13 @@ class CollectionConditionTest implements WithAssertions {
     assertThat(collectionCondition)
       .as("Text in any order content")
       .hasToString("TextsInAnyOrder [One, Two, Three]");
+  }
+
+  @Test
+  void testExplanationIsIncludedToString() {
+    CollectionCondition collectionCondition = CollectionCondition.texts("One").because("should be");
+    assertThat(collectionCondition)
+      .as("Should contain explanation")
+      .hasToString("Texts [One] (because should be)");
   }
 }


### PR DESCRIPTION
## Proposed changes
These changes add condition explanation into CollectionCondition toString() as it is in single Condition.
It's needed for better events logging because LogEvent.toString() for collections verification does not include explanation message (because)

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)