### PR TITLE
First check size of collection on `shouldHave(texts())` assert 

### DIFF
--- a/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.ex.TextsSizeMismatch;
 import com.codeborne.selenide.impl.Html;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.openqa.selenium.WebElement;
@@ -49,6 +50,9 @@ public class ExactTexts extends CollectionCondition {
       ElementNotFound elementNotFound = new ElementNotFound(collection, expectedTexts, lastError);
       elementNotFound.timeoutMs = timeoutMs;
       throw elementNotFound;
+    }
+    if (elements.size() != collection.getElements().size()) {
+      throw new TextsSizeMismatch(collection, ElementsCollection.texts(elements), expectedTexts, explanation, timeoutMs);
     } else {
       throw new TextsMismatch(collection, ElementsCollection.texts(elements), expectedTexts, explanation, timeoutMs);
     }

--- a/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
@@ -51,7 +51,7 @@ public class ExactTexts extends CollectionCondition {
       elementNotFound.timeoutMs = timeoutMs;
       throw elementNotFound;
     }
-    if (elements.size() != expectedTexts.size()) {
+    else if (elements.size() != expectedTexts.size()) {
       throw new TextsSizeMismatch(collection, ElementsCollection.texts(elements), expectedTexts, explanation, timeoutMs);
     }
     else {

--- a/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
@@ -51,9 +51,10 @@ public class ExactTexts extends CollectionCondition {
       elementNotFound.timeoutMs = timeoutMs;
       throw elementNotFound;
     }
-    if (elements.size() != collection.getElements().size()) {
+    if (elements.size() != expectedTexts.size()) {
       throw new TextsSizeMismatch(collection, ElementsCollection.texts(elements), expectedTexts, explanation, timeoutMs);
-    } else {
+    }
+    else {
       throw new TextsMismatch(collection, ElementsCollection.texts(elements), expectedTexts, explanation, timeoutMs);
     }
   }

--- a/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
@@ -4,14 +4,16 @@ import com.codeborne.selenide.impl.WebElementsCollection;
 
 import java.util.List;
 
+import static java.lang.System.lineSeparator;
+
 public class TextsSizeMismatch extends UIAssertionError {
   public TextsSizeMismatch(WebElementsCollection collection, List<String> actualTexts,
                        List<String> expectedTexts, String explanation, long timeoutMs) {
     super(collection.driver(),
-        "\nActual: " + actualTexts + ", List size: " + actualTexts.size() +
-        "\nExpected: " + expectedTexts + ", List size: " + expectedTexts.size() +
-        (explanation == null ? "" : "\nBecause: " + explanation) +
-        "\nCollection: " + collection.description());
+        lineSeparator() + "Actual: " + actualTexts + ", List size: " + actualTexts.size() +
+        lineSeparator() + "Expected: " + expectedTexts + ", List size: " + expectedTexts.size() +
+        (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
+        lineSeparator() + "Collection: " + collection.description());
     super.timeoutMs = timeoutMs;
   }
 

--- a/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
@@ -8,9 +8,9 @@ public class TextsSizeMismatch extends UIAssertionError {
   public TextsSizeMismatch(WebElementsCollection collection, List<String> actualTexts,
                        List<String> expectedTexts, String explanation, long timeoutMs) {
     super(collection.driver(),
-      "\nTexts size mismatch: "+
+      "\nTexts size mismatch: " +
         "\nActual: " + actualTexts + ", List size :" + actualTexts.size() +
-        "\nExpected: " + expectedTexts + ", List size :" + expectedTexts.size()+
+        "\nExpected: " + expectedTexts + ", List size :" + expectedTexts.size() +
         (explanation == null ? "" : "\nBecause: " + explanation) +
         "\nCollection: " + collection.description());
     super.timeoutMs = timeoutMs;

--- a/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
@@ -1,0 +1,23 @@
+package com.codeborne.selenide.ex;
+
+import com.codeborne.selenide.impl.WebElementsCollection;
+
+import java.util.List;
+
+public class TextsSizeMismatch extends UIAssertionError {
+  public TextsSizeMismatch(WebElementsCollection collection, List<String> actualTexts,
+                       List<String> expectedTexts, String explanation, long timeoutMs) {
+    super(collection.driver(),
+      "\nTexts size mismatch: "+
+        "\nActual: " + actualTexts + ", List size :" + actualTexts.size() +
+        "\nExpected: " + expectedTexts + ", List size :" + expectedTexts.size()+
+        (explanation == null ? "" : "\nBecause: " + explanation) +
+        "\nCollection: " + collection.description());
+    super.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + ' ' + getMessage() + uiDetails();
+  }
+}

--- a/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
@@ -8,9 +8,8 @@ public class TextsSizeMismatch extends UIAssertionError {
   public TextsSizeMismatch(WebElementsCollection collection, List<String> actualTexts,
                        List<String> expectedTexts, String explanation, long timeoutMs) {
     super(collection.driver(),
-      "\nTexts size mismatch: " +
-        "\nActual: " + actualTexts + ", List size :" + actualTexts.size() +
-        "\nExpected: " + expectedTexts + ", List size :" + expectedTexts.size() +
+        "\nActual: " + actualTexts + ", List size: " + actualTexts.size() +
+        "\nExpected: " + expectedTexts + ", List size: " + expectedTexts.size() +
         (explanation == null ? "" : "\nBecause: " + explanation) +
         "\nCollection: " + collection.description());
     super.timeoutMs = timeoutMs;

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.ex.TextsSizeMismatch;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
@@ -95,6 +96,28 @@ class ExactTextsTest implements WithAssertions {
     } catch (TextsMismatch ex) {
       assertThat(ex)
         .hasMessage("\nActual: [Hello]\nExpected: [One]\nCollection: Collection description");
+    }
+  }
+
+  @Test
+  void failOnTextSizeMismatch() {
+    ExactTexts exactTexts = new ExactTexts("One", "Two");
+    Exception exception = new Exception("Exception method");
+
+    WebElement mockedWebElement = mock(WebElement.class);
+    when(mockedWebElement.getText()).thenReturn("One, Two");
+
+    WebElementsCollection mockedElementsCollection = mock(WebElementsCollection.class);
+    when(mockedElementsCollection.description()).thenReturn("Collection description");
+
+    try {
+      exactTexts.fail(mockedElementsCollection,
+        singletonList(mockedWebElement),
+        exception,
+        10000);
+    } catch (TextsSizeMismatch ex) {
+      assertThat(ex)
+        .hasMessage("\nActual: [One, Two], List size: 1\nExpected: [One, Two], List size: 2\nCollection: Collection description");
     }
   }
 

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
@@ -110,15 +110,12 @@ class ExactTextsTest implements WithAssertions {
     WebElementsCollection mockedElementsCollection = mock(WebElementsCollection.class);
     when(mockedElementsCollection.description()).thenReturn("Collection description");
 
-    try {
-      exactTexts.fail(mockedElementsCollection,
-        singletonList(mockedWebElement),
-        exception,
-        10000);
-    } catch (TextsSizeMismatch ex) {
-      assertThat(ex)
-        .hasMessage("\nActual: [One, Two], List size: 1\nExpected: [One, Two], List size: 2\nCollection: Collection description");
-    }
+    assertThatThrownBy(() -> exactTexts.fail(mockedElementsCollection,
+      singletonList(mockedWebElement), exception, 10000))
+      .isInstanceOf(TextsSizeMismatch.class)
+      .hasMessageContaining("Actual: [One, Two], List size: 1")
+      .hasMessageContaining("Expected: [One, Two], List size: 2")
+      .hasMessageEndingWith("Collection: Collection description");
   }
 
   @Test

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.ex.TextsSizeMismatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -139,8 +140,15 @@ class CollectionMethodsTest extends ITest {
   }
 
   @Test
-  void textsCheckThrowsTextsMismatch() {
-    assertThatThrownBy(() -> $$("#dynamic-content-container span").shouldHave(texts("static-content1", "static-content2", "static3")))
+  void textsCheckThrowsTextsSizeMismatch() {
+    assertThatThrownBy(() -> $$("#dynamic-content-container span")
+      .shouldHave(texts("static-content1", "static-content2", "dynamic-content1")))
+      .isInstanceOf(TextsSizeMismatch.class);
+  }
+
+  @Test
+  void textCheckThrowsTextsMismatch() {
+    assertThatThrownBy(() -> $$("#dynamic-content-container span").shouldHave(texts("static-content1", "static-content2")))
       .isInstanceOf(TextsMismatch.class);
   }
 

--- a/statics/src/test/java/integration/CollectionBecauseTest.java
+++ b/statics/src/test/java/integration/CollectionBecauseTest.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.ex.TextsMismatch;
 
+import com.codeborne.selenide.ex.TextsSizeMismatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,28 +22,53 @@ class CollectionBecauseTest extends IntegrationTest {
   }
 
   @Test
-  void canExplainWhyConditionIsExpected_texts() {
+  void canExplainWhyConditionIsExpected_textsMismatch() {
     try {
-      $$("#dropdown-list-container option").shouldHave(texts("foo", "bar").because("that's why"));
+      $$("#dropdown-list-container option").shouldHave(texts("foo", "bar", "var", "buzz").because("that's why"));
     } catch (TextsMismatch expected) {
-
       assertThat(expected.toString())
         .contains("TextsMismatch \n" +
           "Actual: [@livemail.ru, @myrambler.ru, @rusmail.ru, @мыло.ру]\n" +
-          "Expected: [foo, bar]\n" +
+          "Expected: [foo, bar, var, buzz]\n" +
           "Because: that's why\n");
     }
   }
 
   @Test
-  void canExplainWhyConditionIsExpected_exactTexts() {
+  void canExplainWhyConditionIsExpected_textsSizeMismatch() {
     try {
-      $$("#dropdown-list-container option").shouldHave(exactTexts("foo", "bar").because("that's why"));
+      $$("#dropdown-list-container option").shouldHave(texts("foo", "bar", "var, buzz").because("that's why"));
+    } catch (TextsSizeMismatch expected) {
+      assertThat(expected.toString())
+        .contains("TextsSizeMismatch \n" +
+          "Actual: [@livemail.ru, @myrambler.ru, @rusmail.ru, @мыло.ру], List size: 4\n" +
+          "Expected: [foo, bar, var, buzz], List size: 3\n" +
+          "Because: that's why\n");
+    }
+  }
+
+  @Test
+  void canExplainWhyConditionIsExpected_exactTextsMismatch() {
+    try {
+      $$("#dropdown-list-container option").shouldHave(exactTexts("foo", "bar", "var", "buzz").because("that's why"));
     } catch (TextsMismatch expected) {
       assertThat(expected.toString())
         .contains("TextsMismatch \n" +
           "Actual: [@livemail.ru, @myrambler.ru, @rusmail.ru, @мыло.ру]\n" +
-          "Expected: [foo, bar]\n" +
+          "Expected: [foo, bar, var, buzz]\n" +
+          "Because: that's why\n");
+    }
+  }
+
+  @Test
+  void canExplainWhyConditionIsExpected_exactTextsSizeMismatch() {
+    try {
+      $$("#dropdown-list-container option").shouldHave(exactTexts("foo", "bar", "var, buzz").because("that's why"));
+    } catch (TextsSizeMismatch expected) {
+      assertThat(expected.toString())
+        .contains("TextsSizeMismatch \n" +
+          "Actual: [@livemail.ru, @myrambler.ru, @rusmail.ru, @мыло.ру], List size: 4\n" +
+          "Expected: [foo, bar, var, buzz], List size: 3\n" +
           "Because: that's why\n");
     }
   }

--- a/statics/src/test/java/integration/CollectionWaitTest.java
+++ b/statics/src/test/java/integration/CollectionWaitTest.java
@@ -2,6 +2,7 @@ package integration;
 
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.ex.TextsSizeMismatch;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,22 +52,32 @@ class CollectionWaitTest extends IntegrationTest {
   }
 
   @Test
-  void firstNElements_errorMessage() {
+  void firstNElements_TextsMismatchErrorMessage() {
     Configuration.timeout = 4000;
-    Assertions.assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element #wrong")))
+    Assertions.assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element", "#wrong")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageContaining("Actual: [Element #0, Element #1]\n" +
-        "Expected: [Element #wrong]\n" +
+        "Expected: [Element, #wrong]\n" +
+        "Collection: #collection li.first(2)");
+  }
+
+  @Test
+  void firstNElements_TextsSizeMismatchErrorMessage() {
+    Configuration.timeout = 4000;
+    Assertions.assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element #wrong")))
+      .isInstanceOf(TextsSizeMismatch.class)
+      .hasMessageContaining("Actual: [Element #0, Element #1], List size: 2\n" +
+        "Expected: [Element #wrong], List size: 1\n" +
         "Collection: #collection li.first(2)");
   }
 
   @Test
   void lastNElements_errorMessage() {
     Configuration.timeout = 4000;
-    Assertions.assertThatThrownBy(() -> $$("#collection li").last(2).shouldHave(texts("Element #wrong")))
+    Assertions.assertThatThrownBy(() -> $$("#collection li").last(2).shouldHave(texts("Element", "#wrong")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageContaining("Actual: [Element #48, Element #49]\n" +
-        "Expected: [Element #wrong]\n" +
+        "Expected: [Element, #wrong]\n" +
         "Collection: #collection li.last(2)");
   }
 


### PR DESCRIPTION
## Proposed changes
Closes https://github.com/selenide/selenide/issues/454
I added a new exception TextsSizeMismatch to divide meaning with TextsMismatch.
New if statement to fail method with check for collections size. 
I has idea with changing returning value from boolean to Boolean(reference type to return null), but current realization is the easier and needs fewer changes.
And I write and rewrite current tests for these exceptions, because now we can check size before checking texts.  

It my first contribution and I would hear and correct all your comments with pleasure.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command 
*except proxy and download tests, because they dont work on MacOS at latest version of master branch* and I don't affect this functions.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)