### PR TITLE
Nullity annotations for the most used APIs

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -54,7 +54,7 @@
     <!--<module name="MutableException"/>-->
     <module name="ClassFanOutComplexity">
       <property name="max" value="29"/>
-      <property name="excludedPackages" value="com.codeborne.selenide.conditions"/>
+      <property name="excludedPackages" value="com.codeborne.selenide.conditions,com.google.errorprone.annotations,javax.annotation"/>
     </module>
     <module name="CyclomaticComplexity">
       <property name="max" value="11"/>

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -31,6 +31,9 @@ import com.codeborne.selenide.conditions.Visible;
 import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
@@ -38,6 +41,7 @@ import static java.util.Arrays.asList;
 /**
  * Conditions to match web elements: checks for visibility, text etc.
  */
+@ParametersAreNonnullByDefault
 public abstract class Condition {
   /**
    * Checks if element is visible
@@ -106,6 +110,7 @@ public abstract class Condition {
    * @return true iff attribute exists
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition attribute(String attributeName) {
     return new Attribute(attributeName);
   }
@@ -117,6 +122,7 @@ public abstract class Condition {
    * @param expectedAttributeValue expected value of attribute
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition attribute(String attributeName, String expectedAttributeValue) {
     return new AttributeWithValue(attributeName, expectedAttributeValue);
   }
@@ -130,6 +136,7 @@ public abstract class Condition {
    * @param attributeRegex regex to match attribute value
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition attributeMatching(String attributeName, String attributeRegex) {
     return new MatchAttributeWithValue(attributeName, attributeRegex);
   }
@@ -143,6 +150,7 @@ public abstract class Condition {
    * @param expectedValue expected value of "value" attribute
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition value(String expectedValue) {
     return new Value(expectedValue);
   }
@@ -157,6 +165,7 @@ public abstract class Condition {
    * @param expectedValue expected value of the property
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition pseudo(String pseudoElementName, String propertyName, String expectedValue) {
     return new PseudoElementPropertyWithValue(pseudoElementName, propertyName, expectedValue);
   }
@@ -169,6 +178,7 @@ public abstract class Condition {
    * @param expectedValue expected content of the pseudo-element
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition pseudo(String pseudoElementName, String expectedValue) {
     return new PseudoElementPropertyWithValue(pseudoElementName, "content", expectedValue);
   }
@@ -179,6 +189,7 @@ public abstract class Condition {
    * @param value expected value of input field
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition exactValue(String value) {
     return attribute("value", value);
   }
@@ -190,6 +201,7 @@ public abstract class Condition {
    * @param name expected name of input field
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition name(String name) {
     return attribute("name", name);
   }
@@ -201,6 +213,7 @@ public abstract class Condition {
    * @param type expected type of input field
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition type(String type) {
     return attribute("type", type);
   }
@@ -211,6 +224,7 @@ public abstract class Condition {
    * @param id expected id of input field
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition id(String id) {
     return attribute("id", id);
   }
@@ -231,6 +245,7 @@ public abstract class Condition {
    * @see #matchText(String)
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition matchesText(String text) {
     return matchText(text);
   }
@@ -243,6 +258,7 @@ public abstract class Condition {
    * @param regex e.g. Kicked.*Chuck Norris - in this case ".*" can contain any characters including spaces, tabs, CR etc.
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition matchText(String regex) {
     return new MatchText(regex);
   }
@@ -258,6 +274,7 @@ public abstract class Condition {
    * @param text expected text of HTML element
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition text(String text) {
     return new Text(text);
   }
@@ -272,6 +289,7 @@ public abstract class Condition {
    * @param expectedText expected selected text of the element
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition selectedText(String expectedText) {
     return new SelectedText(expectedText);
   }
@@ -286,6 +304,7 @@ public abstract class Condition {
    * @param text expected text of HTML element
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition textCaseSensitive(String text) {
     return new CaseSensitiveText(text);
   }
@@ -300,6 +319,7 @@ public abstract class Condition {
    * @param text expected text of HTML element
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition exactText(String text) {
     return new ExactText(text);
   }
@@ -313,6 +333,7 @@ public abstract class Condition {
    * @param text expected text of HTML element
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition exactTextCaseSensitive(String text) {
     return new ExactTextCaseSensitive(text);
   }
@@ -322,6 +343,7 @@ public abstract class Condition {
    * <p>Sample: <code>$("input").shouldHave(cssClass("active"));</code></p>
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition cssClass(String cssClass) {
     return new CssClass(cssClass);
   }
@@ -346,7 +368,8 @@ public abstract class Condition {
    * @see WebElement#getCssValue
    */
   @CheckReturnValue
-  public static Condition cssValue(String propertyName, String expectedValue) {
+  @Nonnull
+  public static Condition cssValue(String propertyName, @Nullable String expectedValue) {
     return new CssValue(propertyName, expectedValue);
   }
 
@@ -359,6 +382,7 @@ public abstract class Condition {
    * @param predicate   the {@link Predicate} to match
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition match(String description, Predicate<WebElement> predicate) {
     return new CustomMatch(description, predicate);
   }
@@ -409,10 +433,12 @@ public abstract class Condition {
    * Typically you don't need to use it.
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition not(final Condition condition) {
     return condition.negate();
   }
 
+  @Nonnull
   public Condition negate() {
     return new Not(this, absentElementMatchesCondition);
   }
@@ -425,6 +451,7 @@ public abstract class Condition {
    * @return logical AND for given conditions.
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition and(String name, Condition... conditions) {
     return new And(name, asList(conditions));
   }
@@ -437,6 +464,7 @@ public abstract class Condition {
    * @return logical OR for given conditions.
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition or(String name, Condition... conditions) {
     return new Or(name, asList(conditions));
   }
@@ -449,6 +477,7 @@ public abstract class Condition {
    * @return Condition
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition be(Condition delegate) {
     return wrap("be", delegate);
   }
@@ -461,6 +490,7 @@ public abstract class Condition {
    * @return Condition
    */
   @CheckReturnValue
+  @Nonnull
   public static Condition have(Condition delegate) {
     return wrap("have", delegate);
   }
@@ -502,6 +532,7 @@ public abstract class Condition {
    * @param element given WebElement
    * @return any string that needs to be appended to error message.
    */
+  @Nullable
   public String actualValue(Driver driver, WebElement element) {
     return null;
   }
@@ -510,6 +541,7 @@ public abstract class Condition {
    * Should be used for explaining the reason of condition
    */
   @CheckReturnValue
+  @Nonnull
   public Condition because(String message) {
     return new ExplainedCondition(this, message);
   }

--- a/src/main/java/com/codeborne/selenide/Credentials.java
+++ b/src/main/java/com/codeborne/selenide/Credentials.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import javax.annotation.Nonnull;
 import java.util.Base64;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -8,7 +9,7 @@ public final class Credentials {
   public final String login;
   public final String password;
 
-  public Credentials(String login, String password) {
+  public Credentials(@Nonnull String login, @Nonnull String password) {
     this.login = login;
     this.password = password;
   }

--- a/src/main/java/com/codeborne/selenide/Selectors.java
+++ b/src/main/java/com/codeborne/selenide/Selectors.java
@@ -5,6 +5,8 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.Quotes;
 
+import javax.annotation.Nonnull;
+
 public class Selectors {
   private static final String NORMALIZE_SPACE_XPATH = "normalize-space(translate(string(.), '\t\n\r\u00a0', '    '))";
 
@@ -18,6 +20,7 @@ public class Selectors {
    * @return standard selenium By criteria`
    */
   @CheckReturnValue
+  @Nonnull
   public static By withText(String elementText) {
     return new WithText(elementText);
   }
@@ -32,6 +35,7 @@ public class Selectors {
    * @return standard selenium By criteria
    */
   @CheckReturnValue
+  @Nonnull
   public static By byText(String elementText) {
     return new ByText(elementText);
   }
@@ -66,6 +70,7 @@ public class Selectors {
    * @return standard selenium By cssSelector criteria
    */
   @CheckReturnValue
+  @Nonnull
   public static By byAttribute(String attributeName, String attributeValue) {
     String escapedAttributeValue = attributeValue.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
     return By.cssSelector(String.format("[%s=\"%s\"]", attributeName, escapedAttributeValue));
@@ -76,6 +81,7 @@ public class Selectors {
    * @since 5.10
    */
   @CheckReturnValue
+  @Nonnull
   public static By shadowCss(String target, String shadowHost, String... innerShadowHosts) {
     return ByShadow.cssSelector(target, shadowHost, innerShadowHosts);
   }
@@ -84,6 +90,7 @@ public class Selectors {
    * Synonym for #byAttribute
    */
   @CheckReturnValue
+  @Nonnull
   public static By by(String attributeName, String attributeValue) {
     return byAttribute(attributeName, attributeValue);
   }
@@ -92,6 +99,7 @@ public class Selectors {
    * Find element with given title ("title" attribute)
    */
   @CheckReturnValue
+  @Nonnull
   public static By byTitle(String title) {
     return byAttribute("title", title);
   }
@@ -100,6 +108,7 @@ public class Selectors {
    * Find input element with given value ("value" attribute)
    */
   @CheckReturnValue
+  @Nonnull
   public static By byValue(String value) {
     return byAttribute("value", value);
   }
@@ -145,6 +154,7 @@ public class Selectors {
    * @since 3.1
    */
   @CheckReturnValue
+  @Nonnull
   public static By byName(String name) {
     return By.name(name);
   }
@@ -154,6 +164,7 @@ public class Selectors {
    * @since 3.1
    */
   @CheckReturnValue
+  @Nonnull
   public static By byXpath(String xpath) {
     return By.xpath(xpath);
   }
@@ -163,6 +174,7 @@ public class Selectors {
    * @since 3.1
    */
   @CheckReturnValue
+  @Nonnull
   public static By byLinkText(String linkText) {
     return By.linkText(linkText);
   }
@@ -172,6 +184,7 @@ public class Selectors {
    * @since 3.1
    */
   @CheckReturnValue
+  @Nonnull
   public static By byPartialLinkText(String partialLinkText) {
     return By.partialLinkText(partialLinkText);
   }
@@ -181,6 +194,7 @@ public class Selectors {
    * @since 3.1
    */
   @CheckReturnValue
+  @Nonnull
   public static By byId(String id) {
     return By.id(id);
   }
@@ -190,6 +204,7 @@ public class Selectors {
    * @since 3.8
    */
   @CheckReturnValue
+  @Nonnull
   public static By byCssSelector(String css) {
     return By.cssSelector(css);
   }
@@ -199,6 +214,7 @@ public class Selectors {
    * @since 3.8
    */
   @CheckReturnValue
+  @Nonnull
   public static By byClassName(String className) {
     return By.className(className);
   }
@@ -208,6 +224,7 @@ public class Selectors {
    * @since 5.11
    */
   @CheckReturnValue
+  @Nonnull
   public static By byTagName(String tagName) {
     return By.tagName(tagName);
   }

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -342,7 +342,7 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   public String url() {
     return getWebDriver().getCurrentUrl();
   }

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -13,6 +13,9 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.events.WebDriverEventListener;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -26,6 +29,7 @@ import static java.util.Collections.emptyList;
 /**
  * "Selenide driver" is a container for WebDriver + proxy server + settings
  */
+@ParametersAreNonnullByDefault
 public class SelenideDriver {
   private static final Navigator navigator = new Navigator();
   private static final SelenidePageFactory pageFactory = new SelenidePageFactory();
@@ -53,11 +57,13 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
+  @Nonnull
   public Config config() {
     return config;
   }
 
   @CheckReturnValue
+  @Nonnull
   public Driver driver() {
     return driver;
   }
@@ -87,18 +93,21 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
+  @Nonnull
   public <PageObjectClass> PageObjectClass open(String relativeOrAbsoluteUrl,
                                                 Class<PageObjectClass> pageObjectClassClass) {
     return open(relativeOrAbsoluteUrl, "", "", "", pageObjectClassClass);
   }
 
   @CheckReturnValue
+  @Nonnull
   public <PageObjectClass> PageObjectClass open(URL absoluteUrl,
                                                 Class<PageObjectClass> pageObjectClassClass) {
     return open(absoluteUrl, "", "", "", pageObjectClassClass);
   }
 
   @CheckReturnValue
+  @Nonnull
   public <PageObjectClass> PageObjectClass open(String relativeOrAbsoluteUrl,
                                                 String domain, String login, String password,
                                                 Class<PageObjectClass> pageObjectClassClass) {
@@ -107,6 +116,7 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
+  @Nonnull
   public <PageObjectClass> PageObjectClass open(URL absoluteUrl, String domain, String login, String password,
                                                 Class<PageObjectClass> pageObjectClassClass) {
     open(absoluteUrl, domain, login, password);
@@ -114,11 +124,13 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
+  @Nonnull
   public <PageObjectClass> PageObjectClass page(Class<PageObjectClass> pageObjectClass) {
     return pageFactory.page(driver(), pageObjectClass);
   }
 
   @CheckReturnValue
+  @Nonnull
   public <PageObjectClass, T extends PageObjectClass> PageObjectClass page(T pageObject) {
     return pageFactory.page(driver(), pageObject);
   }
@@ -141,11 +153,13 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
+  @Nonnull
   public Browser browser() {
     return driver().browser();
   }
 
   @CheckReturnValue
+  @Nullable
   public SelenideProxyServer getProxy() {
     return driver().getProxy();
   }
@@ -155,11 +169,13 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
+  @Nonnull
   public WebDriver getWebDriver() {
     return driver.getWebDriver();
   }
 
   @CheckReturnValue
+  @Nonnull
   public WebDriver getAndCheckWebDriver() {
     return driver.getAndCheckWebDriver();
   }
@@ -181,11 +197,13 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
+  @Nullable
   public WebElement getFocusedElement() {
     return executeJavaScript("return document.activeElement");
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideWait Wait() {
     return new SelenideWait(getWebDriver(), config().timeout(), config().pollingInterval());
   }
@@ -198,81 +216,97 @@ public class SelenideDriver {
     );
   }
 
+  @Nullable
   public String title() {
     return getWebDriver().getTitle();
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement $(WebElement webElement) {
     return wrap(driver(), webElement);
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement $(String cssSelector) {
     return find(cssSelector);
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement find(String cssSelector) {
     return find(By.cssSelector(cssSelector));
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement $x(String xpathExpression) {
     return find(By.xpath(xpathExpression));
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement $(By seleniumSelector) {
     return find(seleniumSelector);
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement $(By seleniumSelector, int index) {
     return find(seleniumSelector, index);
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement $(String cssSelector, int index) {
     return ElementFinder.wrap(driver(), cssSelector, index);
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement find(By criteria) {
     return ElementFinder.wrap(driver(), null, criteria, 0);
   }
 
   @CheckReturnValue
+  @Nonnull
   public SelenideElement find(By criteria, int index) {
     return ElementFinder.wrap(driver(), null, criteria, index);
   }
 
   @CheckReturnValue
+  @Nonnull
   public ElementsCollection $$(Collection<? extends WebElement> elements) {
     return new ElementsCollection(driver(), elements);
   }
 
   @CheckReturnValue
+  @Nonnull
   public ElementsCollection $$(String cssSelector) {
     return new ElementsCollection(driver(), cssSelector);
   }
 
   @CheckReturnValue
+  @Nonnull
   public ElementsCollection $$x(String xpathExpression) {
     return $$(By.xpath(xpathExpression));
   }
 
   @CheckReturnValue
+  @Nonnull
   public ElementsCollection findAll(By seleniumSelector) {
     return new ElementsCollection(driver(), seleniumSelector);
   }
 
   @CheckReturnValue
+  @Nonnull
   public ElementsCollection $$(By criteria) {
     return findAll(criteria);
   }
 
   @CheckReturnValue
+  @Nullable
   public SelenideElement getSelectedRadio(By radioField) {
     for (WebElement radio : $$(radioField)) {
       if (radio.getAttribute("checked") != null) {
@@ -283,11 +317,13 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
+  @Nonnull
   public Modal modal() {
     return new Modal(driver());
   }
 
   @CheckReturnValue
+  @Nonnull
   public WebDriverLogs getWebDriverLogs() {
     return new WebDriverLogs(driver());
   }
@@ -300,34 +336,41 @@ public class SelenideDriver {
     return executeJavaScript("return window.pageYOffset + window.innerHeight >= document.body.scrollHeight");
   }
 
+  @Nonnull
   public SelenideTargetLocator switchTo() {
     return driver().switchTo();
   }
 
   @CheckReturnValue
+  @Nullable
   public String url() {
     return getWebDriver().getCurrentUrl();
   }
 
   @CheckReturnValue
+  @Nullable
   public String source() {
     return getWebDriver().getPageSource();
   }
 
   @CheckReturnValue
+  @Nonnull
   public String getCurrentFrameUrl() {
     return executeJavaScript("return window.location.href").toString();
   }
 
   @CheckReturnValue
+  @Nonnull
   public String getUserAgent() {
     return driver().getUserAgent();
   }
 
+  @Nonnull
   public File download(String url) throws IOException {
     return download(url, config.timeout());
   }
 
+  @Nonnull
   public File download(String url, long timeoutMs) throws IOException {
     return downloadFileWithHttpRequest.download(driver(), url, timeoutMs, none());
   }

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.files.FileFilter;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -92,6 +93,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.PressTab
    */
   @Nonnull
+  @CanIgnoreReturnValue
   SelenideElement pressTab();
 
   /**
@@ -105,6 +107,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.PressEscape
    */
   @Nonnull
+  @CanIgnoreReturnValue
   SelenideElement pressEscape();
 
   /**
@@ -201,7 +204,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @return the property value or "" if the property is missing
    */
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   String pseudo(String pseudoElementName, String propertyName);
 
   /**
@@ -222,6 +225,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.SelectRadio
    */
   @Nonnull
+  @CanIgnoreReturnValue
   SelenideElement selectRadio(String value);
 
   /**
@@ -233,12 +237,20 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   @Nullable
   String data(String dataAttributeName);
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   @Nullable
+  @CheckReturnValue
   String getAttribute(String name);
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
-  @Nullable
+  @Nonnull
+  @CheckReturnValue
   String getCssValue(String propertyName);
 
   /**
@@ -417,6 +429,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.ShouldNotBe
    */
   @Nonnull
+  @CanIgnoreReturnValue
   SelenideElement waitWhile(Condition condition, long timeoutMilliseconds);
 
   /**
@@ -431,6 +444,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.ShouldNotBe
    */
   @Nonnull
+  @CanIgnoreReturnValue
   SelenideElement waitWhile(Condition condition, long timeoutMilliseconds, long pollingIntervalMilliseconds);
 
   /**
@@ -967,6 +981,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.DragAndDropTo
    */
   @Nonnull
+  @CanIgnoreReturnValue
   SelenideElement dragAndDropTo(String targetCssSelector);
 
   /**
@@ -979,6 +994,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.DragAndDropTo
    */
   @Nonnull
+  @CanIgnoreReturnValue
   SelenideElement dragAndDropTo(WebElement target);
 
   /**
@@ -1006,7 +1022,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @return file with screenshot (*.png)
    * @see com.codeborne.selenide.commands.TakeScreenshot
    */
-  @Nonnull
+  @Nullable
   File screenshot();
 
   /**
@@ -1016,6 +1032,6 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.TakeScreenshotAsImage
    */
   @CheckReturnValue
-  @Nonnull
+  @Nullable
   BufferedImage screenshotAsImage();
 }

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -265,9 +265,9 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Check if this element exists and visible.
    *
    * @return false if element does not exists, is invisible, browser is closed or any WebDriver exception happened.
-   * @see com.codeborne.selenide.commands.IsDisplayed
    */
   @Override
+  @CheckReturnValue
   boolean isDisplayed();
 
   /**

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -10,6 +10,9 @@ import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.interactions.Locatable;
 import org.openqa.selenium.internal.WrapsElement;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -18,9 +21,9 @@ import java.io.FileNotFoundException;
  * Wrapper around {@link WebElement} with additional methods like
  * {@link #shouldBe(Condition...)} and {@link #shouldHave(Condition...)}
  */
+@ParametersAreNonnullByDefault
 public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, Locatable, TakesScreenshot {
   /**
-   *
    * <b>Implementation details:</b>
    *
    * <p>If Configuration.versatileSetValue is true, can work as 'selectOptionByValue', 'selectRadio'</p>
@@ -36,20 +39,22 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * </pre>
    *
    * @param text Any text to enter into the text field or set by value for select/radio.
-   *
    * @see com.codeborne.selenide.commands.SetValue
    */
-  SelenideElement setValue(String text);
+  @Nonnull
+  SelenideElement setValue(@Nullable String text);
 
   /**
    * Same as {@link #setValue(java.lang.String)}
+   *
    * @see com.codeborne.selenide.commands.Val
    */
-  SelenideElement val(String text);
+  @Nonnull
+  SelenideElement val(@Nullable String text);
 
   /**
    * Append given test to the text field and trigger "change" event.
-   *
+   * <p>
    * Implementation details:
    * This is the same as
    * <pre>
@@ -58,45 +63,48 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * </pre>
    *
    * @param text Any text to append into the text field.
-   *
    * @see com.codeborne.selenide.commands.Append
    */
+  @Nonnull
   SelenideElement append(String text);
 
   /**
    * Press ENTER. Useful for input field and textareas: <pre>
    *  $("query").val("Aikido techniques").pressEnter();</pre>
-   *
+   * <p>
    * Implementation details:
    * Check that element is displayed and execute <pre>
    *  WebElement.sendKeys(Keys.ENTER)</pre>
    *
    * @see com.codeborne.selenide.commands.PressEnter
    */
+  @Nonnull
   SelenideElement pressEnter();
 
   /**
    * Press TAB. Useful for input field and textareas: <pre>
    *  $("#to").val("stiven@seagal.com").pressTab();</pre>
-   *
+   * <p>
    * Implementation details:
    * Check that element is displayed and execute <pre>
    *  WebElement.sendKeys(Keys.TAB)</pre>
    *
    * @see com.codeborne.selenide.commands.PressTab
    */
+  @Nonnull
   SelenideElement pressTab();
 
   /**
    * Press ESCAPE. Useful for input field and textareas: <pre>
    *  $(".edit").click().pressEscape();</pre>
-   *
+   * <p>
    * Implementation details:
    * Check that element is displayed and execute <pre>
    *  WebElement.sendKeys(Keys.ESCAPE)</pre>
    *
    * @see com.codeborne.selenide.commands.PressEscape
    */
+  @Nonnull
   SelenideElement pressEscape();
 
   /**
@@ -106,95 +114,114 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @return The innerText of this element
    * @see com.codeborne.selenide.commands.GetText
    */
-  @Override String getText();
+  @Nullable
+  @Override
+  String getText();
 
   /**
    * Short form of getText()
+   *
    * @see WebElement#getText()
    * @see com.codeborne.selenide.commands.GetText
    */
   @CheckReturnValue
+  @Nullable
   String text();
 
   /**
    * Get the text code of the element with children.
-   *
+   * <p>
    * Short form of getAttribute("textContent") or getAttribute("innerText") depending on browser.
+   *
    * @see com.codeborne.selenide.commands.GetInnerText
    */
   @CheckReturnValue
+  @Nullable
   String innerText();
 
   /**
    * Get the HTML code of the element with children.
-   *
+   * <p>
    * Short form of getAttribute("innerHTML")
+   *
    * @see com.codeborne.selenide.commands.GetInnerHtml
    */
   @CheckReturnValue
+  @Nullable
   String innerHtml();
 
   /**
    * Get the attribute of the element. Synonym for getAttribute(String).
+   *
    * @return null if attribute is missing
    * @see com.codeborne.selenide.commands.GetAttribute
    */
   @CheckReturnValue
+  @Nullable
   String attr(String attributeName);
 
   /**
    * Get the "name" attribute of the element
+   *
    * @return attribute "name" value or null if attribute is missing
    * @see com.codeborne.selenide.commands.GetName
    */
   @CheckReturnValue
+  @Nullable
   String name();
 
   /**
    * Get the "value" attribute of the element
    * Same as {@link #getValue()}
-   * @return attribute "value" value or null if attribute is missing
    *
+   * @return attribute "value" value or null if attribute is missing
    * @see com.codeborne.selenide.commands.Val
    */
   @CheckReturnValue
+  @Nullable
   String val();
 
   /**
    * Get the "value" attribute of the element
-   * @return attribute "value" value or null if attribute is missing
-   * @since 3.1
    *
+   * @return attribute "value" value or null if attribute is missing
    * @see com.codeborne.selenide.commands.GetValue
+   * @since 3.1
    */
   @CheckReturnValue
+  @Nullable
   String getValue();
 
   /**
    * Get the property value of the pseudo-element
+   *
    * @param pseudoElementName pseudo-element name of the element,
    *                          ":before", ":after", ":first-letter", ":first-line", ":selection"
-   * @param propertyName property name of the pseudo-element
+   * @param propertyName      property name of the pseudo-element
    * @return the property value or "" if the property is missing
    */
   @CheckReturnValue
+  @Nullable
   String pseudo(String pseudoElementName, String propertyName);
 
   /**
    * Get content of the pseudo-element
+   *
    * @param pseudoElementName pseudo-element name of the element, ":before", ":after"
    * @return the content value or "none" if the content is missing
    */
   @CheckReturnValue
+  @Nonnull
   String pseudo(String pseudoElementName);
 
   /**
    * Select radio button
+   *
    * @param value value of radio button to select
    * @return selected "input type=radio" element
-   *
    * @see com.codeborne.selenide.commands.SelectRadio
    */
+  @Nonnull
   SelenideElement selectRadio(String value);
 
   /**
@@ -203,20 +230,29 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.GetDataAttribute
    */
   @CheckReturnValue
+  @Nullable
   String data(String dataAttributeName);
+
+  @Override
+  @Nullable
+  String getAttribute(String name);
+
+  @Override
+  @Nullable
+  String getCssValue(String propertyName);
 
   /**
    * Checks if element exists true on the current page.
-   * @return false if element is not found, browser is closed or any WebDriver exception happened
    *
+   * @return false if element is not found, browser is closed or any WebDriver exception happened
    * @see com.codeborne.selenide.commands.Exists
    */
   boolean exists();
 
   /**
    * Check if this element exists and visible.
-   * @return false if element does not exists, is invisible, browser is closed or any WebDriver exception happened.
    *
+   * @return false if element does not exists, is invisible, browser is closed or any WebDriver exception happened.
    * @see com.codeborne.selenide.commands.IsDisplayed
    */
   @Override
@@ -246,10 +282,11 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
 
   /**
    * Set checkbox state to CHECKED or UNCHECKED.
-   * @param selected true for checked and false for unchecked
    *
+   * @param selected true for checked and false for unchecked
    * @see com.codeborne.selenide.commands.SetSelected
    */
+  @Nonnull
   SelenideElement setSelected(boolean selected);
 
   /**
@@ -263,37 +300,39 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * <p>Timeout is configurable via {@link com.codeborne.selenide.Configuration#timeout}</p>
    *
    * <p>For example: {@code
-   *   $("#errorMessage").should(appear);
+   * $("#errorMessage").should(appear);
    * }</p>
    *
    * @return Given element, useful for chaining:
    * {@code $("#errorMessage").should(appear).shouldBe(enabled);}
-   *
    * @see com.codeborne.selenide.Config#timeout
    * @see com.codeborne.selenide.commands.Should
    */
+  @Nonnull
   SelenideElement should(Condition... condition);
 
   /**
    * <p>Synonym for {@link #should(com.codeborne.selenide.Condition...)}. Useful for better readability.</p>
    * <p>For example: {@code
-   *   $("#errorMessage").shouldHave(text("Hello"), text("World"));
+   * $("#errorMessage").shouldHave(text("Hello"), text("World"));
    * }</p>
-
+   *
    * @see SelenideElement#should(com.codeborne.selenide.Condition...)
    * @see com.codeborne.selenide.commands.ShouldHave
    */
+  @Nonnull
   SelenideElement shouldHave(Condition... condition);
 
   /**
    * <p>Synonym for {@link #should(com.codeborne.selenide.Condition...)}. Useful for better readability.</p>
    * <p>For example: {@code
-   *   $("#errorMessage").shouldBe(visible, enabled);
+   * $("#errorMessage").shouldBe(visible, enabled);
    * }</p>
    *
    * @see SelenideElement#should(com.codeborne.selenide.Condition...)
    * @see com.codeborne.selenide.commands.ShouldBe
    */
+  @Nonnull
   SelenideElement shouldBe(Condition... condition);
 
   /**
@@ -307,34 +346,37 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * <p>Timeout is configurable via {@link com.codeborne.selenide.Configuration#timeout}</p>
    *
    * <p>For example: {@code
-   *   $("#errorMessage").should(exist);
+   * $("#errorMessage").should(exist);
    * }</p>
    *
    * @see com.codeborne.selenide.Config#timeout
    * @see com.codeborne.selenide.commands.ShouldNot
    */
+  @Nonnull
   SelenideElement shouldNot(Condition... condition);
 
   /**
    * <p>Synonym for {@link #shouldNot(com.codeborne.selenide.Condition...)}. Useful for better readability.</p>
    * <p>For example: {@code
-   *   $("#errorMessage").shouldNotHave(text("Exception"), text("Error"));
+   * $("#errorMessage").shouldNotHave(text("Exception"), text("Error"));
    * }</p>
    *
    * @see SelenideElement#shouldNot(com.codeborne.selenide.Condition...)
    * @see com.codeborne.selenide.commands.ShouldNotHave
    */
+  @Nonnull
   SelenideElement shouldNotHave(Condition... condition);
 
   /**
    * <p>Synonym for {@link #shouldNot(com.codeborne.selenide.Condition...)}. Useful for better readability.</p>
    * <p>For example: {@code
-   *   $("#errorMessage").shouldNotBe(visible, enabled);
+   * $("#errorMessage").shouldNotBe(visible, enabled);
    * }</p>
    *
    * @see SelenideElement#shouldNot(com.codeborne.selenide.Condition...)
    * @see com.codeborne.selenide.commands.ShouldNotBe
    */
+  @Nonnull
   SelenideElement shouldNotBe(Condition... condition);
 
   /**
@@ -343,10 +385,11 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * <p>IMPORTANT: in most cases you don't need this method because all should- methods wait too.
    * You need to use #waitUntil or #waitWhile methods only if you need another timeout.</p>
    *
-   * @param condition e.g. enabled, visible, text() and so on
+   * @param condition           e.g. enabled, visible, text() and so on
    * @param timeoutMilliseconds timeout in milliseconds.
    * @see com.codeborne.selenide.commands.ShouldBe
    */
+  @Nonnull
   SelenideElement waitUntil(Condition condition, long timeoutMilliseconds);
 
   /**
@@ -355,12 +398,12 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * <p>IMPORTANT: in most cases you don't need this method because all should- methods wait too.
    * You need to use #waitUntil or #waitWhile methods only if you need another timeout.</p>
    *
-   * @param condition e.g. enabled, visible, text() and so on
-   * @param timeoutMilliseconds timeout in milliseconds.
-   * @param pollingIntervalMilliseconds  interval in milliseconds, when checking condition
-   *
+   * @param condition                   e.g. enabled, visible, text() and so on
+   * @param timeoutMilliseconds         timeout in milliseconds.
+   * @param pollingIntervalMilliseconds interval in milliseconds, when checking condition
    * @see com.codeborne.selenide.commands.ShouldBe
    */
+  @Nonnull
   SelenideElement waitUntil(Condition condition, long timeoutMilliseconds, long pollingIntervalMilliseconds);
 
   /**
@@ -369,11 +412,11 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * <p>IMPORTANT: in most cases you don't need this method because all shouldNot- methods wait too.
    * You need to use #waitUntil or #waitWhile methods only if you need another timeout.</p>
    *
-   * @param condition e.g. enabled, visible, text() and so on
+   * @param condition           e.g. enabled, visible, text() and so on
    * @param timeoutMilliseconds timeout in milliseconds.
-   *
    * @see com.codeborne.selenide.commands.ShouldNotBe
    */
+  @Nonnull
   SelenideElement waitWhile(Condition condition, long timeoutMilliseconds);
 
   /**
@@ -382,12 +425,12 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * <p>IMPORTANT: in most cases you don't need this method because all shouldNot- methods wait too.
    * You need to use #waitUntil or #waitWhile methods only if you need another timeout.</p>
    *
-   * @param condition e.g. enabled, visible, text() and so on
-   * @param timeoutMilliseconds timeout in milliseconds.
-   * @param pollingIntervalMilliseconds  interval in milliseconds, when checking condition
-   *
+   * @param condition                   e.g. enabled, visible, text() and so on
+   * @param timeoutMilliseconds         timeout in milliseconds.
+   * @param pollingIntervalMilliseconds interval in milliseconds, when checking condition
    * @see com.codeborne.selenide.commands.ShouldNotBe
    */
+  @Nonnull
   SelenideElement waitWhile(Condition condition, long timeoutMilliseconds, long pollingIntervalMilliseconds);
 
   /**
@@ -396,20 +439,21 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Not recommended to use for test verifications.
    *
    * @return e.g. <strong id=orderConfirmedStatus class=>Order has been confirmed</strong>
-   *
    * @see com.codeborne.selenide.commands.ToString
    */
-  @Override String toString();
+  @Override
+  String toString();
 
   /**
    * Get parent element of this element
    * ATTENTION! This method doesn't start any search yet!
    * For example, $("td").parent() could give some "tr".
-   * @return Parent element
    *
+   * @return Parent element
    * @see com.codeborne.selenide.commands.GetParent
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement parent();
 
   /**
@@ -419,10 +463,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @param index the index of sibling element
    * @return Sibling element by index
-   *
    * @see com.codeborne.selenide.commands.GetSibling
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement sibling(int index);
 
   /**
@@ -432,10 +476,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @param index the index of sibling element
    * @return Sibling element by index
-   *
    * @see com.codeborne.selenide.commands.GetPreceding
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement preceding(int index);
 
   /**
@@ -444,6 +488,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * For example, $("tr").lastChild(); could give the last "td".
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement lastChild();
 
   /**
@@ -453,10 +498,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @param tagOrClass Either HTML tag or CSS class. E.g. "form" or ".active".
    * @return Matching ancestor element
-   *
    * @see com.codeborne.selenide.commands.GetClosest
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement closest(String tagOrClass);
 
   /**
@@ -467,6 +512,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.Find
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement find(String cssSelector);
 
   /**
@@ -476,11 +522,13 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.Find
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement find(String cssSelector, int index);
 
   /**
    * ATTENTION! This method doesn't start any search yet!
    * Same as {@link #find(String)}
+   *
    * @see com.codeborne.selenide.commands.Find
    */
   @CheckReturnValue
@@ -489,41 +537,51 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   /**
    * ATTENTION! This method doesn't start any search yet!
    * Same as {@link #find(String, int)}
+   *
    * @see com.codeborne.selenide.commands.Find
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement find(By selector, int index);
 
   /**
    * ATTENTION! This method doesn't start any search yet!
    * Same as {@link #find(String)}
+   *
    * @see com.codeborne.selenide.commands.Find
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement $(String cssSelector);
 
   /**
    * ATTENTION! This method doesn't start any search yet!
    * Same as {@link #find(String, int)}
+   *
    * @see com.codeborne.selenide.commands.Find
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement $(String cssSelector, int index);
 
   /**
    * ATTENTION! This method doesn't start any search yet!
    * Same as {@link #find(String)}
+   *
    * @see com.codeborne.selenide.commands.Find
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement $(By selector);
 
   /**
    * ATTENTION! This method doesn't start any search yet!
    * Same as {@link #find(String, int)}
+   *
    * @see com.codeborne.selenide.commands.Find
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement $(By selector, int index);
 
   /**
@@ -534,6 +592,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.FindByXpath
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement $x(String xpath);
 
   /**
@@ -543,6 +602,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.FindByXpath
    */
   @CheckReturnValue
+  @Nonnull
   SelenideElement $x(String xpath, int index);
 
   /**
@@ -555,10 +615,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * </p>
    *
    * @return list of elements inside given element matching given CSS selector
-   *
    * @see com.codeborne.selenide.commands.FindAll
    */
   @CheckReturnValue
+  @Nonnull
   ElementsCollection findAll(String cssSelector);
 
   /**
@@ -571,10 +631,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * </p>
    *
    * @return list of elements inside given element matching given criteria
-   *
    * @see com.codeborne.selenide.commands.FindAll
    */
   @CheckReturnValue
+  @Nonnull
   ElementsCollection findAll(By selector);
 
   /**
@@ -582,12 +642,14 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Same as {@link #findAll(String)}
    */
   @CheckReturnValue
+  @Nonnull
   ElementsCollection $$(String cssSelector);
 
   /**
    * Same as {@link #findAll(By)}
    */
   @CheckReturnValue
+  @Nonnull
   ElementsCollection $$(By selector);
 
   /**
@@ -600,75 +662,78 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * </p>
    *
    * @return list of elements inside given element matching given xpath locator
-   *
    * @see com.codeborne.selenide.commands.FindAllByXpath
    */
   @CheckReturnValue
+  @Nonnull
   ElementsCollection $$x(String xpath);
 
   /**
    * <p>Upload file into file upload field. File is searched from classpath.</p>
    *
    * <p>Multiple file upload is also supported. Just pass as many file names as you wish.</p>
+   *
    * @param fileName name of the file or the relative path in classpath e.g. "files/1.pfd"
    * @return the object of the first file uploaded
    * @throws IllegalArgumentException if any of the files is not found
-   *
    * @see com.codeborne.selenide.commands.UploadFileFromClasspath
    */
+  @Nonnull
   File uploadFromClasspath(String... fileName);
 
   /**
    * <p>Upload file into file upload field.</p>
    *
    * <p>Multiple file upload is also supported. Just pass as many files as you wish.</p>
+   *
    * @param file file object(s)
    * @return the object of the first file uploaded
    * @throws IllegalArgumentException if any of the files is not found, or other errors
-   *
    * @see com.codeborne.selenide.commands.UploadFile
    */
+  @Nonnull
   File uploadFile(File... file);
 
   /**
    * Select an option from dropdown list (by index)
-   * @param index 0..N (0 means first option)
    *
+   * @param index 0..N (0 means first option)
    * @see com.codeborne.selenide.commands.SelectOptionByTextOrIndex
    */
   void selectOption(int... index);
 
   /**
    * Select an option from dropdown list (by text)
-   * @param text visible text of option
    *
+   * @param text visible text of option
    * @see com.codeborne.selenide.commands.SelectOptionByTextOrIndex
    */
   void selectOption(String... text);
 
   /**
    * Select an option from dropdown list that contains given text
-   * @param text substring of visible text of option
    *
+   * @param text substring of visible text of option
    * @see com.codeborne.selenide.commands.SelectOptionContainingText
    */
   void selectOptionContainingText(String text);
 
   /**
    * Select an option from dropdown list (by value)
-   * @param value "value" attribute of option
    *
+   * @param value "value" attribute of option
    * @see com.codeborne.selenide.commands.SelectOptionByValue
    */
   void selectOptionByValue(String... value);
 
   /**
    * Find (first) selected option from this select field
+   *
    * @return WebElement for selected &lt;option&gt; element
    * @throws NoSuchElementException if no options are selected
-   *
    * @see com.codeborne.selenide.commands.GetSelectedOption
    */
+  @Nonnull
   SelenideElement getSelectedOption() throws NoSuchElementException;
 
   /**
@@ -677,6 +742,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @return ElementsCollection for selected &lt;option&gt; elements (empty list if no options are selected)
    * @see com.codeborne.selenide.commands.GetSelectedOptions
    */
+  @Nonnull
   ElementsCollection getSelectedOptions();
 
   /**
@@ -685,6 +751,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.GetSelectedValue
    */
   @CheckReturnValue
+  @Nullable
   String getSelectedValue();
 
   /**
@@ -693,6 +760,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.GetSelectedText
    */
   @CheckReturnValue
+  @Nullable
   String getSelectedText();
 
   /**
@@ -700,6 +768,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.ScrollTo
    */
+  @Nonnull
   SelenideElement scrollTo();
 
   /**
@@ -718,10 +787,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * </pre>
    *
    * @param alignToTop boolean value that indicate how element will be aligned to the visible area of the scrollable ancestor.
-   *
    * @see com.codeborne.selenide.commands.ScrollIntoView
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">Web API reference</a>
    */
+  @Nonnull
   SelenideElement scrollIntoView(boolean alignToTop);
 
   /**
@@ -751,33 +820,32 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * </pre>
    *
    * @param scrollIntoViewOptions is an object with the align properties: behavior, block and inline.
-   *
    * @see com.codeborne.selenide.commands.ScrollIntoView
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">Web API reference</a>
    */
+  @Nonnull
   SelenideElement scrollIntoView(String scrollIntoViewOptions);
 
   /**
    * Download file by clicking this element. Algorithm depends on {@code @{@link Config#fileDownload() }}.
    *
-   * @throws RuntimeException if 50x status code was returned from server
+   * @throws RuntimeException      if 50x status code was returned from server
    * @throws FileNotFoundException if 40x status code was returned from server
-   *
    * @see FileDownloadMode
    * @see com.codeborne.selenide.commands.DownloadFile
    */
+  @Nonnull
   File download() throws FileNotFoundException;
 
   /**
    * Download file by clicking this element. Algorithm depends on {@code @{@link Config#fileDownload() }}.
    *
    * @param timeout download operations timeout.
-   *
    * @throws RuntimeException      if 50x status code was returned from server
    * @throws FileNotFoundException if 40x status code was returned from server
-   *
    * @see com.codeborne.selenide.commands.DownloadFile
    */
+  @Nonnull
   File download(long timeout) throws FileNotFoundException;
 
   /**
@@ -788,56 +856,57 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *                   {@link com.codeborne.selenide.files.FileFilters#withNameMatching(String)},
    *                   {@link com.codeborne.selenide.files.FileFilters#withName(String)}
    *                   ).
-   *
    * @throws RuntimeException      if 50x status code was returned from server
    * @throws FileNotFoundException if 40x status code was returned from server, or the downloaded file didn't match given filter.
-   *
    * @see com.codeborne.selenide.files.FileFilters
    * @see com.codeborne.selenide.commands.DownloadFile
    */
+  @Nonnull
   File download(FileFilter fileFilter) throws FileNotFoundException;
 
   /**
    * Download file by clicking this element. Algorithm depends on {@code @{@link Config#fileDownload() }}.
    *
-   * @param timeout download operations timeout.
+   * @param timeout    download operations timeout.
    * @param fileFilter Criteria for defining which file is expected (
    *                   {@link com.codeborne.selenide.files.FileFilters#withName(String)},
    *                   {@link com.codeborne.selenide.files.FileFilters#withNameMatching(String)},
    *                   {@link com.codeborne.selenide.files.FileFilters#withName(String)}
    *                   ).
-   *
    * @throws RuntimeException      if 50x status code was returned from server
    * @throws FileNotFoundException if 40x status code was returned from server, or the downloaded file didn't match given filter.
-   *
    * @see com.codeborne.selenide.files.FileFilters
    * @see com.codeborne.selenide.commands.DownloadFile
    */
+  @Nonnull
   File download(long timeout, FileFilter fileFilter) throws FileNotFoundException;
 
   /**
    * Return criteria by which this element is located
+   *
    * @return e.g. "#multirowTable.findBy(text 'INVALID-TEXT')/valid-selector"
    */
   @CheckReturnValue
+  @Nonnull
   String getSearchCriteria();
 
   /**
    * @return the original Selenium {@link WebElement} wrapped by this object
-   *
-   * @see com.codeborne.selenide.commands.ToWebElement
    * @throws org.openqa.selenium.NoSuchElementException if element does not exist (without waiting for the element)
+   * @see com.codeborne.selenide.commands.ToWebElement
    */
   @CheckReturnValue
+  @Nonnull
   WebElement toWebElement();
 
   /**
    * @return Underlying {@link WebElement}
-   * @see com.codeborne.selenide.commands.GetWrappedElement
    * @throws org.openqa.selenium.NoSuchElementException if element does not exist (without waiting for the element)
+   * @see com.codeborne.selenide.commands.GetWrappedElement
    */
   @Override
   @CheckReturnValue
+  @Nonnull
   WebElement getWrappedElement();
 
   /**
@@ -853,7 +922,8 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.Click
    */
-  @Override void click();
+  @Override
+  void click();
 
   /**
    * Click the element with a relative offset from the center of the element
@@ -862,50 +932,53 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
 
   /**
    * Click with right mouse button on this element
-   * @return this element
    *
+   * @return this element
    * @see com.codeborne.selenide.commands.ContextClick
    */
+  @Nonnull
   SelenideElement contextClick();
 
   /**
    * Double click the element
-   * @return this element
    *
+   * @return this element
    * @see com.codeborne.selenide.commands.DoubleClick
    */
+  @Nonnull
   SelenideElement doubleClick();
 
   /**
    * Emulate "mouseOver" event. In other words, move mouse cursor over this element (without clicking it).
-   * @return this element
    *
+   * @return this element
    * @see com.codeborne.selenide.commands.Hover
    */
+  @Nonnull
   SelenideElement hover();
 
   /**
    * Drag and drop this element to the target
-   *
+   * <p>
    * Before dropping, waits until target element gets visible.
    *
    * @param targetCssSelector CSS selector defining target element
    * @return this element
-   *
    * @see com.codeborne.selenide.commands.DragAndDropTo
    */
+  @Nonnull
   SelenideElement dragAndDropTo(String targetCssSelector);
 
   /**
    * Drag and drop this element to the target
-   *
+   * <p>
    * Before dropping, waits until target element gets visible.
    *
    * @param target target element
    * @return this element
-   *
    * @see com.codeborne.selenide.commands.DragAndDropTo
    */
+  @Nonnull
   SelenideElement dragAndDropTo(WebElement target);
 
   /**
@@ -913,7 +986,6 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @param command custom command
    * @return this element
-   *
    * @see com.codeborne.selenide.commands.Execute
    * @see com.codeborne.selenide.Command
    */
@@ -923,26 +995,27 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Check if image is properly loaded.
    *
    * @throws IllegalArgumentException if argument is not an "img" element
-   * @since 2.13
-   *
    * @see com.codeborne.selenide.commands.IsImage
+   * @since 2.13
    */
   boolean isImage();
 
   /**
    * Take screenshot of this element
-   * @return file with screenshot (*.png)
    *
+   * @return file with screenshot (*.png)
    * @see com.codeborne.selenide.commands.TakeScreenshot
    */
+  @Nonnull
   File screenshot();
 
   /**
    * Take screenshot of this element
-   * @return buffered image with screenshot
    *
+   * @return buffered image with screenshot
    * @see com.codeborne.selenide.commands.TakeScreenshotAsImage
    */
   @CheckReturnValue
+  @Nonnull
   BufferedImage screenshotAsImage();
 }

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class Commands {
   private static Commands collection;
 
-  private final Map<String, Command> commands = new ConcurrentHashMap<>(128);
+  private final Map<String, Command<?>> commands = new ConcurrentHashMap<>(128);
 
   public static synchronized Commands getInstance() {
     if (collection == null) {
@@ -43,7 +43,7 @@ public class Commands {
     add("screenshot", new TakeScreenshot());
     add("screenshotAsImage", new TakeScreenshotAsImage());
     add("getSearchCriteria", new GetSearchCriteria());
-    add("execute", new Execute());
+    add("execute", new Execute<>());
   }
 
   private void addActionsCommands() {
@@ -55,6 +55,8 @@ public class Commands {
 
   private void addInfoCommands() {
     add("attr", new GetAttribute());
+    add("getAttribute", new GetAttribute());
+    add("getCssValue", new GetCssValue());
     add("data", new GetDataAttribute());
     add("exists", new Exists());
     add("innerText", new GetInnerText());
@@ -134,14 +136,14 @@ public class Commands {
     add("waitUntil", new ShouldBe());
   }
 
-  public void add(String method, Command command) {
+  public void add(String method, Command<?> command) {
     commands.put(method, command);
   }
 
   @SuppressWarnings("unchecked")
   public <T> T execute(Object proxy, WebElementSource webElementSource, String methodName, Object[] args)
       throws IOException {
-    Command command = commands.get(methodName);
+    Command<?> command = commands.get(methodName);
     if (command == null) {
       throw new IllegalArgumentException("Unknown Selenide method: " + methodName);
     }

--- a/src/main/java/com/codeborne/selenide/commands/GetCssValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetCssValue.java
@@ -1,0 +1,12 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+public class GetCssValue implements Command<String> {
+  @Override
+  public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    return locator.getWebElement().getCssValue((String) args[0]);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/And.java
+++ b/src/main/java/com/codeborne/selenide/conditions/And.java
@@ -4,8 +4,10 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
+@ParametersAreNonnullByDefault
 public class And extends Condition {
 
   private final List<Condition> conditions;

--- a/src/main/java/com/codeborne/selenide/conditions/Attribute.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Attribute.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Attribute extends Condition {
   private final String attributeName;
 

--- a/src/main/java/com/codeborne/selenide/conditions/AttributeWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/AttributeWithValue.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class AttributeWithValue extends Condition {
   private final String attributeName;
   private final String expectedAttributeValue;

--- a/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
@@ -5,6 +5,9 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class CaseSensitiveText extends Condition {
   private final String expectedText;
 

--- a/src/main/java/com/codeborne/selenide/conditions/Checked.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Checked.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Checked extends Condition {
 
   public Checked() {

--- a/src/main/java/com/codeborne/selenide/conditions/CssClass.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CssClass.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class CssClass extends Condition {
   private final String expectedCssClass;
 

--- a/src/main/java/com/codeborne/selenide/conditions/CssValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CssValue.java
@@ -4,13 +4,17 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import static org.apache.commons.lang3.StringUtils.defaultString;
 
+@ParametersAreNonnullByDefault
 public class CssValue extends Condition {
   private final String propertyName;
   private final String expectedValue;
 
-  public CssValue(String propertyName, String expectedValue) {
+  public CssValue(String propertyName, @Nullable String expectedValue) {
     super("css value");
     this.propertyName = propertyName;
     this.expectedValue = expectedValue;

--- a/src/main/java/com/codeborne/selenide/conditions/CustomMatch.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CustomMatch.java
@@ -4,12 +4,14 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.function.Predicate;
 
+@ParametersAreNonnullByDefault
 public class CustomMatch extends Condition {
   protected final Predicate<WebElement> predicate;
 
-  public CustomMatch(String description, final Predicate<WebElement> predicate) {
+  public CustomMatch(String description, Predicate<WebElement> predicate) {
     super(description);
     this.predicate = predicate;
   }
@@ -24,5 +26,4 @@ public class CustomMatch extends Condition {
   public String toString() {
     return String.format("match '%s' predicate.", getName());
   }
-
 }

--- a/src/main/java/com/codeborne/selenide/conditions/Disabled.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Disabled.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Disabled extends Condition {
 
   public Disabled() {

--- a/src/main/java/com/codeborne/selenide/conditions/Enabled.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Enabled.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Enabled extends Condition {
 
   public Enabled() {

--- a/src/main/java/com/codeborne/selenide/conditions/ExactText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/ExactText.java
@@ -5,6 +5,9 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class ExactText extends Condition {
   private final String expectedText;
 

--- a/src/main/java/com/codeborne/selenide/conditions/ExactTextCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/conditions/ExactTextCaseSensitive.java
@@ -5,6 +5,9 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class ExactTextCaseSensitive extends Condition {
   private final String expectedText;
 

--- a/src/main/java/com/codeborne/selenide/conditions/Exist.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Exist.java
@@ -5,6 +5,10 @@ import com.codeborne.selenide.Driver;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Exist extends Condition {
   public Exist() {
     super("exist");
@@ -21,6 +25,7 @@ public class Exist extends Condition {
     }
   }
 
+  @Nonnull
   @Override
   public Condition negate() {
     return new Not(this, true);

--- a/src/main/java/com/codeborne/selenide/conditions/ExplainedCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/ExplainedCondition.java
@@ -4,6 +4,10 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class ExplainedCondition extends Condition {
   private final Condition delegate;
   private final String message;
@@ -19,6 +23,7 @@ public class ExplainedCondition extends Condition {
     return delegate.apply(driver, element);
   }
 
+  @Nonnull
   @Override
   public Condition negate() {
     return delegate.negate().because(message);

--- a/src/main/java/com/codeborne/selenide/conditions/Focused.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Focused.java
@@ -5,6 +5,9 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Describe;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Focused extends Condition {
 
   public Focused() {

--- a/src/main/java/com/codeborne/selenide/conditions/Hidden.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Hidden.java
@@ -5,6 +5,10 @@ import com.codeborne.selenide.Driver;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Hidden extends Condition {
   public Hidden() {
     super("hidden", true);
@@ -20,6 +24,7 @@ public class Hidden extends Condition {
     }
   }
 
+  @Nonnull
   @Override
   public Condition negate() {
     return new Not(this, false);

--- a/src/main/java/com/codeborne/selenide/conditions/IsImageLoaded.java
+++ b/src/main/java/com/codeborne/selenide/conditions/IsImageLoaded.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class IsImageLoaded extends Condition {
 
   public IsImageLoaded() {

--- a/src/main/java/com/codeborne/selenide/conditions/MatchAttributeWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/MatchAttributeWithValue.java
@@ -4,8 +4,10 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.regex.Pattern;
 
+@ParametersAreNonnullByDefault
 public class MatchAttributeWithValue extends Condition {
   private final String attributeName;
   private final Pattern attributeRegex;

--- a/src/main/java/com/codeborne/selenide/conditions/MatchText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/MatchText.java
@@ -5,6 +5,9 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class MatchText extends Condition {
   private final String regex;
 

--- a/src/main/java/com/codeborne/selenide/conditions/NamedCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/NamedCondition.java
@@ -4,6 +4,10 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class NamedCondition extends Condition {
   private final String prefix;
   private final Condition delegate;
@@ -24,6 +28,7 @@ public class NamedCondition extends Condition {
     return delegate.actualValue(driver, element);
   }
 
+  @Nonnull
   @Override
   public Condition negate() {
     return delegate.negate();

--- a/src/main/java/com/codeborne/selenide/conditions/Not.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Not.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Not extends Condition {
   private final Condition condition;
 

--- a/src/main/java/com/codeborne/selenide/conditions/Or.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Or.java
@@ -4,10 +4,12 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
 import static java.util.stream.Collectors.joining;
 
+@ParametersAreNonnullByDefault
 public class Or extends Condition {
 
   private final List<Condition> conditions;

--- a/src/main/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValue.java
@@ -4,9 +4,13 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 
+@ParametersAreNonnullByDefault
 public class PseudoElementPropertyWithValue extends Condition {
 
   static final String JS_CODE = "return window.getComputedStyle(arguments[0], arguments[1])" +
@@ -16,7 +20,7 @@ public class PseudoElementPropertyWithValue extends Condition {
   private final String propertyName;
   private final String expectedPropertyValue;
 
-  public PseudoElementPropertyWithValue(String pseudoElementName, String propertyName, String expectedPropertyValue) {
+  public PseudoElementPropertyWithValue(String pseudoElementName, String propertyName, @Nullable String expectedPropertyValue) {
     super("pseudo-element");
     this.pseudoElementName = pseudoElementName;
     this.propertyName = propertyName;

--- a/src/main/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValue.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -20,7 +19,7 @@ public class PseudoElementPropertyWithValue extends Condition {
   private final String propertyName;
   private final String expectedPropertyValue;
 
-  public PseudoElementPropertyWithValue(String pseudoElementName, String propertyName, @Nullable String expectedPropertyValue) {
+  public PseudoElementPropertyWithValue(String pseudoElementName, String propertyName, String expectedPropertyValue) {
     super("pseudo-element");
     this.pseudoElementName = pseudoElementName;
     this.propertyName = propertyName;

--- a/src/main/java/com/codeborne/selenide/conditions/Selected.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Selected.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Selected extends Condition {
 
   public Selected() {

--- a/src/main/java/com/codeborne/selenide/conditions/SelectedText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/SelectedText.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class SelectedText extends Condition {
   private final String expectedText;
 

--- a/src/main/java/com/codeborne/selenide/conditions/Text.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Text.java
@@ -6,8 +6,10 @@ import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
+@ParametersAreNonnullByDefault
 public class Text extends Condition {
   protected final String text;
   public Text(final String text) {

--- a/src/main/java/com/codeborne/selenide/conditions/Value.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Value.java
@@ -5,6 +5,9 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class Value extends Condition {
   private final String expectedValue;
 

--- a/src/main/java/com/codeborne/selenide/conditions/Visible.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Visible.java
@@ -4,6 +4,8 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+
 public class Visible extends Condition {
   public Visible() {
     super("visible");
@@ -19,6 +21,7 @@ public class Visible extends Condition {
     return String.format("visible:%s", element.isDisplayed());
   }
 
+  @Nonnull
   @Override
   public Condition negate() {
     return new Not(this, true);

--- a/src/main/java/com/codeborne/selenide/impl/Events.java
+++ b/src/main/java/com/codeborne/selenide/impl/Events.java
@@ -17,7 +17,7 @@ public class Events {
     this.log = log;
   }
 
-  private final String jsCodeToTriggerEvent =
+  private static final String JS_CODE_TO_TRIGGER_EVENT =
       "var webElement = arguments[0];\n" +
           "var eventNames = arguments[1];\n" +
           "for (var i = 0; i < eventNames.length; i++) {" +
@@ -32,7 +32,7 @@ public class Events {
           "  }\n" +
           '}';
 
-  public void fireEvent(Driver driver, WebElement element, final String... event) {
+  public void fireEvent(Driver driver, WebElement element, String... event) {
     try {
       executeJavaScript(driver, element, event);
     }
@@ -44,6 +44,6 @@ public class Events {
   }
 
   void executeJavaScript(Driver driver, WebElement element, String... event) {
-    driver.executeJavaScript(jsCodeToTriggerEvent, element, event);
+    driver.executeJavaScript(JS_CODE_TO_TRIGGER_EVENT, element, event);
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -35,11 +35,6 @@ class SelenideElementProxy implements InvocationHandler {
       "getSearchCriteria"
   ));
 
-  private static final Set<String> methodOverridesFromWebElement = new HashSet<>(asList(
-    "getCssValue",
-    "getAttribute"
-  ));
-
   private static final Set<String> methodsForSoftAssertion = new HashSet<>(asList(
       "should",
       "shouldBe",
@@ -101,7 +96,7 @@ class SelenideElementProxy implements InvocationHandler {
     Throwable lastError;
     do {
       try {
-        if (isSelenideElementMethod(method)) {
+        if (SelenideElement.class.isAssignableFrom(method.getDeclaringClass())) {
           return Commands.getInstance().execute(proxy, webElementSource, method.getName(), args);
         }
 
@@ -137,11 +132,6 @@ class SelenideElementProxy implements InvocationHandler {
       throw webElementSource.createElementNotFoundError(exist, lastError);
     }
     throw lastError;
-  }
-
-  private boolean isSelenideElementMethod(Method method) {
-    return SelenideElement.class.isAssignableFrom(method.getDeclaringClass())
-        && !methodOverridesFromWebElement.contains(method.getName());
   }
 
   private boolean isElementNotClickableException(Throwable e) {

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -35,6 +35,11 @@ class SelenideElementProxy implements InvocationHandler {
       "getSearchCriteria"
   ));
 
+  private static final Set<String> methodOverridesFromWebElement = new HashSet<>(asList(
+    "getCssValue",
+    "getAttribute"
+  ));
+
   private static final Set<String> methodsForSoftAssertion = new HashSet<>(asList(
       "should",
       "shouldBe",
@@ -96,7 +101,7 @@ class SelenideElementProxy implements InvocationHandler {
     Throwable lastError;
     do {
       try {
-        if (SelenideElement.class.isAssignableFrom(method.getDeclaringClass())) {
+        if (isSelenideElementMethod(method)) {
           return Commands.getInstance().execute(proxy, webElementSource, method.getName(), args);
         }
 
@@ -132,6 +137,11 @@ class SelenideElementProxy implements InvocationHandler {
       throw webElementSource.createElementNotFoundError(exist, lastError);
     }
     throw lastError;
+  }
+
+  private boolean isSelenideElementMethod(Method method) {
+    return SelenideElement.class.isAssignableFrom(method.getDeclaringClass())
+        && !methodOverridesFromWebElement.contains(method.getName());
   }
 
   private boolean isElementNotClickableException(Throwable e) {

--- a/src/test/java/com/codeborne/selenide/commands/GetCssValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetCssValueCommandTest.java
@@ -1,0 +1,35 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetCssValueCommandTest implements WithAssertions {
+  private SelenideElement proxy;
+  private WebElementSource locator;
+  private WebElement mockedElement;
+
+  @BeforeEach
+  void setup() {
+    proxy = mock(SelenideElement.class);
+    locator = mock(WebElementSource.class);
+    mockedElement = mock(WebElement.class);
+    when(locator.getWebElement()).thenReturn(mockedElement);
+  }
+
+  @Test
+  void testExecuteMethod() {
+    GetCssValue getCssValue = new GetCssValue();
+    String argument = "display";
+    String elementAttribute = "none";
+    when(mockedElement.getCssValue(argument)).thenReturn(elementAttribute);
+    assertThat(getCssValue.execute(proxy, locator, new Object[]{argument, "something more"}))
+      .isEqualTo(elementAttribute);
+  }
+}

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -9,6 +9,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.logging.LogType;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -24,6 +27,7 @@ import static com.codeborne.selenide.WebDriverRunner.getSelenideDriver;
  * You start with methods {@link #open(String)} for opening the tested application page and
  * {@link #$(String)} for searching web elements.
  */
+@ParametersAreNonnullByDefault
 public class Selenide {
 
   /**
@@ -133,6 +137,7 @@ public class Selenide {
    * Open a web page and create PageObject for it.
    * @return PageObject of given class
    */
+  @Nonnull
   public static <PageObjectClass> PageObjectClass open(String relativeOrAbsoluteUrl,
                                                        Class<PageObjectClass> pageObjectClassClass) {
     return getSelenideDriver().open(relativeOrAbsoluteUrl, pageObjectClassClass);
@@ -142,6 +147,7 @@ public class Selenide {
    * Open a web page and create PageObject for it.
    * @return PageObject of given class
    */
+  @Nonnull
   public static <PageObjectClass> PageObjectClass open(URL absoluteUrl,
                                                        Class<PageObjectClass> pageObjectClassClass) {
     return getSelenideDriver().open(absoluteUrl, pageObjectClassClass);
@@ -151,6 +157,7 @@ public class Selenide {
    * Open a web page using Basic Auth credentials and create PageObject for it.
    * @return PageObject of given class
    */
+  @Nonnull
   public static <PageObjectClass> PageObjectClass open(String relativeOrAbsoluteUrl,
                                                        String domain, String login, String password,
                                                        Class<PageObjectClass> pageObjectClassClass) {
@@ -161,6 +168,7 @@ public class Selenide {
    * Open a web page using Basic Auth credentials and create PageObject for it.
    * @return PageObject of given class
    */
+  @Nonnull
   public static <PageObjectClass> PageObjectClass open(URL absoluteUrl, String domain, String login, String password,
                                                        Class<PageObjectClass> pageObjectClassClass) {
     return getSelenideDriver().open(absoluteUrl, domain, login, password, pageObjectClassClass);
@@ -242,6 +250,7 @@ public class Selenide {
    * @param fileName Name of file (without extension) to save HTML and PNG to
    * @return The name of resulting file
    */
+  @Nonnull
   public static String screenshot(String fileName) {
     return Screenshots.takeScreenShot(fileName);
   }
@@ -254,6 +263,7 @@ public class Selenide {
    * @return given WebElement wrapped into SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $(WebElement webElement) {
     return getSelenideDriver().$(webElement);
   }
@@ -265,6 +275,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $(String cssSelector) {
     return getSelenideDriver().find(cssSelector);
   }
@@ -276,6 +287,7 @@ public class Selenide {
    * @return SelenideElement which locates elements via XPath
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $x(String xpathExpression) {
     return getSelenideDriver().$x(xpathExpression);
   }
@@ -287,6 +299,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $(By seleniumSelector) {
     return getSelenideDriver().find(seleniumSelector);
   }
@@ -295,6 +308,7 @@ public class Selenide {
    * @see #getElement(By, int)
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $(By seleniumSelector, int index) {
     return getSelenideDriver().find(seleniumSelector, index);
   }
@@ -311,6 +325,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @Deprecated
+  @Nonnull
   public static SelenideElement $(WebElement parent, String cssSelector) {
     return getSelenideDriver().$(parent).find(cssSelector);
   }
@@ -323,6 +338,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $(String cssSelector, int index) {
     return getSelenideDriver().$(cssSelector, index);
   }
@@ -341,6 +357,7 @@ public class Selenide {
    */
   @Deprecated
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $(WebElement parent, String cssSelector, int index) {
     return getSelenideDriver().$(parent).find(cssSelector, index);
   }
@@ -358,6 +375,7 @@ public class Selenide {
    */
   @Deprecated
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $(WebElement parent, By seleniumSelector) {
     return getSelenideDriver().$(parent).find(seleniumSelector);
   }
@@ -376,6 +394,7 @@ public class Selenide {
    */
   @Deprecated
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement $(WebElement parent, By seleniumSelector, int index) {
     return getSelenideDriver().$(parent).find(seleniumSelector, index);
   }
@@ -384,6 +403,7 @@ public class Selenide {
    * Initialize collection with Elements
    */
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection $$(Collection<? extends WebElement> elements) {
     return getSelenideDriver().$$(elements);
   }
@@ -399,6 +419,7 @@ public class Selenide {
    * @return empty list if element was no found
    */
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection $$(String cssSelector) {
     return getSelenideDriver().$$(cssSelector);
   }
@@ -413,6 +434,7 @@ public class Selenide {
    * @return ElementsCollection which locates elements via XPath
    */
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection $$x(String xpathExpression) {
     return getSelenideDriver().$$x(xpathExpression);
   }
@@ -428,6 +450,7 @@ public class Selenide {
    * @return empty list if element was no found
    */
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection $$(By seleniumSelector) {
     return getSelenideDriver().$$(seleniumSelector);
   }
@@ -449,6 +472,7 @@ public class Selenide {
    */
   @Deprecated
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection $$(WebElement parent, String cssSelector) {
     return getSelenideDriver().$(parent).findAll(cssSelector);
   }
@@ -464,6 +488,7 @@ public class Selenide {
    */
   @Deprecated
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection $$(WebElement parent, By seleniumSelector) {
     return getSelenideDriver().$(parent).findAll(seleniumSelector);
   }
@@ -476,6 +501,7 @@ public class Selenide {
    * @return given WebElement wrapped into SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement element(WebElement webElement) {
     return getSelenideDriver().$(webElement);
   }
@@ -487,6 +513,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement element(String cssSelector) {
     return getSelenideDriver().$(cssSelector);
   }
@@ -498,6 +525,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement element(By seleniumSelector) {
     return getSelenideDriver().$(seleniumSelector);
   }
@@ -510,6 +538,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement element(By seleniumSelector, int index) {
     return getSelenideDriver().$(seleniumSelector, index);
   }
@@ -522,6 +551,7 @@ public class Selenide {
    * @return SelenideElement
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement element(String cssSelector, int index) {
     return getSelenideDriver().$(cssSelector, index);
   }
@@ -534,6 +564,7 @@ public class Selenide {
    * @return given WebElement collection wrapped into SelenideElement collection
    */
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection elements(Collection<? extends WebElement> elements) {
     return getSelenideDriver().$$(elements);
   }
@@ -549,6 +580,7 @@ public class Selenide {
    * @return empty list if element was no found
    */
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection elements(String cssSelector) {
     return getSelenideDriver().$$(cssSelector);
   }
@@ -564,6 +596,7 @@ public class Selenide {
    * @return empty list if element was no found
    */
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection elements(By seleniumSelector) {
     return getSelenideDriver().$$(seleniumSelector);
   }
@@ -578,6 +611,7 @@ public class Selenide {
    */
   @Deprecated
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement getElement(By criteria) {
     return getSelenideDriver().find(criteria);
   }
@@ -593,6 +627,7 @@ public class Selenide {
    */
   @Deprecated
   @CheckReturnValue
+  @Nonnull
   public static SelenideElement getElement(By criteria, int index) {
     return getSelenideDriver().find(criteria, index);
   }
@@ -607,6 +642,7 @@ public class Selenide {
    */
   @Deprecated
   @CheckReturnValue
+  @Nonnull
   public static ElementsCollection getElements(By criteria) {
     return getSelenideDriver().findAll(criteria);
   }
@@ -614,6 +650,7 @@ public class Selenide {
   /**
    * @see JavascriptExecutor#executeScript(java.lang.String, java.lang.Object...)
    */
+  @Nullable
   public static <T> T executeJavaScript(String jsCode, Object... arguments) {
     return getSelenideDriver().executeJavaScript(jsCode, arguments);
   }
@@ -621,6 +658,7 @@ public class Selenide {
   /**
    * @see JavascriptExecutor#executeAsyncScript(java.lang.String, java.lang.Object...)
    */
+  @Nullable
   public static <T> T executeAsyncJavaScript(String jsCode, Object... arguments) {
     return getSelenideDriver().executeAsyncJavaScript(jsCode, arguments);
   }
@@ -630,6 +668,7 @@ public class Selenide {
    * @return null if nothing selected
    */
   @CheckReturnValue
+  @Nullable
   public static SelenideElement getSelectedRadio(By radioField) {
     return getSelenideDriver().getSelectedRadio(radioField);
   }
@@ -638,6 +677,7 @@ public class Selenide {
    * Accept (Click "Yes" or "Ok") in the confirmation dialog (javascript 'alert' or 'confirm').
    * @return actual dialog text
    */
+  @Nullable
   public static String confirm() {
     return getSelenideDriver().modal().confirm();
   }
@@ -649,7 +689,8 @@ public class Selenide {
    * @throws DialogTextMismatch if confirmation message differs from expected message
    * @return actual dialog text
    */
-  public static String confirm(String expectedDialogText) {
+  @Nullable
+  public static String confirm(@Nullable String expectedDialogText) {
     return getSelenideDriver().modal().confirm(expectedDialogText);
   }
 
@@ -657,6 +698,7 @@ public class Selenide {
    * Accept (Click "Yes" or "Ok") in the confirmation dialog (javascript 'prompt').
    * @return actual dialog text
    */
+  @Nullable
   public static String prompt() {
     return getSelenideDriver().modal().prompt();
   }
@@ -666,7 +708,8 @@ public class Selenide {
    * @param inputText if not null, sets value in prompt dialog input
    * @return actual dialog text
    */
-  public static String prompt(String inputText) {
+  @Nullable
+  public static String prompt(@Nullable String inputText) {
     return getSelenideDriver().modal().prompt(inputText);
   }
 
@@ -678,7 +721,8 @@ public class Selenide {
    * @throws DialogTextMismatch if confirmation message differs from expected message
    * @return actual dialog text
    */
-  public static String prompt(String expectedDialogText, String inputText) {
+  @Nullable
+  public static String prompt(@Nullable String expectedDialogText, @Nullable String inputText) {
     return getSelenideDriver().modal().prompt(expectedDialogText, inputText);
   }
 
@@ -686,6 +730,7 @@ public class Selenide {
    * Dismiss (click "No" or "Cancel") in the confirmation dialog (javascript 'alert' or 'confirm').
    * @return actual dialog text
    */
+  @Nullable
   public static String dismiss() {
     return getSelenideDriver().modal().dismiss();
   }
@@ -697,7 +742,8 @@ public class Selenide {
    * @throws DialogTextMismatch if confirmation message differs from expected message
    * @return actual dialog text
    */
-  public static String dismiss(String expectedDialogText) {
+  @Nullable
+  public static String dismiss(@Nullable String expectedDialogText) {
     return getSelenideDriver().modal().dismiss(expectedDialogText);
   }
 
@@ -710,6 +756,7 @@ public class Selenide {
    *
    * @return SelenideTargetLocator
    */
+  @Nonnull
   public static SelenideTargetLocator switchTo() {
     return getSelenideDriver().driver().switchTo();
   }
@@ -719,6 +766,7 @@ public class Selenide {
    * @return WebElement, not SelenideElement! which has focus on it
    */
   @CheckReturnValue
+  @Nullable
   public static WebElement getFocusedElement() {
     return getSelenideDriver().getFocusedElement();
   }
@@ -727,6 +775,7 @@ public class Selenide {
    * Create a Page Object instance
    */
   @CheckReturnValue
+  @Nonnull
   public static <PageObjectClass> PageObjectClass page(Class<PageObjectClass> pageObjectClass) {
     return getSelenideDriver().page(pageObjectClass);
   }
@@ -735,6 +784,7 @@ public class Selenide {
    * Initialize a given Page Object instance
    */
   @CheckReturnValue
+  @Nonnull
   public static <PageObjectClass, T extends PageObjectClass> PageObjectClass page(T pageObject) {
     return getSelenideDriver().page(pageObject);
   }
@@ -750,6 +800,7 @@ public class Selenide {
    * @return instance of org.openqa.selenium.support.ui.FluentWait
    */
   @CheckReturnValue
+  @Nonnull
   public static SelenideWait Wait() {
     return getSelenideDriver().Wait();
   }
@@ -768,6 +819,7 @@ public class Selenide {
    * </pre>
    */
   @CheckReturnValue
+  @Nonnull
   public static Actions actions() {
     return getSelenideDriver().driver().actions();
   }
@@ -843,6 +895,7 @@ public class Selenide {
    *
    * @return browser user agent
    */
+  @Nonnull
   public static String getUserAgent() {
     return getSelenideDriver().driver().getUserAgent();
   }
@@ -867,6 +920,7 @@ public class Selenide {
    * @return downloaded File in folder `Configuration.reportsFolder`
    * @throws IOException if failed to download file
    */
+  @Nonnull
   public static File download(String url) throws IOException {
     return getSelenideDriver().download(url);
   }
@@ -883,6 +937,7 @@ public class Selenide {
    * @return downloaded File in folder `Configuration.reportsFolder`
    * @throws IOException if failed to download file
    */
+  @Nonnull
   public static File download(String url, long timeoutMs) throws IOException {
     return getSelenideDriver().download(url, timeoutMs);
   }


### PR DESCRIPTION
## Proposed changes

At the moment, IntelliJ IDEA shows this warning in Kotlin because there is no nullity information in Selenide:

![image](https://user-images.githubusercontent.com/1066152/81110593-6982dd00-8f24-11ea-8338-d76efba75947.png)

These changes improves IDE experience by providing exact type of parameters and return values including information on null/notnull values. This also makes Selenide work better with Kotlin as Kotlin now knows types and may omit excessive warnings and runtime checks.

![image](https://user-images.githubusercontent.com/1066152/81110434-350f2100-8f24-11ea-9c6e-3bfcd1146c9f.png)

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Checkstyle warns about SelenideDriver for some reason.
```
[ant:checkstyle] [ERROR] /home/travis/build/selenide/selenide/src/main/java/com/codeborne/selenide/SelenideDriver.java:32:1: Class Fan-Out Complexity is 30 (max allowed is 29). [ClassFanOutComplexity]
```