### PR TITLE
Add swipe commands

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -794,6 +794,24 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement dragAndDropTo(WebElement target);
 
   /**
+   * Drag and drop center-point of this element to the left-most pixel of the screen.
+   *
+   * @return this element
+   *
+   * @see com.codeborne.selenide.commands.SwipeLeft
+   */
+  SelenideElement swipeLeft();
+
+  /**
+   * Drag and drop center-point of this element to the right-most pixel of the screen.
+   *
+   * @return this element
+   *
+   * @see com.codeborne.selenide.commands.SwipeRight
+   */
+  SelenideElement swipeRight();
+
+  /**
    * Execute custom implemented command
    *
    * @param command custom command

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -51,6 +51,8 @@ public class Commands {
     add("hover", new Hover());
     add("scrollTo", new ScrollTo());
     add("scrollIntoView", new ScrollIntoView());
+    add("swipeRight", new SwipeRight());
+    add("swipeLeft", new SwipeLeft());
   }
 
   private void addInfoCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/Swipe.java
+++ b/src/main/java/com/codeborne/selenide/commands/Swipe.java
@@ -1,0 +1,18 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.interactions.Actions;
+
+abstract class Swipe implements Command<SelenideElement> {
+
+  protected abstract int getSwipingXDistance(SelenideElement proxy, WebElementSource locator);
+
+  @Override
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    new Actions(locator.driver().getWebDriver())
+      .dragAndDropBy(locator.getWebElement(), getSwipingXDistance(proxy, locator), 0).perform();
+    return proxy;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/SwipeLeft.java
+++ b/src/main/java/com/codeborne/selenide/commands/SwipeLeft.java
@@ -1,0 +1,12 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+public class SwipeLeft extends Swipe {
+  @Override
+  protected int getSwipingXDistance(SelenideElement proxy, WebElementSource locator) {
+    int swipingDistance = proxy.getLocation().getX() + proxy.getSize().getWidth() / 2;
+    return -swipingDistance;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/SwipeRight.java
+++ b/src/main/java/com/codeborne/selenide/commands/SwipeRight.java
@@ -1,0 +1,13 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+public class SwipeRight extends Swipe {
+  @Override
+  protected int getSwipingXDistance(SelenideElement proxy, WebElementSource locator) {
+    int windowWidth = locator.driver().getWebDriver().manage().window().getSize().getWidth();
+    int swipingDistance = windowWidth - (proxy.getLocation().getX() + proxy.getSize().getWidth() / 2);
+    return swipingDistance;
+  }
+}


### PR DESCRIPTION
## Proposed changes
Adding native commands to swipe the center of element to the edge of the window

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
