### PR TITLE
Extract duplicated code for predicate conditions and copyFile

### DIFF
--- a/src/main/java/com/codeborne/selenide/collections/AllMatch.java
+++ b/src/main/java/com/codeborne/selenide/collections/AllMatch.java
@@ -1,22 +1,13 @@
 package com.codeborne.selenide.collections;
 
-import com.codeborne.selenide.CollectionCondition;
-import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.MatcherError;
-import com.codeborne.selenide.impl.WebElementsCollection;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
 import java.util.function.Predicate;
 
-public class AllMatch extends CollectionCondition {
-  private static final String MATCHER = "all";
-  protected final String description;
-  protected final Predicate<WebElement> predicate;
-
+public class AllMatch extends PredicateCollectionCondition {
   public AllMatch(String description, Predicate<WebElement> predicate) {
-    this.description = description;
-    this.predicate = predicate;
+    super("all", description, predicate);
   }
 
   @Override
@@ -25,26 +16,5 @@ public class AllMatch extends CollectionCondition {
       return false;
     }
     return elements.stream().allMatch(predicate);
-  }
-
-  @Override
-  public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
-    if (elements == null || elements.isEmpty()) {
-      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
-      elementNotFound.timeoutMs = timeoutMs;
-      throw elementNotFound;
-    } else {
-      throw new MatcherError(MATCHER, description, explanation, collection, elements, lastError, timeoutMs);
-    }
-  }
-
-  @Override
-  public boolean applyNull() {
-    return false;
-  }
-
-  @Override
-  public String toString() {
-    return String.format("%s match [%s] predicate", MATCHER, description);
   }
 }

--- a/src/main/java/com/codeborne/selenide/collections/AnyMatch.java
+++ b/src/main/java/com/codeborne/selenide/collections/AnyMatch.java
@@ -1,47 +1,17 @@
 package com.codeborne.selenide.collections;
 
-import com.codeborne.selenide.CollectionCondition;
-import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.MatcherError;
-import com.codeborne.selenide.impl.WebElementsCollection;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
 import java.util.function.Predicate;
 
-public class AnyMatch extends CollectionCondition {
-  private static final String MATCHER = "any";
-  protected final String description;
-  protected final Predicate<WebElement> predicate;
-
+public class AnyMatch extends PredicateCollectionCondition {
   public AnyMatch(String description, Predicate<WebElement> predicate) {
-    this.description = description;
-    this.predicate = predicate;
+    super("any", description, predicate);
   }
 
   @Override
   public boolean test(List<WebElement> elements) {
     return elements.stream().anyMatch(predicate);
-  }
-
-  @Override
-  public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
-    if (elements == null || elements.isEmpty()) {
-      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
-      elementNotFound.timeoutMs = timeoutMs;
-      throw elementNotFound;
-    } else {
-      throw new MatcherError(MATCHER, description, explanation, collection, elements, lastError, timeoutMs);
-    }
-  }
-
-  @Override
-  public boolean applyNull() {
-    return false;
-  }
-
-  @Override
-  public String toString() {
-    return String.format("%s match [%s] predicate", MATCHER, description);
   }
 }

--- a/src/main/java/com/codeborne/selenide/collections/NoneMatch.java
+++ b/src/main/java/com/codeborne/selenide/collections/NoneMatch.java
@@ -1,22 +1,13 @@
 package com.codeborne.selenide.collections;
 
-import com.codeborne.selenide.CollectionCondition;
-import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.MatcherError;
-import com.codeborne.selenide.impl.WebElementsCollection;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
 import java.util.function.Predicate;
 
-public class NoneMatch extends CollectionCondition {
-  private static final String MATCHER = "none";
-  protected final String description;
-  protected final Predicate<WebElement> predicate;
-
+public class NoneMatch extends PredicateCollectionCondition {
   public NoneMatch(String description, Predicate<WebElement> predicate) {
-    this.description = description;
-    this.predicate = predicate;
+    super("none", description, predicate);
   }
 
   @Override
@@ -25,26 +16,5 @@ public class NoneMatch extends CollectionCondition {
       return false;
     }
     return elements.stream().noneMatch(predicate);
-  }
-
-  @Override
-  public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
-    if (elements == null || elements.isEmpty()) {
-      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
-      elementNotFound.timeoutMs = timeoutMs;
-      throw elementNotFound;
-    } else {
-      throw new MatcherError(MATCHER, description, explanation, collection, elements, lastError, timeoutMs);
-    }
-  }
-
-  @Override
-  public boolean applyNull() {
-    return false;
-  }
-
-  @Override
-  public String toString() {
-    return String.format("%s match [%s] predicate", MATCHER, description);
   }
 }

--- a/src/main/java/com/codeborne/selenide/collections/PredicateCollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/collections/PredicateCollectionCondition.java
@@ -1,0 +1,43 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.MatcherError;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public abstract class PredicateCollectionCondition extends CollectionCondition {
+  protected final String matcher;
+  protected final String description;
+  protected final Predicate<WebElement> predicate;
+
+  protected PredicateCollectionCondition(String matcher, String description, Predicate<WebElement> predicate) {
+    this.matcher = matcher;
+    this.description = description;
+    this.predicate = predicate;
+  }
+
+  @Override
+  public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
+    if (elements == null || elements.isEmpty()) {
+      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
+      elementNotFound.timeoutMs = timeoutMs;
+      throw elementNotFound;
+    } else {
+      throw new MatcherError(matcher, description, explanation, collection, elements, lastError, timeoutMs);
+    }
+  }
+
+  @Override
+  public boolean applyNull() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s match [%s] predicate", matcher, description);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/FileHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileHelper.java
@@ -1,0 +1,45 @@
+package com.codeborne.selenide.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class FileHelper {
+  private static final Logger log = LoggerFactory.getLogger(FileHelper.class);
+
+  private FileHelper() {
+  }
+
+  public static void copyFile(File sourceFile, File targetFile) throws IOException {
+    try (FileInputStream in = new FileInputStream(sourceFile)) {
+      copyFile(in, targetFile);
+    }
+  }
+
+  public static void copyFile(InputStream in, File targetFile) throws IOException {
+    ensureFolderExists(targetFile);
+
+    try (FileOutputStream out = new FileOutputStream(targetFile)) {
+      byte[] buffer = new byte[1024];
+      int len;
+      while ((len = in.read(buffer)) != -1) {
+        out.write(buffer, 0, len);
+      }
+    }
+  }
+
+  private static void ensureFolderExists(File targetFile) {
+    File folder = targetFile.getParentFile();
+    if (!folder.exists()) {
+      log.info("Creating folder: {}", folder);
+      if (!folder.mkdirs()) {
+        log.error("Failed to create {}", folder);
+      }
+    }
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/PageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/PageSourceExtractor.java
@@ -10,9 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 
@@ -55,7 +53,7 @@ public class PageSourceExtractor {
 
   protected void writeToFile(String content, File targetFile) {
     try (ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes(UTF_8))) {
-      copyFile(in, targetFile);
+      FileHelper.copyFile(in, targetFile);
     } catch (IOException e) {
       log.error("Failed to write file {}", targetFile.getAbsolutePath(), e);
     }
@@ -70,28 +68,6 @@ public class PageSourceExtractor {
     }
   }
 
-  protected void copyFile(InputStream in, File targetFile) throws IOException {
-    ensureFolderExists(targetFile);
-
-    try (FileOutputStream out = new FileOutputStream(targetFile)) {
-      byte[] buffer = new byte[1024];
-      int len;
-      while ((len = in.read(buffer)) != -1) {
-        out.write(buffer, 0, len);
-      }
-    }
-  }
-
-  protected void ensureFolderExists(File targetFile) {
-    File folder = targetFile.getParentFile();
-    if (!folder.exists()) {
-      log.info("Creating folder: {}", folder);
-      if (!folder.mkdirs()) {
-        log.error("Failed to create {}", folder);
-      }
-    }
-  }
-
   private void retryingExtractionOnAlert(Exception e) {
     try {
       Alert alert = driver.switchTo().alert();
@@ -102,6 +78,4 @@ public class PageSourceExtractor {
       log.error("Failed to close alert", unableToCloseAlert);
     }
   }
-
-
 }

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -18,10 +18,7 @@ import java.awt.image.BufferedImage;
 import java.awt.image.RasterFormatException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URLEncoder;
@@ -283,7 +280,7 @@ public class ScreenShotLaboratory {
       File scrFile = driver.getScreenshotAs(FILE);
       File imageFile = new File(config.reportsFolder(), fileName + ".png");
       try {
-        copyFile(scrFile, imageFile);
+        FileHelper.copyFile(scrFile, imageFile);
       } catch (IOException e) {
         log.error("Failed to save screenshot to {}", imageFile, e);
       }
@@ -293,25 +290,6 @@ public class ScreenShotLaboratory {
       return null;
     }
   }
-
-  protected void copyFile(File sourceFile, File targetFile) throws IOException {
-    try (FileInputStream in = new FileInputStream(sourceFile)) {
-      copyFile(in, targetFile);
-    }
-  }
-
-  protected void copyFile(InputStream in, File targetFile) throws IOException {
-    ensureFolderExists(targetFile);
-
-    try (FileOutputStream out = new FileOutputStream(targetFile)) {
-      byte[] buffer = new byte[1024];
-      int len;
-      while ((len = in.read(buffer)) != -1) {
-        out.write(buffer, 0, len);
-      }
-    }
-  }
-
 
   public void startContext(String className, String methodName) {
     String context = className.replace('.', separatorChar) + separatorChar + methodName + separatorChar;


### PR DESCRIPTION
## Proposed changes

These minor changes remove duplicated code for:

1. copyFile used in PageSourceExtractor and ScreenShotLaboratory
2. common methods of AllMatch, AnyMatch and NoneMatch collection conditions

## Checklist
- [X] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
