### PR TITLE
#1016 deprecate method `Selenide.close()`

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 
-import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.getSelenideDriver;
 
 /**
@@ -166,8 +165,29 @@ public class Selenide {
   }
 
   /**
-   * Close the browser if it's open
+   * Close the current window, quitting the browser if it's the last window currently open.
+   *
+   * @see WebDriver#close()
    */
+  public static void closeWindow() {
+    WebDriverRunner.closeWindow();
+  }
+
+  /**
+   * <p>Close the browser if it's open.</p>
+   * <br>
+   * <p>NB! Method quits this driver, closing every associated window.</p>
+   *
+   * @see WebDriver#quit()
+   */
+  public static void closeWebDriver() {
+    WebDriverRunner.closeWebDriver();
+  }
+
+  /**
+   * @deprecated Use either {@link #closeWindow()} or {@link #closeWebDriver()}
+   */
+  @Deprecated
   public static void close() {
     closeWebDriver();
   }

--- a/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -107,7 +107,20 @@ public class WebDriverRunner implements Browsers {
   }
 
   /**
-   * Close the browser if it's open
+   * Close the current window, quitting the browser if it's the last window currently open.
+   *
+   * @see WebDriver#close()
+   */
+  public static void closeWindow() {
+    webdriverContainer.closeWindow();
+  }
+
+  /**
+   * <p>Close the browser if it's open.</p>
+   * <br>
+   * <p>NB! Method quits this driver, closing every associated window.</p>
+   *
+   * @see WebDriver#quit()
    */
   public static void closeWebDriver() {
     webdriverContainer.closeWebDriver();

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
@@ -13,6 +13,7 @@ public interface WebDriverContainer {
   SelenideProxyServer getProxyServer();
   void setProxy(Proxy webProxy);
   WebDriver getAndCheckWebDriver();
+  void closeWindow();
   void closeWebDriver();
   boolean hasWebDriverStarted();
 

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -129,6 +129,11 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
   }
 
   @Override
+  public void closeWindow() {
+    getWebDriver().close();
+  }
+
+  @Override
   public void closeWebDriver() {
     WebDriver driver = threadWebDriver.remove(currentThread().getId());
     SelenideProxyServer proxy = threadProxyServer.remove(currentThread().getId());


### PR DESCRIPTION
this name is misleading. Now user has to choose either `closeWebDriver()` or `closeWindow()` (each has clear intention).

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
