### PR TITLE
Fixed #945 Selenide automatically takes screenshots on any test failure with junit5 runner

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
+++ b/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
@@ -88,8 +88,14 @@ public class ScreenShooterExtension implements AfterAllCallback, BeforeAllCallba
   @Override
   public void testFailed(ExtensionContext context, Throwable cause) {
     if (!(cause instanceof UIAssertionError)) {
-      log.info(screenshot(driver()));
+      log.info(getScreenshot());
       SelenideLogger.commitStep(new SelenideLog(context.getTestMethod().toString(), context.getExecutionException().toString()), FAIL);
     }
   }
+
+  protected String getScreenshot() {
+    return screenshot(driver());
+  }
+
+
 }

--- a/statics/src/test/java/com/codeborne/selenide/junit5/ExecutionContextMock.java
+++ b/statics/src/test/java/com/codeborne/selenide/junit5/ExecutionContextMock.java
@@ -1,0 +1,91 @@
+package com.codeborne.selenide.junit5;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstances;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class ExecutionContextMock implements ExtensionContext {
+
+
+  @Override
+  public Optional<ExtensionContext> getParent() {
+    return Optional.empty();
+  }
+
+  @Override
+  public ExtensionContext getRoot() {
+    return null;
+  }
+
+  @Override
+  public String getUniqueId() {
+    return null;
+  }
+
+  @Override
+  public String getDisplayName() {
+    return null;
+  }
+
+  @Override
+  public Set<String> getTags() {
+    return null;
+  }
+
+  @Override
+  public Optional<AnnotatedElement> getElement() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Class<?>> getTestClass() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<TestInstance.Lifecycle> getTestInstanceLifecycle() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Object> getTestInstance() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<TestInstances> getTestInstances() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Method> getTestMethod() {
+    return Optional.of(this.getClass().getMethods()[0]);
+  }
+
+  @Override
+  public Optional<Throwable> getExecutionException() {
+    return Optional.of(new RuntimeException());
+  }
+
+  @Override
+  public Optional<String> getConfigurationParameter(String key) {
+    return Optional.empty();
+  }
+
+  @Override
+  public void publishReportEntry(Map<String, String> map) {
+
+  }
+
+  @Override
+  public Store getStore(Namespace namespace) {
+    return null;
+  }
+
+}

--- a/statics/src/test/java/com/codeborne/selenide/junit5/ScreenShooterExtensionMock.java
+++ b/statics/src/test/java/com/codeborne/selenide/junit5/ScreenShooterExtensionMock.java
@@ -1,0 +1,17 @@
+package com.codeborne.selenide.junit5;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class ScreenShooterExtensionMock extends ScreenShooterExtension {
+  int counter = 0;
+
+  @Override
+  public void testFailed(ExtensionContext context, Throwable cause) {
+    super.testFailed(context, cause);
+    counter++;
+  }
+
+  public int getCounter() {
+    return counter;
+  }
+}

--- a/statics/src/test/java/integration/ScreenshotTest.java
+++ b/statics/src/test/java/integration/ScreenshotTest.java
@@ -3,11 +3,14 @@ package integration;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.ScreenShotLaboratory;
+import com.codeborne.selenide.junit5.ExecutionContextMock;
+import com.codeborne.selenide.junit5.ScreenShooterExtensionMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
+import org.opentest4j.AssertionFailedError;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -19,6 +22,7 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class ScreenshotTest extends IntegrationTest {
@@ -45,6 +49,14 @@ class ScreenshotTest extends IntegrationTest {
     assertThat(screenshot.getPath())
       .withFailMessage(String.format("Screenshot file should be located in %s, but was: %s", screenshotPath, screenshot.getPath()))
       .startsWith(screenshotPath);
+  }
+
+  @Test
+  void canTakeScreenshotOnJunitAssertions() {
+    ScreenShooterExtensionMock screenShooterExtensionMock = new ScreenShooterExtensionMock();
+    ExecutionContextMock contextMock = new ExecutionContextMock();
+    screenShooterExtensionMock.testFailed(contextMock, new AssertionFailedError());
+    assertEquals(1, screenShooterExtensionMock.getCounter(), "Screenshot is not taken on junit5 assertions");
   }
 
   @Test


### PR DESCRIPTION
 - Selenide automatically takes screenshots on any test failure with junit5 runner
 - refactor for using TestWatcher class
 - add SelenideLogger for listeners.

## Proposed changes
#945 

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)