### PR TITLE
Add missing findAll with CSS selector to SelenideDriver

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -301,6 +301,12 @@ public class SelenideDriver {
 
   @CheckReturnValue
   @Nonnull
+  public ElementsCollection findAll(String cssSelector) {
+    return new ElementsCollection(driver(), By.cssSelector(cssSelector));
+  }
+
+  @CheckReturnValue
+  @Nonnull
   public ElementsCollection $$(By criteria) {
     return findAll(criteria);
   }


### PR DESCRIPTION
## Proposed changes

Here we add `findAll(String cssSelector)` to `SelenideDriver` so now it is possible to use it like short `find(String)`. Mostly required for Kotlin tests. For some reason it was missing in `SelenideDriver` while it already has `find(String)`.

## Checklist
- [X] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
