### PR TITLE
Added overloaded window() methods with custom timeout

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
+++ b/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
@@ -14,6 +14,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -194,6 +195,20 @@ public class SelenideTargetLocator implements TargetLocator {
   }
 
   /**
+   * Switch to window/tab by index with a configurable timeout
+   * NB! Order of windows/tabs can be different in different browsers, see Selenide tests.
+   * @param index index of window (0-based)
+   * @param duration the timeout duration. It overrides default Config.timeout()
+   */
+  public WebDriver window(int index, Duration duration) {
+    try {
+      return Wait(duration).until(windowToBeAvailableAndSwitchToIt(index));
+    } catch (TimeoutException e) {
+      throw new NoSuchWindowException("No window found with index: " + index, e);
+    }
+  }
+
+  /**
    * Switch to window/tab by name/handle/title
    * @param nameOrHandleOrTitle name or handle or title of window/tab
    */
@@ -201,6 +216,19 @@ public class SelenideTargetLocator implements TargetLocator {
   public WebDriver window(String nameOrHandleOrTitle) {
     try {
       return Wait().until(windowToBeAvailableAndSwitchToIt(nameOrHandleOrTitle));
+    } catch (TimeoutException e) {
+      throw new NoSuchWindowException("No window found with name or handle or title: " + nameOrHandleOrTitle, e);
+    }
+  }
+
+  /**
+   * Switch to window/tab by name/handle/title with a configurable timeout
+   * @param nameOrHandleOrTitle name or handle or title of window/tab
+   * @param duration the timeout duration. It overrides default Config.timeout()
+   */
+  public WebDriver window(String nameOrHandleOrTitle, Duration duration) {
+    try {
+      return Wait(duration).until(windowToBeAvailableAndSwitchToIt(nameOrHandleOrTitle));
     } catch (TimeoutException e) {
       throw new NoSuchWindowException("No window found with name or handle or title: " + nameOrHandleOrTitle, e);
     }
@@ -224,5 +252,9 @@ public class SelenideTargetLocator implements TargetLocator {
 
   private SelenideWait Wait() {
     return new SelenideWait(webDriver, config.timeout(), config.pollingInterval());
+  }
+
+  private SelenideWait Wait(Duration timeout) {
+    return new SelenideWait(webDriver, timeout.toMillis(), config.pollingInterval());
   }
 }

--- a/src/test/java/integration/TabsCustomWaitTest.java
+++ b/src/test/java/integration/TabsCustomWaitTest.java
@@ -1,0 +1,44 @@
+package integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchWindowException;
+
+import java.time.Duration;
+
+import static com.codeborne.selenide.Condition.text;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TabsCustomWaitTest extends ITest {
+  @BeforeEach
+  void setUp() {
+    openFile("page_with_tabs_with_big_delays.html");
+  }
+
+  @Test
+  void waitsUntilTabAppears_withCustomTimeout() {
+    $("#open-new-tab-with-delay").click();
+    switchTo().window("Test::alerts", Duration.ofSeconds(5));
+    $("h1").shouldHave(text("Page with alerts"));
+  }
+
+  @Test
+  void waitsUntilTabAppears_withoutCustomTimeout() {
+    $("#open-new-tab-with-delay").click();
+    assertThatThrownBy(() -> switchTo().window(1))
+      .isInstanceOf(NoSuchWindowException.class);
+  }
+
+  @Test
+  void waitsUntilTabAppears_withLowerTimeout() {
+    $("#open-new-tab-with-delay").click();
+    assertThatThrownBy(() -> switchTo().window(1, Duration.ofSeconds(1)))
+      .isInstanceOf(NoSuchWindowException.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    driver().close();
+  }
+}

--- a/src/test/resources/page_with_tabs_with_big_delays.html
+++ b/src/test/resources/page_with_tabs_with_big_delays.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Test::tabs with delays</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <script type="text/javascript">
+      function openNewTabWithDelay() {
+        setTimeout(openNewTab, 5000);
+      }
+
+      function openNewTab() {
+        document.getElementById('open-new-tab').click();
+      }
+
+  </script>
+</head>
+<body>
+<h1>New tab will appear soon</h1>
+
+<a id="open-new-tab-with-delay" href="javascript:openNewTabWithDelay();">open new tab after 5 seconds</a>
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+<a id="open-new-tab" target="_blank" href="page_with_alerts.html">open new tab</a>
+</body>
+</html>


### PR DESCRIPTION
## Proposed changes
Add possibility to wait for tab/window with a custom timeout.

Feature request #399

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
