### PR TITLE
shorten the error message as it was before Selenide 5.3.1

### DIFF
--- a/src/main/java/com/codeborne/selenide/ex/ElementIsNotClickableException.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementIsNotClickableException.java
@@ -4,6 +4,6 @@ import com.codeborne.selenide.Driver;
 
 public class ElementIsNotClickableException extends UIAssertionError {
   public ElementIsNotClickableException(Driver driver, Throwable cause) {
-    super(driver, cause);
+    super(driver, "Element is not clickable", cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/InvalidStateException.java
+++ b/src/main/java/com/codeborne/selenide/ex/InvalidStateException.java
@@ -1,13 +1,14 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.impl.Cleanup;
 
 public class InvalidStateException extends UIAssertionError {
   public InvalidStateException(Driver driver, Throwable cause) {
-    super(driver, cause);
+    super(driver, "Invalid element state: " + Cleanup.of.webdriverExceptionMessage(cause.getMessage()), cause);
   }
 
   public InvalidStateException(Driver driver, String message) {
-    super(driver, message);
+    super(driver, "Invalid element state: " + message);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/UIAssertionError.java
+++ b/src/main/java/com/codeborne/selenide/ex/UIAssertionError.java
@@ -15,10 +15,6 @@ public class UIAssertionError extends AssertionError {
   private String screenshot;
   public long timeoutMs;
 
-  public UIAssertionError(Driver driver, Throwable cause) {
-    this(driver, cause.getClass().getSimpleName() + ": " + Cleanup.of.webdriverExceptionMessage(cause.getMessage()), cause);
-  }
-
   protected UIAssertionError(Driver driver, String message) {
     super(message);
     this.driver = driver;
@@ -32,6 +28,11 @@ public class UIAssertionError extends AssertionError {
   @Override
   public final String getMessage() {
     return super.getMessage() + uiDetails();
+  }
+
+  @Override
+  public final String toString() {
+    return getMessage();
   }
 
   protected String uiDetails() {
@@ -55,9 +56,15 @@ public class UIAssertionError extends AssertionError {
   }
 
   private static Error wrapThrowable(Driver driver, Throwable error, long timeoutMs) {
-    UIAssertionError uiError = error instanceof UIAssertionError ? (UIAssertionError) error : new UIAssertionError(driver, error);
+    UIAssertionError uiError = error instanceof UIAssertionError ?
+      (UIAssertionError) error : wrapToUIAssertionError(driver, error);
     uiError.timeoutMs = timeoutMs;
     uiError.screenshot = ScreenShotLaboratory.getInstance().formatScreenShotPath(driver);
     return uiError;
+  }
+
+  private static UIAssertionError wrapToUIAssertionError(Driver driver, Throwable error) {
+    String message = error.getClass().getSimpleName() + ": " + Cleanup.of.webdriverExceptionMessage(error.getMessage());
+    return new UIAssertionError(driver, message, error);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/SelectRadioCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectRadioCommandTest.java
@@ -1,8 +1,5 @@
 package com.codeborne.selenide.commands;
 
-import java.lang.reflect.Field;
-import java.util.Collections;
-
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
@@ -12,6 +9,9 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,7 +58,7 @@ class SelectRadioCommandTest implements WithAssertions {
       selectRadioCommand.execute(proxy, locator, new Object[]{defaultElementValue});
     } catch (InvalidStateException exception) {
       assertThat(exception)
-        .hasMessageStartingWith("Cannot select readonly radio button");
+        .hasMessageStartingWith("Invalid element state: Cannot select readonly radio button");
     }
   }
 

--- a/src/test/java/com/codeborne/selenide/commands/SetSelectedCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SetSelectedCommandTest.java
@@ -44,7 +44,7 @@ class SetSelectedCommandTest implements WithAssertions {
       setSelectedCommand.execute(proxy, locator, new Object[]{true});
     } catch (InvalidStateException exception) {
       assertThat(exception)
-        .hasMessageStartingWith("Cannot change invisible element");
+        .hasMessageStartingWith("Invalid element state: Cannot change invisible element");
     }
   }
 
@@ -61,7 +61,7 @@ class SetSelectedCommandTest implements WithAssertions {
       setSelectedCommand.execute(proxy, locator, new Object[]{true});
     } catch (InvalidStateException exception) {
       assertThat(exception)
-        .hasMessageStartingWith("Only use setSelected on checkbox/option/radio");
+        .hasMessageStartingWith("Invalid element state: Only use setSelected on checkbox/option/radio");
     }
   }
 
@@ -84,7 +84,7 @@ class SetSelectedCommandTest implements WithAssertions {
       setSelectedCommand.execute(proxy, locator, new Object[]{true})
     )
       .isInstanceOf(InvalidStateException.class)
-      .hasMessageStartingWith("Cannot change value of readonly/disabled element");
+      .hasMessageStartingWith("Invalid element state: Cannot change value of readonly/disabled element");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/ex/ElementIsNotClickableExceptionTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementIsNotClickableExceptionTest.java
@@ -13,6 +13,7 @@ class ElementIsNotClickableExceptionTest implements WithAssertions {
     WebDriverException cause = new WebDriverException("Sorry, is not clickable at the moment");
     ElementIsNotClickableException e = new ElementIsNotClickableException(driver, cause);
 
-    assertThat(e).hasMessageStartingWith("WebDriverException: Sorry, is not clickable at the moment");
+    assertThat(e).hasMessageStartingWith("Element is not clickable");
+    assertThat(e).hasMessageContaining("WebDriverException: Sorry, is not clickable at the moment");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/InvalidStateExceptionTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/InvalidStateExceptionTest.java
@@ -14,9 +14,10 @@ class InvalidStateExceptionTest implements WithAssertions {
     StaleElementReferenceException cause = new StaleElementReferenceException("Houston, we have a problem");
     InvalidStateException invalidStateException = new InvalidStateException(driver, cause);
 
-    assertThat(invalidStateException).hasMessageStartingWith("StaleElementReferenceException: Houston, we have a problem");
-    assertThat(invalidStateException).hasToString("com.codeborne.selenide.ex.InvalidStateException: " +
-      "StaleElementReferenceException: Houston, we have a problem\n" +
+    assertThat(invalidStateException).hasMessageStartingWith("Invalid element state");
+    assertThat(invalidStateException).hasMessageEndingWith("StaleElementReferenceException: Houston, we have a problem");
+    assertThat(invalidStateException).hasToString("Invalid element state: " +
+      "Houston, we have a problem\n" +
       "Screenshot: null\n" +
       "Timeout: 0 ms.\n" +
       "Caused by: StaleElementReferenceException: Houston, we have a problem");
@@ -26,8 +27,8 @@ class InvalidStateExceptionTest implements WithAssertions {
   void constructorWithMessage() {
     InvalidStateException invalidStateException = new InvalidStateException(driver, "Houston, we have a problem");
 
-    assertThat(invalidStateException).hasMessageStartingWith("Houston, we have a problem");
-    assertThat(invalidStateException).hasToString("com.codeborne.selenide.ex.InvalidStateException: Houston, we have a problem\n" +
+    assertThat(invalidStateException).hasMessageStartingWith("Invalid element state: Houston, we have a problem");
+    assertThat(invalidStateException).hasToString("Invalid element state: Houston, we have a problem\n" +
       "Screenshot: null\n" +
       "Timeout: 0 ms.");
   }


### PR DESCRIPTION
instead of long message `com.codeborne.selenide.ex.ElementNotFound: Element not found {#customerDashboardButton}`,
just use shorter message `Element not found {#customerDashboardButton}`

* it improves changes done in PR #972 for issue #234
* Maven users with latest surefire plugin will still see the long error message

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome htmlunit` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)