### PR TITLE
Add a JUnit Rule integration Jenkins junit attachment plugin.

### DIFF
--- a/src/main/java/com/codeborne/selenide/junit/JunitAttachment.java
+++ b/src/main/java/com/codeborne/selenide/junit/JunitAttachment.java
@@ -1,0 +1,38 @@
+package com.codeborne.selenide.junit;
+
+import com.codeborne.selenide.ex.UIAssertionError;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Rule for JUnit Attachments Jenkins Plugin.
+ * <a href="https://plugins.jenkins.io/junit-attachments">JUnit Attachments Jenkins Plugin</a>
+ * <br>
+ * Using:
+ * 1. Add rule for test class: {@code @Rule public JunitAttachment junitAttachment = new JunitAttachment();}
+ * <br>
+ * 2. After test fails, output [[ATTACHMENT|/absolute/path/to/screenshot]] automatically.
+ * <br>
+ */
+public class JunitAttachment extends TestWatcher {
+  @Override
+  protected void failed(Throwable e, Description description) {
+    if (e instanceof UIAssertionError) {
+      UIAssertionError uiAssertionError = (com.codeborne.selenide.ex.UIAssertionError) e;
+      String screenshot = uiAssertionError.getScreenshot();
+      if (screenshot.equals("")) {
+        return;
+      }
+      try {
+        URL screenshotURL = new URL(screenshot);
+        System.out.println("[[ATTACHMENT|" + screenshotURL.getFile() + "]]");
+      } catch (MalformedURLException ex) {
+        System.out.println("JunitAttachment Rule: screenshot " + screenshot + " is not a valid URL");
+      }
+    }
+
+  }
+}

--- a/src/main/java/com/codeborne/selenide/junit5/JunitAttachmentExtension.java
+++ b/src/main/java/com/codeborne/selenide/junit5/JunitAttachmentExtension.java
@@ -1,0 +1,37 @@
+package com.codeborne.selenide.junit5;
+
+import com.codeborne.selenide.ex.UIAssertionError;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Extension for JUnit Attachments Jenkins Plugin.
+ * <a href="https://plugins.jenkins.io/junit-attachments">JUnit Attachments Jenkins Plugin</a>
+ * <br>
+ * Using:
+ * 1. @ExtendWith({JunitAttachmentExtension.class})
+ * <br>
+ * 2. After test fails, output [[ATTACHMENT|/absolute/path/to/screenshot]] automatically.
+ * <br>
+ */
+public class JunitAttachmentExtension implements TestWatcher {
+  @Override
+  public void testFailed(ExtensionContext context, Throwable e) {
+    if (e instanceof UIAssertionError) {
+      UIAssertionError uiAssertionError = (com.codeborne.selenide.ex.UIAssertionError) e;
+      String screenshot = uiAssertionError.getScreenshot();
+      if (screenshot.equals("")) {
+        return;
+      }
+      try {
+        URL screenshotURL = new URL(screenshot);
+        System.out.println("[[ATTACHMENT|" + screenshotURL.getFile() + "]]");
+      } catch (MalformedURLException ex) {
+        System.out.println("JunitAttachment Rule: screenshot " + screenshot + " is not a valid URL");
+      }
+    }
+  }
+}

--- a/src/main/java/com/codeborne/selenide/testng/JunitAttachment.java
+++ b/src/main/java/com/codeborne/selenide/testng/JunitAttachment.java
@@ -1,0 +1,45 @@
+package com.codeborne.selenide.testng;
+
+import com.codeborne.selenide.ex.UIAssertionError;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Listener for JUnit Attachments Jenkins Plugin.
+ * <a href="https://plugins.jenkins.io/junit-attachments">JUnit Attachments Jenkins Plugin</a>
+ * <br>
+ * Using:
+ * 1. Annotate your test class with {@code @Listeners({ JunitAttachment.class})}
+ * <br>
+ * 2. After test fails, output [[ATTACHMENT|/absolute/path/to/screenshot]] automatically.
+ * <br>
+ */
+public class JunitAttachment implements IInvokedMethodListener {
+  @Override
+  public void beforeInvocation(IInvokedMethod iInvokedMethod, ITestResult iTestResult) {
+  }
+
+  @Override
+  public void afterInvocation(IInvokedMethod iInvokedMethod, ITestResult testResult) {
+    if (!testResult.isSuccess()) {
+      Throwable e = testResult.getThrowable();
+      if (e instanceof UIAssertionError) {
+        UIAssertionError uiAssertionError = (com.codeborne.selenide.ex.UIAssertionError) e;
+        String screenshot = uiAssertionError.getScreenshot();
+        if (screenshot.equals("")) {
+          return;
+        }
+        try {
+          URL screenshotURL = new URL(screenshot);
+          System.out.println("[[ATTACHMENT|" + screenshotURL.getFile() + "]]");
+        } catch (MalformedURLException ex) {
+          System.out.println("JunitAttachment Rule: screenshot " + screenshot + " is not a valid URL");
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes
See https://plugins.jenkins.io/junit-attachments
After the test fails with UIAssertionError, this change tries to get the screenshot file path and output in the JUnit attachment plugin format.

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
The change is about the test framework rather than the selenide itself. I verify manually.
- [x] I have added necessary documentation (if appropriate)
Javadoc is added
