### PR TITLE
Add CheckReturnValue annotation for methods that only return value

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -54,7 +54,7 @@
     <!--<module name="MutableException"/>-->
     <module name="ClassFanOutComplexity">
       <property name="max" value="29"/>
-      <property name="excludeClassesRegexps" value=".*Condition.*"/>
+      <property name="excludedPackages" value="com.codeborne.selenide.conditions"/>
     </module>
     <module name="CyclomaticComplexity">
       <property name="max" value="11"/>

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -13,11 +13,12 @@ import com.codeborne.selenide.collections.SizeNotEqual;
 import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.collections.TextsInAnyOrder;
 import com.codeborne.selenide.impl.WebElementsCollection;
-import java.util.function.Predicate;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 public abstract class CollectionCondition implements Predicate<List<WebElement>> {
   protected String explanation;
@@ -29,26 +30,32 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
   /**
    * Checks that collection has the given size
    */
+  @CheckReturnValue
   public static CollectionCondition size(int expectedSize) {
     return new ListSize(expectedSize);
   }
 
+  @CheckReturnValue
   public static CollectionCondition sizeGreaterThan(int expectedSize) {
     return new SizeGreaterThan(expectedSize);
   }
 
+  @CheckReturnValue
   public static CollectionCondition sizeGreaterThanOrEqual(int expectedSize) {
     return new SizeGreaterThanOrEqual(expectedSize);
   }
 
+  @CheckReturnValue
   public static CollectionCondition sizeLessThan(int expectedSize) {
     return new SizeLessThan(expectedSize);
   }
 
+  @CheckReturnValue
   public static CollectionCondition sizeLessThanOrEqual(int size) {
     return new SizeLessThanOrEqual(size);
   }
 
+  @CheckReturnValue
   public static CollectionCondition sizeNotEqual(int expectedSize) {
     return new SizeNotEqual(expectedSize);
   }
@@ -58,6 +65,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    *
    * <p>NB! Ignores multiple whitespaces between words</p>
    */
+  @CheckReturnValue
   public static CollectionCondition texts(String... expectedTexts) {
     return new Texts(expectedTexts);
   }
@@ -67,6 +75,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    *
    * <p>NB! Ignores multiple whitespaces between words</p>
    */
+  @CheckReturnValue
   public static CollectionCondition texts(List<String> expectedTexts) {
     return new Texts(expectedTexts);
   }
@@ -76,6 +85,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    *
    * <p>NB! Ignores multiple whitespaces between words</p>
    */
+  @CheckReturnValue
   public static CollectionCondition textsInAnyOrder(String... expectedTexts) {
     return new TextsInAnyOrder(expectedTexts);
   }
@@ -85,6 +95,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    *
    * <p>NB! Ignores multiple whitespaces between words</p>
    */
+  @CheckReturnValue
   public static CollectionCondition textsInAnyOrder(List<String> expectedTexts) {
     return new TextsInAnyOrder(expectedTexts);
   }
@@ -94,6 +105,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    *
    * <p>NB! Ignores multiple whitespaces between words</p>
    */
+  @CheckReturnValue
   public static CollectionCondition exactTexts(String... expectedTexts) {
     return new ExactTexts(expectedTexts);
   }
@@ -103,6 +115,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    *
    * <p>NB! Ignores multiple whitespaces between words</p>
    */
+  @CheckReturnValue
   public static CollectionCondition exactTexts(List<String> expectedTexts) {
     return new ExactTexts(expectedTexts);
   }
@@ -113,6 +126,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    * @param description The description of the given predicate
    * @param predicate   the {@link java.util.function.Predicate} to match
    */
+  @CheckReturnValue
   public static CollectionCondition anyMatch(String description, java.util.function.Predicate<WebElement> predicate) {
     return new AnyMatch(description, predicate);
   }
@@ -123,6 +137,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    * @param description The description of the given predicate
    * @param predicate   the {@link java.util.function.Predicate} to match
    */
+  @CheckReturnValue
   public static CollectionCondition allMatch(String description, java.util.function.Predicate<WebElement> predicate) {
     return new AllMatch(description, predicate);
   }
@@ -133,6 +148,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    * @param description The description of the given predicate
    * @param predicate   the {@link java.util.function.Predicate} to match
    */
+  @CheckReturnValue
   public static CollectionCondition noneMatch(String description, java.util.function.Predicate<WebElement> predicate) {
     return new NoneMatch(description, predicate);
   }

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -28,6 +28,7 @@ import com.codeborne.selenide.conditions.SelectedText;
 import com.codeborne.selenide.conditions.Text;
 import com.codeborne.selenide.conditions.Value;
 import com.codeborne.selenide.conditions.Visible;
+import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.WebElement;
 
 import java.util.function.Predicate;
@@ -104,6 +105,7 @@ public abstract class Condition {
    * @param attributeName name of attribute, not null
    * @return true iff attribute exists
    */
+  @CheckReturnValue
   public static Condition attribute(String attributeName) {
     return new Attribute(attributeName);
   }
@@ -114,6 +116,7 @@ public abstract class Condition {
    * @param attributeName          name of attribute
    * @param expectedAttributeValue expected value of attribute
    */
+  @CheckReturnValue
   public static Condition attribute(String attributeName, String expectedAttributeValue) {
     return new AttributeWithValue(attributeName, expectedAttributeValue);
   }
@@ -126,6 +129,7 @@ public abstract class Condition {
    * @param attributeName  name of attribute
    * @param attributeRegex regex to match attribute value
    */
+  @CheckReturnValue
   public static Condition attributeMatching(String attributeName, String attributeRegex) {
     return new MatchAttributeWithValue(attributeName, attributeRegex);
   }
@@ -138,6 +142,7 @@ public abstract class Condition {
    *
    * @param expectedValue expected value of "value" attribute
    */
+  @CheckReturnValue
   public static Condition value(String expectedValue) {
     return new Value(expectedValue);
   }
@@ -151,6 +156,7 @@ public abstract class Condition {
    * @param propertyName property name of the pseudo-element
    * @param expectedValue expected value of the property
    */
+  @CheckReturnValue
   public static Condition pseudo(String pseudoElementName, String propertyName, String expectedValue) {
     return new PseudoElementPropertyWithValue(pseudoElementName, propertyName, expectedValue);
   }
@@ -162,6 +168,7 @@ public abstract class Condition {
    * @param pseudoElementName pseudo-element name of the element, ":before", ":after"
    * @param expectedValue expected content of the pseudo-element
    */
+  @CheckReturnValue
   public static Condition pseudo(String pseudoElementName, String expectedValue) {
     return new PseudoElementPropertyWithValue(pseudoElementName, "content", expectedValue);
   }
@@ -171,6 +178,7 @@ public abstract class Condition {
    *
    * @param value expected value of input field
    */
+  @CheckReturnValue
   public static Condition exactValue(String value) {
     return attribute("value", value);
   }
@@ -181,6 +189,7 @@ public abstract class Condition {
    *
    * @param name expected name of input field
    */
+  @CheckReturnValue
   public static Condition name(String name) {
     return attribute("name", name);
   }
@@ -191,6 +200,7 @@ public abstract class Condition {
    *
    * @param type expected type of input field
    */
+  @CheckReturnValue
   public static Condition type(String type) {
     return attribute("type", type);
   }
@@ -200,6 +210,7 @@ public abstract class Condition {
    *
    * @param id expected id of input field
    */
+  @CheckReturnValue
   public static Condition id(String id) {
     return attribute("id", id);
   }
@@ -219,6 +230,7 @@ public abstract class Condition {
    *
    * @see #matchText(String)
    */
+  @CheckReturnValue
   public static Condition matchesText(String text) {
     return matchText(text);
   }
@@ -230,6 +242,7 @@ public abstract class Condition {
    *
    * @param regex e.g. Kicked.*Chuck Norris - in this case ".*" can contain any characters including spaces, tabs, CR etc.
    */
+  @CheckReturnValue
   public static Condition matchText(String regex) {
     return new MatchText(regex);
   }
@@ -244,6 +257,7 @@ public abstract class Condition {
    *
    * @param text expected text of HTML element
    */
+  @CheckReturnValue
   public static Condition text(String text) {
     return new Text(text);
   }
@@ -257,6 +271,7 @@ public abstract class Condition {
    *
    * @param expectedText expected selected text of the element
    */
+  @CheckReturnValue
   public static Condition selectedText(String expectedText) {
     return new SelectedText(expectedText);
   }
@@ -270,6 +285,7 @@ public abstract class Condition {
    *
    * @param text expected text of HTML element
    */
+  @CheckReturnValue
   public static Condition textCaseSensitive(String text) {
     return new CaseSensitiveText(text);
   }
@@ -283,6 +299,7 @@ public abstract class Condition {
    *
    * @param text expected text of HTML element
    */
+  @CheckReturnValue
   public static Condition exactText(String text) {
     return new ExactText(text);
   }
@@ -295,6 +312,7 @@ public abstract class Condition {
    *
    * @param text expected text of HTML element
    */
+  @CheckReturnValue
   public static Condition exactTextCaseSensitive(String text) {
     return new ExactTextCaseSensitive(text);
   }
@@ -303,6 +321,7 @@ public abstract class Condition {
    * Asserts that element has the given class. Element may other classes too.
    * <p>Sample: <code>$("input").shouldHave(cssClass("active"));</code></p>
    */
+  @CheckReturnValue
   public static Condition cssClass(String cssClass) {
     return new CssClass(cssClass);
   }
@@ -326,6 +345,7 @@ public abstract class Condition {
    * @param expectedValue expected value of css property
    * @see WebElement#getCssValue
    */
+  @CheckReturnValue
   public static Condition cssValue(String propertyName, String expectedValue) {
     return new CssValue(propertyName, expectedValue);
   }
@@ -338,6 +358,7 @@ public abstract class Condition {
    * @param description the description of the predicate
    * @param predicate   the {@link Predicate} to match
    */
+  @CheckReturnValue
   public static Condition match(String description, Predicate<WebElement> predicate) {
     return new CustomMatch(description, predicate);
   }
@@ -387,6 +408,7 @@ public abstract class Condition {
    * <p>
    * Typically you don't need to use it.
    */
+  @CheckReturnValue
   public static Condition not(final Condition condition) {
     return new Not(condition);
   }
@@ -398,6 +420,7 @@ public abstract class Condition {
    * @param conditions Conditions to match.
    * @return logical AND for given conditions.
    */
+  @CheckReturnValue
   public static Condition and(String name, Condition... conditions) {
     return new And(name, asList(conditions));
   }
@@ -409,6 +432,7 @@ public abstract class Condition {
    * @param conditions Conditions to match.
    * @return logical OR for given conditions.
    */
+  @CheckReturnValue
   public static Condition or(String name, Condition... conditions) {
     return new Or(name, asList(conditions));
   }
@@ -420,6 +444,7 @@ public abstract class Condition {
    * @param delegate next condition to wrap
    * @return Condition
    */
+  @CheckReturnValue
   public static Condition be(Condition delegate) {
     return wrap("be", delegate);
   }
@@ -431,6 +456,7 @@ public abstract class Condition {
    * @param delegate next condition to wrap
    * @return Condition
    */
+  @CheckReturnValue
   public static Condition have(Condition delegate) {
     return wrap("have", delegate);
   }
@@ -468,7 +494,7 @@ public abstract class Condition {
    * Used in error reporting.
    * Optional. Makes sense only if you need to add some additional important info to error message.
    *
-   * @param driver
+   * @param driver given driver
    * @param element given WebElement
    * @return any string that needs to be appended to error message.
    */
@@ -479,6 +505,7 @@ public abstract class Condition {
   /**
    * Should be used for explaining the reason of condition
    */
+  @CheckReturnValue
   public Condition because(String message) {
     return new ExplainedCondition(this, message);
   }

--- a/src/main/java/com/codeborne/selenide/Selectors.java
+++ b/src/main/java/com/codeborne/selenide/Selectors.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.selector.ByShadow;
+import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.Quotes;
 
@@ -16,6 +17,7 @@ public class Selectors {
    * @param elementText Text to search inside element
    * @return standard selenium By criteria`
    */
+  @CheckReturnValue
   public static By withText(String elementText) {
     return new WithText(elementText);
   }
@@ -29,6 +31,7 @@ public class Selectors {
    * @param elementText Text that searched element should have
    * @return standard selenium By criteria
    */
+  @CheckReturnValue
   public static By byText(String elementText) {
     return new ByText(elementText);
   }
@@ -62,6 +65,7 @@ public class Selectors {
    * @param attributeValue value of attribute, should not contain both apostrophes and quotes
    * @return standard selenium By cssSelector criteria
    */
+  @CheckReturnValue
   public static By byAttribute(String attributeName, String attributeValue) {
     String escapedAttributeValue = attributeValue.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
     return By.cssSelector(String.format("[%s=\"%s\"]", attributeName, escapedAttributeValue));
@@ -71,6 +75,7 @@ public class Selectors {
    * @see ByShadow#cssSelector(java.lang.String, java.lang.String, java.lang.String...)
    * @since 5.10
    */
+  @CheckReturnValue
   public static By shadowCss(String target, String shadowHost, String... innerShadowHosts) {
     return ByShadow.cssSelector(target, shadowHost, innerShadowHosts);
   }
@@ -78,6 +83,7 @@ public class Selectors {
   /**
    * Synonym for #byAttribute
    */
+  @CheckReturnValue
   public static By by(String attributeName, String attributeValue) {
     return byAttribute(attributeName, attributeValue);
   }
@@ -85,6 +91,7 @@ public class Selectors {
   /**
    * Find element with given title ("title" attribute)
    */
+  @CheckReturnValue
   public static By byTitle(String title) {
     return byAttribute("title", title);
   }
@@ -92,6 +99,7 @@ public class Selectors {
   /**
    * Find input element with given value ("value" attribute)
    */
+  @CheckReturnValue
   public static By byValue(String value) {
     return byAttribute("value", value);
   }
@@ -136,6 +144,7 @@ public class Selectors {
    * @see By#name(java.lang.String)
    * @since 3.1
    */
+  @CheckReturnValue
   public static By byName(String name) {
     return By.name(name);
   }
@@ -144,6 +153,7 @@ public class Selectors {
    * @see By#xpath(java.lang.String)
    * @since 3.1
    */
+  @CheckReturnValue
   public static By byXpath(String xpath) {
     return By.xpath(xpath);
   }
@@ -152,6 +162,7 @@ public class Selectors {
    * @see By#linkText(java.lang.String)
    * @since 3.1
    */
+  @CheckReturnValue
   public static By byLinkText(String linkText) {
     return By.linkText(linkText);
   }
@@ -160,6 +171,7 @@ public class Selectors {
    * @see By#partialLinkText(java.lang.String)
    * @since 3.1
    */
+  @CheckReturnValue
   public static By byPartialLinkText(String partialLinkText) {
     return By.partialLinkText(partialLinkText);
   }
@@ -168,6 +180,7 @@ public class Selectors {
    * @see By#id(java.lang.String)
    * @since 3.1
    */
+  @CheckReturnValue
   public static By byId(String id) {
     return By.id(id);
   }
@@ -176,6 +189,7 @@ public class Selectors {
    * @see By#cssSelector(java.lang.String)
    * @since 3.8
    */
+  @CheckReturnValue
   public static By byCssSelector(String css) {
     return By.cssSelector(css);
   }
@@ -184,6 +198,7 @@ public class Selectors {
    * @see By#className(java.lang.String)
    * @since 3.8
    */
+  @CheckReturnValue
   public static By byClassName(String className) {
     return By.className(className);
   }
@@ -192,6 +207,7 @@ public class Selectors {
    * @see By#tagName(java.lang.String)
    * @since 5.11
    */
+  @CheckReturnValue
   public static By byTagName(String tagName) {
     return By.tagName(tagName);
   }

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -7,6 +7,7 @@ import com.codeborne.selenide.impl.DownloadFileWithHttpRequest;
 import com.codeborne.selenide.impl.ElementFinder;
 import com.codeborne.selenide.impl.SelenidePageFactory;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
+import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -51,10 +52,12 @@ public class SelenideDriver {
     this.driver = new WebDriverWrapper(config, webDriver, selenideProxy);
   }
 
+  @CheckReturnValue
   public Config config() {
     return config;
   }
 
+  @CheckReturnValue
   public Driver driver() {
     return driver;
   }
@@ -83,16 +86,19 @@ public class SelenideDriver {
     navigator.open(this, absoluteUrl, domain, login, password);
   }
 
+  @CheckReturnValue
   public <PageObjectClass> PageObjectClass open(String relativeOrAbsoluteUrl,
                                                 Class<PageObjectClass> pageObjectClassClass) {
     return open(relativeOrAbsoluteUrl, "", "", "", pageObjectClassClass);
   }
 
+  @CheckReturnValue
   public <PageObjectClass> PageObjectClass open(URL absoluteUrl,
                                                 Class<PageObjectClass> pageObjectClassClass) {
     return open(absoluteUrl, "", "", "", pageObjectClassClass);
   }
 
+  @CheckReturnValue
   public <PageObjectClass> PageObjectClass open(String relativeOrAbsoluteUrl,
                                                 String domain, String login, String password,
                                                 Class<PageObjectClass> pageObjectClassClass) {
@@ -100,16 +106,19 @@ public class SelenideDriver {
     return page(pageObjectClassClass);
   }
 
+  @CheckReturnValue
   public <PageObjectClass> PageObjectClass open(URL absoluteUrl, String domain, String login, String password,
                                                 Class<PageObjectClass> pageObjectClassClass) {
     open(absoluteUrl, domain, login, password);
     return page(pageObjectClassClass);
   }
 
+  @CheckReturnValue
   public <PageObjectClass> PageObjectClass page(Class<PageObjectClass> pageObjectClass) {
     return pageFactory.page(driver(), pageObjectClass);
   }
 
+  @CheckReturnValue
   public <PageObjectClass, T extends PageObjectClass> PageObjectClass page(T pageObject) {
     return pageFactory.page(driver(), pageObject);
   }
@@ -131,10 +140,12 @@ public class SelenideDriver {
     executeJavaScript("window.location.hash='" + localHash + "'");
   }
 
+  @CheckReturnValue
   public Browser browser() {
     return driver().browser();
   }
 
+  @CheckReturnValue
   public SelenideProxyServer getProxy() {
     return driver().getProxy();
   }
@@ -143,10 +154,12 @@ public class SelenideDriver {
     return driver().hasWebDriverStarted();
   }
 
+  @CheckReturnValue
   public WebDriver getWebDriver() {
     return driver.getWebDriver();
   }
 
+  @CheckReturnValue
   public WebDriver getAndCheckWebDriver() {
     return driver.getAndCheckWebDriver();
   }
@@ -167,10 +180,12 @@ public class SelenideDriver {
     return driver().executeAsyncJavaScript(jsCode, arguments);
   }
 
+  @CheckReturnValue
   public WebElement getFocusedElement() {
     return executeJavaScript("return document.activeElement");
   }
 
+  @CheckReturnValue
   public SelenideWait Wait() {
     return new SelenideWait(getWebDriver(), config().timeout(), config().pollingInterval());
   }
@@ -187,62 +202,77 @@ public class SelenideDriver {
     return getWebDriver().getTitle();
   }
 
+  @CheckReturnValue
   public SelenideElement $(WebElement webElement) {
     return wrap(driver(), webElement);
   }
 
+  @CheckReturnValue
   public SelenideElement $(String cssSelector) {
     return find(cssSelector);
   }
 
+  @CheckReturnValue
   public SelenideElement find(String cssSelector) {
     return find(By.cssSelector(cssSelector));
   }
 
+  @CheckReturnValue
   public SelenideElement $x(String xpathExpression) {
     return find(By.xpath(xpathExpression));
   }
 
+  @CheckReturnValue
   public SelenideElement $(By seleniumSelector) {
     return find(seleniumSelector);
   }
 
+  @CheckReturnValue
   public SelenideElement $(By seleniumSelector, int index) {
     return find(seleniumSelector, index);
   }
 
+  @CheckReturnValue
   public SelenideElement $(String cssSelector, int index) {
     return ElementFinder.wrap(driver(), cssSelector, index);
   }
 
+  @CheckReturnValue
   public SelenideElement find(By criteria) {
     return ElementFinder.wrap(driver(), null, criteria, 0);
   }
 
+  @CheckReturnValue
   public SelenideElement find(By criteria, int index) {
     return ElementFinder.wrap(driver(), null, criteria, index);
   }
 
+  @CheckReturnValue
   public ElementsCollection $$(Collection<? extends WebElement> elements) {
     return new ElementsCollection(driver(), elements);
   }
 
+  @CheckReturnValue
   public ElementsCollection $$(String cssSelector) {
     return new ElementsCollection(driver(), cssSelector);
   }
 
+  @CheckReturnValue
   public ElementsCollection $$x(String xpathExpression) {
     return $$(By.xpath(xpathExpression));
   }
 
+  @CheckReturnValue
   public ElementsCollection findAll(By seleniumSelector) {
     return new ElementsCollection(driver(), seleniumSelector);
   }
 
+  @CheckReturnValue
   public ElementsCollection $$(By criteria) {
     return findAll(criteria);
   }
 
+  @CheckReturnValue
   public SelenideElement getSelectedRadio(By radioField) {
     for (WebElement radio : $$(radioField)) {
       if (radio.getAttribute("checked") != null) {
@@ -252,10 +282,12 @@ public class SelenideDriver {
     return null;
   }
 
+  @CheckReturnValue
   public Modal modal() {
     return new Modal(driver());
   }
 
+  @CheckReturnValue
   public WebDriverLogs getWebDriverLogs() {
     return new WebDriverLogs(driver());
   }
@@ -272,18 +304,22 @@ public class SelenideDriver {
     return driver().switchTo();
   }
 
+  @CheckReturnValue
   public String url() {
     return getWebDriver().getCurrentUrl();
   }
 
+  @CheckReturnValue
   public String source() {
     return getWebDriver().getPageSource();
   }
 
+  @CheckReturnValue
   public String getCurrentFrameUrl() {
     return executeJavaScript("return window.location.href").toString();
   }
 
+  @CheckReturnValue
   public String getUserAgent() {
     return driver().getUserAgent();
   }

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.files.FileFilter;
+import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.TakesScreenshot;
@@ -112,6 +113,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see WebElement#getText()
    * @see com.codeborne.selenide.commands.GetText
    */
+  @CheckReturnValue
   String text();
 
   /**
@@ -120,6 +122,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Short form of getAttribute("textContent") or getAttribute("innerText") depending on browser.
    * @see com.codeborne.selenide.commands.GetInnerText
    */
+  @CheckReturnValue
   String innerText();
 
   /**
@@ -128,6 +131,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Short form of getAttribute("innerHTML")
    * @see com.codeborne.selenide.commands.GetInnerHtml
    */
+  @CheckReturnValue
   String innerHtml();
 
   /**
@@ -135,6 +139,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @return null if attribute is missing
    * @see com.codeborne.selenide.commands.GetAttribute
    */
+  @CheckReturnValue
   String attr(String attributeName);
 
   /**
@@ -142,6 +147,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @return attribute "name" value or null if attribute is missing
    * @see com.codeborne.selenide.commands.GetName
    */
+  @CheckReturnValue
   String name();
 
   /**
@@ -151,6 +157,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.Val
    */
+  @CheckReturnValue
   String val();
 
   /**
@@ -160,6 +167,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.GetValue
    */
+  @CheckReturnValue
   String getValue();
 
   /**
@@ -169,6 +177,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @param propertyName property name of the pseudo-element
    * @return the property value or "" if the property is missing
    */
+  @CheckReturnValue
   String pseudo(String pseudoElementName, String propertyName);
 
   /**
@@ -176,6 +185,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @param pseudoElementName pseudo-element name of the element, ":before", ":after"
    * @return the content value or "none" if the content is missing
    */
+  @CheckReturnValue
   String pseudo(String pseudoElementName);
 
   /**
@@ -192,6 +202,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.GetDataAttribute
    */
+  @CheckReturnValue
   String data(String dataAttributeName);
 
   /**
@@ -219,6 +230,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see #has
    * @see com.codeborne.selenide.commands.Matches
    */
+  @CheckReturnValue
   boolean is(Condition condition);
 
   /**
@@ -229,6 +241,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see #is
    * @see com.codeborne.selenide.commands.Matches
    */
+  @CheckReturnValue
   boolean has(Condition condition);
 
   /**
@@ -396,6 +409,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.GetParent
    */
+  @CheckReturnValue
   SelenideElement parent();
 
   /**
@@ -408,6 +422,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.GetSibling
    */
+  @CheckReturnValue
   SelenideElement sibling(int index);
 
   /**
@@ -420,6 +435,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.GetPreceding
    */
+  @CheckReturnValue
   SelenideElement preceding(int index);
 
   /**
@@ -427,6 +443,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * ATTENTION! this method doesn't start any search yet!
    * For example, $("tr").lastChild(); could give the last "td".
    */
+  @CheckReturnValue
   SelenideElement lastChild();
 
   /**
@@ -439,6 +456,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.GetClosest
    */
+  @CheckReturnValue
   SelenideElement closest(String tagOrClass);
 
   /**
@@ -448,6 +466,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.Find
    */
+  @CheckReturnValue
   SelenideElement find(String cssSelector);
 
   /**
@@ -456,6 +475,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.Find
    */
+  @CheckReturnValue
   SelenideElement find(String cssSelector, int index);
 
   /**
@@ -463,6 +483,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Same as {@link #find(String)}
    * @see com.codeborne.selenide.commands.Find
    */
+  @CheckReturnValue
   SelenideElement find(By selector);
 
   /**
@@ -470,6 +491,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Same as {@link #find(String, int)}
    * @see com.codeborne.selenide.commands.Find
    */
+  @CheckReturnValue
   SelenideElement find(By selector, int index);
 
   /**
@@ -477,6 +499,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Same as {@link #find(String)}
    * @see com.codeborne.selenide.commands.Find
    */
+  @CheckReturnValue
   SelenideElement $(String cssSelector);
 
   /**
@@ -484,6 +507,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Same as {@link #find(String, int)}
    * @see com.codeborne.selenide.commands.Find
    */
+  @CheckReturnValue
   SelenideElement $(String cssSelector, int index);
 
   /**
@@ -491,6 +515,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Same as {@link #find(String)}
    * @see com.codeborne.selenide.commands.Find
    */
+  @CheckReturnValue
   SelenideElement $(By selector);
 
   /**
@@ -498,6 +523,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Same as {@link #find(String, int)}
    * @see com.codeborne.selenide.commands.Find
    */
+  @CheckReturnValue
   SelenideElement $(By selector, int index);
 
   /**
@@ -507,6 +533,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.FindByXpath
    */
+  @CheckReturnValue
   SelenideElement $x(String xpath);
 
   /**
@@ -515,6 +542,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.FindByXpath
    */
+  @CheckReturnValue
   SelenideElement $x(String xpath, int index);
 
   /**
@@ -530,6 +558,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.FindAll
    */
+  @CheckReturnValue
   ElementsCollection findAll(String cssSelector);
 
   /**
@@ -545,17 +574,20 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.FindAll
    */
+  @CheckReturnValue
   ElementsCollection findAll(By selector);
 
   /**
    * ATTENTION! This method doesn't start any search yet!
    * Same as {@link #findAll(String)}
    */
+  @CheckReturnValue
   ElementsCollection $$(String cssSelector);
 
   /**
    * Same as {@link #findAll(By)}
    */
+  @CheckReturnValue
   ElementsCollection $$(By selector);
 
   /**
@@ -571,6 +603,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.FindAllByXpath
    */
+  @CheckReturnValue
   ElementsCollection $$x(String xpath);
 
   /**
@@ -613,7 +646,6 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    */
   void selectOption(String... text);
 
-
   /**
    * Select an option from dropdown list that contains given text
    * @param text substring of visible text of option
@@ -652,6 +684,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.GetSelectedValue
    */
+  @CheckReturnValue
   String getSelectedValue();
 
   /**
@@ -659,6 +692,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.GetSelectedText
    */
+  @CheckReturnValue
   String getSelectedText();
 
   /**
@@ -785,6 +819,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Return criteria by which this element is located
    * @return e.g. "#multirowTable.findBy(text 'INVALID-TEXT')/valid-selector"
    */
+  @CheckReturnValue
   String getSearchCriteria();
 
   /**
@@ -792,6 +827,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.ToWebElement
    */
+  @CheckReturnValue
   WebElement toWebElement();
 
   /**
@@ -799,6 +835,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.GetWrappedElement
    */
   @Override
+  @CheckReturnValue
   WebElement getWrappedElement();
 
   /**
@@ -904,5 +941,6 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.TakeScreenshotAsImage
    */
+  @CheckReturnValue
   BufferedImage screenshotAsImage();
 }

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -749,6 +749,7 @@ public class Selenide {
    *
    * @return instance of org.openqa.selenium.support.ui.FluentWait
    */
+  @CheckReturnValue
   public static SelenideWait Wait() {
     return getSelenideDriver().Wait();
   }
@@ -766,6 +767,7 @@ public class Selenide {
    *    .perform();
    * </pre>
    */
+  @CheckReturnValue
   public static Actions actions() {
     return getSelenideDriver().driver().actions();
   }

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.ex.DialogTextMismatch;
+import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -218,6 +219,7 @@ public class Selenide {
    *
    * @return title of the page
    */
+  @CheckReturnValue
   public static String title() {
     return getSelenideDriver().title();
   }
@@ -251,6 +253,7 @@ public class Selenide {
    * @param webElement standard Selenium WebElement
    * @return given WebElement wrapped into SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement $(WebElement webElement) {
     return getSelenideDriver().$(webElement);
   }
@@ -261,6 +264,7 @@ public class Selenide {
    * @param cssSelector any CSS selector like "input[name='first_name']" or "#messages .new_message"
    * @return SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement $(String cssSelector) {
     return getSelenideDriver().find(cssSelector);
   }
@@ -271,6 +275,7 @@ public class Selenide {
    * @param xpathExpression any XPATH expression //*[@id='value'] //E[contains(@A, 'value')]
    * @return SelenideElement which locates elements via XPath
    */
+  @CheckReturnValue
   public static SelenideElement $x(String xpathExpression) {
     return getSelenideDriver().$x(xpathExpression);
   }
@@ -281,6 +286,7 @@ public class Selenide {
    * @param seleniumSelector any Selenium selector like By.id(), By.name() etc.
    * @return SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement $(By seleniumSelector) {
     return getSelenideDriver().find(seleniumSelector);
   }
@@ -288,6 +294,7 @@ public class Selenide {
   /**
    * @see #getElement(By, int)
    */
+  @CheckReturnValue
   public static SelenideElement $(By seleniumSelector, int index) {
     return getSelenideDriver().find(seleniumSelector, index);
   }
@@ -315,6 +322,7 @@ public class Selenide {
    * @param index 0..N
    * @return SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement $(String cssSelector, int index) {
     return getSelenideDriver().$(cssSelector, index);
   }
@@ -332,6 +340,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @Deprecated
+  @CheckReturnValue
   public static SelenideElement $(WebElement parent, String cssSelector, int index) {
     return getSelenideDriver().$(parent).find(cssSelector, index);
   }
@@ -348,6 +357,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @Deprecated
+  @CheckReturnValue
   public static SelenideElement $(WebElement parent, By seleniumSelector) {
     return getSelenideDriver().$(parent).find(seleniumSelector);
   }
@@ -365,6 +375,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @Deprecated
+  @CheckReturnValue
   public static SelenideElement $(WebElement parent, By seleniumSelector, int index) {
     return getSelenideDriver().$(parent).find(seleniumSelector, index);
   }
@@ -372,6 +383,7 @@ public class Selenide {
   /**
    * Initialize collection with Elements
    */
+  @CheckReturnValue
   public static ElementsCollection $$(Collection<? extends WebElement> elements) {
     return getSelenideDriver().$$(elements);
   }
@@ -386,6 +398,7 @@ public class Selenide {
    * @param cssSelector any CSS selector like "input[name='first_name']" or "#messages .new_message"
    * @return empty list if element was no found
    */
+  @CheckReturnValue
   public static ElementsCollection $$(String cssSelector) {
     return getSelenideDriver().$$(cssSelector);
   }
@@ -399,6 +412,7 @@ public class Selenide {
    * @param xpathExpression any XPATH expression //*[@id='value'] //E[contains(@A, 'value')]
    * @return ElementsCollection which locates elements via XPath
    */
+  @CheckReturnValue
   public static ElementsCollection $$x(String xpathExpression) {
     return getSelenideDriver().$$x(xpathExpression);
   }
@@ -413,6 +427,7 @@ public class Selenide {
    * @param seleniumSelector any Selenium selector like By.id(), By.name() etc.
    * @return empty list if element was no found
    */
+  @CheckReturnValue
   public static ElementsCollection $$(By seleniumSelector) {
     return getSelenideDriver().$$(seleniumSelector);
   }
@@ -433,6 +448,7 @@ public class Selenide {
    * @return empty list if element was no found
    */
   @Deprecated
+  @CheckReturnValue
   public static ElementsCollection $$(WebElement parent, String cssSelector) {
     return getSelenideDriver().$(parent).findAll(cssSelector);
   }
@@ -447,6 +463,7 @@ public class Selenide {
    * @see Selenide#$$(WebElement, String)
    */
   @Deprecated
+  @CheckReturnValue
   public static ElementsCollection $$(WebElement parent, By seleniumSelector) {
     return getSelenideDriver().$(parent).findAll(seleniumSelector);
   }
@@ -458,6 +475,7 @@ public class Selenide {
    * @param webElement standard Selenium WebElement
    * @return given WebElement wrapped into SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement element(WebElement webElement) {
     return getSelenideDriver().$(webElement);
   }
@@ -468,6 +486,7 @@ public class Selenide {
    * @param cssSelector any CSS selector like "input[name='first_name']" or "#messages .new_message"
    * @return SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement element(String cssSelector) {
     return getSelenideDriver().$(cssSelector);
   }
@@ -478,6 +497,7 @@ public class Selenide {
    * @param seleniumSelector any Selenium selector like By.id(), By.name() etc.
    * @return SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement element(By seleniumSelector) {
     return getSelenideDriver().$(seleniumSelector);
   }
@@ -489,6 +509,7 @@ public class Selenide {
    * @param index 0..N
    * @return SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement element(By seleniumSelector, int index) {
     return getSelenideDriver().$(seleniumSelector, index);
   }
@@ -500,6 +521,7 @@ public class Selenide {
    * @param index 0..N
    * @return SelenideElement
    */
+  @CheckReturnValue
   public static SelenideElement element(String cssSelector, int index) {
     return getSelenideDriver().$(cssSelector, index);
   }
@@ -511,6 +533,7 @@ public class Selenide {
    * @param elements standard Selenium WebElement collection
    * @return given WebElement collection wrapped into SelenideElement collection
    */
+  @CheckReturnValue
   public static ElementsCollection elements(Collection<? extends WebElement> elements) {
     return getSelenideDriver().$$(elements);
   }
@@ -525,6 +548,7 @@ public class Selenide {
    * @param cssSelector any CSS selector like "input[name='first_name']" or "#messages .new_message"
    * @return empty list if element was no found
    */
+  @CheckReturnValue
   public static ElementsCollection elements(String cssSelector) {
     return getSelenideDriver().$$(cssSelector);
   }
@@ -539,6 +563,7 @@ public class Selenide {
    * @param seleniumSelector any Selenium selector like By.id(), By.name() etc.
    * @return empty list if element was no found
    */
+  @CheckReturnValue
   public static ElementsCollection elements(By seleniumSelector) {
     return getSelenideDriver().$$(seleniumSelector);
   }
@@ -552,6 +577,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @Deprecated
+  @CheckReturnValue
   public static SelenideElement getElement(By criteria) {
     return getSelenideDriver().find(criteria);
   }
@@ -566,6 +592,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @Deprecated
+  @CheckReturnValue
   public static SelenideElement getElement(By criteria, int index) {
     return getSelenideDriver().find(criteria, index);
   }
@@ -579,6 +606,7 @@ public class Selenide {
    * @return empty list if element was no found
    */
   @Deprecated
+  @CheckReturnValue
   public static ElementsCollection getElements(By criteria) {
     return getSelenideDriver().findAll(criteria);
   }
@@ -601,6 +629,7 @@ public class Selenide {
    * Returns selected element in radio group
    * @return null if nothing selected
    */
+  @CheckReturnValue
   public static SelenideElement getSelectedRadio(By radioField) {
     return getSelenideDriver().getSelectedRadio(radioField);
   }
@@ -689,6 +718,7 @@ public class Selenide {
    *
    * @return WebElement, not SelenideElement! which has focus on it
    */
+  @CheckReturnValue
   public static WebElement getFocusedElement() {
     return getSelenideDriver().getFocusedElement();
   }
@@ -696,6 +726,7 @@ public class Selenide {
   /**
    * Create a Page Object instance
    */
+  @CheckReturnValue
   public static <PageObjectClass> PageObjectClass page(Class<PageObjectClass> pageObjectClass) {
     return getSelenideDriver().page(pageObjectClass);
   }
@@ -703,6 +734,7 @@ public class Selenide {
   /**
    * Initialize a given Page Object instance
    */
+  @CheckReturnValue
   public static <PageObjectClass, T extends PageObjectClass> PageObjectClass page(T pageObject) {
     return getSelenideDriver().page(pageObject);
   }


### PR DESCRIPTION
## Proposed changes
Here we add `@CheckReturnValue` annotation from checker framework to methods that only return values and do not have any additional visible effects.
This change helps to spot a bug in IDE when someone uses method that does not have effects but only returns value, example from real tests:
```
$("div").text(); // the value is not used
```

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

FYI: For some reason checkstyle says that `Class Fan-Out Complexity is 30 (max allowed is 29).` for Condition class.