### PR TITLE
#1139 avoid using FirefoxProfile until it's really needed

### DIFF
--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -81,8 +81,10 @@ opera46=2.29
 
 # Browser: Microsoft Edge - Driver: msedgedriver
 # Source: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+edge84=84.0.521.0
+edge83=83.0.478.37
 edge82=82.0.459.1
-edge81=81.0.416.45
+edge81=81.0.416.77
 edge80=80.0.361.111
 edge79=79.0.313.0
 edge78=78.0.277.0

--- a/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
@@ -12,8 +12,10 @@ import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
 import static org.mockito.Mockito.mock;
@@ -23,31 +25,36 @@ class FirefoxDriverFactoryTest implements WithAssertions {
   private final FirefoxDriverFactory driverFactory = new FirefoxDriverFactory();
   private final SelenideConfig config = new SelenideConfig().downloadsFolder("/blah/downloads");
   private final Browser browser = new Browser(config.browser(), config.headless());
+  private Set<String> systemProperties = new HashSet<>();
 
   @AfterEach
   void tearDown() {
-    System.clearProperty("capabilities.some.cap");
-    System.clearProperty("firefoxprofile.some.cap");
-    System.clearProperty("firefoxprofile.some.cap1");
-    System.clearProperty("firefoxprofile.some.cap2");
+    for (String name : systemProperties) {
+      System.clearProperty(name);
+    }
+  }
+
+  private void givenSystemProperty(String name, String value) {
+    systemProperties.add(name);
+    System.setProperty(name, value);
   }
 
   @Test
   void transfersStringCapabilitiesFromSystemPropsToDriver() {
-    System.setProperty("capabilities.some.cap", "abcd");
+    givenSystemProperty("capabilities.some.cap", "abcd");
     assertThat(driverFactory.createCommonCapabilities(config, browser, proxy).getCapability("some.cap")).isEqualTo("abcd");
   }
 
   @Test
   void transfersBooleanCapabilitiesFromSystemPropsToDriver() {
-    System.setProperty("capabilities.some.cap", "true");
+    givenSystemProperty("capabilities.some.cap", "true");
     assertThat(driverFactory.createCommonCapabilities(config, browser, proxy).getCapability("some.cap"))
       .isEqualTo(true);
   }
 
   @Test
   void transfersIntegerCapabilitiesFromSystemPropsToDriver() {
-    System.setProperty("capabilities.some.cap", "25");
+    givenSystemProperty("capabilities.some.cap", "25");
     assertThat(driverFactory.createCommonCapabilities(config, browser, proxy).getCapability("some.cap")).isEqualTo(25);
   }
 
@@ -57,7 +64,7 @@ class FirefoxDriverFactoryTest implements WithAssertions {
     configurationProfile.setPreference("some.conf.cap", 42);
     FirefoxOptions firefoxOptions = new FirefoxOptions().setProfile(configurationProfile);
     config.browserCapabilities(new DesiredCapabilities(firefoxOptions));
-    System.setProperty("firefoxprofile.some.cap", "25");
+    givenSystemProperty("firefoxprofile.some.cap", "25");
 
     FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy).getProfile();
 
@@ -67,15 +74,15 @@ class FirefoxDriverFactoryTest implements WithAssertions {
 
   @Test
   void transferIntegerFirefoxProfilePreferencesFromSystemPropsToDriver() {
-    System.setProperty("firefoxprofile.some.cap", "25");
+    givenSystemProperty("firefoxprofile.some.cap", "25");
     FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy).getProfile();
     assertThat(profile.getIntegerPreference("some.cap", 0)).isEqualTo(25);
   }
 
   @Test
   void transferBooleanFirefoxProfilePreferencesFromSystemPropsToDriver() {
-    System.setProperty("firefoxprofile.some.cap1", "faLSe");
-    System.setProperty("firefoxprofile.some.cap2", "TRue");
+    givenSystemProperty("firefoxprofile.some.cap1", "faLSe");
+    givenSystemProperty("firefoxprofile.some.cap2", "TRue");
     FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy).getProfile();
     assertThat(profile.getBooleanPreference("some.cap1", true)).isEqualTo(false);
     assertThat(profile.getBooleanPreference("some.cap2", false)).isEqualTo(true);
@@ -83,7 +90,7 @@ class FirefoxDriverFactoryTest implements WithAssertions {
 
   @Test
   void transferStringFirefoxProfilePreferencesFromSystemPropsToDriver() {
-    System.setProperty("firefoxprofile.some.cap", "abdd");
+    givenSystemProperty("firefoxprofile.some.cap", "abdd");
     FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy).getProfile();
     assertThat(profile.getStringPreference("some.cap", "sjlj")).isEqualTo("abdd");
   }

--- a/src/test/java/integration/TabsTest.java
+++ b/src/test/java/integration/TabsTest.java
@@ -22,13 +22,12 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 class TabsTest extends ITest {
   @BeforeEach
   void setUp() {
+    setTimeout(1000);
     openFile("page_with_tabs.html");
   }
 
   @Test
   void userCanBrowseTabs_webdriver_api() {
-    setTimeout(1000);
-
     WebDriver driver = driver().getWebDriver();
 
     $(byText("Page1: uploads")).click();

--- a/src/test/java/integration/TabsTest.java
+++ b/src/test/java/integration/TabsTest.java
@@ -1,6 +1,6 @@
 package integration;
 
-import com.automation.remarks.video.annotations.Video;
+import com.codeborne.selenide.Condition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,8 +10,10 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Set;
 
+import static com.codeborne.selenide.Condition.or;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selectors.byText;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -24,7 +26,6 @@ class TabsTest extends ITest {
   }
 
   @Test
-  @Video
   void userCanBrowseTabs_webdriver_api() {
     setTimeout(1000);
 
@@ -53,7 +54,6 @@ class TabsTest extends ITest {
   }
 
   @Test
-  @Video
   void canSwitchToWindowByTitle() {
     $(byText("Page2: alerts")).click();
     $(byText("Page1: uploads")).click();
@@ -71,7 +71,6 @@ class TabsTest extends ITest {
   }
 
   @Test
-  @Video
   void canSwitchToWindowByIndex_chrome() {
     assumeTrue(browser().isChrome());
     $(byText("Page2: alerts")).click();
@@ -91,7 +90,6 @@ class TabsTest extends ITest {
   }
 
   @Test
-  @Video
   void canSwitchToWindowByIndex_other_browsers_but_chrome() {
     assumeFalse(browser().isChrome());
     $(byText("Page2: alerts")).click();
@@ -99,31 +97,41 @@ class TabsTest extends ITest {
     $(byText("Page3: jquery")).click();
 
     $("h1").shouldHave(text("Tabs"));
+    Condition oneOfTitles = or("one of titles", text("Tabs"), text("Page with alerts"), text("File uploads"), text("Page with JQuery"));
 
     switchTo().window(1);
-    $("h1").shouldHave(text("Page with alerts"));
+    $("h1").shouldHave(oneOfTitles);
+    String title1 = $("h1").text();
+
     switchTo().window(2);
-    $("h1").shouldHave(text("File uploads"));
+    $("h1").shouldHave(oneOfTitles);
+    String title2 = $("h1").text();
+
     switchTo().window(3);
-    $("h1").shouldHave(text("Page with JQuery"));
+    $("h1").shouldHave(oneOfTitles);
+    String title3 = $("h1").text();
+
     switchTo().window(0);
-    $("h1").shouldHave(text("Tabs"));
+    $("h1").shouldHave(oneOfTitles);
+    String title0 = $("h1").text();
+
+    assertThat(asList(title0, title1, title2, title3))
+      .containsExactlyInAnyOrder("Tabs", "Page with alerts", "File uploads", "Page with JQuery");
   }
 
   @Test
-  @Video
   void canSwitchBetweenWindowsWithSameTitles() {
     $(byText("Page4: same title")).click();
     $("h1").shouldHave(text("Tabs"));
 
     switchTo().window("Test::tabs::title");
-    $("body").shouldHave(text("Secret phrase 1"));
+    $("body").shouldHave(or("one of tabs with this title", text("Secret phrase 1"), text("Secret phrase 2"), text("Secret phrase 3")));
 
     switchTo().window(0);
     $("h1").shouldHave(text("Tabs"));
     $(byText("Page5: same title")).click();
     switchTo().window("Test::tabs::title");
-    $("body").shouldHave(text("Secret phrase 1"));
+    $("body").shouldHave(or("one of tabs with this title", text("Secret phrase 1"), text("Secret phrase 2"), text("Secret phrase 3")));
     switchTo().window(0);
     $("h1").shouldHave(text("Tabs"));
   }


### PR DESCRIPTION
* it appears that "browser.download.dir" can be set via FirefoxOptions instead of FirefoxProfile
* FirefoxProfile is needed only for legacy Firefox driver
* now we setup FirefoxProfile only if user provided some system properties starting with "firefoxprofile."

it solves https://github.com/selenide/selenide/issues/1139