### PR TITLE
Speedup tests: use short timeout by default

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -35,8 +35,8 @@ public class SelenideConfig implements Config {
   private String reportsUrl = new CiReportUrl().getReportsUrl(System.getProperty("selenide.reportsUrl"));
   private boolean fastSetValue = Boolean.parseBoolean(System.getProperty("selenide.fastSetValue", "false"));
   private boolean versatileSetValue = Boolean.parseBoolean(System.getProperty("selenide.versatileSetValue", "false"));
-  private SelectorMode selectorMode = CSS;
-  private AssertionMode assertionMode = STRICT;
+  private SelectorMode selectorMode = SelectorMode.valueOf(System.getProperty("selenide.selectorMode", CSS.name()));
+  private AssertionMode assertionMode = AssertionMode.valueOf(System.getProperty("selenide.assertionMode", STRICT.name()));
   private FileDownloadMode fileDownload = FileDownloadMode.valueOf(System.getProperty("selenide.fileDownload", HTTPGET.name()));
   private boolean proxyEnabled = Boolean.parseBoolean(System.getProperty("selenide.proxyEnabled", "false"));
   private String proxyHost = System.getProperty("selenide.proxyHost", "");

--- a/src/main/java/com/codeborne/selenide/ex/ElementShould.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShould.java
@@ -6,14 +6,15 @@ import com.codeborne.selenide.impl.Describe;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.ex.ErrorMessages.actualValue;
-import static java.lang.System.lineSeparator;
 
 public class ElementShould extends UIAssertionError {
   public ElementShould(Driver driver, String searchCriteria, String prefix, Condition expectedCondition,
                        WebElement element, Throwable lastError) {
     super(driver,
-      "Element should " + prefix + expectedCondition + " {" + searchCriteria + "}" +
-        lineSeparator() + "Element: '" + Describe.describe(driver, element) + "'" +
-        actualValue(expectedCondition, driver, element), lastError);
+      String.format("Element should %s%s {%s}%nElement: '%s'%s",
+        prefix, expectedCondition, searchCriteria,
+        Describe.describe(driver, element),
+        actualValue(expectedCondition, driver, element)
+      ), lastError);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
@@ -12,8 +12,10 @@ public class ElementShouldNot extends UIAssertionError {
   public ElementShouldNot(Driver driver, String searchCriteria, String prefix, Condition expectedCondition,
                           WebElement element, Throwable lastError) {
     super(driver,
-      "Element should not " + prefix + expectedCondition + " {" + searchCriteria + '}' +
-        lineSeparator() + "Element: '" + Describe.describe(driver, element) + "'" +
-        actualValue(expectedCondition, driver, element), lastError);
+      String.format("Element should not %s%s {%s}%sElement: '%s'%s",
+        prefix, expectedCondition, searchCriteria, lineSeparator(),
+        Describe.describe(driver, element),
+        actualValue(expectedCondition, driver, element)
+      ), lastError);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/MatcherError.java
+++ b/src/main/java/com/codeborne/selenide/ex/MatcherError.java
@@ -6,17 +6,18 @@ import org.openqa.selenium.WebElement;
 import java.util.List;
 
 import static com.codeborne.selenide.ElementsCollection.elementsToString;
+import static java.lang.System.lineSeparator;
 
 public class MatcherError extends UIAssertionError {
 
   public MatcherError(String matcher, String predicateDescription, String explanation,
                       WebElementsCollection collection, List<WebElement> actualElements, Exception lastError, long timeoutMs) {
     super(collection.driver(),
-      String.format("Collection matcher error" +
-        "%nExpected: " + matcher + " of elements to match [" + predicateDescription + "] predicate" +
-        (explanation == null ? "" : "%nBecause: " + explanation) +
-        "%nCollection: " + collection.description() +
-        "%nElements: " + elementsToString(collection.driver(), actualElements)), lastError
+      "Collection matcher error" +
+        lineSeparator() + "Expected: " + matcher + " of elements to match [" + predicateDescription + "] predicate" +
+        (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
+        lineSeparator() + "Collection: " + collection.description() +
+        lineSeparator() + "Elements: " + elementsToString(collection.driver(), actualElements), lastError
     );
     super.timeoutMs = timeoutMs;
   }

--- a/src/main/java/com/codeborne/selenide/ex/TextsMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsMismatch.java
@@ -4,14 +4,17 @@ import com.codeborne.selenide.impl.WebElementsCollection;
 
 import java.util.List;
 
+import static java.lang.System.lineSeparator;
+
 public class TextsMismatch extends UIAssertionError {
   public TextsMismatch(WebElementsCollection collection, List<String> actualTexts,
                        List<String> expectedTexts, String explanation, long timeoutMs) {
     super(collection.driver(),
-      String.format("Texts mismatch%nActual: " + actualTexts +
-        "%nExpected: " + expectedTexts +
-        (explanation == null ? "" : "%nBecause: " + explanation) +
-        "%nCollection: " + collection.description()));
+      "Texts mismatch" +
+        lineSeparator() + "Actual: " + actualTexts +
+        lineSeparator() + "Expected: " + expectedTexts +
+        (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
+        lineSeparator() + "Collection: " + collection.description());
     super.timeoutMs = timeoutMs;
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
@@ -4,15 +4,18 @@ import com.codeborne.selenide.impl.WebElementsCollection;
 
 import java.util.List;
 
+import static java.lang.System.lineSeparator;
+
 public class TextsSizeMismatch extends UIAssertionError {
   public TextsSizeMismatch(WebElementsCollection collection, List<String> actualTexts,
                        List<String> expectedTexts, String explanation, long timeoutMs) {
     super(collection.driver(),
-      String.format("Texts size mismatch" +
-        "%nActual: " + actualTexts + ", List size: " + actualTexts.size() +
-        "%nExpected: " + expectedTexts + ", List size: " + expectedTexts.size() +
-        (explanation == null ? "" : "%nBecause: " + explanation) +
-        "%nCollection: " + collection.description()));
+      "Texts size mismatch" +
+        lineSeparator() + "Actual: " + actualTexts + ", List size: " + actualTexts.size() +
+        lineSeparator() + "Expected: " + expectedTexts + ", List size: " + expectedTexts.size() +
+        (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
+        lineSeparator() + "Collection: " + collection.description()
+    );
     super.timeoutMs = timeoutMs;
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
@@ -7,20 +7,21 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Condition.appear;
+import static java.lang.System.lineSeparator;
 import static org.mockito.Mockito.mock;
 
 class ElementShouldNotTest implements WithAssertions {
-  private Driver driver = new DriverStub();
+  private final Driver driver = new DriverStub();
 
   @Test
   void testToString() {
     ElementShouldNot elementShould = new ElementShouldNot(driver, "by.name: selenide", "be ", appear,
       mock(WebElement.class), new Throwable("Error message"));
-    assertThat(elementShould).hasMessage(String.format("Element should not be visible {by.name: selenide}%n" +
-      "Element: '<null displayed:false></null>'%n" +
-      "Actual value: visible:false%n" +
-      "Screenshot: null%n" +
-      "Timeout: 0 ms.%n" +
-      "Caused by: java.lang.Throwable: Error message"));
+    assertThat(elementShould).hasMessage("Element should not be visible {by.name: selenide}" + lineSeparator() +
+      "Element: '<null displayed:false></null>'" + lineSeparator() +
+      "Actual value: visible:false" + lineSeparator() +
+      "Screenshot: null" + lineSeparator() +
+      "Timeout: 0 ms." + lineSeparator() +
+      "Caused by: java.lang.Throwable: Error message");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
@@ -7,6 +7,7 @@ import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import static java.lang.System.lineSeparator;
 import static org.mockito.Mockito.mock;
 
 class ElementShouldTest implements WithAssertions {
@@ -20,11 +21,11 @@ class ElementShouldTest implements WithAssertions {
     ElementShould elementShould = new ElementShould(driver, searchCriteria, prefix, Condition.appear, webElementMock, exception);
 
     assertThat(elementShould)
-      .hasMessage(String.format("Element should be visible {by.name: selenide}%n" +
-        "Element: '<null displayed:false></null>'%n" +
-        "Actual value: visible:false%n" +
-        "Screenshot: null%n" +
-        "Timeout: 0 ms.%n" +
-        "Caused by: java.lang.Exception: Error message"));
+      .hasMessage("Element should be visible {by.name: selenide}" + lineSeparator() +
+        "Element: '<null displayed:false></null>'" + lineSeparator() +
+        "Actual value: visible:false" + lineSeparator() +
+        "Screenshot: null" + lineSeparator() +
+        "Timeout: 0 ms." + lineSeparator() +
+        "Caused by: java.lang.Exception: Error message");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/MatcherErrorTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/MatcherErrorTest.java
@@ -1,0 +1,49 @@
+package com.codeborne.selenide.ex;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MatcherErrorTest {
+  private final List<WebElement> actualElements = asList(mockElement("mr. %First"), mockElement("mr. %Second"));
+  private final WebDriverException ex = new NoSuchElementException(".third");
+
+  @Test
+  void message() {
+    assertThat(new MatcherError("foo", "blah", null, mockCollection(".rows"), actualElements, ex, 4000).getMessage()).isEqualTo(
+      "Collection matcher error\n" +
+        "Expected: foo of elements to match [blah] predicate\n" +
+        "Collection: .rows\n" +
+        "Elements: [\n" +
+        "\t<div displayed:false>mr. %First</div>,\n" +
+        "\t<div displayed:false>mr. %Second</div>\n" +
+        "]\n" +
+        "Screenshot: null\n" +
+        "Timeout: 4 s.\n" +
+        "Caused by: NoSuchElementException: .third");
+  }
+
+  @Test
+  void message_whtExplanation() {
+    assertThat(new MatcherError("foo", "blah", "I think so", mockCollection(".rows"), actualElements, ex, 4000).getMessage()).isEqualTo(
+      "Collection matcher error\n" +
+        "Expected: foo of elements to match [blah] predicate\n" +
+        "Because: I think so\n" +
+        "Collection: .rows\n" +
+        "Elements: [\n" +
+        "\t<div displayed:false>mr. %First</div>,\n" +
+        "\t<div displayed:false>mr. %Second</div>\n" +
+        "]\n" +
+        "Screenshot: null\n" +
+        "Timeout: 4 s.\n" +
+        "Caused by: NoSuchElementException: .third");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
@@ -9,10 +9,26 @@ import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Arrays.asList;
 
 class TextsMismatchTest implements WithAssertions {
+  private final List<String> actualTexts = asList("Niff", "Naff", "Nuff");
+  private final List<String> expectedTexts = asList("Piff", "Paff", "Puff");
+
   @Test
   void errorMessage() {
-    List<String> actualTexts = asList("Niff", "Naff", "Nuff");
-    List<String> expectedTexts = asList("Piff", "Paff", "Puff");
+    TextsMismatch textsMismatch = new TextsMismatch(mockCollection(".characters"),
+      actualTexts,
+      expectedTexts,
+      null, 9000);
+
+    assertThat(textsMismatch).hasMessage(String.format("Texts mismatch%n" +
+      "Actual: [Niff, Naff, Nuff]%n" +
+      "Expected: [Piff, Paff, Puff]%n" +
+      "Collection: .characters%n" +
+      "Screenshot: null%n" +
+      "Timeout: 9 s."));
+  }
+
+  @Test
+  void errorMessage_withExplanation() {
     TextsMismatch textsMismatch = new TextsMismatch(mockCollection(".characters"),
       actualTexts,
       expectedTexts,

--- a/src/test/java/com/codeborne/selenide/ex/TextsSizeMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsSizeMismatchTest.java
@@ -9,18 +9,34 @@ import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Arrays.asList;
 
 class TextsSizeMismatchTest implements WithAssertions {
+  private final List<String> actualTexts = asList("Niff", "Naff", "Nuff%");
+  private final List<String> expectedTexts = asList("Piff", "Paff", "Puff'\"bro");
+
   @Test
   void errorMessage() {
-    List<String> actualTexts = asList("Niff", "Naff", "Nuff");
-    List<String> expectedTexts = asList("Piff", "Paff", "Puff");
+    TextsSizeMismatch textsMismatch = new TextsSizeMismatch(mockCollection(".characters"),
+      actualTexts,
+      expectedTexts,
+      null, 9000);
+
+    assertThat(textsMismatch).hasMessage(String.format("Texts size mismatch%n" +
+      "Actual: [Niff, Naff, Nuff%%], List size: 3%n" +
+      "Expected: [Piff, Paff, Puff'\"bro], List size: 3%n" +
+      "Collection: .characters%n" +
+      "Screenshot: null%n" +
+      "Timeout: 9 s."));
+  }
+
+  @Test
+  void errorMessage_withExplanation() {
     TextsSizeMismatch textsMismatch = new TextsSizeMismatch(mockCollection(".characters"),
       actualTexts,
       expectedTexts,
       "we expect favorite characters", 9000);
 
     assertThat(textsMismatch).hasMessage(String.format("Texts size mismatch%n" +
-      "Actual: [Niff, Naff, Nuff], List size: 3%n" +
-      "Expected: [Piff, Paff, Puff], List size: 3%n" +
+      "Actual: [Niff, Naff, Nuff%%], List size: 3%n" +
+      "Expected: [Piff, Paff, Puff'\"bro], List size: 3%n" +
       "Because: we expect favorite characters%n" +
       "Collection: .characters%n" +
       "Screenshot: null%n" +

--- a/src/test/java/integration/BaseIntegrationTest.java
+++ b/src/test/java/integration/BaseIntegrationTest.java
@@ -18,7 +18,6 @@ import static org.openqa.selenium.net.PortProber.findFreePort;
 public abstract class BaseIntegrationTest {
   private static final boolean SSL = true;
   protected static LocalHttpServer server;
-  protected static long averageSeleniumCommandDuration = 100;
   private static String protocol;
   private static int port;
   protected static final String browser = System.getProperty("selenide.browser", FIREFOX);

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidSelectorException;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -100,45 +99,53 @@ class CollectionMethodsTest extends ITest {
 
   @Test
   void canCheckSizeOfCollection() {
-    $$(By.name("domain")).shouldHaveSize(1);
-    $$("#theHiddenElement").shouldHaveSize(1);
-    $$("#radioButtons input").shouldHaveSize(4);
-    $$(By.xpath("//select[@name='domain']/option")).shouldHaveSize(4);
-    $$(By.name("non-existing-element")).shouldHaveSize(0);
-    $$("#dynamic-content-container span").shouldHave(size(2));
+    withLongTimeout(() -> {
+      $$(By.name("domain")).shouldHaveSize(1);
+      $$("#theHiddenElement").shouldHaveSize(1);
+      $$("#radioButtons input").shouldHaveSize(4);
+      $$(By.xpath("//select[@name='domain']/option")).shouldHaveSize(4);
+      $$(By.name("non-existing-element")).shouldHaveSize(0);
+      $$("#dynamic-content-container span").shouldHave(size(2));
+    });
   }
 
   @Test
   void shouldWaitUntilCollectionGetsExpectedSize() {
-    ElementsCollection spans = $$("#dynamic-content-container span");
+    withLongTimeout(() -> {
+      ElementsCollection spans = $$("#dynamic-content-container span");
 
-    spans.shouldHave(size(2)); // appears after 2 seconds
+      spans.shouldHave(size(2)); // appears after 2 seconds
 
-    assertThat(spans)
-      .hasSize(2);
-    assertThat(spans.texts())
-      .isEqualTo(Arrays.asList("dynamic content", "dynamic content2"));
+      assertThat(spans).hasSize(2);
+      assertThat(spans.texts()).isEqualTo(asList("dynamic content", "dynamic content2"));
+    });
   }
 
   @Test
   void canCheckThatElementsHaveCorrectTexts() {
-    $$("#dynamic-content-container span").shouldHave(
-      texts("dynamic content", "dynamic content2"),
-      texts("mic cont", "content2"),
-      exactTexts(asList("dynamic content", "dynamic content2")));
+    withLongTimeout(() -> {
+      $$("#dynamic-content-container span").shouldHave(
+        texts("dynamic content", "dynamic content2"),
+        texts("mic cont", "content2"),
+        exactTexts(asList("dynamic content", "dynamic content2")));
+    });
   }
 
   @Test
   void ignoresWhitespacesInTexts() {
-    $$("#dynamic-content-container span").shouldHave(
-      texts("   dynamic \ncontent ", "dynamic \t\t\tcontent2\t\t\r\n"),
-      exactTexts("dynamic \t\n content\n\r", "    dynamic content2      "));
+    withLongTimeout(() -> {
+      $$("#dynamic-content-container span").shouldHave(
+        texts("   dynamic \ncontent ", "dynamic \t\t\tcontent2\t\t\r\n"),
+        exactTexts("dynamic \t\n content\n\r", "    dynamic content2      "));
+    });
   }
 
   @Test
   void canCheckThatElementsHaveExactlyCorrectTexts() {
-    assertThatThrownBy(() -> $$("#dynamic-content-container span").shouldHave(exactTexts("content", "content2")))
-      .isInstanceOf(TextsMismatch.class);
+    withLongTimeout(() -> {
+      assertThatThrownBy(() -> $$("#dynamic-content-container span").shouldHave(exactTexts("content", "content2")))
+        .isInstanceOf(TextsMismatch.class);
+    });
   }
 
   @Test
@@ -155,15 +162,19 @@ class CollectionMethodsTest extends ITest {
 
   @Test
   void textsCheckThrowsTextsSizeMismatch() {
-    assertThatThrownBy(() -> $$("#dynamic-content-container span")
-      .shouldHave(texts("static-content1", "static-content2", "dynamic-content1")))
-      .isInstanceOf(TextsSizeMismatch.class);
+    withLongTimeout(() -> {
+      assertThatThrownBy(() -> $$("#dynamic-content-container span")
+        .shouldHave(texts("static-content1", "static-content2", "dynamic-content1")))
+        .isInstanceOf(TextsSizeMismatch.class);
+    });
   }
 
   @Test
   void textCheckThrowsTextsMismatch() {
-    assertThatThrownBy(() -> $$("#dynamic-content-container span").shouldHave(texts("static-content1", "static-content2")))
-      .isInstanceOf(TextsMismatch.class);
+    withLongTimeout(() -> {
+      assertThatThrownBy(() -> $$("#dynamic-content-container span").shouldHave(texts("static-content1", "static-content2")))
+        .isInstanceOf(TextsMismatch.class);
+    });
   }
 
   @Test
@@ -202,8 +213,10 @@ class CollectionMethodsTest extends ITest {
 
   @Test
   void findWaitsUntilElementMatches() {
-    $$("#dynamic-content-container span").findBy(text("dynamic content2")).shouldBe(visible);
-    $$("#dynamic-content-container span").findBy(text("unexisting")).shouldNot(exist);
+    withLongTimeout(() -> {
+      $$("#dynamic-content-container span").findBy(text("dynamic content2")).shouldBe(visible);
+      $$("#dynamic-content-container span").findBy(text("unexisting")).shouldNot(exist);
+    });
   }
 
   @Test

--- a/src/test/java/integration/CollectionReloadingTest.java
+++ b/src/test/java/integration/CollectionReloadingTest.java
@@ -12,6 +12,7 @@ class CollectionReloadingTest extends ITest {
   @BeforeEach
   void openTestPage() {
     openFile("collection_with_delays.html");
+    setTimeout(4000);
   }
 
   @Test

--- a/src/test/java/integration/DynamicSelectsTest.java
+++ b/src/test/java/integration/DynamicSelectsTest.java
@@ -13,6 +13,7 @@ class DynamicSelectsTest extends ITest {
   @BeforeEach
   void openTestPage() {
     openFile("page_with_dynamic_select.html");
+    setTimeout(4000);
   }
 
   @Test

--- a/src/test/java/integration/ElementHiddenTest.java
+++ b/src/test/java/integration/ElementHiddenTest.java
@@ -13,6 +13,7 @@ import static com.codeborne.selenide.Condition.visible;
 class ElementHiddenTest extends ITest {
   @BeforeEach
   void clickRemovesElement() {
+    setTimeout(4000);
     openFile("elements_disappear_on_click.html");
     $("#hide").click();
   }

--- a/src/test/java/integration/ElementRemovedTest.java
+++ b/src/test/java/integration/ElementRemovedTest.java
@@ -17,6 +17,7 @@ class ElementRemovedTest extends ITest {
   @BeforeEach
   void clickRemovesElement() {
     openFile("elements_disappear_on_click.html");
+    setTimeout(2000);
     $("#remove").click();
   }
 

--- a/src/test/java/integration/FindInsideParentTest.java
+++ b/src/test/java/integration/FindInsideParentTest.java
@@ -11,6 +11,7 @@ class FindInsideParentTest extends ITest {
   @BeforeEach
   void openTestPage() {
     openFile("long_ajax_request.html");
+    setTimeout(4000);
   }
 
   @Test

--- a/src/test/java/integration/FrameWaitTest.java
+++ b/src/test/java/integration/FrameWaitTest.java
@@ -12,6 +12,7 @@ class FrameWaitTest extends ITest {
   @BeforeEach
   void setUp() {
     openFile("page_with_frames_with_delays.html");
+    setTimeout(2000);
   }
 
   @Test

--- a/src/test/java/integration/ITest.java
+++ b/src/test/java/integration/ITest.java
@@ -5,13 +5,38 @@ import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.SelenideDriver;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.SelenideTargetLocator;
+import org.junit.jupiter.api.BeforeEach;
 import org.openqa.selenium.By;
 
 import static java.lang.ThreadLocal.withInitial;
 
 public class ITest extends BaseIntegrationTest {
+  private final long longTimeout = Long.parseLong(System.getProperty("selenide.timeout", "4000"));
+
+  private static final ThreadLocal<SelenideConfig> config = withInitial(() ->
+    new SelenideConfig().browser(browser).baseUrl(getBaseUrl()).timeout(1));
+
   private static final ThreadLocal<SelenideDriver> driver = withInitial(() ->
-    new SelenideDriver(new SelenideConfig().browser(browser).baseUrl(getBaseUrl())));
+    new SelenideDriver(config.get()));
+
+  @BeforeEach
+  final void resetShortTimeout() {
+    config.get().timeout(1);
+  }
+
+  protected void setTimeout(long timeoutMs) {
+    config.get().timeout(timeoutMs);
+  }
+
+  protected final void withLongTimeout(Runnable test) {
+    config.get().timeout(longTimeout);
+    try {
+      test.run();
+    }
+    finally {
+      resetShortTimeout();
+    }
+  }
 
   protected SelenideDriver driver() {
     return driver.get();
@@ -56,10 +81,5 @@ public class ITest extends BaseIntegrationTest {
   protected void openFile(String fileName) {
     driver().open("/" + fileName + "?browser=" + browser +
       "&timeout=" + driver().config().timeout());
-  }
-
-  <T> T openFile(String fileName, Class<T> pageObjectClass) {
-    return driver().open("/" + fileName + "?browser=" + browser +
-      "&timeout=" + driver().config().timeout(), pageObjectClass);
   }
 }

--- a/src/test/java/integration/LongRunningAjaxRequestTest.java
+++ b/src/test/java/integration/LongRunningAjaxRequestTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class LongRunningAjaxRequestTest extends ITest {
   @BeforeEach
   void openTestPage() {
+    setTimeout(4000);
     openFile("long_ajax_request.html");
     $("#loading").shouldNot(exist);
     $(byText("Run long request")).click();

--- a/src/test/java/integration/NotExistingElementTest.java
+++ b/src/test/java/integration/NotExistingElementTest.java
@@ -42,11 +42,13 @@ class NotExistingElementTest extends ITest {
 
   @Test
   void toWebElement_shouldNotWait() {
+    setTimeout(4000);
     long start = System.nanoTime();
     try {
       assertThatThrownBy(() -> $("#not_exist").toWebElement())
         .isInstanceOf(org.openqa.selenium.NoSuchElementException.class)
-        .hasMessageStartingWith("Unable to locate element: #not_exist");
+        .hasMessageContaining("Unable to locate element:")
+        .hasMessageContaining("#not_exist");
     }
     finally {
       long end = System.nanoTime();

--- a/src/test/java/integration/ReplacingElementTest.java
+++ b/src/test/java/integration/ReplacingElementTest.java
@@ -17,11 +17,13 @@ class ReplacingElementTest extends ITest {
 
   @Test
   void shouldWaitsUntilElementIsReplaced() {
-    $("#dynamic-element").shouldHave(value("I will be replaced soon"));
+    withLongTimeout(() -> {
+      $("#dynamic-element").shouldHave(value("I will be replaced soon"));
 
-    driver().executeJavaScript("replaceElement()");
-    $("#dynamic-element").shouldHave(value("Hello, I am back"), cssClass("reloaded"));
-    $("#dynamic-element").setValue("New value");
+      driver().executeJavaScript("replaceElement()");
+      $("#dynamic-element").shouldHave(value("Hello, I am back"), cssClass("reloaded"));
+      $("#dynamic-element").setValue("New value");
+    });
   }
 
   @Test

--- a/src/test/java/integration/TabsCustomWaitTest.java
+++ b/src/test/java/integration/TabsCustomWaitTest.java
@@ -18,8 +18,9 @@ class TabsCustomWaitTest extends ITest {
 
   @Test
   void waitsUntilTabAppears_withCustomTimeout() {
+    setTimeout(1000);
     $("#open-new-tab-with-delay").click();
-    switchTo().window("Test::alerts", Duration.ofSeconds(5));
+    switchTo().window("Test::alerts", Duration.ofSeconds(3));
     $("h1").shouldHave(text("Page with alerts"));
   }
 

--- a/src/test/java/integration/TabsTest.java
+++ b/src/test/java/integration/TabsTest.java
@@ -26,7 +26,7 @@ class TabsTest extends ITest {
   @Test
   @Video
   void userCanBrowseTabs_webdriver_api() {
-    openFile("page_with_tabs.html");
+    setTimeout(1000);
 
     WebDriver driver = driver().getWebDriver();
 

--- a/src/test/java/integration/TabsWaitTest.java
+++ b/src/test/java/integration/TabsWaitTest.java
@@ -9,6 +9,7 @@ class TabsWaitTest extends ITest {
   @BeforeEach
   void setUp() {
     openFile("page_with_tabs_with_delays.html");
+    setTimeout(2000);
   }
 
   @Test

--- a/src/test/resources/collection_with_delays.html
+++ b/src/test/resources/collection_with_delays.html
@@ -11,8 +11,8 @@
         document.getElementById('collection').innerHTML += '<li>Element #' + size + '</li>';
         size++;
 
-        if (size < 50) {
-          setTimeout(growCollection, 50);
+        if (size < 20) {
+          setTimeout(growCollection, 20);
         }
         else {
           document.getElementById('status').innerHTML += "Generated in " + (new Date() - totalTime) / 1000.0 + " seconds";

--- a/src/test/resources/page_with_tabs_with_big_delays.html
+++ b/src/test/resources/page_with_tabs_with_big_delays.html
@@ -6,7 +6,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <script type="text/javascript">
       function openNewTabWithDelay() {
-        setTimeout(openNewTab, 5000);
+        setTimeout(openNewTab, 2000);
       }
 
       function openNewTab() {
@@ -18,7 +18,7 @@
 <body>
 <h1>New tab will appear soon</h1>
 
-<a id="open-new-tab-with-delay" href="javascript:openNewTabWithDelay();">open new tab after 5 seconds</a>
+<a id="open-new-tab-with-delay" href="javascript:openNewTabWithDelay();">open new tab after 2 seconds</a>
 <br/>
 <br/>
 <br/>

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -238,13 +238,29 @@ public class Configuration {
   public static boolean versatileSetValue = defaults.versatileSetValue();
 
   /**
-   * Choose how Selenide should retrieve web elements: using default CSS or Sizzle (CSS3)
+   * <p>Choose how Selenide should retrieve web elements: using default CSS or Sizzle (CSS3).</p>
+   * <br>
+   * <p>
+   * Can be configured either programmatically or by system property "-Dselenide.selectorMode=Sizzle".
+   * </p>
+   * <br>
+   *   Possible values: "CSS" or "Sizzle"
+   * <br>
+   *   Default value: CSS
+   *
+   * @see SelectorMode
    */
   public static SelectorMode selectorMode = defaults.selectorMode();
 
   /**
-   * Assertion mode - STRICT or SOFT Asserts
-   * Default value: STRICT
+   * <p>Assertion mode</p>
+   *
+   * <p>Can be configured either programmatically or by system property "-Dselenide.assertionMode=SOFT".</p>
+   *
+   * <br>
+   *   Possible values: "STRICT" or "SOFT"
+   * <br>
+   *   Default value: STRICT
    *
    * @see AssertionMode
    */

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -273,7 +273,7 @@ public class Configuration {
   /**
    * Host of Selenide proxy server.
    * Used only if proxyEnabled == true.
-   * Can be configured either programmatically or by system property "-DproxyHost=127.0.0.1"
+   * Can be configured either programmatically or by system property "-Dselenide.proxyHost=127.0.0.1"
    * <br>
    * Default: empty (meaning that Selenide will detect current machine's ip/hostname automatically)
    *

--- a/statics/src/test/java/integration/AlertTest.java
+++ b/statics/src/test/java/integration/AlertTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.ex.DialogTextMismatch;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,6 +69,7 @@ class AlertTest extends IntegrationTest {
 
   @Test
   void waitsUntilAlertDialogAppears() {
+    Configuration.timeout = 4000;
     $(By.name("username")).val("Быстрый Гарри");
     $(byValue("Slow alert")).click();
     confirm("Are you sure, Быстрый Гарри?");
@@ -77,6 +79,7 @@ class AlertTest extends IntegrationTest {
 
   @Test
   void waitsUntilPromptDialogAppears() {
+    Configuration.timeout = 4000;
     $(By.name("username")).val("Медленный Барри");
     $(byValue("Slow prompt")).click();
     prompt("Медленный Барри");

--- a/statics/src/test/java/integration/CollectionWaitTest.java
+++ b/statics/src/test/java/integration/CollectionWaitTest.java
@@ -17,28 +17,29 @@ class CollectionWaitTest extends IntegrationTest {
   @BeforeEach
   void openTestPage() {
     openFile("collection_with_delays.html");
+    Configuration.timeout = 1000;
   }
 
   @Test
   void waitsUntilNthElementAppears() {
     $$("#collection li").get(5).shouldBe(visible);
-    $$("#collection li").get(33).shouldBe(visible);
-    $$("#collection li").get(49).shouldBe(visible);
+    $$("#collection li").get(13).shouldBe(visible);
+    $$("#collection li").get(19).shouldBe(visible);
 
     $$("#collection li").first().shouldBe(visible).shouldHave(text("Element #0"));
-    $$("#collection li").last().shouldBe(visible).shouldHave(text("Element #49"));
+    $$("#collection li").last().shouldBe(visible).shouldHave(text("Element #19"));
   }
 
   @Test
   void failsIfWrongSize() {
     assertThatThrownBy(() -> $$("#collection li").shouldHave(size(-1)))
       .isInstanceOf(AssertionError.class)
-      .hasMessageContaining("expected: = -1, actual: 50, collection: #collection li");
+      .hasMessageContaining("expected: = -1, actual: 20, collection: #collection li");
   }
 
   @Test
   void canDetermineSize() {
-    $$("#collection li").shouldHave(size(50));
+    $$("#collection li").shouldHave(size(20));
   }
 
   @Test
@@ -48,12 +49,11 @@ class CollectionWaitTest extends IntegrationTest {
 
   @Test
   void waitsUntilLastNElementsGetLoaded() {
-    $$("#collection li").last(2).shouldHave(texts("Element #48", "Element #49"));
+    $$("#collection li").last(2).shouldHave(texts("Element #18", "Element #19"));
   }
 
   @Test
   void firstNElements_TextsMismatchErrorMessage() {
-    Configuration.timeout = 4000;
     assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element", "#wrong")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageContaining(String.format("Actual: [Element #0, Element #1]%n" +
@@ -63,7 +63,6 @@ class CollectionWaitTest extends IntegrationTest {
 
   @Test
   void firstNElements_TextsSizeMismatchErrorMessage() {
-    Configuration.timeout = 4000;
     assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element #wrong")))
       .isInstanceOf(TextsSizeMismatch.class)
       .hasMessageContaining(String.format("Actual: [Element #0, Element #1], List size: 2%n" +
@@ -73,10 +72,9 @@ class CollectionWaitTest extends IntegrationTest {
 
   @Test
   void lastNElements_errorMessage() {
-    Configuration.timeout = 4000;
     assertThatThrownBy(() -> $$("#collection li").last(2).shouldHave(texts("Element", "#wrong")))
       .isInstanceOf(TextsMismatch.class)
-      .hasMessageContaining(String.format("Actual: [Element #48, Element #49]%n" +
+      .hasMessageContaining(String.format("Actual: [Element #18, Element #19]%n" +
         "Expected: [Element, #wrong]%n" +
         "Collection: #collection li.last(2)"));
   }
@@ -84,6 +82,6 @@ class CollectionWaitTest extends IntegrationTest {
   @Test
   void customTimeoutForCollections() {
     Configuration.timeout = 1;
-    $$("#collection li").last(2).shouldHave(texts("Element #48", "Element #49"), 5000);
+    $$("#collection li").last(2).shouldHave(texts("Element #18", "Element #19"), 5000);
   }
 }

--- a/statics/src/test/java/integration/ConfirmTest.java
+++ b/statics/src/test/java/integration/ConfirmTest.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.closeWebDriver;
@@ -18,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConfirmTest extends IntegrationTest {
-  private String userName = "John Mc'Clane";
+  private final String userName = "John Mc'Clane";
 
   @AfterAll
   static void tearDown() {
@@ -27,6 +28,7 @@ class ConfirmTest extends IntegrationTest {
 
   @BeforeEach
   void openTestPage() {
+    timeout = 1000;
     openFile("page_with_alerts.html");
     $("h1").shouldHave(text("Page with alerts"));
     $(By.name("username")).val(userName);
@@ -67,7 +69,7 @@ class ConfirmTest extends IntegrationTest {
       .hasMessageContaining("Expected: Get out of this page, Maria?")
       .hasMessageMatching("(?s).*Screenshot: file:.+\\.png.*")
       .hasMessageMatching("(?s).*Page source: file:.+\\.html.*")
-      .hasMessageMatching("(?s).*Timeout: .+ s\\..*");
+      .hasMessageMatching("(?s).*Timeout: .+ m?s\\..*");
   }
 
   @Test
@@ -89,6 +91,7 @@ class ConfirmTest extends IntegrationTest {
   @Test
   @Video
   void waitsUntilConfirmDialogAppears() {
+    timeout = 2000;
     $(byText("Slow confirm")).click();
     String confirmDialogText = confirm();
 

--- a/statics/src/test/java/integration/DirectFileDownloadTest.java
+++ b/statics/src/test/java/integration/DirectFileDownloadTest.java
@@ -20,6 +20,7 @@ public class DirectFileDownloadTest extends IntegrationTest {
 
   @Test
   void downloadFileByDirectLink() throws IOException {
+    Configuration.timeout = 4000;
     File file = download("/files/hello_world.txt");
     assertThat(file.getName()).isEqualTo("hello_world.txt");
     assertThat(readFileToString(file, UTF_8)).isEqualTo("Hello, WinRar!");
@@ -27,6 +28,7 @@ public class DirectFileDownloadTest extends IntegrationTest {
 
   @Test
   void downloadFileWithCyrillicName() throws IOException {
+    Configuration.timeout = 4000;
     File file = download("/files/файл-с-русским-названием.txt");
     assertThat(file.getName()).isEqualTo("файл-с-русским-названием.txt");
     assertThat(readFileToString(file, UTF_8)).isEqualTo("Превед медвед!");

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -18,11 +18,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 
 class FileDownloadViaHttpGetTest extends IntegrationTest {
-  private File folder = new File(Configuration.downloadsFolder);
+  private final File folder = new File(Configuration.downloadsFolder);
 
   @BeforeEach
   void setUp() {
     useProxy(false);
+    Configuration.timeout = 1000;
     openFile("page_with_uploads.html");
   }
 
@@ -62,7 +63,7 @@ class FileDownloadViaHttpGetTest extends IntegrationTest {
   void downloadFileByName() {
     assertThatThrownBy(() -> $(byText("Download me")).download(FileFilters.withName("good_bye_world.txt")))
       .isInstanceOf(FileNotFoundException.class)
-      .hasMessageMatching("Failed to download file from http.+/files/hello_world.txt in 4000 ms." +
+      .hasMessageMatching("Failed to download file from http.+/files/hello_world.txt in 1000 ms." +
         " with file name \"good_bye_world.txt\" " + System.lineSeparator() + "; actually downloaded: .+hello_world.txt");
   }
 

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -30,8 +30,6 @@ import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
 
 @ExtendWith({ScreenShooterExtension.class, VideoExtension.class})
 public abstract class IntegrationTest extends BaseIntegrationTest {
-  private long defaultTimeout;
-
   @BeforeAll
   static void resetSettingsBeforeClass() {
     resetSettings();
@@ -40,12 +38,11 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
   @BeforeEach
   final void setUpEach() {
     resetSettings();
-    rememberTimeout();
   }
 
   @AfterEach
   public void restoreDefaultProperties() {
-    timeout = defaultTimeout;
+    timeout = 1;
     clickViaJs = false;
   }
 
@@ -57,6 +54,7 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
   }
 
   private static void resetSettings() {
+    timeout = 1;
     Configuration.browser = System.getProperty("selenide.browser", CHROME);
     Configuration.baseUrl = getBaseUrl();
     Configuration.headless = Boolean.parseBoolean(System.getProperty("selenide.headless", "false"));
@@ -67,10 +65,6 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     Configuration.proxyPort = 0;
     Configuration.proxyHost = "";
     useProxy(true);
-  }
-
-  private void rememberTimeout() {
-    defaultTimeout = timeout;
   }
 
   protected void openFile(String fileName) {

--- a/statics/src/test/java/integration/PageObjectTest.java
+++ b/statics/src/test/java/integration/PageObjectTest.java
@@ -15,9 +15,9 @@ import java.util.List;
 
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.page;
-import static com.codeborne.selenide.Selenide.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -27,7 +27,6 @@ class PageObjectTest extends IntegrationTest {
   @BeforeEach
   void openTestPage() {
     openFile("page_with_selects_without_jquery.html");
-    sleep(100);
     pageWithSelects = page(SelectsPage.class);
   }
 
@@ -66,6 +65,7 @@ class PageObjectTest extends IntegrationTest {
 
   @Test
   void canInjectSelenideElement() {
+    timeout = 4000;
     pageWithSelects.h1.shouldHave(Condition.text("Page with selects"));
     pageWithSelects.dynamicContent.shouldHave(text("dynamic content"));
   }

--- a/statics/src/test/java/integration/ReadonlyElementsTest.java
+++ b/statics/src/test/java/integration/ReadonlyElementsTest.java
@@ -14,9 +14,8 @@ import java.util.List;
 
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.exactValue;
-import static com.codeborne.selenide.Condition.selected;
 import static com.codeborne.selenide.Condition.readonly;
-import static com.codeborne.selenide.Configuration.timeout;
+import static com.codeborne.selenide.Condition.selected;
 import static com.codeborne.selenide.Selenide.$;
 import static org.assertj.core.api.Assertions.anyOf;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,9 +26,10 @@ class ReadonlyElementsTest extends IntegrationTest {
   @BeforeEach
   void openTestPage() {
     openFile("page_with_readonly_elements.html");
-    timeout = 10 * averageSeleniumCommandDuration;
+    Configuration.timeout = 1000;
   }
 
+  @BeforeEach
   @AfterEach
   void cleanUp() {
     Configuration.fastSetValue = false;

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -248,6 +248,7 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void elementIsEmptyIfTextAndValueAreBothEmpty() {
+    timeout = 4000;
     $("br").shouldBe(empty);
     $("h2").shouldNotBe(empty);
     $(By.name("password")).shouldBe(empty);
@@ -393,11 +394,13 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void findWaitsUntilParentAppears() {
+    timeout = 4000;
     $("#container").find("#dynamic-content2").shouldBe(visible);
   }
 
   @Test
   void findWaitsUntilElementMatchesCondition() {
+    timeout = 4000;
     $("#dynamic-content-container").find("#dynamic-content2").shouldBe(visible);
   }
 
@@ -454,8 +457,6 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void shouldMethodsMayContainOptionalMessageThatIsPartOfErrorMessage_1() {
-    timeout = 100L;
-
     assertThatThrownBy(() -> $("h1").should(text("Some wrong test").because("it's wrong text")))
       .isInstanceOf(ElementShould.class)
       .hasMessageContaining("because it's wrong text");
@@ -463,8 +464,6 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void shouldMethodsMayContainOptionalMessageThatIsPartOfErrorMessage_2() {
-    timeout = 100L;
-
     assertThatThrownBy(() -> $("h1").shouldHave(text("Some wrong test").because("it's wrong text")))
       .isInstanceOf(ElementShould.class)
       .hasMessageContaining("because it's wrong text");
@@ -472,8 +471,6 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void shouldMethodsMayContainOptionalMessageThatIsPartOfErrorMessage_3() {
-    timeout = 100L;
-
     assertThatThrownBy(() -> $("h1").shouldBe(text("Some wrong test").because("it's wrong text")))
       .isInstanceOf(ElementShould.class)
       .hasMessageContaining("because it's wrong text");
@@ -481,8 +478,6 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void shouldNotMethodsMayContainOptionalMessageThatIsPartOfErrorMessage() {
-    timeout = 100L;
-
     assertThatThrownBy(() -> $("h1").shouldNot(text("Page with selects").because("it's wrong text")))
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageContaining("because it's wrong text");
@@ -573,7 +568,7 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void canExecuteAsyncJavascript() {
-    long value = (Long) Selenide.executeAsyncJavaScript(
+    long value = Selenide.executeAsyncJavaScript(
       "var callback = arguments[arguments.length - 1]; setTimeout(function() { callback(10); }, 50);"
     );
     assertThat(value).isEqualTo(10);


### PR DESCRIPTION
## Proposed changes
* use timeout 1 ms in most tests

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
