### PR TITLE
Make javadoc processor happy

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -172,7 +172,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   /**
    * Filters collection elements based on the given condition (lazy evaluation)
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied
-   * @param condition
+   * @param condition condition
    * @return ElementsCollection
    */
   public ElementsCollection filter(Condition condition) {
@@ -183,7 +183,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * Filters collection elements based on the given condition (lazy evaluation)
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied
    * @see #filter(Condition)
-   * @param condition
+   * @param condition condition
    * @return ElementsCollection
    */
   public ElementsCollection filterBy(Condition condition) {
@@ -193,7 +193,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   /**
    * Filters elements excluding those which met the given condition (lazy evaluation)
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied
-   * @param condition
+   * @param condition condition
    * @return ElementsCollection
    */
   public ElementsCollection exclude(Condition condition) {
@@ -204,7 +204,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * Filters elements excluding those which met the given condition (lazy evaluation)
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied
    * @see #exclude(Condition)
-   * @param condition
+   * @param condition condition
    * @return ElementsCollection
    */
   public ElementsCollection excludeWith(Condition condition) {
@@ -214,7 +214,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   /**
    * Find the first element which met the given condition (lazy evaluation)
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied
-   * @param condition
+   * @param condition condition
    * @return SelenideElement
    */
   public SelenideElement find(Condition condition) {
@@ -225,7 +225,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * Find the first element which met the given condition (lazy evaluation)
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied
    * @see #find(Condition)
-   * @param condition
+   * @param condition condition
    * @return SelenideElement
    */
   public SelenideElement findBy(Condition condition) {
@@ -263,7 +263,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
 
   /**
    * Outputs string presentation of the element's collection
-   * @param elements
+   * @param elements elements of string
    * @return String
    */
   public static String elementsToString(Driver driver, Collection<WebElement> elements) {
@@ -292,7 +292,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied (.click(), should..() etc.)
    *
    * @param index 0..N
-   * @return
+   * @return the n-th element of collection
    */
   @Override
   public SelenideElement get(int index) {
@@ -303,7 +303,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * returns the first element of the collection
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied (.click(), should..() etc.)
    * NOTICE: $(css) is faster and returns the same result as $$(css).first()
-   * @return
+   * @return the first element of the collection
    */
   public SelenideElement first() {
     return get(0);
@@ -312,7 +312,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   /**
    * returns the last element of the collection (lazy evaluation)
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied (.click(), should..() etc.)
-   * @return
+   * @return the last element of the collection
    */
   public SelenideElement last() {
     return LastCollectionElement.wrap(collection);
@@ -339,7 +339,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   /**
    * return actual size of the collection, doesn't wait on collection to be loaded.
    * ATTENTION not recommended for use in tests. Use collection.shouldHave(size(n)); for assertions instead.
-   * @return
+   * @return actual size of the collection
    */
   @Override
   public int size() {

--- a/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
+++ b/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
@@ -21,45 +21,37 @@ import static com.codeborne.selenide.ex.ErrorMessages.screenshot;
  * <p>
  * How to use in Java:
  * <pre>
- * {@code
- *    @ExtendWith({ScreenShooterExtension.class})
+ *   {@code @ExtendWith({ScreenShooterExtension.class})}
  *    public class MyTest {...}
- * }
  * </pre>
  * <p>
  * How to use in Java (with customization):
  * <pre>
- * {@code
  *   public class MyTest {
- *     @RegisterExtension
+ *    {@code @RegisterExtension}
  *     static ScreenShooterExtension screenshotEmAll = new ScreenShooterExtension(true);
  *     ...
  *   }
- * }
  * </pre>
  * <p>
  * How to use in Kotlin:
  *
  * <pre>
- *   {@code
- *     @ExtendWith(ScreenShooterExtension::class)
+ *    {@code @ExtendWith(ScreenShooterExtension::class)}
  *     public class MyTest {...}
- *   }
  * </pre>
  * <p>
  * How to use in Kotlin (with customization):
  *
  * <pre>
- * {@code
  *   public class MyTest {
  *     companion object {
- *       @JvmField
- *       @RegisterExtension
+ *      {@code @JvmField}
+ *      {@code @RegisterExtension}
  *       val screenshotEmAll: ScreenShooterExtension = ScreenShooterExtension(true);
  *     }
  *     ...
  *   }
- * }
  * </pre>
  *
  * @author Aliaksandr Rasolka


### PR DESCRIPTION
## Proposed changes

This change fixes javadoc warnings shown during `gradlew assemble` run:
```
~/projects/selenide/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java:68: warning - Missing closing '}' character for inline tag: "{@code"
~/projects/selenide/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java:68: warning - @ExtendWith({ScreenShooterExtension.class}) is an unknown tag.
~/projects/selenide/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java:68: warning - @RegisterExtension is an unknown tag.
~/projects/selenide/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java:68: warning - @ExtendWith(ScreenShooterExtension::class) is an unknown tag.
~/projects/selenide/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java:68: warning - @JvmField is an unknown tag.
~/projects/selenide/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java:68: warning - @RegisterExtension is an unknown tag.
~/projects/selenide/src/main/java/com/codeborne/selenide/ElementsCollection.java:298: warning - @return tag has no arguments.
~/projects/selenide/src/main/java/com/codeborne/selenide/ElementsCollection.java:308: warning - @return tag has no arguments.
~/projects/selenide/src/main/java/com/codeborne/selenide/ElementsCollection.java:317: warning - @return tag has no arguments.
~/projects/selenide/src/main/java/com/codeborne/selenide/ElementsCollection.java:345: warning - @return tag has no arguments.
```

In a nutshell, `@code` tag should be used only as inline tag, it cannot have block body.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
