### PR TITLE
Get rid of org.checkerframework:checker dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,6 @@ dependencies {
   }
   api('io.github.bonigarcia:webdrivermanager:3.8.1')
 
-  compileOnly('org.checkerframework:checker:3.2.0')
   compileOnly('com.browserup:browserup-proxy-core:2.0.1')
   testCompile('com.browserup:browserup-proxy-core:2.0.1')
   compileOnly('io.netty:netty-all:4.1.48.Final')

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -14,7 +14,7 @@ import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.collections.TextsInAnyOrder;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -28,7 +28,7 @@ import com.codeborne.selenide.conditions.SelectedText;
 import com.codeborne.selenide.conditions.Text;
 import com.codeborne.selenide.conditions.Value;
 import com.codeborne.selenide.conditions.Visible;
-import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.WebElement;
 
 import java.util.function.Predicate;

--- a/src/main/java/com/codeborne/selenide/Selectors.java
+++ b/src/main/java/com/codeborne/selenide/Selectors.java
@@ -1,7 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.selector.ByShadow;
-import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.Quotes;
 

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -7,7 +7,7 @@ import com.codeborne.selenide.impl.DownloadFileWithHttpRequest;
 import com.codeborne.selenide.impl.ElementFinder;
 import com.codeborne.selenide.impl.SelenidePageFactory;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
-import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,7 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.files.FileFilter;
-import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.TakesScreenshot;

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -1,7 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.ex.DialogTextMismatch;
-import org.checkerframework.com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;


### PR DESCRIPTION
## Proposed changes

There is no need to use full-blown 16 MB dependency just for compilation with a single annotation. Better use `CheckReturnValue` from errorprone and remove `org.checkerframework:checker` dependency completely.

One more reason for this change is how source code of library looks when we read it from projects:

![image](https://user-images.githubusercontent.com/1066152/79769844-4a395c80-8335-11ea-847c-f381c11cf5f8.png)

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
