### PR TITLE
Add ability to execute custom command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * support URLs with newlines
 * #469 improve error message of OR condition
 * upgrade to webdrivermanager:3.6.2
+* add custom command executor
 
 ## 5.2.8 (released 03.08.2019)
 * #961 Fix spam in logs "Failed to get attributes via JS..."

--- a/src/main/java/com/codeborne/selenide/Command.java
+++ b/src/main/java/com/codeborne/selenide/Command.java
@@ -6,6 +6,6 @@ import java.io.IOException;
 
 public interface Command<T> {
   Object[] NO_ARGS = new Object[0];
-  
+
   T execute(SelenideElement proxy, WebElementSource locator, Object[] args) throws IOException;
 }

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -799,10 +799,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @param command custom command
    * @return this element
    *
-   * @see com.codeborne.selenide.commands.CustomCommand
+   * @see com.codeborne.selenide.commands.Execute
    * @see com.codeborne.selenide.Command
    */
-  SelenideElement customCommand(Command<SelenideElement> command);
+  SelenideElement execute(Command<SelenideElement> command);
 
   /**
    * Check if image is properly loaded.

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -794,6 +794,17 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement dragAndDropTo(WebElement target);
 
   /**
+   * Execute custom implemented command
+   *
+   * @param command custom command
+   * @return this element
+   *
+   * @see com.codeborne.selenide.commands.CustomCommand
+   * @see com.codeborne.selenide.Command
+   */
+  SelenideElement customCommand(Command<SelenideElement> command);
+
+  /**
    * Check if image is properly loaded.
    *
    * @throws IllegalArgumentException if argument is not an "img" element

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -43,6 +43,7 @@ public class Commands {
     add("screenshot", new TakeScreenshot());
     add("screenshotAsImage", new TakeScreenshotAsImage());
     add("getSearchCriteria", new GetSearchCriteria());
+    add("customCommand", new CustomCommand());
   }
 
   private void addActionsCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -43,7 +43,7 @@ public class Commands {
     add("screenshot", new TakeScreenshot());
     add("screenshotAsImage", new TakeScreenshotAsImage());
     add("getSearchCriteria", new GetSearchCriteria());
-    add("customCommand", new CustomCommand());
+    add("execute", new Execute());
   }
 
   private void addActionsCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/CustomCommand.java
+++ b/src/main/java/com/codeborne/selenide/commands/CustomCommand.java
@@ -1,0 +1,20 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import java.io.IOException;
+
+public class CustomCommand implements Command<SelenideElement> {
+  @Override
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    Command command = (Command) args[0];
+    try {
+      command.execute(proxy, locator, args);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to execute custom command", e);
+    }
+    return proxy;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/Execute.java
+++ b/src/main/java/com/codeborne/selenide/commands/Execute.java
@@ -6,7 +6,7 @@ import com.codeborne.selenide.impl.WebElementSource;
 
 import java.io.IOException;
 
-public class CustomCommand implements Command<SelenideElement> {
+public class Execute implements Command<SelenideElement> {
   @Override
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     Command command = (Command) args[0];

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -576,7 +576,8 @@ class SelenideMethodsTest extends IntegrationTest {
   @Test
   void canExecuteCustomCommand() {
     final Replace replace = new Replace();
-    $("#username").scrollTo().customCommand(replace.withValue("custom value")).pressEnter();
+    $("#username").setValue("value");
+    $("#username").scrollTo().execute(replace.withValue("custom value")).pressEnter();
     String mirrorText = $("#username-mirror").text();
     assertThat(mirrorText).startsWith("custom value");
   }
@@ -591,7 +592,7 @@ class SelenideMethodsTest extends IntegrationTest {
 
     @Override
     public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
-      proxy.sendKeys(Keys.chord(Keys.CONTROL, "a"), value);
+      proxy.doubleClick().sendKeys(value);
       return proxy;
     }
   }

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -56,6 +56,7 @@ import static com.codeborne.selenide.WebDriverRunner.isChrome;
 import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static com.codeborne.selenide.WebDriverRunner.url;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class SelenideMethodsTest extends IntegrationTest {
   @BeforeEach
@@ -574,6 +575,8 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void canExecuteCustomCommand() {
+    assumeFalse(browser().isHtmlUnit());
+
     final Replace replace = new Replace();
     $("#username").setValue("value");
     $("#username").scrollTo().execute(replace.withValue("custom value")).pressEnter();

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -1,14 +1,18 @@
 package integration;
 
+import com.codeborne.selenide.Command;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.ElementShould;
 import com.codeborne.selenide.ex.ElementShouldNot;
+import com.codeborne.selenide.impl.WebElementSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidSelectorException;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
@@ -567,5 +571,28 @@ class SelenideMethodsTest extends IntegrationTest {
     elements("[name='me']").shouldHave(size(4));
     elements(By.cssSelector("[name='me']")).shouldHave(size(4));
     elements(getWebDriver().findElements(By.cssSelector("[name='me']"))).shouldHave(size(4));
+  }
+
+  @Test
+  void canExecuteCustomCommand() {
+    final Replace replace = new Replace();
+    $("#username").scrollTo().customCommand(replace.withValue("custom value")).pressEnter();
+    String mirrorText = $("#username-mirror").text();
+    assertThat(mirrorText).startsWith("custom value");
+  }
+
+  static class Replace implements Command<SelenideElement> {
+    private String value;
+
+    Replace withValue(String value) {
+      this.value = value;
+      return this;
+    }
+
+    @Override
+    public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+      proxy.sendKeys(Keys.chord(Keys.CONTROL, "a"), value);
+      return proxy;
+    }
   }
 }

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidSelectorException;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 


### PR DESCRIPTION
## Proposed changes
Implement `Command` interface and pass a new command to `customCommand` method to execute it.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)