### PR TITLE
#1039 Microsoft Edge doesn't start using Selenide 5.6.0

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -15,6 +15,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import static com.codeborne.selenide.Browsers.IE;
 import static com.codeborne.selenide.Browsers.INTERNET_EXPLORER;
+import static com.codeborne.selenide.Browsers.EDGE;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
@@ -66,7 +67,11 @@ abstract class AbstractDriverFactory {
     }
     browserCapabilities.setCapability(PAGE_LOAD_STRATEGY, config.pageLoadStrategy());
     browserCapabilities.setCapability(ACCEPT_SSL_CERTS, true);
-    if (!INTERNET_EXPLORER.equalsIgnoreCase(config.browser()) && !IE.equalsIgnoreCase(config.browser())) {
+    boolean isNotMicrosoftBrowsers =
+      !INTERNET_EXPLORER.equalsIgnoreCase(config.browser())
+      && !IE.equalsIgnoreCase(config.browser())
+      && !EDGE.equalsIgnoreCase(config.browser());
+    if (isNotMicrosoftBrowsers) {
       browserCapabilities.setCapability(ACCEPT_INSECURE_CERTS, true);
     }
     transferCapabilitiesFromSystemProperties(browserCapabilities);

--- a/src/test/java/com/codeborne/selenide/webdriver/CommonCapabilitiesTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/CommonCapabilitiesTest.java
@@ -10,8 +10,7 @@ import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import static com.codeborne.selenide.Browsers.IE;
-import static com.codeborne.selenide.Browsers.INTERNET_EXPLORER;
+import static com.codeborne.selenide.Browsers.*;
 import static org.mockito.Mockito.mock;
 import static org.openqa.selenium.remote.CapabilityType.*;
 
@@ -45,7 +44,7 @@ public class CommonCapabilitiesTest implements WithAssertions {
   }
 
   @Test
-  void transferCapabilitiesFromConfiguration1() {
+  void transferCapabilitiesFromConfigurationInternetExplorer() {
     SelenideConfig config = new SelenideConfig();
     config.browser(INTERNET_EXPLORER);
     DesiredCapabilities commonCapabilities = driverFactory.createCommonCapabilities(config, proxy);
@@ -54,9 +53,18 @@ public class CommonCapabilitiesTest implements WithAssertions {
   }
 
   @Test
-  void transferCapabilitiesFromConfiguration2() {
+  void transferCapabilitiesFromConfigurationIE() {
     SelenideConfig config = new SelenideConfig();
     config.browser(IE);
+    DesiredCapabilities commonCapabilities = driverFactory.createCommonCapabilities(config, proxy);
+    assertThat(asBool(commonCapabilities.getCapability(ACCEPT_INSECURE_CERTS))).isFalse();
+    assertThat(asBool(commonCapabilities.getCapability(ACCEPT_SSL_CERTS))).isTrue();
+  }
+
+  @Test
+  void transferCapabilitiesFromConfigurationEdge() {
+    SelenideConfig config = new SelenideConfig();
+    config.browser(EDGE);
     DesiredCapabilities commonCapabilities = driverFactory.createCommonCapabilities(config, proxy);
     assertThat(asBool(commonCapabilities.getCapability(ACCEPT_INSECURE_CERTS))).isFalse();
     assertThat(asBool(commonCapabilities.getCapability(ACCEPT_SSL_CERTS))).isTrue();


### PR DESCRIPTION
Don't set ACCEPT_INSECURE_CERTS for Edge

