### PR TITLE
Add support for hidden strings - passwords, sensitive data

### DIFF
--- a/src/main/java/com/codeborne/selenide/HiddenString.java
+++ b/src/main/java/com/codeborne/selenide/HiddenString.java
@@ -1,7 +1,6 @@
 package com.codeborne.selenide;
 
 public class HiddenString {
-
   private final String plainTextValue;
   private final String toStringValue;
 
@@ -18,5 +17,4 @@ public class HiddenString {
   public String toString() {
     return toStringValue;
   }
-
 }

--- a/src/main/java/com/codeborne/selenide/HiddenString.java
+++ b/src/main/java/com/codeborne/selenide/HiddenString.java
@@ -1,0 +1,22 @@
+package com.codeborne.selenide;
+
+public class HiddenString {
+
+  private final String plainTextValue;
+  private final String toStringValue;
+
+  public HiddenString(String plainTextValue, String toStringValue) {
+    this.plainTextValue = plainTextValue;
+    this.toStringValue = toStringValue;
+  }
+
+  public String getPlainTextValue() {
+    return plainTextValue;
+  }
+
+  @Override
+  public String toString() {
+    return toStringValue;
+  }
+
+}

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -40,6 +40,29 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement setValue(String text);
 
   /**
+   *
+   * <b>Implementation details:</b>
+   *
+   * <p>If Configuration.versatileSetValue is true, can work as 'selectOptionByValue', 'selectRadio'</p>
+   *
+   * <p>If Configuration.fastSetValue is true, sets value by javascript instead of using Selenium built-in "sendKey" function
+   * and trigger "focus", "keydown", "keypress", "input", "keyup", "change" events.
+   *
+   * <p>In other case behavior will be:
+   * <pre>
+   * 1. WebElement.clear()
+   * 2. WebElement.sendKeys(text)
+   * 3. Trigger change event
+   * </pre>
+   *
+   * @param hiddenString Useful for entering passwords or sensitive data. HiddenString plainTextValue to enter into the text field or set by value for select/radio,
+   * HiddenString toStringValue to log and report.
+   *
+   * @see com.codeborne.selenide.commands.SetValue
+   */
+  SelenideElement setValue(HiddenString hiddenString);
+
+  /**
    * Same as #setValue(java.lang.String)
    * @see com.codeborne.selenide.commands.Val
    */

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -40,23 +40,9 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement setValue(String text);
 
   /**
-   *
-   * <b>Implementation details:</b>
-   *
-   * <p>If Configuration.versatileSetValue is true, can work as 'selectOptionByValue', 'selectRadio'</p>
-   *
-   * <p>If Configuration.fastSetValue is true, sets value by javascript instead of using Selenium built-in "sendKey" function
-   * and trigger "focus", "keydown", "keypress", "input", "keyup", "change" events.
-   *
-   * <p>In other case behavior will be:
-   * <pre>
-   * 1. WebElement.clear()
-   * 2. WebElement.sendKeys(text)
-   * 3. Trigger change event
-   * </pre>
-   *
-   * @param hiddenString Useful for entering passwords or sensitive data. HiddenString plainTextValue to enter into the text field or set by value for select/radio,
-   * HiddenString toStringValue to log and report.
+   * Useful for entering passwords or sensitive data.
+   * @param hiddenString HiddenString plainTextValue is used to interact with browser,
+   * while HiddenString toStringValue is used in logs and reports.
    *
    * @see com.codeborne.selenide.commands.SetValue
    */

--- a/src/main/java/com/codeborne/selenide/commands/SetValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SetValue.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.HiddenString;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.InvalidStateException;
 import com.codeborne.selenide.impl.WebElementSource;
@@ -26,6 +27,12 @@ public class SetValue implements Command<WebElement> {
   @Override
   public WebElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     String text = (String) args[0];
+
+    if (args[0] instanceof HiddenString) {
+      HiddenString hiddenString = (HiddenString) args[0];
+      text = hiddenString.getPlainTextValue();
+    }
+
     WebElement element = locator.findAndAssertElementIsInteractable();
 
     if (locator.driver().config().versatileSetValue()


### PR DESCRIPTION
## Proposed changes
Sometimes you do not want to log/report passwords/sensitive data to logs/reports when using SelenideElement setValue.

I have created a simple HiddenString class to store plainTextValue (e.g. password) and user defined toStringValue. User defined toStringValue can be set e.g. to:

- "********"
- "Description of password for user A"
- "HashiCorp Vault path: 'path-for-password-for-user-a', Vault crypted value: 'sg363hey343h366g'"

The HashiCorp Vault version allows:

- to have all passwords be stored in HashiCorp Vault
- all test logs and reports be public without exposing or leaking passwords or sensitive data
- privileged users be able to decrypt values from logs and reports from HashiCorp Vault

You can use setValue("some string text") as before (backward compatibility)
or:

```
HiddenString hiddenPassword = new HiddenString(PasswordManager.getPasswordForUserA(), "This is description of my password visible in logs and reports");

$("#password").setValue(hiddenPassword);
```

Or with Vault in a way (simplified):

```
String vaultPath = "vault-store/prod-users/team-a/user-123";
String plaintextPassword = VaultUtils.getPasswordForUser(vaultPath);
String cryptedPassword = VaultUtils.encryptPassword(vaultPath, plaintextPassword);
String toStringValue = "Path: '" + vaultPath + "'";
toStringValue +=  "; CryptedPassword: ''" + cryptedPassword + "";

HiddenString hiddenPassword = new HiddenString(plaintextPassword, toStringValue);

$("#password").setValue(hiddenPassword);
```