### PR TITLE
#1015 $.getWrappedElement() should not wait for timeout if element do…

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -823,9 +823,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   String getSearchCriteria();
 
   /**
-   * @return the original Selenium WebElement wrapped by this object
+   * @return the original Selenium {@link WebElement} wrapped by this object
    *
    * @see com.codeborne.selenide.commands.ToWebElement
+   * @throws org.openqa.selenium.NoSuchElementException if element does not exist (without waiting for the element)
    */
   @CheckReturnValue
   WebElement toWebElement();
@@ -833,6 +834,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   /**
    * @return Underlying {@link WebElement}
    * @see com.codeborne.selenide.commands.GetWrappedElement
+   * @throws org.openqa.selenium.NoSuchElementException if element does not exist (without waiting for the element)
    */
   @Override
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -30,6 +30,7 @@ import static java.util.Arrays.asList;
 class SelenideElementProxy implements InvocationHandler {
   private static final Set<String> methodsToSkipLogging = new HashSet<>(asList(
       "toWebElement",
+      "getWrappedElement",
       "toString",
       "getSearchCriteria"
   ));

--- a/src/test/java/integration/NotExistingElementTest.java
+++ b/src/test/java/integration/NotExistingElementTest.java
@@ -52,7 +52,23 @@ class NotExistingElementTest extends ITest {
     }
     finally {
       long end = System.nanoTime();
-      assertThat(TimeUnit.NANOSECONDS.toMillis(end - start)).isLessThan(200);
+      assertThat(TimeUnit.NANOSECONDS.toMillis(end - start)).isLessThan(500);
+    }
+  }
+
+  @Test
+  void getWrappedElement_shouldNotWait() {
+    setTimeout(4000);
+    long start = System.nanoTime();
+    try {
+      assertThatThrownBy(() -> $("#not_exist").getWrappedElement())
+        .isInstanceOf(org.openqa.selenium.NoSuchElementException.class)
+        .hasMessageContaining("Unable to locate element:")
+        .hasMessageContaining("#not_exist");
+    }
+    finally {
+      long end = System.nanoTime();
+      assertThat(TimeUnit.NANOSECONDS.toMillis(end - start)).isLessThan(500);
     }
   }
 


### PR DESCRIPTION
…es not exist

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
