### PR TITLE
fix false error message in ErrorMessagesTest for returnScreenshotFile…

### DIFF
--- a/src/test/java/com/codeborne/selenide/ex/ErrorMessagesTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ErrorMessagesTest.java
@@ -86,6 +86,8 @@ class ErrorMessagesTest implements WithAssertions {
       currentDir = '/' + currentDir.replace('\\', '/');
     }
 
+    currentDir = currentDir.replace(" ", "%20"); //the screenshot path uses %20 instead of the space character
+
     doReturn(new File("src/test/resources/screenshot.png")).when(webDriver).getScreenshotAs(OutputType.FILE);
 
     String screenshot = ErrorMessages.screenshot(driver);


### PR DESCRIPTION
name: John Pratt

## Proposed changes
This allows the returnScreenshotFilname test to pass when the path to the screenshot includes a space character (such as in a Window account's username), which is transformed into "%20" in the actual file path.
