### PR TITLE
Add nullity annotations to ElementsCollection

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -22,6 +22,9 @@ import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -35,6 +38,7 @@ import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
 import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.toList;
 
+@ParametersAreNonnullByDefault
 public class ElementsCollection extends AbstractList<SelenideElement> {
   private final WebElementsCollection collection;
 
@@ -65,6 +69,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   /**
    * Deprecated. Use {@code $$.shouldHave(size(expectedSize))} instead.
    */
+  @Nonnull
   public ElementsCollection shouldHaveSize(int expectedSize) {
     return shouldHave(CollectionCondition.size(expectedSize));
   }
@@ -72,10 +77,12 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   /**
    * For example: {@code $$(".error").shouldBe(empty)}
    */
+  @Nonnull
   public ElementsCollection shouldBe(CollectionCondition... conditions) {
     return should("be", driver().config().timeout(), conditions);
   }
 
+  @Nonnull
   public ElementsCollection shouldBe(CollectionCondition condition, long timeoutMs) {
     return should("be", timeoutMs, toArray(condition));
   }
@@ -85,6 +92,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * {@code $$(".error").shouldHave(size(3))}
    * {@code $$(".error").shouldHave(texts("Error1", "Error2"))}
    */
+  @Nonnull
   public ElementsCollection shouldHave(CollectionCondition... conditions) {
     return should("have", driver().config().timeout(), conditions);
   }
@@ -94,6 +102,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    *
    * @param timeoutMs maximum waiting time in milliseconds
    */
+  @Nonnull
   public ElementsCollection shouldHave(CollectionCondition condition, long timeoutMs) {
     return should("have", timeoutMs, toArray(condition));
   }
@@ -178,6 +187,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @param condition condition
    * @return ElementsCollection
    */
+  @Nonnull
   public ElementsCollection filter(Condition condition) {
     return new ElementsCollection(new FilteringCollection(collection, condition));
   }
@@ -189,6 +199,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @param condition condition
    * @return ElementsCollection
    */
+  @Nonnull
   public ElementsCollection filterBy(Condition condition) {
     return filter(condition);
   }
@@ -199,6 +210,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @param condition condition
    * @return ElementsCollection
    */
+  @Nonnull
   public ElementsCollection exclude(Condition condition) {
     return new ElementsCollection(new FilteringCollection(collection, not(condition)));
   }
@@ -210,6 +222,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @param condition condition
    * @return ElementsCollection
    */
+  @Nonnull
   public ElementsCollection excludeWith(Condition condition) {
     return exclude(condition);
   }
@@ -220,6 +233,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @param condition condition
    * @return SelenideElement
    */
+  @Nonnull
   public SelenideElement find(Condition condition) {
     return CollectionElementByCondition.wrap(collection, condition);
   }
@@ -231,6 +245,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @param condition condition
    * @return SelenideElement
    */
+  @Nonnull
   public SelenideElement findBy(Condition condition) {
     return find(condition);
   }
@@ -243,6 +258,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * Gets all the texts in elements collection
    * @return array of texts
    */
+  @Nonnull
   public List<String> texts() {
     return texts(getElements());
   }
@@ -252,6 +268,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @param elements Any collection of WebElements
    * @return Array of texts (or exceptions in case of any WebDriverExceptions)
    */
+  @Nonnull
   public static List<String> texts(Collection<WebElement> elements) {
     return elements.stream().map(ElementsCollection::getText).collect(toList());
   }
@@ -269,7 +286,8 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * @param elements elements of string
    * @return String
    */
-  public static String elementsToString(Driver driver, Collection<WebElement> elements) {
+  @Nonnull
+  public static String elementsToString(Driver driver, @Nullable Collection<WebElement> elements) {
     if (elements == null) {
       return "[not loaded yet...]";
     }
@@ -308,6 +326,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * NOTICE: $(css) is faster and returns the same result as $$(css).first()
    * @return the first element of the collection
    */
+  @Nonnull
   public SelenideElement first() {
     return get(0);
   }
@@ -317,6 +336,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied (.click(), should..() etc.)
    * @return the last element of the collection
    */
+  @Nonnull
   public SelenideElement last() {
     return LastCollectionElement.wrap(collection);
   }
@@ -326,6 +346,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied (.click(), should..() etc.)
    * @param elements number of elements 1..N
    */
+  @Nonnull
   public ElementsCollection first(int elements) {
     return new ElementsCollection(new HeadOfCollection(collection, elements));
   }
@@ -335,6 +356,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * ATTENTION! Doesn't start any search yet. Search will be started when action or assert is applied (.click(), should..() etc.)
    * @param elements number of elements 1..N
    */
+  @Nonnull
   public ElementsCollection last(int elements) {
     return new ElementsCollection(new TailOfCollection(collection, elements));
   }
@@ -354,11 +376,13 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   }
 
   @Override
+  @Nonnull
   public Iterator<SelenideElement> iterator() {
     return new SelenideElementIterator(fetch());
   }
 
   @Override
+  @Nonnull
   public ListIterator<SelenideElement> listIterator(int index) {
     return new SelenideElementListIterator(fetch(), index);
   }
@@ -369,6 +393,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   }
 
   @Override
+  @Nonnull
   public Object[] toArray() {
     List<WebElement> fetchedElements = collection.getElements();
     Object[] result = new Object[fetchedElements.size()];
@@ -386,6 +411,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    *
    * @return current state of this collection
    */
+  @Nonnull
   public ElementsCollection snapshot() {
     return new ElementsCollection(fetch());
   }


### PR DESCRIPTION
## Proposed changes

Here we add `@Nonnull` annotations for `ElementsCollection` as the next step of #1140

## Checklist
- [X] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
