### PR TITLE
Fix config javadoc for chromeoptions.prefs

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -22,7 +22,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
  *  Example: --no-sandbox,--disable-3d-apis,"--user-agent=Firefox 45, Mozilla"
  * </p>
  * <p>
- *  <b>chromeoptions.prefs</b> - ser the preferences for chrome options, which are comma separated
+ *  <b>chromeoptions.prefs</b> - Sets the preferences for chrome options, which are comma separated
  *   keyX=valueX preferences. If comma is a part of the value, use double quotes around the preference
  *   List of preferences can be found at
  *   https://chromium.googlesource.com/chromium/src/+/master/chrome/common/pref_names.cc


### PR DESCRIPTION
## Proposed changes
Fix typo in javadoc for `chromeoptions.prefs`

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)