### PR TITLE
fix 'emptyMethod' folder name

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
+++ b/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
@@ -3,9 +3,8 @@ package com.codeborne.selenide.junit5;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.Screenshots;
 import com.codeborne.selenide.ex.UIAssertionError;
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +56,7 @@ import static com.codeborne.selenide.ex.ErrorMessages.screenshot;
  * @author Aliaksandr Rasolka
  * @since 4.12.2
  */
-public class ScreenShooterExtension implements BeforeAllCallback, AfterEachCallback, AfterAllCallback {
+public class ScreenShooterExtension implements BeforeEachCallback, AfterEachCallback {
   private static final Logger log = LoggerFactory.getLogger(ScreenShooterExtension.class);
 
   private final boolean captureSuccessfulTests;
@@ -85,15 +84,13 @@ public class ScreenShooterExtension implements BeforeAllCallback, AfterEachCallb
   }
 
   @Override
-  public void beforeAll(final ExtensionContext context) {
+  public void beforeEach(final ExtensionContext context) {
     final Optional<Class<?>> testClass = context.getTestClass();
-    final String className = testClass.isPresent()
-      ? testClass.get().getName()
-      : "EmptyClass";
+    final String className = testClass.map(Class::getName).orElse("EmptyClass");
+
     final Optional<Method> testMethod = context.getTestMethod();
-    final String methodName = testMethod.isPresent()
-      ? testMethod.get().getName()
-      : "emptyMethod";
+    final String methodName = testMethod.map(Method::getName).orElse("emptyMethod");
+
     Screenshots.startContext(className, methodName);
   }
 
@@ -108,10 +105,6 @@ public class ScreenShooterExtension implements BeforeAllCallback, AfterEachCallb
         }
       });
     }
-  }
-
-  @Override
-  public void afterAll(final ExtensionContext context) {
     Screenshots.finishContext();
   }
 }

--- a/statics/src/test/java/integration/errormessages/ErrorMsgWithScreenshotsTest.java
+++ b/statics/src/test/java/integration/errormessages/ErrorMsgWithScreenshotsTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
-class ErrorMessagesWithScreenshotsTest extends IntegrationTest {
+class ErrorMsgWithScreenshotsTest extends IntegrationTest {
   private String reportsUrl;
   private String reportsFolder;
 
@@ -36,7 +36,7 @@ class ErrorMessagesWithScreenshotsTest extends IntegrationTest {
   void mockScreenshots() {
     reportsUrl = Configuration.reportsUrl;
     reportsFolder = Configuration.reportsFolder;
-    Configuration.reportsFolder = "build/reports/tests/ErrorMessagesWithScreenshotsTest";
+    Configuration.reportsFolder = "build/reports/tests/ErrorMsgWithScreenshotsTest";
     Configuration.reportsUrl = "http://ci.org/";
     Screenshots.screenshots = new ScreenShotLaboratory() {
       @Override
@@ -66,7 +66,7 @@ class ErrorMessagesWithScreenshotsTest extends IntegrationTest {
   }
 
   @Test
-  void itShouldBeReportedWhichParentElementIsNotFound() {
+  void reportWhichParentElementIsNotFound() {
     assertThatThrownBy(() ->
       $("#multirowTable")
         .find("thead")
@@ -77,14 +77,14 @@ class ErrorMessagesWithScreenshotsTest extends IntegrationTest {
       .isInstanceOf(ElementNotFound.class)
       .hasMessageContaining("Element not found {thead}")
       .matches(e -> {
-        String path = "/integration/errormessages/ErrorMessagesWithScreenshotsTest/emptyMethod";
+        String path = "/integration/errormessages/ErrorMsgWithScreenshotsTest/reportWhichParentElementIsNotFound";
         return ((ElementNotFound) e).getScreenshot()
-          .matches("http://ci\\.org/build/reports/tests/ErrorMessagesWithScreenshotsTest" + path + "/\\d+\\.\\d+\\.(png|html)");
+          .matches("http://ci\\.org/build/reports/tests/ErrorMsgWithScreenshotsTest" + path + "/\\d+\\.\\d+\\.(png|html)");
       });
   }
 
   @Test
-  void itShouldBeReportedIfParentCollectionIsNotFound() {
+  void reportIfParentCollectionIsNotFound() {
     try {
       $("#multirowTable")
         .findAll("thead")
@@ -96,9 +96,9 @@ class ErrorMessagesWithScreenshotsTest extends IntegrationTest {
     catch (ElementNotFound e) {
       assertThat(e)
         .hasMessageContaining("Element not found {#multirowTable/thead");
-      String path = "/integration/errormessages/ErrorMessagesWithScreenshotsTest/emptyMethod";
+      String path = "/integration/errormessages/ErrorMsgWithScreenshotsTest/reportIfParentCollectionIsNotFound";
       assertThat(e.getScreenshot())
-        .matches("http://ci\\.org/build/reports/tests/ErrorMessagesWithScreenshotsTest" + path + "/\\d+\\.\\d+\\.(png|html)");
+        .matches("http://ci\\.org/build/reports/tests/ErrorMsgWithScreenshotsTest" + path + "/\\d+\\.\\d+\\.(png|html)");
     }
   }
 

--- a/statics/src/test/java/integration/errormessages/MissingElementTest.java
+++ b/statics/src/test/java/integration/errormessages/MissingElementTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-class ErrorMessagesForMissingElementTest extends IntegrationTest {
+class MissingElementTest extends IntegrationTest {
   private PageObject pageObject;
   private String reportsUrl;
   private String reportsFolder;
@@ -44,7 +44,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
     reportsUrl = Configuration.reportsUrl;
     reportsFolder = Configuration.reportsFolder;
     Configuration.reportsUrl = "http://ci.org/";
-    Configuration.reportsFolder = "build/reports/tests/EMFMET";
+    Configuration.reportsFolder = "build/reports/tests";
   }
 
   @AfterEach
@@ -60,7 +60,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
       fail("Expected ElementNotFound");
     }
     catch (ElementNotFound expected) {
-      String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+      String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/elementNotFound";
       assertThat(expected)
         .hasMessageMatching(String.format("Element not found \\{h9}%n" +
           "Expected: text 'expected text'%n" +
@@ -74,7 +74,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void elementTextDoesNotMatch() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/elementTextDoesNotMatch";
     assertThatThrownBy(() ->
       $("h2").shouldHave(text("expected text"))
     )
@@ -88,7 +88,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void elementAttributeDoesNotMatch() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/elementAttributeDoesNotMatch";
     assertThatThrownBy(() ->
       $("h2").shouldHave(attribute("name", "header"))
     )
@@ -103,7 +103,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void wrapperTextDoesNotMatch() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/wrapperTextDoesNotMatch";
     assertThatThrownBy(() ->
       $(element(By.tagName("h2"))).shouldHave(text("expected text"))
     )
@@ -117,7 +117,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void clickHiddenElement() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/clickHiddenElement";
     assertThatThrownBy(() ->
       $("#theHiddenElement").click()
     )
@@ -133,7 +133,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void pageObjectElementTextDoesNotMatch() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/pageObjectElementTextDoesNotMatch";
     assertThatThrownBy(() ->
       $(pageObject.header1).shouldHave(text("expected text"))
     )
@@ -147,7 +147,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void pageObjectWrapperTextDoesNotMatch() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/pageObjectWrapperTextDoesNotMatch";
     assertThatThrownBy(() ->
       $(pageObject.header2).shouldHave(text("expected text"))
     )
@@ -170,7 +170,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void clickUnexistingWrappedElement() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/clickUnexistingWrappedElement";
     assertThatThrownBy(() ->
       $(pageObject.categoryDropdown).click()
     ).isInstanceOf(ElementNotFound.class)
@@ -184,7 +184,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void existingElementShouldNotExist() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/existingElementShouldNotExist";
     assertThatThrownBy(() ->
       $("h2").shouldNot(exist)
     )
@@ -198,7 +198,7 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
 
   @Test
   void nonExistingElementShouldNotBeHidden() {
-    String path = "http://ci.org/build/reports/tests/EMFMET/integration/errormessages/ErrorMessagesForMissingElementTest/emptyMethod";
+    String path = "http://ci.org/build/reports/tests/integration/errormessages/MissingElementTest/nonExistingElementShouldNotBeHidden";
     assertThatThrownBy(() ->
       $("h14").shouldNotBe(hidden)
     )
@@ -222,8 +222,8 @@ class ErrorMessagesForMissingElementTest extends IntegrationTest {
       .hasMessageContainingAll(
         "is not clickable at point",
         "Other element would receive the click",
-        "Screenshot: http://ci.org/build/reports/tests/EMFMET",
-        "Page source: http://ci.org/build/reports/tests/EMFMET"
+        "Screenshot: http://ci.org/build/reports/tests",
+        "Page source: http://ci.org/build/reports/tests"
       );
   }
 


### PR DESCRIPTION
## Proposed changes
If Selenide is used with JUnit 5 all reports and screenshots about failed tests will be stored at '../UserRegistrationTests/**emptyMethod**/1588171516595.0.png'. It is inconvenient, because everything goes to the same folder. With this fix **emptyMethod** will be replaces with the actual test method name **createUserAndLogin**, like it is working in Selenide + JUnit 4. 

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
