### PR TITLE
Add missing byTagName to Selectors to make it consistent with By

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selectors.java
+++ b/src/main/java/com/codeborne/selenide/Selectors.java
@@ -187,4 +187,12 @@ public class Selectors {
   public static By byClassName(String className) {
     return By.className(className);
   }
+
+  /**
+   * @see By#tagName(java.lang.String)
+   * @since 5.11
+   */
+  public static By byTagName(String tagName) {
+    return By.tagName(tagName);
+  }
 }

--- a/src/test/java/com/codeborne/selenide/SelectorsTest.java
+++ b/src/test/java/com/codeborne/selenide/SelectorsTest.java
@@ -176,4 +176,14 @@ class SelectorsTest implements WithAssertions {
     assertThat(cssSelector)
       .hasToString("By.cssSelector: " + shadow + " [" + innerShadow + "] " + target);
   }
+
+  @Test
+  void byTagName() {
+    String tagName = "selenide";
+    By tagNameSelector = Selectors.byTagName(tagName);
+    assertThat(tagNameSelector)
+      .isInstanceOf(By.ByTagName.class);
+    assertThat(tagNameSelector)
+      .hasToString("By.tagName: " + tagName);
+  }
 }


### PR DESCRIPTION
## Proposed changes

Usually, I use static imports with Selectors class and one thing is missing there in comparison to By: By.tagName. This change adds `Selectors.byTagName` so now we will be able to use it like:
```
$(byTagName("ng-details")).shouldBe(visible);
```

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
