### PR TITLE
Add support for Chrome option "useAutomationExtension"

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 
 class ChromeDriverFactory extends AbstractDriverFactory {
   private static final Logger log = Logger.getLogger(ChromeDriverFactory.class.getName());
+  static final String USE_AUTOMATION_EXTENSION = "chromeoptions.useautomationextension";
 
   @Override
   WebDriver create(Config config, Proxy proxy) {
@@ -62,6 +63,10 @@ class ChromeDriverFactory extends AbstractDriverFactory {
     if (System.getProperty("chromeoptions.prefs") != null) {
       Map<String, Object> prefs = parsePreferencesFromString(System.getProperty("chromeoptions.prefs"));
       currentChromeOptions.setExperimentalOption("prefs", prefs);
+    }
+    if (System.getProperty(USE_AUTOMATION_EXTENSION) != null) {
+      Boolean useAutomationExtension = Boolean.parseBoolean(System.getProperty(USE_AUTOMATION_EXTENSION));
+      currentChromeOptions.setExperimentalOption("useAutomationExtension", useAutomationExtension);
     }
     return currentChromeOptions;
   }

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -12,8 +12,10 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import java.util.List;
 import java.util.Map;
 
+import static com.codeborne.selenide.webdriver.ChromeDriverFactory.USE_AUTOMATION_EXTENSION;
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchPrefs;
+import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getUseAutomationExtension;
 import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("unchecked")
@@ -79,6 +81,16 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
     assertThat(prefsMap).hasSize(1);
     assertThat(prefsMap).containsEntry("key1", 1);
+  }
+
+  @Test
+  void transferChromeOptionUseAutomationExtension() {
+    System.setProperty(USE_AUTOMATION_EXTENSION, "true");
+
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
+    Boolean useAutomationExtension = getUseAutomationExtension(ChromeOptions.CAPABILITY, chromeOptions);
+
+    assertThat(useAutomationExtension).isEqualTo(true);
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/webdriver/SeleniumCapabilitiesHelper.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/SeleniumCapabilitiesHelper.java
@@ -28,4 +28,15 @@ class SeleniumCapabilitiesHelper {
     }
     return (Map<String, Object>) arguments.get("prefs");
   }
+
+  @SuppressWarnings("unchecked")
+  static Boolean getUseAutomationExtension(String capability, Capabilities capabilities) {
+    // it depends on internal Selenium capabilities structure
+    // but there are no ways to do the same by public interfaces
+    Map<String, Object> arguments = (Map<String, Object>) capabilities.asMap().get(capability);
+    if (arguments == null) {
+      return null;
+    }
+    return (Boolean) arguments.get("useAutomationExtension");
+  }
 }

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -22,12 +22,18 @@ import org.openqa.selenium.remote.DesiredCapabilities;
  *  Example: --no-sandbox,--disable-3d-apis,"--user-agent=Firefox 45, Mozilla"
  * </p>
  * <p>
- *  <b>chromeoptions.prefs</b> - ser the preferences for chrome options, which are comma separated
+ *  <b>chromeoptions.prefs</b> - Sets the preferences for chrome options, which are comma separated
  *   keyX=valueX preferences. If comma is a part of the value, use double quotes around the preference
  *   List of preferences can be found at
  *   https://chromium.googlesource.com/chromium/src/+/master/chrome/common/pref_names.cc
  *
  *   Example: homepage=http://google.com,"intl.allowed_languages=en,ru,es"
+ * </p>
+ * <p>
+ *  <b>chromeoptions.useautomationextension</b> - Controls Chrome Automation Extension, Boolean value
+ *   https://bugs.chromium.org/p/chromedriver/issues/detail?id=1749#c5
+ *
+ *   Example: false
  * </p>
  */
 public class Configuration {


### PR DESCRIPTION
https://bugs.chromium.org/p/chromedriver/issues/detail?id=1749#c5

## Proposed changes
Configure useAutomationExtension using system property - same as args and prefs

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
> Caused by: com.puppycrawl.tools.checkstyle.api.CheckstyleException: Unable to find: config/checkstyle/suppressions.xml
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)