### PR TITLE
Normalize reports URL with spaces

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -348,19 +348,9 @@ public class ScreenShotLaboratory {
     }
 
     if (driver.config().reportsUrl() != null) {
-      Path current = Paths.get(System.getProperty("user.dir"));
-      Path target = Paths.get(screenshot).normalize();
-      String screenshotUrl;
-      if (isInsideFolder(current, target)) {
-        Path relativePath = current.relativize(target);
-        screenshotUrl = driver.config().reportsUrl() + relativePath.toString().replace('\\', '/');
-      } else {
-        String name = target.toFile().getName();
-        screenshotUrl = driver.config().reportsUrl() + name;
-      }
-      screenshotUrl = normalizeURL(screenshotUrl);
-      log.debug("Replaced screenshot file path '{}' by public CI URL '{}'", screenshot, screenshotUrl);
-      return screenshotUrl;
+      String screenShotURL = formatScreenShotURL(driver.config().reportsUrl(), screenshot);
+      log.info("Replaced screenshot file path '{}' by public CI URL '{}'", screenshot, screenShotURL);
+      return screenShotURL;
     }
 
     log.debug("reportsUrl is not configured. Returning screenshot file name '{}'", screenshot);
@@ -369,6 +359,18 @@ public class ScreenShotLaboratory {
     } catch (MalformedURLException e) {
       return "file://" + screenshot;
     }
+  }
+
+  private String formatScreenShotURL(String reportsURL, String screenshot) {
+    Path current = Paths.get(System.getProperty("user.dir"));
+    Path target = Paths.get(screenshot).normalize();
+    String screenShotPath;
+    if (isInsideFolder(current, target)) {
+      screenShotPath = current.relativize(target).toString().replace('\\', '/');
+    } else {
+      screenShotPath = target.toFile().getName();
+    }
+    return normalizeURL(reportsURL + screenShotPath);
   }
 
   private String normalizeURL(String url) {

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -23,6 +23,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -356,11 +358,7 @@ public class ScreenShotLaboratory {
         String name = target.toFile().getName();
         screenshotUrl = driver.config().reportsUrl() + name;
       }
-      try {
-        screenshotUrl = new URL(screenshotUrl).toExternalForm();
-      } catch (MalformedURLException ignore) {
-        // ignored exception
-      }
+      screenshotUrl = normalizeURL(screenshotUrl);
       log.debug("Replaced screenshot file path '{}' by public CI URL '{}'", screenshot, screenshotUrl);
       return screenshotUrl;
     }
@@ -370,6 +368,17 @@ public class ScreenShotLaboratory {
       return new File(screenshot).toURI().toURL().toExternalForm();
     } catch (MalformedURLException e) {
       return "file://" + screenshot;
+    }
+  }
+
+  private String normalizeURL(String url) {
+    try {
+      URL aURL = new URL(url);
+      return new URI(aURL.getProtocol(), aURL.getAuthority(), aURL.getPath(), aURL.getQuery(), aURL.getRef())
+        .toURL().toExternalForm();
+    } catch (MalformedURLException | URISyntaxException e) {
+      log.error("URL syntax error: {}", url, e);
+      return url;
     }
   }
 

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -1,13 +1,18 @@
 package com.codeborne.selenide.impl;
 
+import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.chrome.ChromeDriver;
 
 import java.io.File;
 import java.util.List;
 
 import static java.io.File.separatorChar;
+import static org.mockito.Mockito.mock;
 
 class ScreenShotLaboratoryTest implements WithAssertions {
   private ScreenShotLaboratory screenshots = new ScreenShotLaboratory() {
@@ -94,6 +99,17 @@ class ScreenShotLaboratoryTest implements WithAssertions {
       .hasToString("12356789.3");
     assertThat(allScreenshots.get(4))
       .hasToString("12356789.4");
+  }
+
+  @Test
+  void canFormatReportsURLWithSpaces() {
+    Driver driver = new DriverStub(new SelenideConfig().reportsUrl("http://ci.org/with space/"),
+      new Browser("chrome", false), mock(ChromeDriver.class), null);
+
+    String screenShotPath = screenshots.formatScreenShotPath(driver);
+
+    assertThat(screenShotPath)
+      .hasToString("http://ci.org/with%20space/12356789.0");
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes

Fix #1072 

## Checklist
- [x] Checkstyle and unit tests pass locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
