### PR TITLE
#368 fail test for `$("#missingElement").shouldNotHave(text(...))`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 5.11.0
+* #368 $("#missingElement").shouldNotHave(text("whatever")) now throws an exception    --  NB! It's a breaking change! See PR #1116
 * #996 Add MatchAttributeWithValue condition -- thanks to Dmytro Stekanov for PR #1100
 * Add CheckReturnValue annotation for methods that only return value  --  thanks to Yuriy Artamonov for PR #1106
 * Add missing byTagName to Selectors to make it consistent with By  --  thanks to Yuriy Artamonov for PR #1104
@@ -12,7 +13,7 @@
 * #1091 Migrated Guava API to the equivalent Java API  --  thanks to Wladimir Schmidt for PR #1091
 * #1032 Add quotes around selectors in Selenide logger  --  thanks to Dmytro Stekanov for #1092
 * #1069 add condition `$.shouldBe(image)`  --  thanks to Dmytro Stekanov for #1086
-* #1060 fix finding element by attribute which contains quotes  --  thanks to Denys Lystopadskyy for PR #1062 
+* #1060 fix finding element by an attribute which contains quotes  --  thanks to Denys Lystopadskyy for PR #1062 
 
 ## 5.9.0 (released 10.03.2020)
 * #1065 add method $.download(FileFilter)  --  see PR #1080
@@ -58,7 +59,7 @@
 * Remove built-in support for jbrowser driver
 * #1000 make `$.execute(command)` generic: it now can return any value, or even be Void  --  see PR #1001
 * #999 make `holdBrowserOpen` setting work again  --  see PR #1005
-* #907 take screenshot in case of `DialogTextMismatch` error  --  thanks to Nick Holloway @nwholloway for PR #986
+* #907 take a screenshot in case of `DialogTextMismatch` error  --  thanks to Nick Holloway @nwholloway for PR #986
 * refactor ScreenShotLaboratory  --  thanks to @SeleniumTestAB for PRs #1004 and #1006
 * add "selenide.remote" to exception info (in addition to "selenide.url" and "selenide.baseUrl")  --  see commit ba4f0544448de
 
@@ -66,7 +67,7 @@
 * bugfix: close webdriver in the end of all tests
 
 ## 5.4.0 (released 16.10.2019)
-* #862 #902 #954 #922 fix "IIlegalStateException WebDriver has been closed" (with a heavy heart!)   --  see PR #989
+* #862 #902 #954 #922 fix "IllegalStateException WebDriver has been closed" (with a heavy heart!)   --  see PR #989
 * #896 Do close the browser in SelenideDriver.close()  --  see PR #989
 * #993 shorten the error message as it was before Selenide 5.3.1
 * #976 add method "using" to easy switch between webdrivers
@@ -75,7 +76,7 @@
 * exclude old Guava dependency coming from net.lightbody.bmp:browsermob-core:2.1.5
 
 ## 5.3.1 (released 08.09.2019)
-* #234 add screenshot to error message in Maven too  -- see PR #972
+* #234 add a screenshot to error message in Maven too  -- see PR #972
 
 ## 5.3.0 (released 02.09.2019)
 * support URLs with newlines
@@ -157,7 +158,7 @@
 * #817 fix "FirefoxDriverFactory overwrites Firefox profile provided by Configuration"  --  thanks @BorisOsipov for PR #821
 * bugfix: method Selenide.download() should not fail if there is no opened browser yet
 * #825 Upgrade to WebDriverManager 3.0.0 (again)
-* #825 Add workaround for WebDriverManager issue when it calls github too often and gets 403 error
+* #825 Add a workaround for WebDriverManager issue when it calls github too often and gets 403 error
 * #832 Added support for screenshots outside of "user.dir" in CI server
 
 Technical changes (probably should not affect end users):
@@ -185,7 +186,7 @@ Technical changes (probably should not affect end users):
 
 ## 4.13.0 (released 20.08.2018)
 * #771 Added method `$.lastChild()` for retrieving the last child element of a given element
-* #601 Added collection checks with custom timeout  --  see PR #781
+* #601 Added collection checks with a custom timeout  --  see PR #781
 * #782 Added method `Selenide.download(url)`
 
 * #773 Upgraded to Selenium 3.14.0. 
@@ -195,7 +196,7 @@ Technical changes (probably should not affect end users):
 * #273 Method `switchTo().alert()` now throws `NoAlertPresentException` instead of `TimeoutException`  -- thanks to @tsukakei for PR #774
 * #709 Fixed a misleading error message $.selectOptionByValue() reports  -- thanks to Keita Tsukamoto for PR #780
 * #734 Fixed incorrect filename of downloaded file  -- thanks to @rosolko for PR 768
-* #783 Upgraded to webdrivermanager 2.2.5   -- see [https://github.com/bonigarcia/webdrivermanager/blob/master/changelog](changelog)
+* #783 Upgraded to webdrivermanager 2.2.5   -- see [changelog](https://github.com/bonigarcia/webdrivermanager/blob/master/changelog)
 * #775 Upgrade to htmlunit 2.32.1
 * #778 Fixed Selenide tests for FireFox
 
@@ -275,7 +276,7 @@ Technical changes (probably should not affect end users):
 
 * See #641 Increased Elements Collection performance -- thanks to Artem Savosik @CaBocuk for PR 653
 * See #639 Add "User-Agent" header when downloading file -- thanks to Aleksandr Rasolka @rosolko
-* See #556 add possibility to set custom capabilities for custom Chrome options or Firefox profies --Thanks to @SergeyPirogov for PR 556 and @BorisOsipov for PR 664
+* See #556 add possibility to set custom capabilities for custom Chrome options or Firefox profiles --Thanks to @SergeyPirogov for PR 556 and @BorisOsipov for PR 664
 * See #660 add possibility to create headless RemoteDriver -- thanks to @BorisOsipov for PR 661
 * See #597 support non-breakable spaces in `byText` and `withText`
 * See #649 Provide scrollIntoView to workaround problems in Firefox
@@ -284,7 +285,7 @@ Technical changes (probably should not affect end users):
 
 ## 4.9.1 (released 31.12.2017)
 
-* fixed bug where disabled input fields were not handled properly by setValue()
+* fixed a bug where disabled input fields were not handled properly by setValue()
 * fixed behaviour of setFastValue, which caused blur event to be ignored
 * See #654 fixed ClassCastException in WebDriverFactory#logBrowserVersion()
 
@@ -354,7 +355,7 @@ Technical changes (probably should not affect end users):
 
 ## 4.4.1 (released 28.03.2017)
 
-* Add workaround for invalid resolving of `selenium-api` dependency by Maven
+* Add a workaround for invalid resolving of `selenium-api` dependency by Maven
 
 ## 4.4 (released 27.03.2017)
 

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -410,7 +410,11 @@ public abstract class Condition {
    */
   @CheckReturnValue
   public static Condition not(final Condition condition) {
-    return new Not(condition);
+    return condition.negate();
+  }
+
+  protected Condition negate() {
+    return new Not(this, absentElementMatchesCondition);
   }
 
   /**
@@ -466,7 +470,7 @@ public abstract class Condition {
   }
 
   private final String name;
-  private final boolean nullIsAllowed;
+  private final boolean absentElementMatchesCondition;
 
   public Condition(String name) {
     this(name, false);
@@ -474,7 +478,7 @@ public abstract class Condition {
 
   public Condition(String name, boolean absentElementMatchesCondition) {
     this.name = name;
-    this.nullIsAllowed = absentElementMatchesCondition;
+    this.absentElementMatchesCondition = absentElementMatchesCondition;
   }
 
   /**
@@ -486,7 +490,7 @@ public abstract class Condition {
   public abstract boolean apply(Driver driver, WebElement element);
 
   public boolean applyNull() {
-    return nullIsAllowed;
+    return absentElementMatchesCondition;
   }
 
   /**
@@ -520,6 +524,6 @@ public abstract class Condition {
   }
 
   public boolean missingElementSatisfiesCondition() {
-    return nullIsAllowed;
+    return absentElementMatchesCondition;
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/Exist.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Exist.java
@@ -20,4 +20,9 @@ public class Exist extends Condition {
       return false;
     }
   }
+
+  @Override
+  protected Condition negate() {
+    return new Not(this, true);
+  }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/Hidden.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Hidden.java
@@ -19,4 +19,9 @@ public class Hidden extends Condition {
       return true;
     }
   }
+
+  @Override
+  protected Condition negate() {
+    return new Not(this, false);
+  }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/Not.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Not.java
@@ -7,8 +7,8 @@ import org.openqa.selenium.WebElement;
 public class Not extends Condition {
   private final Condition condition;
 
-  public Not(Condition originalCondition) {
-    super("not " + originalCondition.getName(), !originalCondition.missingElementSatisfiesCondition());
+  public Not(Condition originalCondition, boolean absentElementMatchesCondition) {
+    super("not " + originalCondition.getName(), absentElementMatchesCondition);
     this.condition = originalCondition;
   }
 

--- a/src/main/java/com/codeborne/selenide/conditions/Visible.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Visible.java
@@ -18,4 +18,9 @@ public class Visible extends Condition {
   public String actualValue(Driver driver, WebElement element) {
     return String.format("visible:%s", element.isDisplayed());
   }
+
+  @Override
+  protected Condition negate() {
+    return new Not(this, true);
+  }
 }

--- a/src/test/java/com/codeborne/selenide/conditions/ExistTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/ExistTest.java
@@ -1,0 +1,44 @@
+package com.codeborne.selenide.conditions;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ExistTest {
+  private final Exist condition = new Exist();
+  private final WebElement element = mock(WebElement.class);
+
+  @Test
+  void negate() {
+    assertThat(condition.missingElementSatisfiesCondition()).isFalse();
+    assertThat(condition.negate().missingElementSatisfiesCondition()).isTrue();
+  }
+
+  @Test
+  void name() {
+    assertThat(condition.getName()).isEqualTo("exist");
+    assertThat(condition.negate().getName()).isEqualTo("not exist");
+  }
+
+  @Test
+  void satisfied_if_element_is_visible() {
+    when(element.isDisplayed()).thenReturn(true);
+    assertThat(condition.apply(null, element)).isTrue();
+  }
+
+  @Test
+  void satisfied_if_element_exists_even_if_invisible() {
+    when(element.isDisplayed()).thenReturn(false);
+    assertThat(condition.apply(null, element)).isTrue();
+  }
+
+  @Test
+  void not_satisfied_if_element_is_stolen() {
+    when(element.isDisplayed()).thenThrow(StaleElementReferenceException.class);
+    assertThat(condition.apply(null, element)).isFalse();
+  }
+}

--- a/src/test/java/com/codeborne/selenide/conditions/HiddenTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/HiddenTest.java
@@ -1,0 +1,37 @@
+package com.codeborne.selenide.conditions;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HiddenTest {
+  private final Hidden condition = new Hidden();
+  private final WebElement element = mock(WebElement.class);
+
+  @Test
+  void negate() {
+    assertThat(condition.missingElementSatisfiesCondition()).isTrue();
+    assertThat(condition.negate().missingElementSatisfiesCondition()).isFalse();
+  }
+
+  @Test
+  void name() {
+    assertThat(condition.getName()).isEqualTo("hidden");
+    assertThat(condition.negate().getName()).isEqualTo("not hidden");
+  }
+
+  @Test
+  void satisfied_if_element_is_not_visible() {
+    when(element.isDisplayed()).thenReturn(false);
+    assertThat(condition.apply(null, element)).isTrue();
+  }
+
+  @Test
+  void not_satisfied_if_element_is_visible() {
+    when(element.isDisplayed()).thenReturn(true);
+    assertThat(condition.apply(null, element)).isFalse();
+  }
+}

--- a/src/test/java/com/codeborne/selenide/conditions/VisibleTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/VisibleTest.java
@@ -1,0 +1,56 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Condition;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class VisibleTest {
+  private final VisibleForTest condition = new VisibleForTest();
+  private final WebElement element = mock(WebElement.class);
+
+  @Test
+  void negate() {
+    assertThat(condition.missingElementSatisfiesCondition()).isFalse();
+    assertThat(condition.negate().missingElementSatisfiesCondition()).isTrue();
+  }
+
+  @Test
+  void name() {
+    assertThat(condition.getName()).isEqualTo("visible");
+    assertThat(condition.negate().getName()).isEqualTo("not visible");
+  }
+
+  @Test
+  void satisfied_if_element_is_visible() {
+    when(element.isDisplayed()).thenReturn(true);
+    assertThat(condition.apply(null, element)).isTrue();
+  }
+
+  @Test
+  void not_satisfied_if_element_is_invisible() {
+    when(element.isDisplayed()).thenReturn(false);
+    assertThat(condition.apply(null, element)).isFalse();
+  }
+
+  @Test
+  void actualValue_invisible() {
+    assertThat(condition.actualValue(null, element)).isEqualTo("visible:false");
+  }
+
+  @Test
+  void actualValue_visible() {
+    when(element.isDisplayed()).thenReturn(true);
+    assertThat(condition.actualValue(null, element)).isEqualTo("visible:true");
+  }
+
+  private static class VisibleForTest extends Visible {
+    @Override
+    protected Condition negate() {
+      return super.negate();
+    }
+  }
+}

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
@@ -9,8 +9,6 @@ import com.codeborne.selenide.logevents.LogEvent;
 import com.codeborne.selenide.logevents.LogEvent.EventStatus;
 import com.codeborne.selenide.logevents.LogEventListener;
 import com.codeborne.selenide.logevents.SelenideLogger;
-import java.util.HashMap;
-import java.util.Map;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.enabled;
@@ -115,8 +115,8 @@ class SelenideElementProxyTest implements WithAssertions {
     driver.find("#firstName").shouldNotBe(exist);
     driver.find("#firstName").should(disappear);
     driver.find("#firstName").shouldNotBe(visible);
-    driver.find("#firstName").shouldNotBe(enabled);
-    driver.find("#firstName").shouldNotHave(text("goodbye"));
+    assertThatThrownBy(() -> driver.find("#firstName").shouldNotBe(enabled)).isInstanceOf(ElementNotFound.class);
+    assertThatThrownBy(() -> driver.find("#firstName").shouldNotHave(text("goodbye"))).isInstanceOf(ElementNotFound.class);
   }
 
   @Test
@@ -126,8 +126,8 @@ class SelenideElementProxyTest implements WithAssertions {
     driver.find("#firstName").shouldNot(exist);
     driver.find("#firstName").should(disappear);
     driver.find("#firstName").shouldNotBe(visible);
-    driver.find("#firstName").shouldNotBe(enabled);
-    driver.find("#firstName").shouldNotHave(text("goodbye"));
+    assertThatThrownBy(() -> driver.find("#firstName").shouldNotBe(enabled)).isInstanceOf(ElementNotFound.class);
+    assertThatThrownBy(() -> driver.find("#firstName").shouldNotHave(text("goodbye"))).isInstanceOf(ElementNotFound.class);
   }
 
   @Test

--- a/src/test/java/integration/BaseIntegrationTest.java
+++ b/src/test/java/integration/BaseIntegrationTest.java
@@ -1,13 +1,10 @@
 package integration;
 
 import com.codeborne.selenide.Browser;
-import com.codeborne.selenide.junit5.TextReportExtension;
 import integration.server.LocalHttpServer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Locale;
@@ -17,28 +14,21 @@ import static com.codeborne.selenide.Browsers.FIREFOX;
 import static java.lang.Boolean.parseBoolean;
 import static org.openqa.selenium.net.PortProber.findFreePort;
 
-@ExtendWith({TextReportExtension.class})
+@ExtendWith({LogTestNameExtension.class})
 public abstract class BaseIntegrationTest {
-  private static final Logger log = LoggerFactory.getLogger(BaseIntegrationTest.class);
-
   private static final boolean SSL = true;
   protected static LocalHttpServer server;
   protected static long averageSeleniumCommandDuration = 100;
   private static String protocol;
   private static int port;
   protected static final String browser = System.getProperty("selenide.browser", FIREFOX);
-  private static final boolean headless = parseBoolean(System.getProperty("selenide.headless", "false"));
+  static final boolean headless = parseBoolean(System.getProperty("selenide.headless", "false"));
 
   @BeforeAll
   static void setUpAll() throws Exception {
     Locale.setDefault(Locale.ENGLISH);
     runLocalHttpServer();
     setUpVideoRecorder();
-  }
-
-  @BeforeAll
-  static void logBrowserName() {
-    log.info("START {}{} TESTS", browser, headless ? " (headless)" : "");
   }
 
   @BeforeEach

--- a/src/test/java/integration/LogTestNameExtension.java
+++ b/src/test/java/integration/LogTestNameExtension.java
@@ -1,0 +1,42 @@
+package integration;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.opentest4j.TestAbortedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static integration.BaseIntegrationTest.browser;
+
+class LogTestNameExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
+  private static final Logger log = LoggerFactory.getLogger(LogTestNameExtension.class);
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    log.info("Starting {} @ {}", context.getDisplayName(), browser);
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    log.info("Finished {} @ {} - {}", context.getDisplayName(), browser, verdict(context));
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    log.info("  starting {} ...", context.getDisplayName());
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    log.info("  finished {} - {}", context.getDisplayName(), verdict(context));
+  }
+
+  private String verdict(ExtensionContext context) {
+    return context.getExecutionException().isPresent() ?
+      (context.getExecutionException().get() instanceof TestAbortedException ? "skipped" : "NOK") :
+      "OK";
+  }
+}

--- a/src/test/java/integration/NotExistingElementTest.java
+++ b/src/test/java/integration/NotExistingElementTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.codeborne.selenide.ex.ElementNotFound;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +9,7 @@ import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NotExistingElementTest extends ITest {
   @BeforeEach
@@ -36,12 +38,18 @@ class NotExistingElementTest extends ITest {
   }
 
   @Test
-  void shouldNotHaveTextRemove() {
-    $("#not_exist").shouldNotHave(text("Remove me"));
+  void shouldNotHaveText_fails_ifElementIsNotFound() {
+    assertThatThrownBy(() ->
+      $("#not_exist").shouldNotHave(text("Remove me"))
+    ).isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {#not_exist}");
   }
 
   @Test
-  void shouldNotHaveAttributeAbc() {
-    $("#not_exist").shouldNotHave(attribute("abc"));
+  void shouldNotHaveAttribute_fails_ifElementIsNotFound() {
+    assertThatThrownBy(() ->
+      $("#not_exist").shouldNotHave(attribute("abc"))
+    ).isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {#not_exist}");
   }
 }

--- a/statics/src/test/java/integration/ChecksOnMissingParentElementTest.java
+++ b/statics/src/test/java/integration/ChecksOnMissingParentElementTest.java
@@ -1,0 +1,38 @@
+package integration;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.ex.ElementNotFound;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ChecksOnMissingParentElementTest extends IntegrationTest {
+  @BeforeEach
+  void openTestPage() {
+    Configuration.timeout = 10;
+    openFile("page_with_jquery.html");
+  }
+
+  @Test
+  void should_not_exist_is_ok() {
+    $("#abracadabra").find(".magic").shouldNot(exist);
+  }
+
+  @Test
+  void should_not_be_visible_is_ok() {
+    $("#abracadabra").find(".magic").shouldNotBe(visible);
+  }
+
+  @Test
+  void should_not_have_text_is_nok() {
+    assertThatThrownBy(() ->
+      $("#abracadabra").find(".magic").shouldNotHave(text("Search"))
+    ).isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {#abracadabra}");
+  }
+}

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -4,7 +4,6 @@ import com.automation.remarks.junit5.VideoExtension;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.junit5.ScreenShooterExtension;
-import com.codeborne.selenide.junit5.TextReportExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,7 +28,7 @@ import static com.codeborne.selenide.WebDriverRunner.isIE;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
 
-@ExtendWith({ScreenShooterExtension.class, TextReportExtension.class, VideoExtension.class})
+@ExtendWith({ScreenShooterExtension.class, VideoExtension.class})
 public abstract class IntegrationTest extends BaseIntegrationTest {
   private long defaultTimeout;
 


### PR DESCRIPTION
NB! This is breaking change of current Selenide behaviour _in case of checks on missing elements_.

Provided that element `h1` **does not exist**:

Check                                                                              | Selenide 5.10- | Selenide 5.11+
--------------------------------------------------|----------------|----------------
`h1.shouldNot(exist)`                                                   | ok                      | ok
`h1.shouldNotBe(visible)`                                           | ok                      | ok
`h1.shouldBe(hidden)`                                                | ok                      | ok
`h1.shouldNotHave(text("foo"))`                               | ok                      | FAIL
`h1.shouldNotHave(attribute("bar"))`                       | ok                      | FAIL
`h1.find("h2").shouldNot(exist)`                                 | ok                      | ok
`h1.find("h2").shouldNotHave(text("foo"))`             | ok                      | FAIL
