### PR TITLE
Custom condition

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.collections.AllMatch;
 import com.codeborne.selenide.collections.AnyMatch;
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.collections.ListSize;
@@ -110,10 +111,19 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    *
    * @param description The description of the given predicate
    * @param predicate   the {@link java.util.function.Predicate} to match
-   * @return
    */
   public static CollectionCondition anyMatch(String description, java.util.function.Predicate<WebElement> predicate) {
     return new AnyMatch(description, predicate);
+  }
+
+  /**
+   * Checks if ALL elements of this collection match the provided predicate
+   *
+   * @param description The description of the given predicate
+   * @param predicate   the {@link java.util.function.Predicate} to match
+   */
+  public static CollectionCondition allMatch(String description, java.util.function.Predicate<WebElement> predicate) {
+    return new AllMatch(description, predicate);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.collections.AllMatch;
 import com.codeborne.selenide.collections.AnyMatch;
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.collections.ListSize;
+import com.codeborne.selenide.collections.NoneMatch;
 import com.codeborne.selenide.collections.SizeGreaterThan;
 import com.codeborne.selenide.collections.SizeGreaterThanOrEqual;
 import com.codeborne.selenide.collections.SizeLessThan;
@@ -124,6 +125,16 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    */
   public static CollectionCondition allMatch(String description, java.util.function.Predicate<WebElement> predicate) {
     return new AllMatch(description, predicate);
+  }
+
+  /**
+   * Checks if NONE elements of this collection match the provided predicate
+   *
+   * @param description The description of the given predicate
+   * @param predicate   the {@link java.util.function.Predicate} to match
+   */
+  public static CollectionCondition noneMatch(String description, java.util.function.Predicate<WebElement> predicate) {
+    return new NoneMatch(description, predicate);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.collections.AnyMatch;
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.collections.ListSize;
 import com.codeborne.selenide.collections.SizeGreaterThan;
@@ -102,6 +103,17 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    */
   public static CollectionCondition exactTexts(List<String> expectedTexts) {
     return new ExactTexts(expectedTexts);
+  }
+
+  /**
+   * Checks if ANY elements of this collection match the provided predicate
+   *
+   * @param description The description of the given predicate
+   * @param predicate   the {@link java.util.function.Predicate} to match
+   * @return
+   */
+  public static CollectionCondition anyMatch(String description, java.util.function.Predicate<WebElement> predicate) {
+    return new AnyMatch(description, predicate);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -7,6 +7,7 @@ import com.codeborne.selenide.conditions.CaseSensitiveText;
 import com.codeborne.selenide.conditions.Checked;
 import com.codeborne.selenide.conditions.CssClass;
 import com.codeborne.selenide.conditions.CssValue;
+import com.codeborne.selenide.conditions.CustomMatch;
 import com.codeborne.selenide.conditions.Disabled;
 import com.codeborne.selenide.conditions.Enabled;
 import com.codeborne.selenide.conditions.ExactText;
@@ -25,6 +26,8 @@ import com.codeborne.selenide.conditions.Text;
 import com.codeborne.selenide.conditions.Value;
 import com.codeborne.selenide.conditions.Visible;
 import org.openqa.selenium.WebElement;
+
+import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 
@@ -282,6 +285,18 @@ public abstract class Condition {
   }
 
   /**
+   * Checks if element matches the given predicate.
+   *
+   * <p>Sample: {@code $("input").should(match("empty value attribute", el -> el.getAttribute("value").isEmpty()));}</p>
+   *
+   * @param description the description of the predicate
+   * @param predicate   the {@link Predicate} to match
+   */
+  public static Condition match(String description, Predicate<WebElement> predicate) {
+    return new CustomMatch(description, predicate);
+  }
+
+  /**
    * Check if browser focus is currently in given element.
    */
   public static final Condition focused = new Focused();
@@ -328,7 +343,7 @@ public abstract class Condition {
   /**
    * Check if element matches ALL given conditions.
    *
-   * @param name      Name of this condition, like "empty" (meaning e.g. empty text AND empty value).
+   * @param name       Name of this condition, like "empty" (meaning e.g. empty text AND empty value).
    * @param conditions Conditions to match.
    * @return logical AND for given conditions.
    */
@@ -339,7 +354,7 @@ public abstract class Condition {
   /**
    * Check if element matches ANY of given conditions.
    *
-   * @param name      Name of this condition, like "error" (meaning e.g. "error" OR "failed").
+   * @param name       Name of this condition, like "error" (meaning e.g. "error" OR "failed").
    * @param conditions Conditions to match.
    * @return logical OR for given conditions.
    */

--- a/src/main/java/com/codeborne/selenide/collections/AllMatch.java
+++ b/src/main/java/com/codeborne/selenide/collections/AllMatch.java
@@ -1,0 +1,50 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.MatcherError;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class AllMatch extends CollectionCondition {
+  private static final String MATCHER = "all";
+  protected final String description;
+  protected final Predicate<WebElement> predicate;
+
+  public AllMatch(String description, Predicate<WebElement> predicate) {
+    this.description = description;
+    this.predicate = predicate;
+  }
+
+  @Override
+  public boolean apply(List<WebElement> elements) {
+    if (elements.isEmpty()) {
+      return false;
+    }
+    return elements.stream().allMatch(predicate);
+  }
+
+  @Override
+  public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
+    if (elements == null || elements.isEmpty()) {
+      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
+      elementNotFound.timeoutMs = timeoutMs;
+      throw elementNotFound;
+    } else {
+      throw new MatcherError(MATCHER, description, explanation, collection, elements, lastError, timeoutMs);
+    }
+  }
+
+  @Override
+  public boolean applyNull() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s match [%s] predicate", MATCHER, description);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/collections/AnyMatch.java
+++ b/src/main/java/com/codeborne/selenide/collections/AnyMatch.java
@@ -1,0 +1,47 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.MatcherError;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class AnyMatch extends CollectionCondition {
+  private static final String MATCHER = "any";
+  protected final String description;
+  protected final Predicate<WebElement> predicate;
+
+  public AnyMatch(String description, Predicate<WebElement> predicate) {
+    this.description = description;
+    this.predicate = predicate;
+  }
+
+  @Override
+  public boolean apply(List<WebElement> elements) {
+    return elements.stream().anyMatch(predicate);
+  }
+
+  @Override
+  public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
+    if (elements == null || elements.isEmpty()) {
+      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
+      elementNotFound.timeoutMs = timeoutMs;
+      throw elementNotFound;
+    } else {
+      throw new MatcherError(MATCHER, description, explanation, collection, elements, lastError, timeoutMs);
+    }
+  }
+
+  @Override
+  public boolean applyNull() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s match [%s] predicate", MATCHER, description);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/collections/NoneMatch.java
+++ b/src/main/java/com/codeborne/selenide/collections/NoneMatch.java
@@ -1,0 +1,50 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.MatcherError;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class NoneMatch extends CollectionCondition {
+  private static final String MATCHER = "none";
+  protected final String description;
+  protected final Predicate<WebElement> predicate;
+
+  public NoneMatch(String description, Predicate<WebElement> predicate) {
+    this.description = description;
+    this.predicate = predicate;
+  }
+
+  @Override
+  public boolean apply(List<WebElement> elements) {
+    if (elements.isEmpty()) {
+      return false;
+    }
+    return elements.stream().noneMatch(predicate);
+  }
+
+  @Override
+  public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
+    if (elements == null || elements.isEmpty()) {
+      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
+      elementNotFound.timeoutMs = timeoutMs;
+      throw elementNotFound;
+    } else {
+      throw new MatcherError(MATCHER, description, explanation, collection, elements, lastError, timeoutMs);
+    }
+  }
+
+  @Override
+  public boolean applyNull() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s match [%s] predicate", MATCHER, description);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/CustomMatch.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CustomMatch.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Driver;
+import org.openqa.selenium.WebElement;
+
+import java.util.function.Predicate;
+
+public class CustomMatch extends Condition {
+  protected final Predicate<WebElement> predicate;
+
+  public CustomMatch(String description, final Predicate<WebElement> predicate) {
+    super(description);
+    this.predicate = predicate;
+  }
+
+  @Override
+  public boolean apply(Driver driver, WebElement element) {
+    return predicate.test(element);
+  }
+
+
+  @Override
+  public String toString() {
+    return String.format("match '%s' predicate but did not.", getName());
+  }
+
+}

--- a/src/main/java/com/codeborne/selenide/conditions/CustomMatch.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CustomMatch.java
@@ -22,7 +22,7 @@ public class CustomMatch extends Condition {
 
   @Override
   public String toString() {
-    return String.format("match '%s' predicate but did not.", getName());
+    return String.format("match '%s' predicate.", getName());
   }
 
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
@@ -29,4 +29,10 @@ public class ElementNotFound extends UIAssertionError {
       "Element not found {" + collection.description() + '}' +
         "\nExpected: " + expectedTexts, lastError);
   }
+
+  public ElementNotFound(WebElementsCollection collection, String description, Throwable lastError) {
+    super(collection.driver(),
+      "Element not found {" + collection.description() + '}' +
+        "\nExpected: " + description, lastError);
+  }
 }

--- a/src/main/java/com/codeborne/selenide/ex/MatcherError.java
+++ b/src/main/java/com/codeborne/selenide/ex/MatcherError.java
@@ -1,0 +1,24 @@
+package com.codeborne.selenide.ex;
+
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static com.codeborne.selenide.ElementsCollection.elementsToString;
+
+public class MatcherError extends UIAssertionError {
+
+  public MatcherError(String matcher, String predicateDescription, String explanation,
+                      WebElementsCollection collection, List<WebElement> actualElements, Exception lastError, long timeoutMs) {
+    super(collection.driver(),
+      "Collection matcher error" +
+        "\nExpected: " + matcher + " of elements to match [" + predicateDescription + "] predicate" +
+        (explanation == null ? "" : "\nBecause: " + explanation) +
+        "\nCollection: " + collection.description() +
+        "\nElements: " + elementsToString(collection.driver(), actualElements), lastError
+    );
+    super.timeoutMs = timeoutMs;
+  }
+
+}

--- a/src/test/java/com/codeborne/selenide/collections/AllMatchTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/AllMatchTest.java
@@ -1,0 +1,69 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.MatcherError;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static java.util.Collections.emptyList;
+
+class AllMatchTest implements WithAssertions {
+  private SelenideElement element1 = mockElement("Test-One");
+  private SelenideElement element2 = mockElement("Test-Two");
+  private SelenideElement element3 = mockElement("Test-Three");
+  private WebElementsCollection collection = mockCollection("Collection description", element1, element2, element3);
+
+  @Test
+  void applyWithEmptyList() {
+    assertThat(new AllMatch("Predicate description", it -> it.getText().equals("EmptyList"))
+      .apply(mockCollection("Collection description").getElements()))
+      .isFalse();
+  }
+
+  @Test
+  void applyWithNonMatchingPredicate() {
+    assertThat(new AllMatch("Predicate description", it -> it.getText().equals("NotPresent"))
+      .apply(collection.getElements()))
+      .isFalse();
+  }
+
+  @Test
+  void applyWithMatchingPredicate() {
+    assertThat(new AllMatch("Predicate description", it -> it.getText().contains("Test"))
+      .apply(collection.getElements()))
+      .isTrue();
+  }
+
+  @Test
+  void failOnMatcherError() {
+    assertThatThrownBy(() ->
+      new AllMatch("Predicate description", it -> it.getText().contains("Foo"))
+        .fail(collection,
+          collection.getElements(),
+          new Exception("Exception message"), 10000))
+      .isInstanceOf(MatcherError.class)
+      .hasMessageStartingWith("Collection matcher error" +
+        "\nExpected: all of elements to match [Predicate description] predicate" +
+        "\nCollection: Collection description");
+  }
+
+  @Test
+  void failOnEmptyCollection() {
+    assertThatThrownBy(() ->
+      new AllMatch("Predicate description", it -> it.getText().equals("Test"))
+        .fail(mockCollection("Collection description"),
+          emptyList(),
+          new Exception("Exception message"), 10000))
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void testToString() {
+    assertThat(new AllMatch("Predicate description", it -> true))
+      .hasToString("all match [Predicate description] predicate");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/collections/AnyMatchTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/AnyMatchTest.java
@@ -1,0 +1,72 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.MatcherError;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+class AnyMatchTest implements WithAssertions {
+  private SelenideElement element1 = mockElement("Hello");
+  private SelenideElement element2 = mockElement("World");
+
+  @Test
+  void applyWithEmptyList() {
+    assertThat(new AnyMatch("Predicate description", it -> it.getText().equals("World"))
+      .apply(mockCollection("Collection description").getElements()))
+      .isFalse();
+  }
+
+  @Test
+  void applyWithNonMatchingPredicate() {
+    assertThat(new AnyMatch("Predicate description", it -> it.getText().equals("World"))
+      .apply(singletonList(element1)))
+      .isFalse();
+  }
+
+  @Test
+  void applyWithMatchingPredicate() {
+    WebElementsCollection collection = mockCollection("Collection description", element1, element2);
+
+    assertThat(new AnyMatch("Predicate description", it -> it.getText().equals("World"))
+      .apply(collection.getElements()))
+      .isTrue();
+  }
+
+  @Test
+  void failOnMatcherError() {
+    WebElementsCollection collection = mockCollection("Collection description");
+
+    assertThatThrownBy(() ->
+      new AnyMatch("Predicate description", it -> it.getText().equals("World"))
+        .fail(collection,
+          singletonList(element1),
+          new Exception("Exception message"), 10000))
+      .isInstanceOf(MatcherError.class)
+      .hasMessageStartingWith("Collection matcher error" +
+        "\nExpected: any of elements to match [Predicate description] predicate" +
+        "\nCollection: Collection description");
+  }
+
+  @Test
+  void failOnEmptyCollection() {
+    assertThatThrownBy(() ->
+      new AnyMatch("Predicate description", it -> it.getText().equals("World"))
+        .fail(mockCollection("Collection description"),
+          emptyList(),
+          new Exception("Exception message"), 10000))
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void testToString() {
+    assertThat(new AnyMatch("Predicate description", it -> true))
+      .hasToString("any match [Predicate description] predicate");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/collections/NoneMatchTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/NoneMatchTest.java
@@ -1,0 +1,69 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.MatcherError;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static java.util.Collections.emptyList;
+
+class NoneMatchTest implements WithAssertions {
+  private SelenideElement element1 = mockElement("Test-One");
+  private SelenideElement element2 = mockElement("Test-Two");
+  private SelenideElement element3 = mockElement("Test-Three");
+  private WebElementsCollection collection = mockCollection("Collection description", element1, element2, element3);
+
+  @Test
+  void applyWithEmptyList() {
+    assertThat(new NoneMatch("Predicate description", it -> it.getText().equals("EmptyList"))
+      .apply(mockCollection("Collection description").getElements()))
+      .isFalse();
+  }
+
+  @Test
+  void applyWithMatchingPredicate() {
+    assertThat(new NoneMatch("Predicate description", it -> it.getText().contains("Test"))
+      .apply(collection.getElements()))
+      .isFalse();
+  }
+
+  @Test
+  void applyWithNonMatchingPredicate() {
+    assertThat(new NoneMatch("Predicate description", it -> it.getText().equals("NotPresent"))
+      .apply(collection.getElements()))
+      .isTrue();
+  }
+
+  @Test
+  void failOnEmptyCollection() {
+    assertThatThrownBy(() ->
+      new NoneMatch("Predicate description", it -> it.getText().equals("Test"))
+        .fail(mockCollection("Collection description"),
+          emptyList(),
+          new Exception("Exception message"), 10000))
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void failOnMatcherError() {
+    assertThatThrownBy(() ->
+      new NoneMatch("Predicate description", it -> it.getText().contains("One"))
+        .fail(collection,
+          collection.getElements(),
+          new Exception("Exception message"), 10000))
+      .isInstanceOf(MatcherError.class)
+      .hasMessageStartingWith("Collection matcher error" +
+        "\nExpected: none of elements to match [Predicate description] predicate" +
+        "\nCollection: Collection description");
+  }
+
+  @Test
+  void testToString() {
+    assertThat(new NoneMatch("Predicate description", it -> true))
+      .hasToString("none match [Predicate description] predicate");
+  }
+}

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -21,6 +21,7 @@ import static com.codeborne.selenide.CollectionCondition.allMatch;
 import static com.codeborne.selenide.CollectionCondition.anyMatch;
 import static com.codeborne.selenide.CollectionCondition.empty;
 import static com.codeborne.selenide.CollectionCondition.exactTexts;
+import static com.codeborne.selenide.CollectionCondition.noneMatch;
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
@@ -434,4 +435,21 @@ class CollectionMethodsTest extends ITest {
       .hasMessageContaining("Collection matcher error" +
         "\nExpected: all of elements to match [value==cat] predicate");
   }
+
+  @Test
+  void shouldNoneMatchPredicate() {
+    $$("#radioButtons input")
+      .shouldBe(noneMatch("name==you",
+        el -> el.getAttribute("name").equals("you")));
+  }
+
+  @Test
+  void errorWhenSomeMatchedButNoneShould() {
+    assertThatThrownBy(() -> $$("#radioButtons input").shouldBe(noneMatch("value==cat",
+      el -> el.getAttribute("value").equals("cat"))))
+      .isInstanceOf(MatcherError.class)
+      .hasMessageContaining("Collection matcher error" +
+        "\nExpected: none of elements to match [value==cat] predicate");
+  }
+
 }

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Collectors;
 
+import static com.codeborne.selenide.CollectionCondition.allMatch;
 import static com.codeborne.selenide.CollectionCondition.anyMatch;
 import static com.codeborne.selenide.CollectionCondition.empty;
 import static com.codeborne.selenide.CollectionCondition.exactTexts;
@@ -403,18 +404,34 @@ class CollectionMethodsTest extends ITest {
   }
 
   @Test
-  void shouldMatchPredicate() {
+  void shouldAnyMatchPredicate() {
     $$("#radioButtons input")
       .shouldBe(anyMatch("value==cat",
         el -> el.getAttribute("value").equals("cat")));
   }
 
   @Test
-  void errorWhenPredicateNotMatchedButShouldBe() {
+  void errorWhenAnyNotMatchedButShouldBe() {
     assertThatThrownBy(() -> $$("#radioButtons input").shouldBe(anyMatch("value==cat",
-        el -> el.getAttribute("value").equals("dog"))))
+      el -> el.getAttribute("value").equals("dog"))))
       .isInstanceOf(MatcherError.class)
       .hasMessageContaining("Collection matcher error" +
         "\nExpected: any of elements to match [value==cat] predicate");
+  }
+
+  @Test
+  void shouldAllMatchPredicate() {
+    $$("#radioButtons input")
+      .shouldBe(allMatch("name==me",
+        el -> el.getAttribute("name").equals("me")));
+  }
+
+  @Test
+  void errorWhenAllNotMatchedButShouldBe() {
+    assertThatThrownBy(() -> $$("#radioButtons input").shouldBe(allMatch("value==cat",
+      el -> el.getAttribute("value").equals("cat"))))
+      .isInstanceOf(MatcherError.class)
+      .hasMessageContaining("Collection matcher error" +
+        "\nExpected: all of elements to match [value==cat] predicate");
   }
 }

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -3,6 +3,7 @@ package integration;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.MatcherError;
 import com.codeborne.selenide.ex.TextsMismatch;
 import com.codeborne.selenide.ex.TextsSizeMismatch;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Collectors;
 
+import static com.codeborne.selenide.CollectionCondition.anyMatch;
 import static com.codeborne.selenide.CollectionCondition.empty;
 import static com.codeborne.selenide.CollectionCondition.exactTexts;
 import static com.codeborne.selenide.CollectionCondition.size;
@@ -398,5 +400,21 @@ class CollectionMethodsTest extends ITest {
   @Test
   void shouldHaveZeroSizeWhenFindCollectionInLastElementOfFullCollection() {
     $$("#user-table td").last().$$("#not_exist").shouldHaveSize(0);
+  }
+
+  @Test
+  void shouldMatchPredicate() {
+    $$("#radioButtons input")
+      .shouldBe(anyMatch("value==cat",
+        el -> el.getAttribute("value").equals("cat")));
+  }
+
+  @Test
+  void errorWhenPredicateNotMatchedButShouldBe() {
+    assertThatThrownBy(() -> $$("#radioButtons input").shouldBe(anyMatch("value==cat",
+        el -> el.getAttribute("value").equals("dog"))))
+      .isInstanceOf(MatcherError.class)
+      .hasMessageContaining("Collection matcher error" +
+        "\nExpected: any of elements to match [value==cat] predicate");
   }
 }

--- a/src/test/java/integration/ConditionsTest.java
+++ b/src/test/java/integration/ConditionsTest.java
@@ -5,16 +5,7 @@ import com.codeborne.selenide.ex.ElementShould;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Condition.and;
-import static com.codeborne.selenide.Condition.attribute;
-import static com.codeborne.selenide.Condition.be;
-import static com.codeborne.selenide.Condition.cssClass;
-import static com.codeborne.selenide.Condition.disabled;
-import static com.codeborne.selenide.Condition.have;
-import static com.codeborne.selenide.Condition.hidden;
-import static com.codeborne.selenide.Condition.or;
-import static com.codeborne.selenide.Condition.text;
-import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Condition.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConditionsTest extends ITest {
@@ -75,5 +66,29 @@ class ConditionsTest extends ITest {
 
     Condition none_of_conditions = or("baskerville", text("pasker"), text("wille"));
     $("#baskerville").shouldNotBe(none_of_conditions);
+  }
+
+
+  @Test
+  void matchWithCustomPredicateShouldCheckCondition() {
+    $("#multirowTable").should(match("border=1", el -> el.getAttribute("border").equals("1")));
+  }
+
+  @Test
+  void matchWithPredicateShouldReportErrorMessage() {
+    assertThatThrownBy(() ->
+      $("#multirowTable").should(match("tag=input", el -> el.getTagName().equals("input1")))
+    )
+      .hasMessageStartingWith(
+        "Element should match 'tag=input' predicate. {#multirowTable}");
+  }
+
+  @Test
+  void matchWithShouldNotPredicateReportErrorMessage() {
+    assertThatThrownBy(() ->
+      $("#multirowTable").shouldNot(match("border=1", el -> el.getAttribute("border").equals("1")))
+    )
+      .hasMessageStartingWith(
+        "Element should not match 'border=1' predicate. {#multirowTable}");
   }
 }

--- a/src/test/java/integration/ConditionsTest.java
+++ b/src/test/java/integration/ConditionsTest.java
@@ -5,7 +5,17 @@ import com.codeborne.selenide.ex.ElementShould;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Condition.*;
+import static com.codeborne.selenide.Condition.and;
+import static com.codeborne.selenide.Condition.attribute;
+import static com.codeborne.selenide.Condition.be;
+import static com.codeborne.selenide.Condition.cssClass;
+import static com.codeborne.selenide.Condition.disabled;
+import static com.codeborne.selenide.Condition.have;
+import static com.codeborne.selenide.Condition.hidden;
+import static com.codeborne.selenide.Condition.match;
+import static com.codeborne.selenide.Condition.or;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConditionsTest extends ITest {


### PR DESCRIPTION
## Proposed changes
Added possibility to make checks with a custom predicate.

Example:

`$("#element").should(match("tag=input", el -> el.getTagName().equals("input"))`

If resolves a feature request #662 

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
