### PR TITLE
Log event listener improvements

### DIFF
--- a/src/main/java/com/codeborne/selenide/logevents/ErrorsCollector.java
+++ b/src/main/java/com/codeborne/selenide/logevents/ErrorsCollector.java
@@ -15,12 +15,17 @@ public class ErrorsCollector implements LogEventListener {
   private final List<Throwable> errors = new ArrayList<>();
 
   @Override
-  public void onEvent(LogEvent event) {
+  public void afterEvent(LogEvent event) {
     if (event.getStatus() == FAIL) {
       errors.add(event.getError());
     }
   }
-  
+
+  @Override
+  public void beforeEvent(LogEvent currentLog) {
+    // ignore
+  }
+
   public void clear() {
     errors.clear();
   }

--- a/src/main/java/com/codeborne/selenide/logevents/EventsCollector.java
+++ b/src/main/java/com/codeborne/selenide/logevents/EventsCollector.java
@@ -8,10 +8,15 @@ public class EventsCollector implements LogEventListener {
   private final List<LogEvent> logEvents = new ArrayList<>();
 
   @Override
-  public void onEvent(LogEvent currentLog) {
+  public void afterEvent(LogEvent currentLog) {
     logEvents.add(currentLog);
   }
-  
+
+  @Override
+  public void beforeEvent(LogEvent currentLog) {
+    //ignore
+  }
+
   public List<LogEvent> events() {
     return Collections.unmodifiableList(logEvents);
   }

--- a/src/main/java/com/codeborne/selenide/logevents/LogEventListener.java
+++ b/src/main/java/com/codeborne/selenide/logevents/LogEventListener.java
@@ -8,5 +8,7 @@ package com.codeborne.selenide.logevents;
  */
 public interface LogEventListener {
 
-  void onEvent(LogEvent currentLog);
+  void afterEvent(LogEvent currentLog);
+
+  void beforeEvent(LogEvent currentLog);
 }

--- a/src/main/java/com/codeborne/selenide/logevents/SelenideLogger.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SelenideLogger.java
@@ -48,7 +48,13 @@ public class SelenideLogger {
   }
 
   public static SelenideLog beginStep(String source, String subject) {
-    return new SelenideLog(source, subject);
+    Collection<LogEventListener> listeners = getEventLoggerListeners();
+
+    SelenideLog log = new SelenideLog(source, subject);
+    for (LogEventListener listener : listeners) {
+      listener.beforeEvent(log);
+    }
+    return log;
   }
 
   public static void commitStep(SelenideLog log, Throwable error) {
@@ -61,7 +67,7 @@ public class SelenideLogger {
 
     Collection<LogEventListener> listeners = getEventLoggerListeners();
     for (LogEventListener listener : listeners) {
-      listener.onEvent(log);
+      listener.afterEvent(log);
     }
   }
 

--- a/src/test/java/com/codeborne/selenide/drivercommands/NavigatorTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/NavigatorTest.java
@@ -93,7 +93,7 @@ class NavigatorTest implements WithAssertions {
     navigator.open(selenideDriver, "https://some.com/login");
 
     Mockito.verify(navigation).to("https://some.com/login");
-    Mockito.verify(listener).onEvent(ArgumentMatchers.argThat(log ->
+    Mockito.verify(listener).afterEvent(ArgumentMatchers.argThat(log ->
       "open".equals(log.getElement()) && "https://some.com/login".equals(log.getSubject())));
   }
 

--- a/src/test/java/com/codeborne/selenide/logevents/ErrorsCollectorTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/ErrorsCollectorTest.java
@@ -37,15 +37,15 @@ class ErrorsCollectorTest implements WithAssertions {
   void testOnEvent() throws IllegalAccessException {
     List<Throwable> errors = (List<Throwable>) errorsField.get(errorsCollector);
 
-    errorsCollector.onEvent(mockedInProgressEvent);
+    errorsCollector.afterEvent(mockedInProgressEvent);
     assertThat(errors)
       .hasSize(0);
 
-    errorsCollector.onEvent(mockedPassedEvent);
+    errorsCollector.afterEvent(mockedPassedEvent);
     assertThat(errors)
       .hasSize(0);
 
-    errorsCollector.onEvent(mockedFailedEvent);
+    errorsCollector.afterEvent(mockedFailedEvent);
     assertThat(errors)
       .hasSize(1);
     Throwable error = errors.get(0);
@@ -59,9 +59,9 @@ class ErrorsCollectorTest implements WithAssertions {
   void testClearMethod() throws IllegalAccessException {
     List<Throwable> errors = (List<Throwable>) errorsField.get(errorsCollector);
 
-    errorsCollector.onEvent(mockedFailedEvent);
-    errorsCollector.onEvent(mockedFailedEvent);
-    errorsCollector.onEvent(mockedFailedEvent);
+    errorsCollector.afterEvent(mockedFailedEvent);
+    errorsCollector.afterEvent(mockedFailedEvent);
+    errorsCollector.afterEvent(mockedFailedEvent);
 
     assertThat(errors)
       .hasSize(3);
@@ -73,7 +73,7 @@ class ErrorsCollectorTest implements WithAssertions {
 
   @Test
   void testFailIfErrorMethodWhenOnlyOneError() {
-    errorsCollector.onEvent(mockedFailedEvent);
+    errorsCollector.afterEvent(mockedFailedEvent);
     try {
       errorsCollector.failIfErrors(defaultTestName);
     } catch (SoftAssertionError error) {
@@ -90,8 +90,8 @@ class ErrorsCollectorTest implements WithAssertions {
     when(mockedFailedEvent2.getStatus()).thenReturn(LogEvent.EventStatus.FAIL);
     when(mockedFailedEvent2.getError()).thenReturn(new StaleElementReferenceException(failedEvent2Message));
 
-    errorsCollector.onEvent(mockedFailedEvent);
-    errorsCollector.onEvent(mockedFailedEvent2);
+    errorsCollector.afterEvent(mockedFailedEvent);
+    errorsCollector.afterEvent(mockedFailedEvent2);
     try {
       errorsCollector.failIfErrors(defaultTestName);
     } catch (SoftAssertionError error) {

--- a/src/test/java/com/codeborne/selenide/logevents/EventsCollectorTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/EventsCollectorTest.java
@@ -8,7 +8,7 @@ class EventsCollectorTest implements WithAssertions {
   void testOnEvent() {
     EventsCollector eventsCollector = new EventsCollector();
     SelenideLog selenideLog = new SelenideLog("Link", "Not Found");
-    eventsCollector.onEvent(selenideLog);
+    eventsCollector.afterEvent(selenideLog);
 
     assertThat(eventsCollector.events())
       .contains(selenideLog);

--- a/src/test/java/com/codeborne/selenide/logevents/SelenideLoggerTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/SelenideLoggerTest.java
@@ -79,9 +79,10 @@ class SelenideLoggerTest implements WithAssertions {
     verifyNoMoreInteractions(listener1, listener2, listener3);
   }
 
-  private void verifyEvent(LogEventListener listener1) {
+  private void verifyEvent(LogEventListener listener) {
     ArgumentCaptor<LogEvent> event = ArgumentCaptor.forClass(LogEvent.class);
-    verify(listener1).onEvent(event.capture());
+    verify(listener).beforeEvent(event.capture());
+    verify(listener).afterEvent(event.capture());
     LogEvent value = event.getValue();
     assertThat(value.getElement()).isEqualTo("div");
     assertThat(value.getSubject()).isEqualTo("click()");

--- a/src/test/java/integration/LogEventListenerTest.java
+++ b/src/test/java/integration/LogEventListenerTest.java
@@ -1,0 +1,70 @@
+package integration;
+
+import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.logevents.LogEvent;
+import com.codeborne.selenide.logevents.LogEventListener;
+import com.codeborne.selenide.logevents.SelenideLogger;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.codeborne.selenide.Condition.visible;
+import static java.lang.String.format;
+
+public class LogEventListenerTest extends BaseIntegrationTest {
+  SelenideDriver driver = new SelenideDriver(new SelenideConfig().baseUrl(getBaseUrl()));
+  List<String> beforeEvents;
+  List<String> afterEvents;
+
+  @AfterEach
+  void tearDown() {
+    driver.close();
+  }
+
+  @Test
+  void canCatchBeforeAndAfterEvents() {
+    SelenideLogger.addListener("log events collector", new SelenideListener());
+
+    beforeEvents = new ArrayList<>();
+    afterEvents = new ArrayList<>();
+
+    driver.open("/elements_disappear_on_click.html");
+
+    SelenideElement removeMeButton = driver.$("#remove").shouldBe(visible);
+    removeMeButton.click();
+    removeMeButton.shouldNotBe(visible);
+
+    SoftAssertions sa = new SoftAssertions();
+    sa.assertThat(beforeEvents).hasSize(1);
+    sa.assertThat(beforeEvents.get(0)).isEqualTo("before: $(#remove) click()");
+
+    sa.assertThat(afterEvents).hasSize(4);
+
+    sa.assertThat(afterEvents.get(0)).startsWith("after: $(open)");
+    sa.assertThat(afterEvents.get(1)).isEqualTo("after: $(#remove) should be(visible)");
+    sa.assertThat(afterEvents.get(2)).isEqualTo("after: $(#remove) click()");
+    sa.assertThat(afterEvents.get(3)).isEqualTo("after: $(#remove) should not be(visible)");
+
+    sa.assertAll();
+  }
+
+  private class SelenideListener implements LogEventListener {
+    @Override
+    public void afterEvent(LogEvent logEvent) {
+      afterEvents.add(format("after: $(%s) %s", logEvent.getElement(), logEvent.getSubject()));
+    }
+
+    @Override
+    public void beforeEvent(LogEvent logEvent) {
+      if (logEvent.getSubject().contains("click()")) {
+        beforeEvents.add(format("before: $(%s) %s", logEvent.getElement(), logEvent.getSubject()));
+      }
+    }
+  }
+}

--- a/src/test/java/integration/LogEventListenerTest.java
+++ b/src/test/java/integration/LogEventListenerTest.java
@@ -24,7 +24,7 @@ public class LogEventListenerTest extends BaseIntegrationTest {
   private List<String> afterEvents;
 
   @BeforeEach
-  void setup(){
+  void setup() {
     beforeEvents = new ArrayList<>();
     afterEvents = new ArrayList<>();
     driver = new SelenideDriver(new SelenideConfig().baseUrl(getBaseUrl()));

--- a/src/test/java/integration/LogEventListenerTest.java
+++ b/src/test/java/integration/LogEventListenerTest.java
@@ -9,6 +9,7 @@ import com.codeborne.selenide.logevents.SelenideLogger;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -18,9 +19,16 @@ import static com.codeborne.selenide.Condition.visible;
 import static java.lang.String.format;
 
 public class LogEventListenerTest extends BaseIntegrationTest {
-  SelenideDriver driver = new SelenideDriver(new SelenideConfig().baseUrl(getBaseUrl()));
-  List<String> beforeEvents;
-  List<String> afterEvents;
+  private SelenideDriver driver;
+  private List<String> beforeEvents;
+  private List<String> afterEvents;
+
+  @BeforeEach
+  void setup(){
+    beforeEvents = new ArrayList<>();
+    afterEvents = new ArrayList<>();
+    driver = new SelenideDriver(new SelenideConfig().baseUrl(getBaseUrl()));
+  }
 
   @AfterEach
   void tearDown() {
@@ -30,9 +38,6 @@ public class LogEventListenerTest extends BaseIntegrationTest {
   @Test
   void canCatchBeforeAndAfterEvents() {
     SelenideLogger.addListener("log events collector", new SelenideListener());
-
-    beforeEvents = new ArrayList<>();
-    afterEvents = new ArrayList<>();
 
     driver.open("/elements_disappear_on_click.html");
 

--- a/src/test/java/integration/testng/SoftAssertTestNGScreenshotsTest.java
+++ b/src/test/java/integration/testng/SoftAssertTestNGScreenshotsTest.java
@@ -48,8 +48,13 @@ public class SoftAssertTestNGScreenshotsTest extends AbstractSoftAssertTestNGTes
     }
 
     @Override
-    public void onEvent(LogEvent currentLog) {
+    public void afterEvent(LogEvent currentLog) {
       events.add(currentLog);
+    }
+
+    @Override
+    public void beforeEvent(LogEvent currentLog) {
+      //ignore
     }
   }
 


### PR DESCRIPTION
## Proposed changes
Currently SelenideLogger only logs stuff after each event happened, so in order to apply some logic before some action happens we have to resort to implementing custom WebDriverEventListener, which does not support all the methods that we might be interested in. 

Example: I want to log click() methods before click happened. Currently I can not do it, as onEvent logs after event happened.

Added beforeEvent() method to LogEventListener and renamed onEvent to afterEvent to make it clear and consistent. beforeEvent() will be called in SelenideLogger.beginStep(...) method, which is used in SelenideElementProxy.invoke(...) method before dispatchAndRetry(), which will ensure the event is logged before action.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)