### PR TITLE
Add selenoid support for local test execution for chrome and firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ To build Selenide on Windows use `gradlew.bat jar` command.
 
 Feel free to fork, clone, build, run tests and contribute pull requests for Selenide!
 
+## Run test locally inside docker containers
+
+- Syncing browser images from existing configuration file
+  - Install [jq](https://stedolan.github.io/jq)
+  - Extract image names from JSON and automatically pull them:
+     > cat /config/selenoid/browsers.json | jq -r '..|.image?|strings' | xargs -I{} docker pull {}
+- Start selenoid container
+  - Install [docker](https://www.docker.com/products/docker-desktop)
+  - Based on your operation system execute script. Check official [document](https://aerokube.com/selenoid/latest/#_option_2_start_selenoid_container) for correct script.
+- Start tests passing `selenide.remote` configuration variable with `http://localhost:4444/wd/hub` value
+
 ## Authors
 
 Selenide was originally designed and developed by [Andrei Solntsev](http://asolntsev.github.io/) in 2011-2015.

--- a/config/selenoid/browsers.json
+++ b/config/selenoid/browsers.json
@@ -1,0 +1,28 @@
+{
+  "chrome": {
+    "default": "71.0",
+    "versions": {
+      "71.0": {
+        "image": "selenoid/chrome:71.0",
+        "port": "4444",
+        "path": "/",
+        "tmpfs": {
+          "/tmp": "size=128m"
+        }
+      }
+    }
+  },
+  "firefox": {
+    "default": "66.0",
+    "versions": {
+      "66.0": {
+        "image": "selenoid/firefox:66.0",
+        "port": "4444",
+        "path": "/",
+        "tmpfs": {
+          "/tmp": "size=128m"
+        }
+      }
+    }
+  }
+}

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -34,6 +34,14 @@ task chrome_headless(type: Test) {
   exclude 'com/codeborne/selenide/**/*'
 }
 
+task chrome_remote(type: Test) {
+  systemProperties['selenide.remote'] = 'http://localhost:4444/wd/hub'
+  systemProperties['selenide.browser'] = 'chrome'
+  systemProperties['selenide.reportsFolder'] = 'build/reports/tests/chrome_remote'
+  include 'integration/**/*'
+  exclude 'com/codeborne/selenide/**/*'
+}
+
 task safari(type: Test) {
   systemProperties['selenide.browser'] = 'safari'
   systemProperties['selenide.reportsFolder'] = 'build/reports/tests/safari'
@@ -66,6 +74,14 @@ task firefox_headless(type: Test) {
   systemProperties['selenide.browser'] = 'firefox'
   systemProperties['selenide.headless'] = 'true'
   systemProperties['selenide.reportsFolder'] = 'build/reports/tests/firefox_headless'
+  include 'integration/**/*'
+  exclude 'com/codeborne/selenide/**/*'
+}
+
+task firefox_remote(type: Test) {
+  systemProperties['selenide.remote'] = 'http://localhost:4444/wd/hub'
+  systemProperties['selenide.browser'] = 'firefox'
+  systemProperties['selenide.reportsFolder'] = 'build/reports/tests/firefox_remote'
   include 'integration/**/*'
   exclude 'com/codeborne/selenide/**/*'
 }


### PR DESCRIPTION
## Proposed changes
Add selenoid support for local test execution for chrome and firefox.
Lock browser versions:
- chrome - 71
- firefox - 66

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)