### PR TITLE
#990 show "readonly" attribute of element

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/Describe.java
+++ b/src/main/java/com/codeborne/selenide/impl/Describe.java
@@ -100,8 +100,12 @@ public class Describe {
   }
 
   private Describe attr(String attributeName, String attributeValue) {
-    if (attributeValue != null && attributeValue.length() > 0) {
-      sb.append(' ').append(attributeName).append("=\"").append(attributeValue).append('"');
+    if (attributeValue != null) {
+      if (attributeValue.length() > 0) {
+        sb.append(' ').append(attributeName).append("=\"").append(attributeValue).append('"');
+      } else {
+        sb.append(' ').append(attributeName);
+      }
     }
     return this;
   }

--- a/statics/src/test/java/integration/ReadonlyElementsTest.java
+++ b/statics/src/test/java/integration/ReadonlyElementsTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.exactValue;
 import static com.codeborne.selenide.Condition.selected;
+import static com.codeborne.selenide.Condition.readonly;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selenide.$;
 import static org.assertj.core.api.Assertions.anyOf;
@@ -187,5 +188,11 @@ class ReadonlyElementsTest extends IntegrationTest {
     $("#enable-inputs").click();
     $(By.name("me")).selectRadio("margarita");
     $(Selectors.byValue("margarita")).shouldBe(selected);
+  }
+
+  @Test
+  void readonlyAttributeIsShownInErrorMessage() {
+    assertThatThrownBy(() -> $(By.name("username")).shouldNotHave(readonly))
+      .hasMessageMatching("(?s).*<input.*readonly.*");
   }
 }


### PR DESCRIPTION
## Proposed changes
Changed Describe.attr to append readonly attribute in toString

It fixes a bug #990

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
