### PR TITLE
`$` inside PageObject should search elements inside SelenideDriver in…

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,6 +14,7 @@ dependencies {
     exclude group: 'net.bytebuddy', module: 'byte-buddy'
   }
   api('io.github.bonigarcia:webdrivermanager:3.8.1')
+  implementation('org.javassist:javassist:3.27.0-GA')
 
   compileOnly('org.checkerframework:checker:3.2.0')
   compileOnly('com.browserup:browserup-proxy-core:2.0.1')

--- a/src/main/java/com/codeborne/selenide/impl/DriverOrchestrator.java
+++ b/src/main/java/com/codeborne/selenide/impl/DriverOrchestrator.java
@@ -1,0 +1,9 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.Driver;
+
+import java.util.concurrent.Callable;
+
+public interface DriverOrchestrator {
+  <V> V using(Driver driver, Callable<V> r) throws Exception;
+}

--- a/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
@@ -1,10 +1,17 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.Proxy;
+import javassist.util.proxy.ProxyFactory;
 import org.openqa.selenium.support.pagefactory.FieldDecorator;
 
+import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 /**
  * Factory class to make using Page Objects simpler and easier.
@@ -14,16 +21,78 @@ import java.lang.reflect.Field;
 public class SelenidePageFactory {
   public <PageObjectClass> PageObjectClass page(Driver driver, Class<PageObjectClass> pageObjectClass) {
     try {
-      Constructor<PageObjectClass> constructor = pageObjectClass.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      return page(driver, constructor.newInstance());
-    }
-    catch (Exception e) {
+      return createPageObject(pageObjectClass, driver);
+    } catch (Exception e) {
       throw new RuntimeException("Failed to create new instance of " + pageObjectClass, e);
     }
   }
 
+  @SuppressWarnings("unchecked")
+  private <PageObjectClass> PageObjectClass createPageObject(Class<PageObjectClass> pageObjectClass, Driver driver)
+    throws Exception {
+
+    if ((pageObjectClass.getModifiers() & Modifier.FINAL) != Modifier.FINAL
+      && hasConstructor(pageObjectClass)) {
+
+      DriverOrchestrator orchestrator = getDriverOrchestrator();
+
+      if (orchestrator != null) {
+        ProxyFactory proxyFactory = new ProxyFactory();
+        proxyFactory.setSuperclass(pageObjectClass);
+        proxyFactory.setFilter(m -> !m.getName().equals("finalize"));
+
+        Class<?> proxyClass = proxyFactory.createClass();
+        Constructor<?> constructor = proxyClass.getConstructor();
+        constructor.setAccessible(true);
+
+        PageObjectClass wrapper = (PageObjectClass) constructor.newInstance();
+        ((Proxy) wrapper).setHandler(new PageObjectInvocationHandler(driver, orchestrator));
+
+        orchestrator.using(driver, () -> {
+          initPageObject(driver, wrapper);
+          return null;
+        });
+
+        return wrapper;
+      }
+    }
+
+    Constructor<PageObjectClass> constructor = pageObjectClass.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    PageObjectClass target = constructor.newInstance();
+    initPageObject(driver, target);
+
+    return target;
+  }
+
+  private <PageObjectClass> boolean hasConstructor(Class<PageObjectClass> pageObjectClass) {
+    try {
+      pageObjectClass.getConstructor();
+      return true;
+    } catch (NoSuchMethodException ignored) {
+      return false;
+    }
+  }
+
+  @Nullable
+  private DriverOrchestrator getDriverOrchestrator()
+    throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+
+    // only if there is static facade in classpath
+    Class<?> aClass;
+    try {
+      aClass = Class.forName("com.codeborne.selenide.impl.DriverOrchestratorImpl");
+    } catch (ClassNotFoundException | NoClassDefFoundError e) {
+      return null;
+    }
+    return (DriverOrchestrator) aClass.getDeclaredConstructor().newInstance();
+  }
+
   public <PageObjectClass, T extends PageObjectClass> PageObjectClass page(Driver driver, T pageObject) {
+    return initPageObject(driver, pageObject);
+  }
+
+  private <PageObjectClass, T extends PageObjectClass> PageObjectClass initPageObject(Driver driver, T pageObject) {
     initElements(new SelenideFieldDecorator(this, driver, driver.getWebDriver()), pageObject);
     return pageObject;
   }
@@ -54,8 +123,7 @@ public class SelenidePageFactory {
         try {
           field.setAccessible(true);
           field.set(page, value);
-        }
-        catch (IllegalAccessException e) {
+        } catch (IllegalAccessException e) {
           throw new RuntimeException(e);
         }
       }
@@ -66,9 +134,39 @@ public class SelenidePageFactory {
     try {
       field.setAccessible(true);
       return field.get(page) != null;
-    }
-    catch (IllegalAccessException e) {
+    } catch (IllegalAccessException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  private final static class PageObjectInvocationHandler implements MethodHandler {
+    private final Driver driver;
+    private final DriverOrchestrator orchestrator;
+
+    private PageObjectInvocationHandler(Driver driver, DriverOrchestrator orchestrator) {
+      this.driver = driver;
+      this.orchestrator = orchestrator;
+    }
+
+    @Override
+    public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {
+      String methodName = thisMethod.getName();
+      if (methodName.equals("toString")
+        || methodName.equals("equals")
+        || methodName.equals("hashCode")) {
+        return proceed.invoke(self, args);
+      }
+
+      Object result;
+      try {
+        result = orchestrator.using(driver, () ->
+          proceed.invoke(self, args)
+        );
+      } catch (InvocationTargetException e) {
+        throw e.getTargetException();
+      }
+
+      return result;
     }
   }
 }

--- a/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -8,6 +8,8 @@ import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.events.WebDriverEventListener;
 
+import java.util.concurrent.Callable;
+
 import static com.codeborne.selenide.Configuration.browser;
 import static com.codeborne.selenide.Configuration.headless;
 
@@ -151,6 +153,16 @@ public class WebDriverRunner implements Browsers {
       finally {
         webdriverContainer.resetWebDriver();
       }
+    }
+  }
+
+  public static <V> V using(Driver driver, Callable<V> lambda) throws Exception {
+    setWebDriver(driver.getWebDriver(), driver.getProxy());
+    try {
+      return lambda.call();
+    }
+    finally {
+      webdriverContainer.resetWebDriver();
     }
   }
 

--- a/statics/src/main/java/com/codeborne/selenide/impl/DriverOrchestratorImpl.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/DriverOrchestratorImpl.java
@@ -1,0 +1,14 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebDriverRunner;
+
+import java.util.concurrent.Callable;
+
+@SuppressWarnings("unused")
+public class DriverOrchestratorImpl implements DriverOrchestrator {
+  @Override
+  public <V> V using(Driver driver, Callable<V> r) throws Exception {
+    return WebDriverRunner.using(driver, r);
+  }
+}

--- a/statics/src/test/java/integration/PageObjectTest.java
+++ b/statics/src/test/java/integration/PageObjectTest.java
@@ -144,7 +144,7 @@ class PageObjectTest extends IntegrationTest {
       .isInstanceOf(ElementNotFound.class);
   }
 
-  private static class SelectsPage {
+  public static class SelectsPage {
     @FindBy(xpath = "//select[@name='domain']")
     WebElement domainSelect;
 
@@ -187,7 +187,7 @@ class PageObjectTest extends IntegrationTest {
     SelenideElement lastLogin;
   }
 
-  static class UserInfo extends ElementsContainer {
+  public static class UserInfo extends ElementsContainer {
     @FindBy(className = "firstname")
     SelenideElement firstName;
     @FindBy(className = "lastname")
@@ -196,7 +196,7 @@ class PageObjectTest extends IntegrationTest {
     SelenideElement age;
   }
 
-  static class MissingSelectsPage {
+  public static class MissingSelectsPage {
     @FindBy(xpath = "//select[@name='wrong-select-name']")
     WebElement domainSelect;
     @FindBy(id = "wrong-id")


### PR DESCRIPTION
… which PageObject was created #1048

## Proposed changes

This is very rough PoC of driver for PageObject instance.
Key changes:

- Javassist dependency to create sub-class proxies of PageObject classes
- DriverOrchestrator bridge from driver to static facade required
- Proxy can be created only for public and non-final classes
- PageObject created in context of the driver, fields set with correct driver
- On each method invocation of PageObject proxy correct driver set to main ThreadLocal

Only illustrates the general idea and should not be merged.
