### PR TITLE
make possible to connect webdriver to already existed instance of chr…

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -71,6 +71,9 @@ class ChromeDriverFactory extends AbstractDriverFactory {
     }
     currentChromeOptions.setExperimentalOption("prefs", chromePreferences);
 
+    if (System.getProperty("chromeoptions.debuggerAddress") != null) {
+      currentChromeOptions.setExperimentalOption("debuggerAddress", System.getProperty("chromeoptions.debuggerAddress"));
+    }
     if (System.getProperty("chromeoptions.mobileEmulation") != null) {
       Map<String, Object> prefs = parsePreferencesFromString(System.getProperty("chromeoptions.mobileEmulation"));
       currentChromeOptions.setExperimentalOption("mobileEmulation", prefs);
@@ -103,6 +106,7 @@ class ChromeDriverFactory extends AbstractDriverFactory {
 
   /**
    * parse parameters which can come from command-line interface
+   *
    * @param csvString comma-separated values, quotes can be used to mask spaces and commas
    *                  Example: 123,"foo bar","bar,foo"
    * @return values as array, quotes are preserved
@@ -114,6 +118,7 @@ class ChromeDriverFactory extends AbstractDriverFactory {
 
   /**
    * Converts String to Boolean\Integer or returns original String.
+   *
    * @param value string to convert
    * @return string's object representation
    */

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -13,13 +13,13 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
-import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchPrefs;
+import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.*;
 import static org.mockito.Mockito.mock;
 
 class ChromeDriverFactoryTest implements WithAssertions {
   private static final String CHROME_OPTIONS_PREFS = "chromeoptions.prefs";
   private static final String CHROME_OPTIONS_ARGS = "chromeoptions.args";
+  private static final String CHROME_OPTIONS_DEBUGGER_ADDRESS = "chromeoptions.debuggerAddress";
 
   private final Proxy proxy = mock(Proxy.class);
   private final SelenideConfig config = new SelenideConfig().downloadsFolder("/blah/downloads");
@@ -29,6 +29,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   void tearDown() {
     System.clearProperty(CHROME_OPTIONS_ARGS);
     System.clearProperty(CHROME_OPTIONS_PREFS);
+    System.clearProperty(CHROME_OPTIONS_DEBUGGER_ADDRESS);
   }
 
   @Test
@@ -110,5 +111,16 @@ class ChromeDriverFactoryTest implements WithAssertions {
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments).contains("--headless");
+  }
+
+  @Test
+  void debuggerAddressCanBeSet() {
+    String hostAndPort = "localhost:12345";
+    System.setProperty(CHROME_OPTIONS_DEBUGGER_ADDRESS, hostAndPort);
+
+    ChromeOptions chromeOptions = new ChromeDriverFactory().createChromeOptions(config, proxy);
+    String debuggerAddress = getBrowserLaunchDebuggerAddress(ChromeOptions.CAPABILITY, chromeOptions);
+
+    assertThat(debuggerAddress).isEqualTo(hostAndPort);
   }
 }

--- a/src/test/java/com/codeborne/selenide/webdriver/SeleniumCapabilitiesHelper.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/SeleniumCapabilitiesHelper.java
@@ -1,10 +1,10 @@
 package com.codeborne.selenide.webdriver;
 
+import org.openqa.selenium.Capabilities;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import org.openqa.selenium.Capabilities;
 
 class SeleniumCapabilitiesHelper {
   @SuppressWarnings("unchecked")
@@ -27,5 +27,17 @@ class SeleniumCapabilitiesHelper {
       return Collections.emptyMap();
     }
     return (Map<String, Object>) arguments.get("prefs");
+  }
+
+  @SuppressWarnings("unchecked")
+  static String getBrowserLaunchDebuggerAddress(String capability, Capabilities capabilities) {
+    // it depends on internal Selenium capabilities structure
+    // but there are no ways to do the same by public interfaces
+    Map<String, Object> arguments = (Map<String, Object>) capabilities.asMap().get(capability);
+    if (arguments == null) {
+      return null;
+    }
+
+    return (String) arguments.get("debuggerAddress");
   }
 }

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -29,6 +29,12 @@ import org.openqa.selenium.remote.DesiredCapabilities;
  *
  *   Example: homepage=http://google.com,"intl.allowed_languages=en,ru,es"
  * </p>
+ * <p>
+ *  <b>chromeoptions.debuggerAddress</b> - Set an address of a Chrome debugger server to connect to for chrome
+ *  options, in the form of <hostname/ip:port>
+ *
+ *   Example: debuggerAddress=localhost:9222
+ * </p>
  */
 public class Configuration {
   private static final SelenideConfig defaults = new SelenideConfig();


### PR DESCRIPTION
## Proposed changes
Make possible to connect webdriver to already existed instance of chromuim/chrome/electron instead of creating new one (in my case it is electron application)
I want simply set it with `System.setProperty("chromeoptions.debuggerAddress", "localhost:1234");` 
 or `-Dchromeoptions.debuggerAddress=localhost:1234`

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
