### PR TITLE
#1021 don't include BrowserUpProxy by default

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,10 +15,12 @@ dependencies {
   }
   api('io.github.bonigarcia:webdrivermanager:3.8.1')
 
-  implementation('com.browserup:browserup-proxy-core:2.0.1')
-  implementation('io.netty:netty-all:4.1.47.Final')
-  implementation('xyz.rogfam:littleproxy:2.0.0-beta-5')
-  implementation('org.slf4j:slf4j-api:1.7.30')
+  compileOnly('org.checkerframework:checker:3.2.0')
+  compileOnly('com.browserup:browserup-proxy-core:2.0.1')
+  testCompile('com.browserup:browserup-proxy-core:2.0.1')
+  compileOnly('io.netty:netty-all:4.1.48.Final')
+  testCompile('io.netty:netty-all:4.1.48.Final')
+  compileOnly('xyz.rogfam:littleproxy:2.0.0-beta-5')
 
   compileOnly("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   compileOnly("org.junit.jupiter:junit-jupiter-migrationsupport:$junitVersion")
@@ -34,6 +36,7 @@ dependencies {
   testImplementation('com.automation-remarks:video-recorder-junit5:2.0')
   testImplementation("org.assertj:assertj-core:3.15.0")
 
+  implementation('org.slf4j:slf4j-api:1.7.30')
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testRuntimeOnly('org.slf4j:slf4j-simple:1.7.30')
 }

--- a/src/main/java/com/codeborne/selenide/drivercommands/CreateDriverCommand.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/CreateDriverCommand.java
@@ -31,9 +31,14 @@ public class CreateDriverCommand {
     Proxy browserProxy = userProvidedProxy;
 
     if (config.proxyEnabled()) {
-      selenideProxyServer = new SelenideProxyServer(config, userProvidedProxy);
-      selenideProxyServer.start();
-      browserProxy = selenideProxyServer.createSeleniumProxy();
+      try {
+        selenideProxyServer = new SelenideProxyServer(config, userProvidedProxy);
+        selenideProxyServer.start();
+        browserProxy = selenideProxyServer.createSeleniumProxy();
+      }
+      catch (NoClassDefFoundError e) {
+        throw new IllegalStateException("Cannot initialize proxy. Probably you should add BrowserUpProxy dependency to your project.", e);
+      }
     }
 
     WebDriver webdriver = factory.createWebDriver(config, browserProxy);


### PR DESCRIPTION
* we assume that most of users don't use proxy, so they will not fetch this bunch of unused JARs anymore (BUP, Netty, LittleProxy etc.)
* those who use proxy, will need to add a dependency `testRuntime 'com.browserup:browserup-proxy-core:2.0.1'`

## Benefit
A sample project which depends on Selenide fetches:
* 26M   (with BrowserUpProxy and its dependencies)
* 8.9M  (without BrowserUpProxy)

This is the full list of BUP dependencies (apparently taking 17mb of disk space):
* animal-sniffer-annotations-1.17.jar
* barchart-udt-bundle-2.3.0.jar
* bcpkix-jdk15on-1.62.jar
* bcprov-jdk15on-1.62.jar
* browserup-proxy-core-2.0.1.jar
* browserup-proxy-mitm-2.0.1.jar
* checker-qual-2.5.2.jar
* dec-0.1.2.jar
* dnsjava-2.1.9.jar
* error_prone_annotations-2.2.0.jar
* failureaccess-1.0.1.jar
* guava-27.1-jre.jar
* jackson-annotations-2.9.9.jar
* jackson-core-2.9.9.jar
* jackson-databind-2.9.9.1.jar
* javassist-3.25.0-GA.jar
* javax.activation-api-1.2.0.jar
* jaxb-api-2.3.1.jar
* jcl-over-slf4j-1.7.28.jar
* jsr305-3.0.2.jar
* jzlib-1.1.3.jar
* listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
* littleproxy-2.0.0-beta-5.jar
* netty-all-4.1.39.Final.jar