### PR TITLE
Line separator issue

### DIFF
--- a/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
@@ -4,17 +4,15 @@ import com.codeborne.selenide.impl.WebElementsCollection;
 
 import java.util.List;
 
-import static java.lang.System.lineSeparator;
-
 public class TextsSizeMismatch extends UIAssertionError {
   public TextsSizeMismatch(WebElementsCollection collection, List<String> actualTexts,
                        List<String> expectedTexts, String explanation, long timeoutMs) {
     super(collection.driver(),
         "Texts size mismatch" +
-        lineSeparator() + "Actual: " + actualTexts + ", List size: " + actualTexts.size() +
-        lineSeparator() + "Expected: " + expectedTexts + ", List size: " + expectedTexts.size() +
-        (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
-        lineSeparator() + "Collection: " + collection.description());
+        "\nActual: " + actualTexts + ", List size: " + actualTexts.size() +
+        "\nExpected: " + expectedTexts + ", List size: " + expectedTexts.size() +
+        (explanation == null ? "" : "\nBecause: " + explanation) +
+        "\nCollection: " + collection.description());
     super.timeoutMs = timeoutMs;
   }
 }

--- a/src/test/java/com/codeborne/selenide/ModalTest.java
+++ b/src/test/java/com/codeborne/selenide/ModalTest.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.chrome.ChromeDriver;
 
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -101,7 +102,7 @@ class ModalTest {
     verify(alert).accept();
     assertThat(exception.getMessage())
       .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n")
-      .contains("Screenshot: file:" + System.getProperty("user.dir") + "/" + config.reportsFolder() + "/");
+      .contains("Screenshot: " +  convertFilePath(System.getProperty("user.dir") + "/" + config.reportsFolder() + "/"));
   }
 
   @Test
@@ -129,6 +130,14 @@ class ModalTest {
     verify(alert).dismiss();
     assertThat(exception.getMessage())
       .contains("Actual: " + ALERT_TEXT + "\nExpected: Are you sure?\n")
-      .contains("Screenshot: file:" + System.getProperty("user.dir") + "/" + config.reportsFolder() + "/");
+      .contains("Screenshot: " + convertFilePath(System.getProperty("user.dir") + "/" + config.reportsFolder() + "/"));
+  }
+
+  private String convertFilePath(String path) {
+    try {
+      return new File(path).toURI().toURL().toExternalForm();
+    } catch (MalformedURLException e) {
+      return "file://" + path;
+    }
   }
 }

--- a/src/test/java/com/codeborne/selenide/proxy/FileDownloadFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/FileDownloadFilterTest.java
@@ -99,8 +99,9 @@ class FileDownloadFilterTest implements WithAssertions {
       .isEqualTo(1);
 
     File file = filter.getDownloadedFiles().get(0).getFile();
+    File expectedFile = new File("build/downloads/random-text/report.pdf");
     assertThat(file.getName()).isEqualTo("report.pdf");
-    assertThat(file.getPath()).endsWith("build/downloads/random-text/report.pdf");
+    assertThat(file.getPath()).endsWith(expectedFile.getPath());
     assertThat(readFileToByteArray(file)).isEqualTo(new byte[]{1, 2, 3, 4, 5});
   }
 
@@ -117,8 +118,9 @@ class FileDownloadFilterTest implements WithAssertions {
     assertThat(filter.responsesAsString())
       .isEqualTo("Intercepted 1 responses:\n  #1  /foo/bar/cv.pdf?42 -> 200 \"200=success\" {} app/json  (7 bytes)\n");
     File file = filter.getDownloadedFiles().get(0).getFile();
+    File expectedFile = new File("build/downloads/random-text/cv.pdf");
     assertThat(file.getName()).isEqualTo("cv.pdf");
-    assertThat(file.getPath()).endsWith("build/downloads/random-text/cv.pdf");
+    assertThat(file.getPath()).endsWith(expectedFile.getPath());
     assertThat(readFileToString(file, UTF_8)).isEqualTo("HELLO");
   }
 }


### PR DESCRIPTION
## Proposed changes
There were issues with running tests on Windows.

TextsSizeMismatch: lineSeparator() was changed to '\n' in order to be consistent with the project (after reviewing I've noticed it was the only place with lineSeparator() method)

FileDownloadFilterTest and ModalTest had hardcoded slashes in the filepath 

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
