### PR TITLE
Add downloadsFolder setting

### DIFF
--- a/src/main/java/com/codeborne/selenide/Config.java
+++ b/src/main/java/com/codeborne/selenide/Config.java
@@ -24,6 +24,7 @@ public interface Config {
   boolean screenshots();
   boolean savePageSource();
   String reportsFolder();
+  String downloadsFolder();
   String reportsUrl();
   boolean fastSetValue();
   boolean versatileSetValue();

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -31,6 +31,7 @@ public class SelenideConfig implements Config {
 
   private boolean savePageSource = Boolean.parseBoolean(System.getProperty("selenide.savePageSource", "true"));
   private String reportsFolder = System.getProperty("selenide.reportsFolder", "build/reports/tests");
+  private String downloadsFolder = System.getProperty("selenide.downloadFolder", "build/downloads");
   private String reportsUrl = new CiReportUrl().getReportsUrl(System.getProperty("selenide.reportsUrl"));
   private boolean fastSetValue = Boolean.parseBoolean(System.getProperty("selenide.fastSetValue", "false"));
   private boolean versatileSetValue = Boolean.parseBoolean(System.getProperty("selenide.versatileSetValue", "false"));
@@ -128,6 +129,16 @@ public class SelenideConfig implements Config {
 
   public SelenideConfig reportsFolder(String reportsFolder) {
     this.reportsFolder = reportsFolder;
+    return this;
+  }
+
+  @Override
+  public String downloadsFolder() {
+    return downloadsFolder;
+  }
+
+  public SelenideConfig downloadsFolder(String downloadsFolder) {
+    this.downloadsFolder = downloadsFolder;
     return this;
   }
 

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -31,7 +31,7 @@ public class SelenideConfig implements Config {
 
   private boolean savePageSource = Boolean.parseBoolean(System.getProperty("selenide.savePageSource", "true"));
   private String reportsFolder = System.getProperty("selenide.reportsFolder", "build/reports/tests");
-  private String downloadsFolder = System.getProperty("selenide.downloadFolder", "build/downloads");
+  private String downloadsFolder = System.getProperty("selenide.downloadsFolder", "build/downloads");
   private String reportsUrl = new CiReportUrl().getReportsUrl(System.getProperty("selenide.reportsUrl"));
   private boolean fastSetValue = Boolean.parseBoolean(System.getProperty("selenide.fastSetValue", "false"));
   private boolean versatileSetValue = Boolean.parseBoolean(System.getProperty("selenide.versatileSetValue", "false"));

--- a/src/main/java/com/codeborne/selenide/impl/Downloader.java
+++ b/src/main/java/com/codeborne/selenide/impl/Downloader.java
@@ -20,7 +20,7 @@ public class Downloader {
   }
 
   public File prepareTargetFile(Config config, String fileName) {
-    File uniqueFolder = new File(config.reportsFolder(), random.text());
+    File uniqueFolder = new File(config.downloadsFolder(), random.text());
     if (uniqueFolder.exists()) {
       throw new IllegalStateException("Unbelievable! Unique folder already exists: " + uniqueFolder.getAbsolutePath());
     }

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
@@ -43,7 +43,7 @@ class DownloadFileWithProxyServerTest implements WithAssertions {
   private SelenideProxyServer proxy = mock(SelenideProxyServer.class);
   private WebElementSource linkWithHref = mock(WebElementSource.class);
   private WebElement link = mock(WebElement.class);
-  private FileDownloadFilter filter = spy(new FileDownloadFilter(new SelenideConfig().reportsFolder("build/downloads")));
+  private FileDownloadFilter filter = spy(new FileDownloadFilter(new SelenideConfig().downloadsFolder("build/downloads")));
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/com/codeborne/selenide/proxy/FileDownloadFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/FileDownloadFilterTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 class FileDownloadFilterTest implements WithAssertions {
   private FileDownloadFilter filter = new FileDownloadFilter(
-    new SelenideConfig().reportsFolder("build/downloads"), new Downloader(new DummyRandomizer("random-text"))
+    new SelenideConfig().downloadsFolder("build/downloads"), new Downloader(new DummyRandomizer("random-text"))
   );
   private HttpResponse response = mock(HttpResponse.class);
   private HttpMessageContents contents = mock(HttpMessageContents.class);

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -187,6 +187,14 @@ public class Configuration {
    */
   public static String reportsFolder = defaults.reportsFolder();
 
+    /**
+   * Folder to store downloaded files to.
+   * Can be configured either programmatically or by system property "-Dselenide.downloadsFolder=test-result/downloads".
+   * <br>
+   * Default value: "build/downloads" (this is default for Gradle projects)
+   */
+  public static String downloadsFolder = defaults.downloadsFolder();
+
   /**
    * Optional: URL of CI server where reports are published to.
    * In case of Jenkins, it is "BUILD_URL/artifact" by default.

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
@@ -62,6 +62,11 @@ public class StaticConfig implements Config {
   }
 
   @Override
+  public String downloadsFolder() {
+    return Configuration.downloadsFolder;
+  }
+
+  @Override
   public String reportsUrl() {
     return Configuration.reportsUrl;
   }

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class FileDownloadViaHttpGetTest extends IntegrationTest {
-  private File folder = new File(Configuration.reportsFolder);
+  private File folder = new File(Configuration.downloadsFolder);
 
   @BeforeEach
   void setUp() {
@@ -81,5 +81,16 @@ class FileDownloadViaHttpGetTest extends IntegrationTest {
     final File downloadedFile = $("#link").download();
     assertThat(downloadedFile.getName())
       .isEqualTo("hello_world.txt");
+  }
+
+  @Test
+  void downloadsFilesToCustomFolder() throws IOException {
+    String downloadsFolder = "build/custom-folder";
+    Configuration.downloadsFolder = downloadsFolder;
+
+    File downloadedFile = $(byText("Download me")).download();
+
+    assertThat(downloadedFile.getAbsolutePath())
+      .startsWith(new File(downloadsFolder).getAbsolutePath());
   }
 }

--- a/statics/src/test/java/integration/FileDownloadViaProxyTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaProxyTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FileDownloadViaProxyTest extends IntegrationTest {
-  private File folder = new File(Configuration.reportsFolder);
+  private File folder = new File(Configuration.downloadsFolder);
 
   @BeforeEach
   void setUp() {
@@ -69,5 +69,16 @@ class FileDownloadViaProxyTest extends IntegrationTest {
 
     assertThat(downloadedFile.getName())
       .isEqualTo("hello_world.txt");
+  }
+
+  @Test
+  void downloadsFilesToCustomFolder() throws IOException {
+    String downloadsFolder = "build/custom-folder";
+    Configuration.downloadsFolder = downloadsFolder;
+
+    File downloadedFile = $(byText("Download me")).download();
+
+    assertThat(downloadedFile.getAbsolutePath())
+      .startsWith(new File(downloadsFolder).getAbsolutePath());
   }
 }


### PR DESCRIPTION
## Proposed changes
Add a new setting Configuration.downloadsFolder that helps to download items to a custom location.

Feature request #1025 

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
