### PR TITLE
#1065 add method $.download(FileFilter)

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -18,6 +18,7 @@ import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 
+import static com.codeborne.selenide.files.FileFilters.none;
 import static com.codeborne.selenide.impl.WebElementWrapper.wrap;
 import static java.util.Collections.emptyList;
 
@@ -292,6 +293,6 @@ public class SelenideDriver {
   }
 
   public File download(String url, long timeoutMs) throws IOException {
-    return downloadFileWithHttpRequest.download(driver(), url, timeoutMs);
+    return downloadFileWithHttpRequest.download(driver(), url, timeoutMs, none());
   }
 }

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.files.FileFilter;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.TakesScreenshot;
@@ -723,16 +724,18 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement scrollIntoView(String scrollIntoViewOptions);
 
   /**
-   * Download file linked by "href" attribute of this element
+   * Download file by clicking this element. Algorithm depends on {@code @{@link Config#fileDownload() }}.
+   *
    * @throws RuntimeException if 50x status code was returned from server
    * @throws FileNotFoundException if 40x status code was returned from server
    *
+   * @see FileDownloadMode
    * @see com.codeborne.selenide.commands.DownloadFile
    */
   File download() throws FileNotFoundException;
 
   /**
-   * Download file linked by "href" attribute of this element or any file to which this element redirects.
+   * Download file by clicking this element. Algorithm depends on {@code @{@link Config#fileDownload() }}.
    *
    * @param timeout download operations timeout.
    *
@@ -742,6 +745,41 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.DownloadFile
    */
   File download(long timeout) throws FileNotFoundException;
+
+  /**
+   * Download file by clicking this element. Algorithm depends on {@code @{@link Config#fileDownload() }}.
+   *
+   * @param fileFilter Criteria for defining which file is expected (
+   *                   {@link com.codeborne.selenide.files.FileFilters#withName(String)},
+   *                   {@link com.codeborne.selenide.files.FileFilters#withNameMatching(String)},
+   *                   {@link com.codeborne.selenide.files.FileFilters#withName(String)}
+   *                   ).
+   *
+   * @throws RuntimeException      if 50x status code was returned from server
+   * @throws FileNotFoundException if 40x status code was returned from server, or the downloaded file didn't match given filter.
+   *
+   * @see com.codeborne.selenide.files.FileFilters
+   * @see com.codeborne.selenide.commands.DownloadFile
+   */
+  File download(FileFilter fileFilter) throws FileNotFoundException;
+
+  /**
+   * Download file by clicking this element. Algorithm depends on {@code @{@link Config#fileDownload() }}.
+   *
+   * @param timeout download operations timeout.
+   * @param fileFilter Criteria for defining which file is expected (
+   *                   {@link com.codeborne.selenide.files.FileFilters#withName(String)},
+   *                   {@link com.codeborne.selenide.files.FileFilters#withNameMatching(String)},
+   *                   {@link com.codeborne.selenide.files.FileFilters#withName(String)}
+   *                   ).
+   *
+   * @throws RuntimeException      if 50x status code was returned from server
+   * @throws FileNotFoundException if 40x status code was returned from server, or the downloaded file didn't match given filter.
+   *
+   * @see com.codeborne.selenide.files.FileFilters
+   * @see com.codeborne.selenide.commands.DownloadFile
+   */
+  File download(long timeout, FileFilter fileFilter) throws FileNotFoundException;
 
   /**
    * Return criteria by which this element is located

--- a/src/main/java/com/codeborne/selenide/commands/DownloadFile.java
+++ b/src/main/java/com/codeborne/selenide/commands/DownloadFile.java
@@ -3,6 +3,8 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.Config;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.files.FileFilter;
+import com.codeborne.selenide.files.FileFilters;
 import com.codeborne.selenide.impl.DownloadFileWithHttpRequest;
 import com.codeborne.selenide.impl.DownloadFileWithProxyServer;
 import com.codeborne.selenide.impl.WebElementSource;
@@ -12,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 
 import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 
@@ -37,10 +38,11 @@ public class DownloadFile implements Command<File> {
     Config config = linkWithHref.driver().config();
 
     long timeout = getTimeout(config, args);
+    FileFilter fileFilter = getFileFilter(args);
 
     if (config.fileDownload() == HTTPGET) {
       log.debug("selenide.fileDownload = {} download file via http get", System.getProperty("selenide.fileDownload"));
-      return downloadFileWithHttpRequest.download(linkWithHref.driver(), link, timeout);
+      return downloadFileWithHttpRequest.download(linkWithHref.driver(), link, timeout, fileFilter);
     }
     if (!config.proxyEnabled()) {
       throw new IllegalStateException("Cannot download file: proxy server is not enabled. Setup proxyEnabled");
@@ -49,20 +51,27 @@ public class DownloadFile implements Command<File> {
       throw new IllegalStateException("Cannot download file: proxy server is not started");
     }
 
-    return downloadFileWithProxyServer.download(linkWithHref, link, linkWithHref.driver().getProxy(), timeout);
+    return downloadFileWithProxyServer.download(linkWithHref, link, linkWithHref.driver().getProxy(), timeout, fileFilter);
   }
 
   long getTimeout(Config config, Object[] args) {
-    try {
-      if (args != null && args.length > 0) {
-        return (long) args[0];
-      }
-      else {
-        return config.timeout();
-      }
+    if (args != null && args.length > 0 && args[0] instanceof Long) {
+      return (long) args[0];
     }
-    catch (ClassCastException e) {
-      throw new IllegalArgumentException("Unknown target type: " + Arrays.toString(args) + " (only long is supported)");
+    else {
+      return config.timeout();
+    }
+  }
+
+  FileFilter getFileFilter(Object[] args) {
+    if (args != null && args.length > 0 && args[0] instanceof FileFilter) {
+      return (FileFilter) args[0];
+    }
+    if (args != null && args.length > 1 && args[1] instanceof FileFilter) {
+      return (FileFilter) args[1];
+    }
+    else {
+      return FileFilters.none();
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/files/EmptyFileFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/EmptyFileFilter.java
@@ -1,0 +1,13 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+
+class EmptyFileFilter implements FileFilter {
+  @Override public boolean match(DownloadedFile file) {
+    return true;
+  }
+
+  @Override public String description() {
+    return "";
+  }
+}

--- a/src/main/java/com/codeborne/selenide/files/ExtensionFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/ExtensionFilter.java
@@ -1,0 +1,21 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+
+import static org.apache.commons.io.FilenameUtils.isExtension;
+
+class ExtensionFilter implements FileFilter {
+  private final String extension;
+
+  ExtensionFilter(String extension) {
+    this.extension = extension;
+  }
+
+  @Override public boolean match(DownloadedFile file) {
+    return isExtension(file.getFile().getName(), extension);
+  }
+
+  @Override public String description() {
+    return " with extension \"" + extension + "\"";
+  }
+}

--- a/src/main/java/com/codeborne/selenide/files/FileFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/FileFilter.java
@@ -1,0 +1,10 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+
+import java.io.Serializable;
+
+public interface FileFilter extends Serializable {
+  boolean match(DownloadedFile file);
+  String description();
+}

--- a/src/main/java/com/codeborne/selenide/files/FileFilters.java
+++ b/src/main/java/com/codeborne/selenide/files/FileFilters.java
@@ -1,0 +1,21 @@
+package com.codeborne.selenide.files;
+
+public class FileFilters {
+  private static final FileFilter NONE = new EmptyFileFilter();
+
+  public static FileFilter none() {
+    return NONE;
+  }
+
+  public static FileFilter withName(String fileName) {
+    return new FilenameFilter(fileName);
+  }
+
+  public static FileFilter withNameMatching(String fileNameRegex) {
+    return new FilenameRegexFilter(fileNameRegex);
+  }
+
+  public static FileFilter withExtension(String extension) {
+    return new ExtensionFilter(extension);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/files/FilenameFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/FilenameFilter.java
@@ -1,0 +1,19 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+
+class FilenameFilter implements FileFilter {
+  private final String fileName;
+
+  FilenameFilter(String fileName) {
+    this.fileName = fileName;
+  }
+
+  @Override public boolean match(DownloadedFile file) {
+    return file.getFile().getName().equals(fileName);
+  }
+
+  @Override public String description() {
+    return " with file name \"" + fileName + "\"";
+  }
+}

--- a/src/main/java/com/codeborne/selenide/files/FilenameRegexFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/FilenameRegexFilter.java
@@ -1,0 +1,21 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+
+import java.util.regex.Pattern;
+
+class FilenameRegexFilter implements FileFilter {
+  private final Pattern fileNameRegex;
+
+  FilenameRegexFilter(String fileNameRegex) {
+    this.fileNameRegex = Pattern.compile(fileNameRegex);
+  }
+
+  @Override public boolean match(DownloadedFile file) {
+    return fileNameRegex.matcher(file.getFile().getName()).matches();
+  }
+
+  @Override public String description() {
+    return " with file name matching \"" + fileNameRegex + "\"";
+  }
+}

--- a/src/main/java/com/codeborne/selenide/proxy/FileDownloadFilter.java
+++ b/src/main/java/com/codeborne/selenide/proxy/FileDownloadFilter.java
@@ -4,6 +4,7 @@ import com.browserup.bup.filters.ResponseFilter;
 import com.browserup.bup.util.HttpMessageContents;
 import com.browserup.bup.util.HttpMessageInfo;
 import com.codeborne.selenide.Config;
+import com.codeborne.selenide.files.FileFilter;
 import com.codeborne.selenide.impl.Downloader;
 import com.codeborne.selenide.impl.HttpHelper;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -14,11 +15,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class FileDownloadFilter implements ResponseFilter {
@@ -29,8 +31,8 @@ public class FileDownloadFilter implements ResponseFilter {
 
   private HttpHelper httpHelper = new HttpHelper();
   private boolean active;
-  private final List<DownloadedFile> downloadedFiles = new ArrayList<>();
-  private final List<Response> responses = new ArrayList<>();
+  private final List<DownloadedFile> downloadedFiles = new CopyOnWriteArrayList<>();
+  private final List<Response> responses = new CopyOnWriteArrayList<>();
 
   public FileDownloadFilter(Config config) {
     this(config, new Downloader());
@@ -104,6 +106,13 @@ public class FileDownloadFilter implements ResponseFilter {
    */
   public List<DownloadedFile> getDownloadedFiles() {
     return downloadedFiles;
+  }
+
+  /**
+   * @return list of downloaded files matching given criteria
+   */
+  public List<DownloadedFile> getDownloadedFiles(FileFilter fileFilter) {
+    return downloadedFiles.stream().filter(fileFilter::match).collect(toList());
   }
 
   private String getFileName(Response response) {

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -39,6 +39,7 @@ class ChromeDriverFactory extends AbstractDriverFactory {
       log.info("Using browser binary: {}", config.browserBinary());
       options.setBinary(config.browserBinary());
     }
+    options.setExperimentalOption("excludeSwitches", new String[]{"enable-automation"});
     options.addArguments("--proxy-bypass-list=<-loopback>");
     options.merge(createCommonCapabilities(config, proxy));
     transferChromeOptionsFromSystemProperties(config, options);

--- a/src/test/java/com/codeborne/selenide/files/EmptyFileFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/EmptyFileFilterTest.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmptyFileFilterTest {
+  private final FileFilter filter = new EmptyFileFilter();
+
+  @Test
+  void matchesAnyFile() {
+    assertThat(filter.match(new DownloadedFile(new File(""), emptyMap()))).isTrue();
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdf"), emptyMap()))).isTrue();
+    assertThat(filter.match(new DownloadedFile(new File("cv1.pdf"), emptyMap()))).isTrue();
+    assertThat(filter.match(new DownloadedFile(new File(" cv.pdf"), emptyMap()))).isTrue();
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdf "), emptyMap()))).isTrue();
+  }
+
+  @Test
+  void description() {
+    assertThat(filter.description()).isEqualTo("");
+  }
+
+}

--- a/src/test/java/com/codeborne/selenide/files/ExtensionFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/ExtensionFilterTest.java
@@ -1,0 +1,31 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExtensionFilterTest {
+  private final FileFilter filter = new ExtensionFilter("pdf");
+
+  @Test
+  void matchesFileByExtension() {
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdf"), emptyMap()))).isTrue();
+    assertThat(filter.match(new DownloadedFile(new File("report.pdf"), emptyMap()))).isTrue();
+    assertThat(filter.match(new DownloadedFile(new File("report.PDF"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdff"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File("cv.ppdf"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdf.gz"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File("cv.xpdf"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdfx"), emptyMap()))).isFalse();
+  }
+
+  @Test
+  void description() {
+    assertThat(filter.description()).isEqualTo(" with extension \"pdf\"");
+  }
+
+}

--- a/src/test/java/com/codeborne/selenide/files/FilenameFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/FilenameFilterTest.java
@@ -1,0 +1,26 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilenameFilterTest {
+  private final FileFilter filter = new FilenameFilter("cv.pdf");
+
+  @Test
+  void matchesFileByName() {
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdf"), emptyMap()))).isTrue();
+    assertThat(filter.match(new DownloadedFile(new File("cv1.pdf"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File(" cv.pdf"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdf "), emptyMap()))).isFalse();
+  }
+
+  @Test
+  void description() {
+    assertThat(filter.description()).isEqualTo(" with file name \"cv.pdf\"");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/files/FilenameRegexFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/FilenameRegexFilterTest.java
@@ -1,0 +1,26 @@
+package com.codeborne.selenide.files;
+
+import com.codeborne.selenide.proxy.DownloadedFile;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilenameRegexFilterTest {
+  private final FileFilter filter = new FilenameRegexFilter("cv-\\d+.pdf");
+
+  @Test
+  void matchesFileByNameUsingGivenRegularExpression() {
+    assertThat(filter.match(new DownloadedFile(new File("cv-100.pdf"), emptyMap()))).isTrue();
+    assertThat(filter.match(new DownloadedFile(new File("cv100.pdf"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File("cv.pdf"), emptyMap()))).isFalse();
+    assertThat(filter.match(new DownloadedFile(new File("cv-ten.pdf"), emptyMap()))).isFalse();
+  }
+
+  @Test
+  void description() {
+    assertThat(filter.description()).isEqualTo(" with file name matching \"cv-\\d+.pdf\"");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequestTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequestTest.java
@@ -23,7 +23,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class DownloadFileWithHttpRequestTest {
-  DownloadFileWithHttpRequest download = new DownloadFileWithHttpRequest(new Downloader(new DummyRandomizer("111-222-333-444")));
+  private final DownloadFileWithHttpRequest download = new DownloadFileWithHttpRequest(
+    new Downloader(new DummyRandomizer("111-222-333-444"))
+  );
 
   @Test
   void makeAbsoluteUrl() {

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+import static com.codeborne.selenide.files.FileFilters.none;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.mockito.ArgumentMatchers.any;
@@ -60,7 +61,7 @@ class DownloadFileWithProxyServerTest implements WithAssertions {
   void canInterceptFileViaProxyServer() throws IOException {
     emulateServerResponseWithFiles(new File("report.pdf"));
 
-    File file = command.download(linkWithHref, link, proxy, 3000);
+    File file = command.download(linkWithHref, link, proxy, 3000, none());
     assertThat(file.getName())
       .isEqualTo("report.pdf");
 
@@ -84,7 +85,7 @@ class DownloadFileWithProxyServerTest implements WithAssertions {
       .thenReturn(ImmutableSet.of("tab1", "tab2", "tab3"))
       .thenReturn(ImmutableSet.of("tab1", "tab2", "tab3", "tab-with-pdf"));
 
-    File file = command.download(linkWithHref, link, proxy, 3000);
+    File file = command.download(linkWithHref, link, proxy, 3000, none());
     assertThat(file.getName())
       .isEqualTo("report.pdf");
 
@@ -106,7 +107,7 @@ class DownloadFileWithProxyServerTest implements WithAssertions {
       .thenReturn(ImmutableSet.of("tab1", "tab2", "tab3"))
       .thenReturn(ImmutableSet.of("tab1", "tab2", "tab3", "tab-with-pdf"));
 
-    File file = command.download(linkWithHref, link, proxy, 3000);
+    File file = command.download(linkWithHref, link, proxy, 3000, none());
     assertThat(file.getName())
       .isEqualTo("report.pdf");
 
@@ -120,7 +121,7 @@ class DownloadFileWithProxyServerTest implements WithAssertions {
   void throwsFileNotFoundExceptionIfNoFilesHaveBeenDownloadedAfterClick() {
     emulateServerResponseWithFiles();
 
-    assertThatThrownBy(() -> command.download(linkWithHref, link, proxy, 3000))
+    assertThatThrownBy(() -> command.download(linkWithHref, link, proxy, 3000, none()))
       .isInstanceOf(FileNotFoundException.class)
       .hasMessageStartingWith("Failed to download file <a href='report.pdf'>report</a>");
   }

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -2,6 +2,7 @@ package integration;
 
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.ex.TimeoutException;
+import com.codeborne.selenide.files.FileFilters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +53,25 @@ class FileDownloadViaHttpGetTest extends IntegrationTest {
   @Test
   void downloadMissingFile() {
     assertThatThrownBy(() -> $(byText("Download missing file")).download())
-      .isInstanceOf(FileNotFoundException.class);
+      .isInstanceOf(FileNotFoundException.class)
+      .hasMessageStartingWith("Failed to download file http")
+      .hasMessageMatching("Failed to download file http.+/files/unexisting_file.png: .+");
+  }
+
+  @Test
+  void downloadFileByName() {
+    assertThatThrownBy(() -> $(byText("Download me")).download(FileFilters.withName("good_bye_world.txt")))
+      .isInstanceOf(FileNotFoundException.class)
+      .hasMessageMatching("Failed to download file from http.+/files/hello_world.txt in 4000 ms." +
+        " with file name \"good_bye_world.txt\" \n" +
+        "; actually downloaded: .+/hello_world.txt");
+  }
+
+  @Test
+  void downloadFile() {
+    assertThatThrownBy(() -> $(byText("Download missing file")).download())
+      .isInstanceOf(FileNotFoundException.class)
+      .hasMessageMatching("Failed to download file http.+/files/unexisting_file.png: .+");
   }
 
   @Test

--- a/statics/src/test/java/integration/FileDownloadViaProxyTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaProxyTest.java
@@ -9,9 +9,13 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.files.FileFilters.withExtension;
+import static com.codeborne.selenide.files.FileFilters.withName;
+import static com.codeborne.selenide.files.FileFilters.withNameMatching;
 import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -69,6 +73,27 @@ class FileDownloadViaProxyTest extends IntegrationTest {
 
     assertThat(downloadedFile.getName())
       .isEqualTo("hello_world.txt");
+  }
+
+  @Test
+  public void download_byName() throws FileNotFoundException {
+    File downloadedFile = $(byText("Download me slowly (2000 ms)")).download(withName("hello_world.txt"));
+
+    assertThat(downloadedFile.getName()).isEqualTo("hello_world.txt");
+  }
+
+  @Test
+  public void download_byNameRegex() throws FileNotFoundException {
+    File downloadedFile = $(byText("Download me slowly (2000 ms)")).download(withNameMatching("hello_.\\w+\\.txt"));
+
+    assertThat(downloadedFile.getName()).isEqualTo("hello_world.txt");
+  }
+
+  @Test
+  public void download_byExtension() throws FileNotFoundException {
+    File downloadedFile = $(byText("Download me slowly (2000 ms)")).download(timeout, withExtension("txt"));
+
+    assertThat(downloadedFile.getName()).isEqualTo("hello_world.txt");
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes
This PR adds an overloaded method `$.download(FileFilter)` which would allow to explicitly set file name, extensions or other criteria. 

```java
File pdf = $("#btn-print").download(withName("cv.pdf"));
File pdf = $("#btn-print").download(withNameMatching("\\w+-cv-\\d+\\.pdf"));
File pdf = $("#btn-print").download(withExtension("pdf"));
```

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
