### PR TITLE
Add shadow-dom support

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selectors.java
+++ b/src/main/java/com/codeborne/selenide/Selectors.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.selector.ByShadow;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.Quotes;
 
@@ -63,6 +64,14 @@ public class Selectors {
    */
   public static By byAttribute(String attributeName, String attributeValue) {
     return By.cssSelector(String.format("[%s='%s']", attributeName, attributeValue));
+  }
+
+  /**
+   * @see ByShadow#cssSelector(java.lang.String, java.lang.String, java.lang.String...)
+   * @since 5.10
+   */
+  public static By shadowCss(String target, String shadowHost, String... innerShadowHosts) {
+    return ByShadow.cssSelector(target, shadowHost, innerShadowHosts);
   }
 
   /**

--- a/src/test/java/com/codeborne/selenide/SelectorsTest.java
+++ b/src/test/java/com/codeborne/selenide/SelectorsTest.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide;
 
 import com.codeborne.selenide.Selectors.ByText;
 import com.codeborne.selenide.Selectors.WithText;
+import com.codeborne.selenide.selector.ByShadow;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -157,5 +158,17 @@ class SelectorsTest implements WithAssertions {
       .isInstanceOf(By.ByClassName.class);
     assertThat(classNameSelector)
       .hasToString("By.className: " + className);
+  }
+
+  @Test
+  void byShadowCss() {
+    String target = "#target";
+    String shadow = "#shadow";
+    String innerShadow = "#inner-shadow";
+    By cssSelector = Selectors.shadowCss(target, shadow, innerShadow);
+    assertThat(cssSelector)
+      .isInstanceOf(ByShadow.ByShadowCss.class);
+    assertThat(cssSelector)
+      .hasToString("By.cssSelector: " + shadow + " [" + innerShadow + "] " + target);
   }
 }

--- a/src/test/java/integration/ShadowElementTest.java
+++ b/src/test/java/integration/ShadowElementTest.java
@@ -1,0 +1,76 @@
+package integration;
+
+import com.codeborne.selenide.ex.ElementNotFound;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchElementException;
+
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selectors.shadowCss;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ShadowElementTest extends ITest {
+  @BeforeEach
+  void openTestPage() {
+    openFile("page_with_shadow_dom.html");
+  }
+
+  @Test
+  void getTargetElementViaShadowHost() {
+    $(shadowCss("p", "#shadow-host"))
+      .shouldHave(text("Inside Shadow-DOM"));
+  }
+
+  @Test
+  void getElementInsideInnerShadowHost() {
+    $(shadowCss("p", "#shadow-host", "#inner-shadow-host"))
+      .shouldHave(text("The Shadow-DOM inside another shadow tree"));
+  }
+
+  @Test
+  void throwErrorWhenGetNonExistingTargetInsideShadowRoot() {
+    assertThatThrownBy(() -> $(shadowCss("#nonexistent", "#shadow-host")).text())
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void throwErrorWhenBypassingShadowHost() {
+    assertThatThrownBy(() -> $("p").text())
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void throwErrorWhenShadowHostDoesNotHaveShadowRoot() {
+    assertThatThrownBy(() -> $(shadowCss("p", "h1")).text())
+      .isInstanceOf(ElementNotFound.class)
+      .hasCauseInstanceOf(NoSuchElementException.class)
+      .hasMessageContaining("The element is not a shadow host:");
+  }
+
+  @Test
+  void throwErrorWhenInnerShadowHostAbsent() {
+    assertThatThrownBy(() -> $(shadowCss("p", "#shadow-host", "#nonexistent")).text())
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageContaining("Element not found {#shadow-host [#nonexistent] p}")
+      .hasCauseInstanceOf(NoSuchElementException.class)
+      .hasMessageContaining("The element was not found: #nonexistent");
+  }
+
+  @Test
+  void getTargetElementsViaShadowHost() {
+    $$(shadowCss("div.test-class", "#shadow-host"))
+      .shouldHaveSize(2);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost() {
+    $$(shadowCss("p", "#shadow-host", "#inner-shadow-host"))
+      .shouldHaveSize(1);
+  }
+
+  @Test
+  void getNonExistingTargetElementsInsideShadowHost() {
+    $$(shadowCss("#nonexistent", "#shadow-host"))
+      .shouldHaveSize(0);
+  }
+}

--- a/src/test/java/integration/ShadowElementTest.java
+++ b/src/test/java/integration/ShadowElementTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,13 @@ public class ShadowElementTest extends ITest {
   @BeforeEach
   void openTestPage() {
     openFile("page_with_shadow_dom.html");
+  }
+
+  @Test
+  void clickInsideShadowHost() {
+    SelenideElement button = $(shadowCss("#anyButton", "#shadow-host"));
+    button.click();
+    button.shouldHave(text("Changed text"));
   }
 
   @Test

--- a/src/test/resources/page_with_shadow_dom.html
+++ b/src/test/resources/page_with_shadow_dom.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Test: elements with Shadow-DOM</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <script type="text/javascript" src="jquery.min.js"></script>
+  <script type="text/javascript">
+
+    $(function () {
+      var shadow = document.getElementById('shadow-host').attachShadow( { mode: "open" } )
+
+      var p = document.createElement("p");
+      var div = document.createElement("div");
+      var div2 = document.createElement("div");
+      var div3 = document.createElement("div");
+      div.setAttribute('id', 'inner-shadow-host');
+      div2.setAttribute('class', 'test-class');
+      div3.setAttribute('class', 'test-class');
+      var text = document.createTextNode("Inside Shadow-DOM");
+      p.appendChild(text);
+      shadow.appendChild(p);
+      shadow.appendChild(div);
+      shadow.appendChild(div2);
+      shadow.appendChild(div3);
+
+      var shadow2 = shadow.getElementById("inner-shadow-host").attachShadow( { mode: "open" } )
+
+      var p2 = document.createElement("p");
+      var text2 = document.createTextNode("The Shadow-DOM inside another shadow tree");
+      p2.appendChild(text2);
+      shadow2.appendChild(p2);
+    });
+
+  </script>
+</head>
+<body>
+<h1>Page with Shadow DOM</h1>
+
+<div id="shadow-host">
+</div>
+
+</body>
+</html>

--- a/src/test/resources/page_with_shadow_dom.html
+++ b/src/test/resources/page_with_shadow_dom.html
@@ -14,6 +14,12 @@
       var div = document.createElement("div");
       var div2 = document.createElement("div");
       var div3 = document.createElement("div");
+      var input = document.createElement("input");
+      var button = document.createElement("button");
+      button.setAttribute("id", "anyButton");
+      button.textContent = `Button`;
+      button.onclick = function() {this.textContent = "Changed text";};
+      input.setAttribute("type", "text");
       div.setAttribute('id', 'inner-shadow-host');
       div2.setAttribute('class', 'test-class');
       div3.setAttribute('class', 'test-class');
@@ -23,6 +29,8 @@
       shadow.appendChild(div);
       shadow.appendChild(div2);
       shadow.appendChild(div3);
+      shadow.appendChild(input);
+      shadow.appendChild(button);
 
       var shadow2 = shadow.getElementById("inner-shadow-host").attachShadow( { mode: "open" } )
 
@@ -31,6 +39,8 @@
       p2.appendChild(text2);
       shadow2.appendChild(p2);
     });
+
+
 
   </script>
 </head>

--- a/src/test/resources/page_with_shadow_dom_inside_iframe.html
+++ b/src/test/resources/page_with_shadow_dom_inside_iframe.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Test::Shadow-DOM inside IFrame</title>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  </head>
+  <iframe src="page_with_shadow_dom.html" height="500" width="300" id="iframe_page" style="border:1px"></iframe>
+</html>

--- a/statics/src/test/java/integration/ShadowDomInsideIFrameTest.java
+++ b/statics/src/test/java/integration/ShadowDomInsideIFrameTest.java
@@ -9,6 +9,8 @@ import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Selectors.shadowCss;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.switchTo;
+import static com.codeborne.selenide.WebDriverRunner.isFirefox;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class ShadowDomInsideIFrameTest extends IntegrationTest {
   @BeforeEach
@@ -25,6 +27,8 @@ class ShadowDomInsideIFrameTest extends IntegrationTest {
 
   @Test
   void setValueViaShadowDomInsideIFrame() {
+    // Firefox says that the input is "not reachable by keyboard" (inside shadow-dom)
+    assumeFalse(isFirefox());
     switchTo().frame("iframe_page");
     Configuration.fastSetValue = false;
     $(shadowCss("input", "#shadow-host")).setValue("test").shouldHave(value("test"));

--- a/statics/src/test/java/integration/ShadowDomInsideIFrameTest.java
+++ b/statics/src/test/java/integration/ShadowDomInsideIFrameTest.java
@@ -1,0 +1,39 @@
+package integration;
+
+import com.codeborne.selenide.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.value;
+import static com.codeborne.selenide.Selectors.shadowCss;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.switchTo;
+
+class ShadowDomInsideIFrameTest extends IntegrationTest {
+  @BeforeEach
+  void setUp() {
+    openFile("page_with_shadow_dom_inside_iframe.html");
+  }
+
+  @Test
+  void getTargetElementViaShadowHostInsideIFrame() {
+    switchTo().frame("iframe_page");
+    $(shadowCss("p", "#shadow-host"))
+      .shouldHave(text("Inside Shadow-DOM"));
+  }
+
+  @Test
+  void setValueViaShadowDomInsideIFrame() {
+    switchTo().frame("iframe_page");
+    Configuration.fastSetValue = false;
+    $(shadowCss("input", "#shadow-host")).setValue("test").shouldHave(value("test"));
+  }
+
+  @Test
+  void setFastValueViaShadowDomInsideIFrame() {
+    switchTo().frame("iframe_page");
+    Configuration.fastSetValue = true;
+    $(shadowCss("input", "#shadow-host")).setValue("test").shouldHave(value("test"));
+  }
+}


### PR DESCRIPTION
## Proposed changes
Add support for searching elements inside Shadow-DOM tree. Currently, it does not have native support by WebDriver so it is a good helper who faced with such elements.

In order to be able to findElement inside shadow-dom, you have to specify its shadow-host element (it is a root element that has attached shadow tree). There is a good explanation about it https://javascript.info/shadow-dom 

Also, one note is that if you have inner shadow roots, you must explicitly specify each its shadow host.

It resolves a feature request #1014 

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradle check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
