### PR TITLE
#1061 IEDriverServer 3.150 is not work. Don't set ACCEPT_INSECURE_CERTS for IE

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+import static com.codeborne.selenide.Browsers.IE;
+import static com.codeborne.selenide.Browsers.INTERNET_EXPLORER;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
@@ -64,8 +66,9 @@ abstract class AbstractDriverFactory {
     }
     browserCapabilities.setCapability(PAGE_LOAD_STRATEGY, config.pageLoadStrategy());
     browserCapabilities.setCapability(ACCEPT_SSL_CERTS, true);
-    browserCapabilities.setCapability(ACCEPT_INSECURE_CERTS, true);
-
+    if (!INTERNET_EXPLORER.equalsIgnoreCase(config.browser()) && !IE.equalsIgnoreCase(config.browser())) {
+      browserCapabilities.setCapability(ACCEPT_INSECURE_CERTS, true);
+    }
     transferCapabilitiesFromSystemProperties(browserCapabilities);
     browserCapabilities = mergeCapabilitiesFromConfiguration(config, browserCapabilities);
     return browserCapabilities;

--- a/src/test/java/com/codeborne/selenide/webdriver/CommonCapabilitiesTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/CommonCapabilitiesTest.java
@@ -1,0 +1,75 @@
+package com.codeborne.selenide.webdriver;
+
+import com.codeborne.selenide.Browser;
+import com.codeborne.selenide.Config;
+import com.codeborne.selenide.SelenideConfig;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import static com.codeborne.selenide.Browsers.IE;
+import static com.codeborne.selenide.Browsers.INTERNET_EXPLORER;
+import static org.mockito.Mockito.mock;
+import static org.openqa.selenium.remote.CapabilityType.*;
+
+public class CommonCapabilitiesTest implements WithAssertions {
+  private AbstractDriverFactory driverFactory;
+  private Proxy proxy = mock(Proxy.class);
+
+  @BeforeEach
+  void createFactory() {
+    driverFactory = new AbstractDriverFactory() {
+      @Override
+      boolean supports(Config config, Browser browser) {
+        return false;
+      }
+
+      @Override
+      WebDriver create(Config config, Proxy proxy) {
+        return null;
+      }
+    };
+  }
+
+  @Test
+  void transferCapabilitiesFromConfiguration() {
+    SelenideConfig config = new SelenideConfig();
+    config.pageLoadStrategy("foo");
+    DesiredCapabilities commonCapabilities = driverFactory.createCommonCapabilities(config, proxy);
+    assertThat(asBool(commonCapabilities.getCapability(ACCEPT_INSECURE_CERTS))).isTrue();
+    assertThat(asBool(commonCapabilities.getCapability(ACCEPT_SSL_CERTS))).isTrue();
+    assertThat(commonCapabilities.getCapability(PAGE_LOAD_STRATEGY)).isEqualTo(config.pageLoadStrategy());
+  }
+
+  @Test
+  void transferCapabilitiesFromConfiguration1() {
+    SelenideConfig config = new SelenideConfig();
+    config.browser(INTERNET_EXPLORER);
+    DesiredCapabilities commonCapabilities = driverFactory.createCommonCapabilities(config, proxy);
+    assertThat(asBool(commonCapabilities.getCapability(ACCEPT_INSECURE_CERTS))).isFalse();
+    assertThat(asBool(commonCapabilities.getCapability(ACCEPT_SSL_CERTS))).isTrue();
+  }
+
+  @Test
+  void transferCapabilitiesFromConfiguration2() {
+    SelenideConfig config = new SelenideConfig();
+    config.browser(IE);
+    DesiredCapabilities commonCapabilities = driverFactory.createCommonCapabilities(config, proxy);
+    assertThat(asBool(commonCapabilities.getCapability(ACCEPT_INSECURE_CERTS))).isFalse();
+    assertThat(asBool(commonCapabilities.getCapability(ACCEPT_SSL_CERTS))).isTrue();
+  }
+
+  private boolean asBool(Object raw) {
+    if (raw != null) {
+      if (raw instanceof String) {
+        return Boolean.parseBoolean((String) raw);
+      } else if (raw instanceof Boolean) {
+        return (Boolean) raw;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
Fix #1061

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
