### PR TITLE
Capture screenshot on failure of Selenide.confirm("Expected")

### DIFF
--- a/src/main/java/com/codeborne/selenide/Modal.java
+++ b/src/main/java/com/codeborne/selenide/Modal.java
@@ -1,6 +1,8 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.ex.DialogTextMismatch;
+import com.codeborne.selenide.ex.UIAssertionError;
+
 import org.openqa.selenium.Alert;
 
 public class Modal {
@@ -54,7 +56,7 @@ public class Modal {
 
   private static void checkDialogText(Driver driver, String expectedDialogText, String actualDialogText) {
     if (expectedDialogText != null && !expectedDialogText.equals(actualDialogText)) {
-      throw new DialogTextMismatch(driver, actualDialogText, expectedDialogText);
+      throw UIAssertionError.wrap(driver, new DialogTextMismatch(driver, actualDialogText, expectedDialogText), 0);
     }
   }
 }

--- a/src/test/java/com/codeborne/selenide/ModalTest.java
+++ b/src/test/java/com/codeborne/selenide/ModalTest.java
@@ -4,7 +4,11 @@ import com.codeborne.selenide.ex.DialogTextMismatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Alert;
+import org.openqa.selenium.OutputType;
 import org.openqa.selenium.chrome.ChromeDriver;
+
+import java.io.File;
+import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,11 +23,18 @@ class ModalTest {
   private final ChromeDriver webDriver = mock(ChromeDriver.class, RETURNS_DEEP_STUBS);
   private final SelenideConfig config = new SelenideConfig();
   private final Driver driver = new DriverStub(config, new Browser("chrome", false), webDriver, null);
+  private URI reportsBaseUri;
 
   @BeforeEach
   void setUp() {
     when(webDriver.switchTo().alert()).thenReturn(alert);
     when(alert.getText()).thenReturn(ALERT_TEXT);
+
+    config.reportsFolder("build/reports/tests/ModalTest");
+    when(webDriver.getPageSource()).thenReturn("<html/>");
+    when(webDriver.getScreenshotAs(OutputType.FILE)).thenReturn(new File("src/test/resources/screenshot.png"));
+
+    reportsBaseUri = new File(System.getProperty("user.dir"), config.reportsFolder()).toURI();
   }
 
   @Test
@@ -50,7 +61,8 @@ class ModalTest {
 
     verify(alert).accept();
     assertThat(exception.getMessage())
-      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n");
+      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n")
+      .contains("Screenshot: " + reportsBaseUri);
   }
 
   @Test
@@ -88,7 +100,8 @@ class ModalTest {
     verify(alert).sendKeys("Sure do");
     verify(alert).accept();
     assertThat(exception.getMessage())
-      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n");
+      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n")
+      .contains("Screenshot: file:" + System.getProperty("user.dir") + "/" + config.reportsFolder() + "/");
   }
 
   @Test
@@ -115,6 +128,7 @@ class ModalTest {
 
     verify(alert).dismiss();
     assertThat(exception.getMessage())
-      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n");
+      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n")
+      .contains("Screenshot: file:" + System.getProperty("user.dir") + "/" + config.reportsFolder() + "/");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ModalTest.java
+++ b/src/test/java/com/codeborne/selenide/ModalTest.java
@@ -1,0 +1,120 @@
+package com.codeborne.selenide;
+
+import com.codeborne.selenide.ex.DialogTextMismatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ModalTest {
+  private static final String ALERT_TEXT = "You really want it?";
+  private final Alert alert = mock(Alert.class);
+  private final ChromeDriver webDriver = mock(ChromeDriver.class, RETURNS_DEEP_STUBS);
+  private final SelenideConfig config = new SelenideConfig();
+  private final Driver driver = new DriverStub(config, new Browser("chrome", false), webDriver, null);
+
+  @BeforeEach
+  void setUp() {
+    when(webDriver.switchTo().alert()).thenReturn(alert);
+    when(alert.getText()).thenReturn(ALERT_TEXT);
+  }
+
+  @Test
+  void confirmAcceptsDialogAndReturnsText() {
+    String text = new Modal(driver).confirm();
+
+    verify(alert).accept();
+    assertThat(text).isEqualTo(ALERT_TEXT);
+  }
+
+  @Test
+  void confirmWithExpectedTextAcceptsDialogAndReturnsText() {
+    String text = new Modal(driver).confirm(ALERT_TEXT);
+
+    verify(alert).accept();
+    assertThat(text).isEqualTo(ALERT_TEXT);
+  }
+
+  @Test
+  void confirmWithIncorrectExpectedTextAcceptsDialogAndThrowsException() {
+    DialogTextMismatch exception = assertThrows(
+      DialogTextMismatch.class,
+      () -> new Modal(driver).confirm("Are you sure?"));
+
+    verify(alert).accept();
+    assertThat(exception.getMessage())
+      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n");
+  }
+
+  @Test
+  void promptAcceptsDialogAndReturnsText() {
+    String text = new Modal(driver).prompt();
+
+    verify(alert).accept();
+    assertThat(text).isEqualTo(ALERT_TEXT);
+  }
+
+  @Test
+  void promptWithInputAcceptsDialogAndReturnsText() {
+    String text = new Modal(driver).prompt("Sure do");
+
+    verify(alert).sendKeys("Sure do");
+    verify(alert).accept();
+    assertThat(text).isEqualTo(ALERT_TEXT);
+  }
+
+  @Test
+  void promptWithExpectedTextAndInputAcceptsDialogAndReturnsText() {
+    String text = new Modal(driver).prompt(ALERT_TEXT, "Sure do");
+
+    verify(alert).sendKeys("Sure do");
+    verify(alert).accept();
+    assertThat(text).isEqualTo(ALERT_TEXT);
+  }
+
+  @Test
+  void promptWithIncorrectExpectedTextAndInputAcceptsDialogAndReturnsText() {
+    DialogTextMismatch exception = assertThrows(
+      DialogTextMismatch.class,
+      () -> new Modal(driver).prompt("Are you sure?", "Sure do"));
+
+    verify(alert).sendKeys("Sure do");
+    verify(alert).accept();
+    assertThat(exception.getMessage())
+      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n");
+  }
+
+  @Test
+  void dismissDismissesDialogAndReturnsText() {
+    String text = new Modal(driver).dismiss();
+
+    verify(alert).dismiss();
+    assertThat(text).isEqualTo(ALERT_TEXT);
+  }
+
+  @Test
+  void dismissWithExpectedTextAcceptsDialogAndReturnsText() {
+    String text = new Modal(driver).dismiss(ALERT_TEXT);
+
+    verify(alert).dismiss();
+    assertThat(text).isEqualTo(ALERT_TEXT);
+  }
+
+  @Test
+  void dismissWithIncorrectExpectedTextAcceptsDialogAndThrowsException() {
+    DialogTextMismatch exception = assertThrows(
+      DialogTextMismatch.class,
+      () -> new Modal(driver).dismiss("Are you sure?"));
+
+    verify(alert).dismiss();
+    assertThat(exception.getMessage())
+      .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n");
+  }
+}


### PR DESCRIPTION
## Proposed changes
I found issue #907 when looking for something to contribute on a project I use for Hacktoberfest.

The 2nd commit is the change to capture a screenshot on a dialog mismatch.  This seemed the simplest way to achieve this.

As a precursor to this, I added unit tests for the methods on `Modal`.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)