### PR TITLE
Add the methods to process the pseudo-elements

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -69,11 +69,11 @@
       <property name="arrayInitIndent" value="2"/>
       <property name="lineWrappingIndentation" value="2"/>
     </module>
-	
-	<module name="LineLength">
-      <property name="ignorePattern" value="^ *\* *@see.+$"/>
-      <property name="max" value="136"/>
-    </module>
+  </module>
+
+  <module name="LineLength">
+    <property name="ignorePattern" value="^ *\* *@see.+$"/>
+    <property name="max" value="136"/>
   </module>
 
   <module name="NewlineAtEndOfFile">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -69,11 +69,11 @@
       <property name="arrayInitIndent" value="2"/>
       <property name="lineWrappingIndentation" value="2"/>
     </module>
-  </module>
-
-  <module name="LineLength">
-    <property name="ignorePattern" value="^ *\* *@see.+$"/>
-    <property name="max" value="136"/>
+	
+	<module name="LineLength">
+      <property name="ignorePattern" value="^ *\* *@see.+$"/>
+      <property name="max" value="136"/>
+    </module>
   </module>
 
   <module name="NewlineAtEndOfFile">

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -19,6 +19,7 @@ import com.codeborne.selenide.conditions.MatchText;
 import com.codeborne.selenide.conditions.NamedCondition;
 import com.codeborne.selenide.conditions.Not;
 import com.codeborne.selenide.conditions.Or;
+import com.codeborne.selenide.conditions.PseudoElementPropertyWithValue;
 import com.codeborne.selenide.conditions.Selected;
 import com.codeborne.selenide.conditions.SelectedText;
 import com.codeborne.selenide.conditions.Text;
@@ -124,6 +125,30 @@ public abstract class Condition {
    */
   public static Condition value(String expectedValue) {
     return new Value(expectedValue);
+  }
+
+  /**
+   * Check that element has given the property value of the pseudo-element
+   * <p>Sample: <code>$("input").shouldHave(pseudo(":first-letter", "color", "#ff0000"));</code></p>
+   *
+   * @param pseudoElementName pseudo-element name of the element,
+   *                          ":before", ":after", ":first-letter", ":first-line", ":selection"
+   * @param propertyName property name of the pseudo-element
+   * @param expectedValue expected value of the property
+   */
+  public static Condition pseudo(String pseudoElementName, String propertyName, String expectedValue) {
+    return new PseudoElementPropertyWithValue(pseudoElementName, propertyName, expectedValue);
+  }
+
+  /**
+   * Check that element has given the "content" property of the pseudo-element
+   * <p>Sample: <code>$("input").shouldHave(pseudo(":before", "Hello"));</code></p>
+   *
+   * @param pseudoElementName pseudo-element name of the element, ":before", ":after"
+   * @param expectedValue expected content of the pseudo-element
+   */
+  public static Condition pseudo(String pseudoElementName, String expectedValue) {
+    return new PseudoElementPropertyWithValue(pseudoElementName, "content", expectedValue);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -164,6 +164,22 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   String getValue();
 
   /**
+   * Get the property value of the pseudo-element
+   * @param pseudoElementName pseudo-element name of the element,
+   *                          ":before", ":after", ":first-letter", ":first-line", ":selection"
+   * @param propertyName property name of the pseudo-element
+   * @return the property value or "" if the property is missing
+   */
+  String pseudo(String pseudoElementName, String propertyName);
+
+  /**
+   * Get content of the pseudo-element
+   * @param pseudoElementName pseudo-element name of the element, ":before", ":after"
+   * @return the content value or "none" if the content is missing
+   */
+  String pseudo(String pseudoElementName);
+
+  /**
    * Select radio button
    * @param value value of radio button to select
    * @return selected "input type=radio" element

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -67,6 +67,7 @@ public class Commands {
     add("name", new GetName());
     add("text", new GetText());
     add("getValue", new GetValue());
+    add("pseudo", new GetPseudoValue());
   }
 
   private void addClickCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/GetPseudoValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetPseudoValue.java
@@ -1,0 +1,20 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+public class GetPseudoValue implements Command<String> {
+
+  static final String JS_CODE = "return window.getComputedStyle(arguments[0], arguments[1])" +
+    ".getPropertyValue(arguments[2]);";
+
+  @Override
+  public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    if (args.length > 1) {
+      return locator.driver().executeJavaScript(JS_CODE, locator.getWebElement(), args[0], args[1]);
+    }
+
+    return locator.driver().executeJavaScript(JS_CODE, locator.getWebElement(), args[0], "content");
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValue.java
@@ -1,0 +1,47 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Driver;
+import org.openqa.selenium.WebElement;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.defaultString;
+
+public class PseudoElementPropertyWithValue extends Condition {
+
+  static final String JS_CODE = "return window.getComputedStyle(arguments[0], arguments[1])" +
+    ".getPropertyValue(arguments[2]);";
+
+  private final String pseudoElementName;
+  private final String propertyName;
+  private final String expectedPropertyValue;
+
+  public PseudoElementPropertyWithValue(String pseudoElementName, String propertyName, String expectedPropertyValue) {
+    super("pseudo-element");
+    this.pseudoElementName = pseudoElementName;
+    this.propertyName = propertyName;
+    this.expectedPropertyValue = expectedPropertyValue;
+  }
+
+  @Override
+  public boolean apply(Driver driver, WebElement element) {
+    return defaultString(expectedPropertyValue)
+      .equalsIgnoreCase(getPseudoElementPropertyValue(driver, element));
+  }
+
+  @Override
+  public String actualValue(Driver driver, WebElement element) {
+    return String.format("%s {%s: %s;}", pseudoElementName, propertyName,
+      getPseudoElementPropertyValue(driver, element));
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s %s {%s: %s;}", getName(), pseudoElementName, propertyName, expectedPropertyValue);
+  }
+
+  private String getPseudoElementPropertyValue(Driver driver, WebElement element) {
+    String propertyValue = driver.executeJavaScript(JS_CODE, element, pseudoElementName, propertyName);
+    return propertyValue == null ? EMPTY : propertyValue;
+  }
+}

--- a/src/test/java/com/codeborne/selenide/commands/GetPseudoValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetPseudoValueCommandTest.java
@@ -1,0 +1,41 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GetPseudoValueCommandTest implements WithAssertions {
+
+  private static final String PSEUDO_ELEMENT_NAME = ":before";
+  private static final String PROPERTY_NAME = "content";
+  private static final String ACTUAL_VALUE = "hello";
+
+  private SelenideElement proxy;
+  private WebElementSource locator;
+
+  @BeforeEach
+  void setup() {
+    proxy = mock(SelenideElement.class);
+    locator = mock(WebElementSource.class);
+    WebElement element = mock(WebElement.class);
+    Driver driver = mock(Driver.class);
+
+    when(locator.driver()).thenReturn(driver);
+    when(locator.getWebElement()).thenReturn(element);
+    when(driver.executeJavaScript(GetPseudoValue.JS_CODE, element, PSEUDO_ELEMENT_NAME, PROPERTY_NAME))
+      .thenReturn(ACTUAL_VALUE);
+  }
+
+  @Test
+  void testExecuteMethod() {
+    assertThat(new GetPseudoValue().execute(proxy, locator, new Object[]{PSEUDO_ELEMENT_NAME, PROPERTY_NAME}))
+      .isEqualTo(ACTUAL_VALUE);
+  }
+}

--- a/src/test/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValueTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValueTest.java
@@ -1,0 +1,48 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PseudoElementPropertyWithValueTest {
+
+  private static final String PSEUDO_ELEMENT_NAME = ":before";
+  private static final String PROPERTY_NAME = "content";
+  private static final String ACTUAL_VALUE = "hello";
+
+  private Driver driver = mock(Driver.class);
+  private WebElement element = mock(WebElement.class);
+
+  @BeforeEach
+  void setUp() {
+    when(driver.executeJavaScript(PseudoElementPropertyWithValue.JS_CODE, element, PSEUDO_ELEMENT_NAME, PROPERTY_NAME))
+      .thenReturn(ACTUAL_VALUE);
+  }
+
+  @Test
+  void apply() {
+    assertThat(new PseudoElementPropertyWithValue(PSEUDO_ELEMENT_NAME, PROPERTY_NAME, ACTUAL_VALUE)
+      .apply(driver, element)).isTrue();
+    assertThat(new PseudoElementPropertyWithValue(PSEUDO_ELEMENT_NAME, PROPERTY_NAME, "Hello")
+      .apply(driver, element)).isTrue();
+    assertThat(new PseudoElementPropertyWithValue(PSEUDO_ELEMENT_NAME, PROPERTY_NAME, "dummy")
+      .apply(driver, element)).isFalse();
+  }
+
+  @Test
+  void actualValue() {
+    assertThat(new PseudoElementPropertyWithValue(PSEUDO_ELEMENT_NAME, PROPERTY_NAME, ACTUAL_VALUE)
+      .actualValue(driver, element)).isEqualTo(":before {content: hello;}");
+  }
+
+  @Test
+  void tostring() {
+    assertThat(new PseudoElementPropertyWithValue(PSEUDO_ELEMENT_NAME, PROPERTY_NAME, ACTUAL_VALUE))
+      .hasToString("pseudo-element :before {content: hello;}");
+  }
+}

--- a/src/test/java/integration/PseudoTest.java
+++ b/src/test/java/integration/PseudoTest.java
@@ -1,0 +1,50 @@
+package integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.pseudo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PseudoTest extends ITest {
+
+  private static final String LOCATOR_H1 = "h1";
+  private static final String LOCATOR_H2 = "h2";
+  private static final String LOCATOR_ABBR = "abbr";
+  private static final String LOCATOR_P = "p";
+
+  private static final String PSEUDO_FIRST_LETTER = ":first-letter";
+  private static final String PSEUDO_BEFORE = ":before";
+  private static final String PSEUDO_AFTER = ":after";
+
+  private static final String PROPERTY_COLOR = "color";
+  private static final String PROPERTY_CONTENT = "content";
+
+  private static final String COLOR_RED = "rgb(255, 0, 0)";
+  private static final String CONTENT_EXPECTED_VALUE = "\"beforeContent\"";
+  private static final String CONTENT_NO_VALUE = "none";
+
+  @BeforeEach
+  void openTestPage() {
+    openFile("page_with_pseudo_elements.html");
+  }
+
+  @Test
+  void shouldHavePseudo() {
+    $(LOCATOR_H1).shouldHave(pseudo(PSEUDO_FIRST_LETTER, PROPERTY_COLOR, COLOR_RED));
+    $(LOCATOR_H2).shouldNotHave(pseudo(PSEUDO_FIRST_LETTER, PROPERTY_COLOR, COLOR_RED));
+    $(LOCATOR_ABBR).shouldHave(pseudo(PSEUDO_BEFORE, PROPERTY_CONTENT, CONTENT_EXPECTED_VALUE));
+    $(LOCATOR_P).shouldNotHave(pseudo(PSEUDO_BEFORE, PROPERTY_CONTENT, CONTENT_EXPECTED_VALUE));
+    $(LOCATOR_ABBR).shouldHave(pseudo(PSEUDO_BEFORE, CONTENT_EXPECTED_VALUE));
+    $(LOCATOR_P).shouldNotHave(pseudo(PSEUDO_BEFORE, CONTENT_EXPECTED_VALUE));
+  }
+
+  @Test
+  void getPseudo() {
+    assertThat($(LOCATOR_H1).pseudo(PSEUDO_FIRST_LETTER, PROPERTY_COLOR)).isEqualTo(COLOR_RED);
+    assertThat($(LOCATOR_ABBR).pseudo(PSEUDO_BEFORE, PROPERTY_CONTENT)).isEqualTo(CONTENT_EXPECTED_VALUE);
+    assertThat($(LOCATOR_P).pseudo(PSEUDO_AFTER, PROPERTY_CONTENT)).isEqualTo(CONTENT_NO_VALUE);
+    assertThat($(LOCATOR_ABBR).pseudo(PSEUDO_BEFORE)).isEqualTo(CONTENT_EXPECTED_VALUE);
+    assertThat($(LOCATOR_P).pseudo(PSEUDO_AFTER)).isEqualTo(CONTENT_NO_VALUE);
+  }
+}

--- a/src/test/resources/page_with_pseudo_elements.html
+++ b/src/test/resources/page_with_pseudo_elements.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Test page :: pseudo-elements</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+  <style type="text/css">
+    h1::first-letter {color: #ff0000;}
+    abbr::before {content: 'beforeContent'; color: blue;}
+  </style>
+</head>
+<body>
+  <h1>H1 - Hello World!</h1>
+  <h2>H2 - Hello World!</h2>
+  <p>The <abbr title="World Wide Web">WWW</abbr> was invented in 1989.</p>
+</body>
+</html>


### PR DESCRIPTION
## Proposed changes
Added processing the pseudo-elements in Commands and Conditions - #994:
- Condition.pseudo(String pseudoElementName, String propertyName, String expectedValue);
- Condition.pseudo(String pseudoElementName, String expectedValue);
- SelenideElement.pseudo(String pseudoElementName, String propertyName);
- SelenideElement.pseudo(String pseudoElementName);

~~Fixed checkstyle.xml:~~
~~- "LineLength" module was moved from "Checker" to "TreeWalker" module.~~

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
