### PR TITLE
Accept insecure ssl certs

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
+import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
 import static org.openqa.selenium.remote.CapabilityType.PROXY;
 import static org.openqa.selenium.remote.CapabilityType.SUPPORTS_ALERTS;
@@ -63,6 +64,7 @@ abstract class AbstractDriverFactory {
     }
     browserCapabilities.setCapability(PAGE_LOAD_STRATEGY, config.pageLoadStrategy());
     browserCapabilities.setCapability(ACCEPT_SSL_CERTS, true);
+    browserCapabilities.setCapability(ACCEPT_INSECURE_CERTS, true);
 
     transferCapabilitiesFromSystemProperties(browserCapabilities);
     browserCapabilities = mergeCapabilitiesFromConfiguration(config, browserCapabilities);

--- a/statics/src/test/java/grid/CustomWebdriverProviderWithRemoteBrowser.java
+++ b/statics/src/test/java/grid/CustomWebdriverProviderWithRemoteBrowser.java
@@ -40,6 +40,7 @@ public class CustomWebdriverProviderWithRemoteBrowser extends AbstractGridTest {
     public WebDriver createDriver(DesiredCapabilities desiredCapabilities) {
       ChromeOptions options = new ChromeOptions();
       options.setHeadless(true);
+      addSslErrorIgnoreCapabilities(options);
 
       RemoteWebDriver webDriver = new RemoteWebDriver(toURL("http://localhost:" + port + "/wd/hub"), options);
       webDriver.setFileDetector(new LocalFileDetector());

--- a/statics/src/test/java/integration/CustomWebdriverTest.java
+++ b/statics/src/test/java/integration/CustomWebdriverTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
@@ -34,8 +36,13 @@ class CustomWebdriverTest extends IntegrationTest {
   @BeforeEach
   void setUpTwoBrowsers() {
     useProxy(false);
-    browser1 = isFirefox() ? new FirefoxDriver() : new ChromeDriver();
-    browser2 = isFirefox() ? new FirefoxDriver() : new ChromeDriver();
+
+    browser1 = isFirefox() ?
+      new FirefoxDriver(addSslErrorIgnoreCapabilities(new FirefoxOptions())) :
+      new ChromeDriver(addSslErrorIgnoreCapabilities(new ChromeOptions()));
+    browser2 = isFirefox() ?
+      new FirefoxDriver(addSslErrorIgnoreCapabilities(new FirefoxOptions())) :
+      new ChromeDriver(addSslErrorIgnoreCapabilities(new ChromeOptions()));
   }
 
   @Test

--- a/statics/src/test/java/integration/CustomWebdriverWithSelenideProxyTest.java
+++ b/statics/src/test/java/integration/CustomWebdriverWithSelenideProxyTest.java
@@ -61,6 +61,7 @@ public class CustomWebdriverWithSelenideProxyTest extends IntegrationTest {
     ChromeOptions options = new ChromeOptions();
     if (isHeadless()) options.setHeadless(true);
     options.setProxy(proxy.createSeleniumProxy());
+    addSslErrorIgnoreCapabilities(options);
     options.addArguments("--proxy-bypass-list=<-loopback>");
     return new ChromeDriver(options);
   }

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
 
 import static com.codeborne.selenide.Browsers.CHROME;
 import static com.codeborne.selenide.Configuration.browserSize;
@@ -23,6 +26,8 @@ import static com.codeborne.selenide.Selenide.executeJavaScript;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.isIE;
+import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
+import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
 
 @ExtendWith({ScreenShooterExtension.class, TextReportExtension.class, VideoExtension.class})
 public abstract class IntegrationTest extends BaseIntegrationTest {
@@ -98,5 +103,20 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
       "document.querySelector('body').innerHTML = arguments[0];",
       String.join(" ", html)
     );
+  }
+
+  protected static ChromeOptions addSslErrorIgnoreCapabilities(ChromeOptions options) {
+    addSslErrorIgnoreOptions(options);
+    return options;
+  }
+
+  protected static FirefoxOptions addSslErrorIgnoreCapabilities(FirefoxOptions options) {
+    addSslErrorIgnoreOptions(options);
+    return options;
+  }
+
+  private static void addSslErrorIgnoreOptions(MutableCapabilities options) {
+    options.setCapability(ACCEPT_SSL_CERTS, true);
+    options.setCapability(ACCEPT_INSECURE_CERTS, true);
   }
 }

--- a/statics/src/test/java/integration/ReadonlyElementsTest.java
+++ b/statics/src/test/java/integration/ReadonlyElementsTest.java
@@ -40,6 +40,7 @@ class ReadonlyElementsTest extends IntegrationTest {
       "Element is read-only and so may not be used for actions",
       "Element must be user-editable in order to clear it",
       "You may only edit editable elements",
+      "Invalid element state: invalid element state",
       "Element is read-only: <input name=\"username\">"
     );
 
@@ -74,6 +75,7 @@ class ReadonlyElementsTest extends IntegrationTest {
       "You may only edit editable elements",
       "You may only interact with enabled elements",
       "Element is not currently interactable and may not be manipulated",
+      "Invalid element state: invalid element state: Element is not currently interactable and may not be manipulated",
       "Element is disabled");
 
     Configuration.fastSetValue = false;

--- a/statics/src/test/java/integration/UnopenedBrowserTest.java
+++ b/statics/src/test/java/integration/UnopenedBrowserTest.java
@@ -7,6 +7,7 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.texts;
@@ -75,7 +76,8 @@ class UnopenedBrowserTest extends IntegrationTest {
     useProxy(false);
 
     SelenideElement header = $("h1");
-    ChromeDriver driver = new ChromeDriver();
+    ChromeOptions options = new ChromeOptions();
+    ChromeDriver driver = new ChromeDriver(addSslErrorIgnoreCapabilities(options));
     try {
       WebDriverRunner.setWebDriver(driver);
       openFile("page_with_selects_without_jquery.html");


### PR DESCRIPTION
## Proposed changes
Fix ssl errors for new chrome version.

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
