### PR TITLE
#991 fix exception thrown by ElementsCollection when searching from first/last element of empty collection

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.UIAssertionError;
 import com.codeborne.selenide.impl.BySelectorCollection;
 import com.codeborne.selenide.impl.Cleanup;
@@ -27,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.not;
 import static com.codeborne.selenide.logevents.ErrorsCollector.validateAssertionMode;
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
@@ -152,7 +154,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
           return;
         }
 
-        throw outOfCollection;
+        throw new ElementNotFound(collection.driver(), collection.description(), exist, outOfCollection);
       }
       sleep(driver().config().pollingInterval());
     }

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -334,33 +334,69 @@ class CollectionMethodsTest extends ITest {
   @Test
   void shouldThrowIndexOutOfBoundsException() {
     ElementsCollection elementsCollection = $$("not-existing-locator").first().$$("#multirowTable");
-    String description = "Check throwing IndexOutOfBoundsException for %s";
+    String description = "Check throwing ElementNotFound for %s";
 
     assertThatThrownBy(() -> elementsCollection.shouldHaveSize(1))
-      .as(description, "shouldHaveSize").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "shouldHaveSize").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
 
     assertThatThrownBy(() -> elementsCollection.shouldHave(size(1)))
-      .as(description, "size").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "size").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
 
     assertThatThrownBy(() -> elementsCollection.shouldHave(sizeGreaterThan(0)))
-      .as(description, "sizeGreaterThan").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "sizeGreaterThan").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
 
     assertThatThrownBy(() -> elementsCollection.shouldHave(sizeGreaterThanOrEqual(1)))
-      .as(description, "sizeGreaterThanOrEqual").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "sizeGreaterThanOrEqual").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
 
     assertThatThrownBy(() -> elementsCollection.shouldHave(sizeNotEqual(0)))
-      .as(description, "sizeNotEqual").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "sizeNotEqual").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
 
     assertThatThrownBy(() -> elementsCollection.shouldHave(sizeLessThan(0)))
-      .as(description, "sizeLessThan").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "sizeLessThan").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
 
     assertThatThrownBy(() -> elementsCollection.shouldHave(sizeLessThanOrEqual(-1)))
-      .as(description, "sizeLessThanOrEqual").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "sizeLessThanOrEqual").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
 
     assertThatThrownBy(() -> elementsCollection.shouldHave(exactTexts("any text")))
-      .as(description, "exactTexts").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "exactTexts").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
 
     assertThatThrownBy(() -> elementsCollection.shouldHave(texts("any text")))
-      .as(description, "texts").isInstanceOf(IndexOutOfBoundsException.class);
+      .as(description, "texts").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
+  }
+
+  @Test
+  void errorWhenFindInLastElementOfEmptyCollection() {
+    assertThatThrownBy(() -> $$("#not_exist").last().$("#multirowTable").should(exist))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {#not_exist}")
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class)
+      .hasCause(new IndexOutOfBoundsException("Index -1 out of bounds for length 0"));
+  }
+
+  @Test
+  void errorWhenFindCollectionInLastElementOfEmptyCollection() {
+    assertThatThrownBy(() -> $$("#not_exist").last().$$("#multirowTable").shouldHaveSize(1))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {#not_exist.last/#multirowTable}")
+      .hasCause(new IndexOutOfBoundsException("Index -1 out of bounds for length 0"));
+  }
+
+  @Test
+  void shouldHaveZeroSizeWhenFindCollectionInLastElementOfEmptyCollection() {
+    $$("#not_exist").last().$$("#multirowTable").shouldHaveSize(0);
+  }
+
+  @Test
+  void shouldHaveZeroSizeWhenFindCollectionInLastElementOfFullCollection() {
+    $$("#user-table td").last().$$("#not_exist").shouldHaveSize(0);
   }
 }


### PR DESCRIPTION
## Proposed changes
Fixes `IndexOutOfBoundsException` exception that was thrown by such construction: `$$("#not_exist").last().$$("#element").shouldHave(...)` 
and `$$("#not_exist").first().$$("#element").shouldHave(...)`

Now it will throw `ElementNotFound `with cause `IndexOutOfBoundsException` 

But it will have a message `"Element not found {#not_exist[0]/#element}"` and I am not sure how to solve it and if it needs to. From the message, it is not clear that the first collection was empty.

For example, with another construction `$$("#not_exist").last().$("#element").should(exist)` it will throw `"Element not found {#not_exist}"`.

Bug #991

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
