### PR TITLE
remove `implements WithAssertions` from base test class

### DIFF
--- a/src/test/java/integration/AttributeTest.java
+++ b/src/test/java/integration/AttributeTest.java
@@ -10,6 +10,7 @@ import static com.codeborne.selenide.Selectors.byAttribute;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selectors.byTitle;
 import static com.codeborne.selenide.Selectors.byValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AttributeTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/BaseIntegrationTest.java
+++ b/src/test/java/integration/BaseIntegrationTest.java
@@ -3,7 +3,6 @@ package integration;
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.junit5.TextReportExtension;
 import integration.server.LocalHttpServer;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +17,7 @@ import static java.lang.Boolean.parseBoolean;
 import static org.openqa.selenium.net.PortProber.findFreePort;
 
 @ExtendWith({TextReportExtension.class})
-public abstract class BaseIntegrationTest implements WithAssertions {
+public abstract class BaseIntegrationTest {
   private static final Logger log = Logger.getLogger(BaseIntegrationTest.class.getName());
 
   private static final boolean SSL = false;

--- a/src/test/java/integration/ByTextTest.java
+++ b/src/test/java/integration/ByTextTest.java
@@ -11,6 +11,7 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selectors.withText;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ByTextTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/CheckboxTest.java
+++ b/src/test/java/integration/CheckboxTest.java
@@ -7,6 +7,8 @@ import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.Condition.checked;
 import static com.codeborne.selenide.Condition.selected;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CheckboxTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -16,7 +16,15 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Collectors;
 
-import static com.codeborne.selenide.CollectionCondition.*;
+import static com.codeborne.selenide.CollectionCondition.empty;
+import static com.codeborne.selenide.CollectionCondition.exactTexts;
+import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
+import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
+import static com.codeborne.selenide.CollectionCondition.sizeLessThan;
+import static com.codeborne.selenide.CollectionCondition.sizeLessThanOrEqual;
+import static com.codeborne.selenide.CollectionCondition.sizeNotEqual;
+import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.text;
@@ -24,6 +32,8 @@ import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CollectionMethodsTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/CollectionSizeTest.java
+++ b/src/test/java/integration/CollectionSizeTest.java
@@ -10,6 +10,7 @@ import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
 import static com.codeborne.selenide.CollectionCondition.sizeLessThan;
 import static com.codeborne.selenide.CollectionCondition.sizeLessThanOrEqual;
 import static com.codeborne.selenide.CollectionCondition.sizeNotEqual;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CollectionSizeTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/ConditionsTest.java
+++ b/src/test/java/integration/ConditionsTest.java
@@ -15,6 +15,7 @@ import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.or;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConditionsTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/CustomWebDriverProviderTest.java
+++ b/src/test/java/integration/CustomWebDriverProviderTest.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class CustomWebDriverProviderTest extends BaseIntegrationTest {

--- a/src/test/java/integration/DynamicSelectsTest.java
+++ b/src/test/java/integration/DynamicSelectsTest.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.Condition.selected;
 import static com.codeborne.selenide.Condition.text;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DynamicSelectsTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/ElementEnabledTest.java
+++ b/src/test/java/integration/ElementEnabledTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.enabled;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ElementEnabledTest extends ITest {
 

--- a/src/test/java/integration/FileUploadTest.java
+++ b/src/test/java/integration/FileUploadTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 
 import static com.codeborne.selenide.Condition.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class FileUploadTest extends ITest {

--- a/src/test/java/integration/FrameWaitTest.java
+++ b/src/test/java/integration/FrameWaitTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.name;
 import static com.codeborne.selenide.Condition.text;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class FrameWaitTest extends ITest {

--- a/src/test/java/integration/FramesTest.java
+++ b/src/test/java/integration/FramesTest.java
@@ -6,6 +6,8 @@ import org.openqa.selenium.NoSuchFrameException;
 
 import static com.codeborne.selenide.Condition.name;
 import static com.codeborne.selenide.Condition.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class FramesTest extends ITest {

--- a/src/test/java/integration/ImageTest.java
+++ b/src/test/java/integration/ImageTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 class ImageTest extends ITest {
   @BeforeEach
   void openTestPageWithImages() {

--- a/src/test/java/integration/InputFieldTest.java
+++ b/src/test/java/integration/InputFieldTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class InputFieldTest extends ITest {
   @BeforeEach
   void setup() {
@@ -17,21 +19,18 @@ class InputFieldTest extends ITest {
     Assumptions.assumeFalse(browser().isPhantomjs(), "Fails with Expected: '456', but: was ''");
 
     SelenideElement input = $("#id1");
-    assertThat(input.getValue())
-      .isNullOrEmpty();
+    assertThat(input.getValue()).isNullOrEmpty();
 
     input.clear();
     input.setValue(",.123");
     input.clear();
     input.setValue("456");
-    assertThat(input.getValue())
-      .isEqualTo("456");
+    assertThat(input.getValue()).isEqualTo("456");
 
     input.clear();
     input.setValue(",.123");
     input.clear();
     input.setValue("456");
-    assertThat(input.getValue())
-      .isEqualTo("456");
+    assertThat(input.getValue()).isEqualTo("456");
   }
 }

--- a/src/test/java/integration/InvalidXPathTest.java
+++ b/src/test/java/integration/InvalidXPathTest.java
@@ -7,6 +7,9 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidSelectorException;
 
 import static com.codeborne.selenide.Condition.exist;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 class InvalidXPathTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/LastChildTest.java
+++ b/src/test/java/integration/LastChildTest.java
@@ -8,6 +8,7 @@ import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.be;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class LastChildTest extends ITest {
 

--- a/src/test/java/integration/LongRunningAjaxRequestTest.java
+++ b/src/test/java/integration/LongRunningAjaxRequestTest.java
@@ -9,6 +9,8 @@ import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LongRunningAjaxRequestTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/OverrideCommandsTest.java
+++ b/src/test/java/integration/OverrideCommandsTest.java
@@ -10,6 +10,8 @@ import org.openqa.selenium.WebElement;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class OverrideCommandsTest extends ITest {
   private AtomicInteger clickCounter = new AtomicInteger();
 
@@ -28,8 +30,7 @@ class OverrideCommandsTest extends ITest {
     Commands.getInstance().add("click", new MyClick());
     $("#valid-image").click();
     $("#invalid-image").click();
-    assertThat(clickCounter.get())
-      .isEqualTo(2);
+    assertThat(clickCounter.get()).isEqualTo(2);
   }
 
   private class MyClick extends Click {

--- a/src/test/java/integration/ParentTest.java
+++ b/src/test/java/integration/ParentTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class ParentTest extends ITest {
   @BeforeEach
   void openTestPageWithJQuery() {

--- a/src/test/java/integration/ReplacingElementTest.java
+++ b/src/test/java/integration/ReplacingElementTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import static com.codeborne.selenide.CollectionCondition.empty;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.value;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ReplacingElementTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/SelenideDriverITest.java
+++ b/src/test/java/integration/SelenideDriverITest.java
@@ -13,6 +13,7 @@ import java.io.FileNotFoundException;
 
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SelenideDriverITest extends ITest {
   private SelenideDriver browser1;

--- a/src/test/java/integration/SelenideElementToStringTest.java
+++ b/src/test/java/integration/SelenideElementToStringTest.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.By;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Selectors.byText;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SelenideElementToStringTest extends ITest {
   @Test

--- a/src/test/java/integration/SizzleSelectorsTest.java
+++ b/src/test/java/integration/SizzleSelectorsTest.java
@@ -9,6 +9,7 @@ import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.SelectorMode.Sizzle;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SizzleSelectorsTest extends BaseIntegrationTest {
   SelenideDriver driver = new SelenideDriver(new SelenideConfig().baseUrl(getBaseUrl()).selectorMode(Sizzle));

--- a/src/test/java/integration/TabsTest.java
+++ b/src/test/java/integration/TabsTest.java
@@ -12,6 +12,8 @@ import java.util.Set;
 
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selectors.byText;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 

--- a/src/test/java/integration/TimeoutTest.java
+++ b/src/test/java/integration/TimeoutTest.java
@@ -7,6 +7,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 
 import static com.codeborne.selenide.Condition.visible;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class TimeoutTest extends ITest {
   @BeforeEach

--- a/src/test/java/integration/UserAgentTest.java
+++ b/src/test/java/integration/UserAgentTest.java
@@ -3,6 +3,8 @@ package integration;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class UserAgentTest extends ITest {
   @Test
   void currentUserAgentTest() {
@@ -11,8 +13,7 @@ class UserAgentTest extends ITest {
     driver().open("/start_page.html");
     String userAgent = driver().getUserAgent();
 
-    assertThat(userAgent)
-      .isNotBlank();
+    assertThat(userAgent).isNotBlank();
     assertThat(userAgent)
       .withFailMessage(String.format("Current user agent [%s] should belong to '%s' browser", userAgent, browser))
       .containsIgnoringCase(browser);

--- a/src/test/java/integration/ZoomTest.java
+++ b/src/test/java/integration/ZoomTest.java
@@ -1,8 +1,8 @@
 package integration;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class ZoomTest extends ITest {
@@ -28,10 +28,10 @@ public class ZoomTest extends ITest {
   }
 
   private static void assertBetween(int n, int lower, int upper) {
-    Assertions.assertThat(n >= lower)
+    assertThat(n >= lower)
       .withFailMessage(n + " should be between " + lower + " and " + upper)
       .isTrue();
-    Assertions.assertThat(n <= upper)
+    assertThat(n <= upper)
       .withFailMessage(n + " should be between " + lower + " and " + upper)
       .isTrue();
   }

--- a/statics/src/test/java/grid/SeleniumGridTest.java
+++ b/statics/src/test/java/grid/SeleniumGridTest.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SeleniumGridTest extends AbstractGridTest {
   @BeforeEach

--- a/statics/src/test/java/integration/AlertTest.java
+++ b/statics/src/test/java/integration/AlertTest.java
@@ -10,8 +10,14 @@ import org.openqa.selenium.NoAlertPresentException;
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selectors.byValue;
-import static com.codeborne.selenide.Selenide.*;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.close;
+import static com.codeborne.selenide.Selenide.confirm;
+import static com.codeborne.selenide.Selenide.prompt;
+import static com.codeborne.selenide.Selenide.switchTo;
 import static com.codeborne.selenide.WebDriverRunner.supportsModalDialogs;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class AlertTest extends IntegrationTest {

--- a/statics/src/test/java/integration/BrowserLogsTest.java
+++ b/statics/src/test/java/integration/BrowserLogsTest.java
@@ -15,6 +15,7 @@ import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static com.codeborne.selenide.WebDriverRunner.isPhantomjs;
 import static com.codeborne.selenide.WebDriverRunner.isSafari;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.openqa.selenium.logging.LogType.BROWSER;
 

--- a/statics/src/test/java/integration/BrowserPositionTest.java
+++ b/statics/src/test/java/integration/BrowserPositionTest.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.Point;
 import static com.codeborne.selenide.Selenide.close;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.isHeadless;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class BrowserPositionTest extends IntegrationTest {

--- a/statics/src/test/java/integration/ClearCookiesTest.java
+++ b/statics/src/test/java/integration/ClearCookiesTest.java
@@ -1,17 +1,18 @@
 package integration;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Set;
-
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Cookie;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Set;
+
 import static com.codeborne.selenide.Selenide.clearBrowserCookies;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ClearCookiesTest extends IntegrationTest {
   @BeforeEach
@@ -28,7 +29,6 @@ class ClearCookiesTest extends IntegrationTest {
   void clearCookieTest() {
     clearBrowserCookies();
     Set<Cookie> cookieSet = getWebDriver().manage().getCookies();
-    assertThat(cookieSet)
-      .isEmpty();
+    assertThat(cookieSet).isEmpty();
   }
 }

--- a/statics/src/test/java/integration/ClearLocalStorageTest.java
+++ b/statics/src/test/java/integration/ClearLocalStorageTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import static com.codeborne.selenide.Selenide.clearBrowserLocalStorage;
 import static com.codeborne.selenide.Selenide.executeJavaScript;
 import static com.codeborne.selenide.Selenide.open;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ClearLocalStorageTest extends IntegrationTest {
   @BeforeEach
@@ -17,13 +18,11 @@ class ClearLocalStorageTest extends IntegrationTest {
 
   @Test
   void clearLocalStorageTest() {
-    assertThat(getLocalStorageLength())
-      .isEqualTo(2L);
+    assertThat(getLocalStorageLength()).isEqualTo(2L);
 
     clearBrowserLocalStorage();
 
-    assertThat(getLocalStorageLength())
-      .isEqualTo(0L);
+    assertThat(getLocalStorageLength()).isEqualTo(0L);
   }
 
   private long getLocalStorageLength() {

--- a/statics/src/test/java/integration/CollectionBecauseTest.java
+++ b/statics/src/test/java/integration/CollectionBecauseTest.java
@@ -3,7 +3,6 @@ package integration;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.ex.TextsMismatch;
-
 import com.codeborne.selenide.ex.TextsSizeMismatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,6 +12,7 @@ import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Selenide.$$;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CollectionBecauseTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/CollectionWaitTest.java
+++ b/statics/src/test/java/integration/CollectionWaitTest.java
@@ -3,7 +3,6 @@ package integration;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.ex.TextsMismatch;
 import com.codeborne.selenide.ex.TextsSizeMismatch;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +11,7 @@ import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$$;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CollectionWaitTest extends IntegrationTest {
   @BeforeEach
@@ -54,7 +54,7 @@ class CollectionWaitTest extends IntegrationTest {
   @Test
   void firstNElements_TextsMismatchErrorMessage() {
     Configuration.timeout = 4000;
-    Assertions.assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element", "#wrong")))
+    assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element", "#wrong")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageContaining("Actual: [Element #0, Element #1]\n" +
         "Expected: [Element, #wrong]\n" +
@@ -64,7 +64,7 @@ class CollectionWaitTest extends IntegrationTest {
   @Test
   void firstNElements_TextsSizeMismatchErrorMessage() {
     Configuration.timeout = 4000;
-    Assertions.assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element #wrong")))
+    assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element #wrong")))
       .isInstanceOf(TextsSizeMismatch.class)
       .hasMessageContaining("Actual: [Element #0, Element #1], List size: 2\n" +
         "Expected: [Element #wrong], List size: 1\n" +
@@ -74,7 +74,7 @@ class CollectionWaitTest extends IntegrationTest {
   @Test
   void lastNElements_errorMessage() {
     Configuration.timeout = 4000;
-    Assertions.assertThatThrownBy(() -> $$("#collection li").last(2).shouldHave(texts("Element", "#wrong")))
+    assertThatThrownBy(() -> $$("#collection li").last(2).shouldHave(texts("Element", "#wrong")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageContaining("Actual: [Element #48, Element #49]\n" +
         "Expected: [Element, #wrong]\n" +

--- a/statics/src/test/java/integration/ConfirmTest.java
+++ b/statics/src/test/java/integration/ConfirmTest.java
@@ -15,6 +15,8 @@ import static com.codeborne.selenide.Selenide.close;
 import static com.codeborne.selenide.Selenide.confirm;
 import static com.codeborne.selenide.Selenide.dismiss;
 import static com.codeborne.selenide.WebDriverRunner.supportsModalDialogs;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class ConfirmTest extends IntegrationTest {

--- a/statics/src/test/java/integration/DirectFileDownloadTest.java
+++ b/statics/src/test/java/integration/DirectFileDownloadTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import static com.codeborne.selenide.Selenide.download;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DirectFileDownloadTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -14,6 +14,9 @@ import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.WebDriverRunner.isPhantomjs;
 import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class FileDownloadViaHttpGetTest extends IntegrationTest {
   private File folder = new File(Configuration.reportsFolder);

--- a/statics/src/test/java/integration/FileDownloadViaProxyTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaProxyTest.java
@@ -13,6 +13,8 @@ import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
 import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FileDownloadViaProxyTest extends IntegrationTest {
   private File folder = new File(Configuration.reportsFolder);
@@ -62,7 +64,7 @@ class FileDownloadViaProxyTest extends IntegrationTest {
   }
 
   @Test
-  public void download_withCustomTimeout() throws IOException {
+  public void download_withCustomTimeout() throws FileNotFoundException {
     File downloadedFile = $(byText("Download me slowly (2000 ms)")).download(3000);
 
     assertThat(downloadedFile.getName())

--- a/statics/src/test/java/integration/HrefTest.java
+++ b/statics/src/test/java/integration/HrefTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HrefTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/NonHtmlPageTest.java
+++ b/statics/src/test/java/integration/NonHtmlPageTest.java
@@ -3,13 +3,13 @@ package integration;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.WebDriverRunner.source;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class NonHtmlPageTest extends IntegrationTest {
   @Test
   void canOpenNonHtmlPage() {
     openFile("hello_world.txt");
     String source = source();
-    assertThat(source)
-      .contains("Hello, WinRar!");
+    assertThat(source).contains("Hello, WinRar!");
   }
 }

--- a/statics/src/test/java/integration/PageAtBottomTest.java
+++ b/statics/src/test/java/integration/PageAtBottomTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Selenide.atBottom;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class PageAtBottomTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/PageObjectTest.java
+++ b/statics/src/test/java/integration/PageObjectTest.java
@@ -1,7 +1,5 @@
 package integration;
 
-import java.util.List;
-
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.ElementsContainer;
@@ -13,11 +11,15 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.ui.Select;
 
+import java.util.List;
+
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.page;
 import static com.codeborne.selenide.Selenide.sleep;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PageObjectTest extends IntegrationTest {
   private SelectsPage pageWithSelects;

--- a/statics/src/test/java/integration/PageObjectWithManuallyInitializedFieldsTest.java
+++ b/statics/src/test/java/integration/PageObjectWithManuallyInitializedFieldsTest.java
@@ -1,17 +1,18 @@
 package integration;
 
-import java.util.List;
-
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.Selenide.page;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class PageObjectWithManuallyInitializedFieldsTest extends IntegrationTest {
   @BeforeEach
@@ -24,8 +25,7 @@ class PageObjectWithManuallyInitializedFieldsTest extends IntegrationTest {
     MyPage page = page(MyPage.class);
 
     page.h1.shouldHave(Condition.text("Page with selects"));
-    assertThat(page.h2s)
-      .hasSize(3);
+    assertThat(page.h2s).hasSize(3);
     page.h2s.get(0).shouldBe(visible).shouldHave(text("Dropdown list"));
     page.h2First.shouldBe(visible).shouldHave(text("Dropdown list"));
   }

--- a/statics/src/test/java/integration/RadioTest.java
+++ b/statics/src/test/java/integration/RadioTest.java
@@ -9,6 +9,8 @@ import org.openqa.selenium.By;
 import static com.codeborne.selenide.Selectors.byName;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.getSelectedRadio;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RadioTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/ReadonlyElementsTest.java
+++ b/statics/src/test/java/integration/ReadonlyElementsTest.java
@@ -17,6 +17,10 @@ import static com.codeborne.selenide.Condition.exactValue;
 import static com.codeborne.selenide.Condition.selected;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selenide.$;
+import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 class ReadonlyElementsTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/ScreenshotInIframeTest.java
+++ b/statics/src/test/java/integration/ScreenshotInIframeTest.java
@@ -8,11 +8,13 @@ import org.junit.jupiter.api.Test;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.switchTo;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static com.codeborne.selenide.WebDriverRunner.isPhantomjs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class ScreenshotInIframeTest extends IntegrationTest {
@@ -36,7 +38,7 @@ class ScreenshotInIframeTest extends IntegrationTest {
   }
 
   @Test
-  void canTakeScreenshotOfFullyVisibleElementInIframe() throws Exception {
+  void canTakeScreenshotOfFullyVisibleElementInIframe() throws IOException {
     SelenideElement iframe = $("#iframe_page");
     SelenideElement element = $("#small_div");
     File file = Screenshots.takeScreenShot(iframe, element);
@@ -63,7 +65,7 @@ class ScreenshotInIframeTest extends IntegrationTest {
   }
 
   @Test
-  void canTakeScreenshotOfPartiallyVisibleElementInIframe() throws Exception {
+  void canTakeScreenshotOfPartiallyVisibleElementInIframe() throws IOException {
     SelenideElement iframe = $("#iframe_page");
     SelenideElement element = $("#wide_div");
     File file = Screenshots.takeScreenShot(iframe, element);

--- a/statics/src/test/java/integration/ScreenshotTest.java
+++ b/statics/src/test/java/integration/ScreenshotTest.java
@@ -19,6 +19,7 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class ScreenshotTest extends IntegrationTest {

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -14,6 +14,8 @@ import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Selectors.byName;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$x;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SelectsTest extends IntegrationTest {
 

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -56,6 +56,9 @@ import static com.codeborne.selenide.WebDriverRunner.isChrome;
 import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static com.codeborne.selenide.WebDriverRunner.url;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class SelenideMethodsTest extends IntegrationTest {

--- a/statics/src/test/java/integration/customcommands/CustomCommandsTest.java
+++ b/statics/src/test/java/integration/customcommands/CustomCommandsTest.java
@@ -10,6 +10,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static integration.customcommands.MyFramework.$_;
 import static integration.customcommands.MyFramework.quadrupleClickCounter;
 import static integration.customcommands.MyFramework.tripleClickCounter;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class CustomCommandsTest extends IntegrationTest {
   @BeforeEach
@@ -29,10 +30,8 @@ class CustomCommandsTest extends IntegrationTest {
       .isTrue();
     $_("#valid-image img").shouldBe(visible);
 
-    assertThat(tripleClickCounter.get())
-      .isEqualTo(4);
-    assertThat(quadrupleClickCounter.get())
-      .isEqualTo(1);
+    assertThat(tripleClickCounter.get()).isEqualTo(4);
+    assertThat(quadrupleClickCounter.get()).isEqualTo(1);
   }
 
   @BeforeEach

--- a/statics/src/test/java/integration/errormessages/ErrorMessagesForMissingElementTest.java
+++ b/statics/src/test/java/integration/errormessages/ErrorMessagesForMissingElementTest.java
@@ -16,8 +16,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
-import java.util.regex.Pattern;
-
 import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.hidden;
@@ -27,6 +25,9 @@ import static com.codeborne.selenide.Configuration.headless;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.element;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class ErrorMessagesForMissingElementTest extends IntegrationTest {
@@ -164,14 +165,6 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
     ).isInstanceOf(ElementNotFound.class)
       .hasMessageContaining("Element not found {By.id: invalid_id}")
       .hasMessageContaining("Expected: exist");
-  }
-
-  private void assertContains(UIAssertionError e, String... expectedTexts) {
-    for (String expectedText : expectedTexts) {
-      assertThat(e.toString())
-        .as("Text not found: " + expectedText + " in error message: " + e)
-        .matches(Pattern.compile(".*" + expectedText + ".*", Pattern.DOTALL));
-    }
   }
 
   @Test

--- a/statics/src/test/java/integration/errormessages/ErrorMessagesWithScreenshotsTest.java
+++ b/statics/src/test/java/integration/errormessages/ErrorMessagesWithScreenshotsTest.java
@@ -15,10 +15,12 @@ import java.io.File;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.Configuration.reportsFolder;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 class ErrorMessagesWithScreenshotsTest extends IntegrationTest {
   private String reportsUrl;

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnCollectionFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnCollectionFailsOnTest.java
@@ -19,6 +19,8 @@ import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static com.codeborne.selenide.WebDriverRunner.isPhantomjs;
 import static integration.errormessages.Helper.assertScreenshot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class MethodCalledOnCollectionFailsOnTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnCollectionPassesOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnCollectionPassesOnTest.java
@@ -10,6 +10,7 @@ import static com.codeborne.selenide.CollectionCondition.exactTexts;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class MethodCalledOnCollectionPassesOnTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnElementFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnElementFailsOnTest.java
@@ -21,6 +21,8 @@ import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static com.codeborne.selenide.WebDriverRunner.isHtmlUnit;
 import static com.codeborne.selenide.WebDriverRunner.isPhantomjs;
 import static integration.errormessages.Helper.assertScreenshot;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class MethodCalledOnElementFailsOnTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnElementPassesOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnElementPassesOnTest.java
@@ -12,6 +12,7 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnEntityWithInvalidLocatorFailsOnTest.java
@@ -11,9 +11,14 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.InvalidSelectorException;
 
 import static com.codeborne.selenide.CollectionCondition.exactTexts;
-import static com.codeborne.selenide.Condition.*;
+import static com.codeborne.selenide.Condition.cssClass;
+import static com.codeborne.selenide.Condition.exactTextCaseSensitive;
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @Disabled
 class MethodCalledOnEntityWithInvalidLocatorFailsOnTest extends IntegrationTest {

--- a/statics/src/test/java/integration/proxy/ChainedProxyTest.java
+++ b/statics/src/test/java/integration/proxy/ChainedProxyTest.java
@@ -18,6 +18,7 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.close;
 import static com.codeborne.selenide.WebDriverRunner.isPhantomjs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**

--- a/statics/src/test/java/integration/proxy/ProxyServerUsageTest.java
+++ b/statics/src/test/java/integration/proxy/ProxyServerUsageTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.getSelenideProxy;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ProxyServerUsageTest extends IntegrationTest {
   private List<String> requests = new ArrayList<>();


### PR DESCRIPTION
... because some of its import unexpectedly break compilation (e.g. method `WithAssertions.type` conflicts with `Condition.type`).

instead, import those methods explicitly: `assertThat`, `assertThatThrownBy`, `fail`.

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)