### PR TITLE
Added sibling() and preceding() element commands

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -384,6 +384,18 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement parent();
 
   /**
+   * Get sibling element of this element
+   * ATTENTION! This method doesn't start any search yet!
+   * For example, $("td").sibling(0) will give first sibling of "td"
+   *
+   * @param index the index of sibling element
+   * @return Sibling element by index
+   *
+   * @see com.codeborne.selenide.commands.GetSibling
+   */
+  SelenideElement sibling(int index);
+
+  /**
    * Get last child element of this element
    * ATTENTION! this method doesn't start any search yet!
    * For example, $("tr").lastChild(); could give the last "td".

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -384,9 +384,9 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement parent();
 
   /**
-   * Get sibling element of this element
+   * Get the following sibling element of this element
    * ATTENTION! This method doesn't start any search yet!
-   * For example, $("td").sibling(0) will give first sibling of "td"
+   * For example, $("td").sibling(0) will give the first following sibling element of "td"
    *
    * @param index the index of sibling element
    * @return Sibling element by index
@@ -394,6 +394,18 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.GetSibling
    */
   SelenideElement sibling(int index);
+
+  /**
+   * Get the preceding sibling element of this element
+   * ATTENTION! This method doesn't start any search yet!
+   * For example, $("td").preceding(0) will give the first preceding sibling element of "td"
+   *
+   * @param index the index of sibling element
+   * @return Sibling element by index
+   *
+   * @see com.codeborne.selenide.commands.GetPreceding
+   */
+  SelenideElement preceding(int index);
 
   /**
    * Get last child element of this element

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -92,6 +92,7 @@ public class Commands {
     add("$$x", new FindAllByXpath());
     add("closest", new GetClosest());
     add("parent", new GetParent());
+    add("sibling", new GetSibling());
     add("lastChild", new GetLastChild());
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -93,6 +93,7 @@ public class Commands {
     add("closest", new GetClosest());
     add("parent", new GetParent());
     add("sibling", new GetSibling());
+    add("preceding", new GetPreceding());
     add("lastChild", new GetLastChild());
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/GetPreceding.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetPreceding.java
@@ -1,0 +1,15 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
+
+public class GetPreceding implements Command<SelenideElement> {
+
+  @Override
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    int siblingIndex = (int) args[0] + 1;
+    return locator.find(proxy, By.xpath(String.format("preceding-sibling::*[%d]", siblingIndex)), 0);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/GetSibling.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSibling.java
@@ -1,0 +1,15 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
+
+public class GetSibling implements Command<SelenideElement> {
+
+  @Override
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    int siblingIndex = (int) args[0] + 1;
+    return locator.find(proxy, By.xpath(String.format("following-sibling::*[%d]", siblingIndex)), 0);
+  }
+}

--- a/src/test/java/com/codeborne/selenide/commands/GetPrecedingCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetPrecedingCommandTest.java
@@ -1,0 +1,37 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetPrecedingCommandTest implements WithAssertions {
+
+  private SelenideElement proxy;
+  private WebElementSource locator;
+  private SelenideElement mockedElement;
+  private GetPreceding getPrecedingCommand;
+
+  @BeforeEach
+  void setup() {
+    proxy = mock(SelenideElement.class);
+    locator = mock(WebElementSource.class);
+    mockedElement = mock(SelenideElement.class);
+    getPrecedingCommand = new GetPreceding();
+  }
+
+  @Test
+  void testExecuteMethod() {
+    when(locator.find(proxy,
+      By.xpath("preceding-sibling::*[1]"),
+      0)).
+      thenReturn(mockedElement);
+    assertThat(getPrecedingCommand.execute(proxy, locator, new Object[]{0}))
+      .isEqualTo(mockedElement);
+  }
+}

--- a/src/test/java/com/codeborne/selenide/commands/GetSiblingCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSiblingCommandTest.java
@@ -1,0 +1,37 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetSiblingCommandTest implements WithAssertions {
+
+  private SelenideElement proxy;
+  private WebElementSource locator;
+  private SelenideElement mockedElement;
+  private GetSibling getSiblingCommand;
+
+  @BeforeEach
+  void setup() {
+    proxy = mock(SelenideElement.class);
+    locator = mock(WebElementSource.class);
+    mockedElement = mock(SelenideElement.class);
+    getSiblingCommand = new GetSibling();
+  }
+
+  @Test
+  void testExecuteMethod() {
+    when(locator.find(proxy,
+      By.xpath("following-sibling::*[1]"),
+      0)).
+      thenReturn(mockedElement);
+    assertThat(getSiblingCommand.execute(proxy, locator, new Object[]{0}))
+      .isEqualTo(mockedElement);
+  }
+}

--- a/src/test/java/integration/SiblingTest.java
+++ b/src/test/java/integration/SiblingTest.java
@@ -1,0 +1,36 @@
+package integration;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.ex.ElementNotFound;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SiblingTest extends ITest {
+  @BeforeEach
+  void openTestPageWith() {
+    openFile("page_with_selects_without_jquery.html");
+  }
+
+  @Test
+  void canGetSiblingElement() {
+    assertThat($("#multirowTableFirstRow").sibling(0))
+      .isEqualTo($("#multirowTableSecondRow"));
+    $(".first_row").sibling(0).has(Condition.text("Norris"));
+  }
+
+  @Test
+  void canGetSiblingOfParent() {
+    assertThat($(".first_row").parent().sibling(0).find("td", 1))
+      .isEqualTo($("#baskerville"));
+  }
+
+  @Test
+  void errorWhenSiblingAbsent() {
+    assertThatThrownBy(() -> $("#multirowTableFirstRow").sibling(3).click())
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+}

--- a/src/test/java/integration/SiblingTest.java
+++ b/src/test/java/integration/SiblingTest.java
@@ -33,4 +33,22 @@ class SiblingTest extends ITest {
       .isInstanceOf(ElementNotFound.class);
   }
 
+  @Test
+  void canGetPrecedingElement() {
+    assertThat($("#multirowTableSecondRow").preceding(0))
+      .isEqualTo($("#multirowTableFirstRow"));
+    $("#baskerville").preceding(0).has(Condition.text("Chack"));
+  }
+
+  @Test
+  void canGetPrecedingElementOfParent() {
+    assertThat($(".second_row").parent().preceding(0).find("td", 0))
+      .isEqualTo($(".first_row"));
+  }
+
+  @Test
+  void errorWhenPrecedingElementAbsent() {
+    assertThatThrownBy(() -> $("#multirowTableSecondRow").preceding(3).click())
+      .isInstanceOf(ElementNotFound.class);
+  }
 }


### PR DESCRIPTION
## Proposed changes
Added the ability to move to a sibling or preceding element of the current element.

The argument of sibling() or preceding() methods is the index of a sibling/preceding element relative to the current element, but there are two questions/concerns:


I am not sure about the index. 'preceding-sibling' and 'following-sibling' XPaths do not accept 0-based indexes. So, I'm adding +1 inside GetSibling/GetPreceding. But in the report, you will see (in case if the element was not found) your index+1 that is quite disappointing... 

The question is, if should I leave it as it is or to document SelenideElement.sibling() and preceding() that they should accept indexes starting from 1 ...

Feature request #845 

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
