### PR TITLE
Fix javadoc of ByShadow.cssSelector

### DIFF
--- a/src/main/java/com/codeborne/selenide/selector/ByShadow.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByShadow.java
@@ -17,7 +17,7 @@ public class ByShadow {
    * Find target elements inside shadow-root that attached to shadow-host.
    * <br/> Supports inner shadow-hosts.
    *
-   * <br/> For example: shadow-host > inner-shadow-host > target-element
+   * <br/> For example: shadow-host &gt; inner-shadow-host &gt; target-element
    * (each shadow-host must be specified explicitly).
    *
    * @param target           CSS expression of target element


### PR DESCRIPTION
## Proposed changes

This change fixes the following warning:
```
selenide/src/main/java/com/codeborne/selenide/selector/ByShadow.java:20: warning - invalid usage of tag >
```

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
