### PR TITLE
Fix Screenshots 

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/Screenshots.java
+++ b/statics/src/main/java/com/codeborne/selenide/Screenshots.java
@@ -10,7 +10,7 @@ import java.util.List;
 import static com.codeborne.selenide.WebDriverRunner.driver;
 
 public class Screenshots {
-  public static ScreenShotLaboratory screenshots = new ScreenShotLaboratory();
+  public static ScreenShotLaboratory screenshots = ScreenShotLaboratory.getInstance();
 
   public static String takeScreenShot(String className, String methodName) {
     return screenshots.takeScreenShot(driver(), className, methodName);


### PR DESCRIPTION
## Proposed changes
Fix concurrent problem when using Selenide + TestNg with ScreenShooter listener(related to [814](https://github.com/selenide/selenide/issues/814) ). To Screenshots field screenshots - was assigned new instance of ScreenShotLaboratory, that produce bug in ScreenShooter listener, finishContext() always returns empty List, because currentContextScreenshots - always was null when was started by method Screenshots. startContext(String className, String methodName).
Also if ScreenShotLaboratory planned to be used as Singleton, default Contstructor must be private. To avoid similar bugs in future

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
