### PR TITLE
Add opportunity to get screenshots from current thread

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -252,14 +253,8 @@ public class ScreenShotLaboratory {
     synchronized (allScreenshots) {
       allScreenshots.add(screenshot);
     }
-    addScreenshotToCurrentThread(screenshot);
+    threadScreenshots.get().add(screenshot);
     return screenshot;
-  }
-
-  private void addScreenshotToCurrentThread(File screenshot) {
-    List<File> files = threadScreenshots.get();
-    files.add(screenshot);
-    threadScreenshots.set(files);
   }
 
   protected File takeScreenshotInMemory(TakesScreenshot driver) {
@@ -347,9 +342,9 @@ public class ScreenShotLaboratory {
 
   public List<File> getContextScreenshots() {
     List<File> screenshots = currentContextScreenshots.get();
-    return Collections.unmodifiableList(screenshots == null
+    return screenshots == null
       ? Collections.emptyList()
-      : screenshots);
+      : Collections.unmodifiableList(screenshots);
   }
 
   public File getLastScreenshot() {
@@ -358,18 +353,20 @@ public class ScreenShotLaboratory {
     }
   }
 
-  public File getLastThreadScreenshot() {
+  public Optional<File> getLastThreadScreenshot() {
     List<File> screenshots = threadScreenshots.get();
-    return screenshots.isEmpty()
-      ? null
-      : screenshots.get(screenshots.size() - 1);
+    return getLastScreenshot(screenshots);
   }
 
-  public File getLastContextScreenshot() {
+  public Optional<File> getLastContextScreenshot() {
     List<File> screenshots = currentContextScreenshots.get();
+    return getLastScreenshot(screenshots);
+  }
+
+  private Optional<File> getLastScreenshot(List<File> screenshots) {
     return screenshots == null || screenshots.isEmpty()
-      ? null
-      : screenshots.get(screenshots.size() - 1);
+      ? Optional.empty()
+      : Optional.of(screenshots.get(screenshots.size() - 1));
   }
 
   public String formatScreenShotPath(Driver driver) {

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -173,40 +173,40 @@ class ScreenShotLaboratoryTest implements WithAssertions {
   @Test
   void canGetLastThreadScreenshot() {
     assertThat(screenshots.getLastThreadScreenshot())
-      .isNull();
+      .isEmpty();
 
     screenshots.takeScreenShot(null);
     assertThat(screenshots.getLastThreadScreenshot())
-      .hasToString("12356789.0");
+      .hasValue(new File("12356789.0"));
 
     screenshots.takeScreenShot(null);
     assertThat(screenshots.getLastThreadScreenshot())
-      .hasToString("12356789.1");
+      .hasValue(new File("12356789.1"));
 
     screenshots.takeScreenShot(null);
     assertThat(screenshots.getLastThreadScreenshot())
-      .hasToString("12356789.2");
+      .hasValue(new File("12356789.2"));
   }
 
   @Test
   void canGetLastContextScreenshot() {
     assertThat(screenshots.getLastContextScreenshot())
-      .isNull();
+      .isEmpty();
 
     screenshots.startContext("ui/MyTest/test_some_method/");
     assertThat(screenshots.getLastContextScreenshot())
-      .isNull();
+      .isEmpty();
     screenshots.takeScreenShot(null);
     assertThat(screenshots.getLastContextScreenshot())
-      .isEqualTo(new File("ui/MyTest/test_some_method/12356789.0"));
+      .hasValue(new File("ui/MyTest/test_some_method/12356789.0"));
 
     screenshots.takeScreenShot(null);
     assertThat(screenshots.getLastContextScreenshot())
-      .isEqualTo(new File("ui/MyTest/test_some_method/12356789.1"));
+      .hasValue(new File("ui/MyTest/test_some_method/12356789.1"));
 
     screenshots.takeScreenShot(null);
     assertThat(screenshots.getLastContextScreenshot())
-      .isEqualTo(new File("ui/MyTest/test_some_method/12356789.2"));
+      .hasValue(new File("ui/MyTest/test_some_method/12356789.2"));
   }
 
   @Test

--- a/statics/src/main/java/com/codeborne/selenide/Screenshots.java
+++ b/statics/src/main/java/com/codeborne/selenide/Screenshots.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.WebElement;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 
 import static com.codeborne.selenide.WebDriverRunner.driver;
 
@@ -77,9 +78,30 @@ public class Screenshots {
 
   /**
    * Get the last screenshot taken
+   *
    * @return null if there were no any screenshots taken
    */
   public static File getLastScreenshot() {
     return screenshots.getLastScreenshot();
+  }
+
+  /**
+   * Get the last screenshot taken in current thread
+   *
+   * @return {@link java.util.Optional} with screenshot of current thread,
+   * or an empty Optional if there were no any screenshots taken.
+   */
+  public static Optional<File> getLastThreadScreenshot() {
+    return screenshots.getLastThreadScreenshot();
+  }
+
+  /**
+   * Get the last screenshot taken in current {@code context} thread
+   *
+   * @return {@link java.util.Optional} with screenshot of current {@code context} thread,
+   * or an empty Optional if there were no any screenshots taken.
+   */
+  public static Optional<File> getLastContextScreenshot() {
+    return screenshots.getLastContextScreenshot();
   }
 }


### PR DESCRIPTION
## Proposed changes
Added possibility to get all screenshots and the last screenshot from the current thread and context thread.

Getting screenshots from `currentContextScreenshots` fixes #1029
Getting screenshots from `threadScreenshots` I hope can be used to fix https://github.com/selenide/selenide/issues/1002 

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
