### PR TITLE
#1179 @Nullable -> @Nonnull for getText(), innerText(), innerHtml(), …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.12.2
+* #1172 don't close browser if `holdBrowserOpen=true`  --  see PR #1176
+* #1179 fix @Nonnull annotation for methods getText(), innerText(), innerHtml(), getSelectedText()  --  see PR #1181
+
 ## 5.12.1 (released 25.05.2020)
 * Enable running Selenide without "selenium-ie-driver.jar" "selenium-opera-driver.jar" etc.
 * #1170 fixed Concurrent modification exception in WebDriverFactory  -- see PR #1171

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -117,18 +117,18 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @return The innerText of this element
    * @see com.codeborne.selenide.commands.GetText
    */
-  @Nullable
+  @Nonnull
   @Override
   String getText();
 
   /**
-   * Short form of getText()
+   * Short form of {@link #getText()}
    *
    * @see WebElement#getText()
    * @see com.codeborne.selenide.commands.GetText
    */
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   String text();
 
   /**
@@ -139,7 +139,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.GetInnerText
    */
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   String innerText();
 
   /**
@@ -150,11 +150,11 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.GetInnerHtml
    */
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   String innerHtml();
 
   /**
-   * Get the attribute of the element. Synonym for getAttribute(String).
+   * Get the attribute of the element. Synonym for {@link #getAttribute(String)}
    *
    * @return null if attribute is missing
    * @see com.codeborne.selenide.commands.GetAttribute
@@ -763,6 +763,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Get value of selected option in select field
    *
    * @see com.codeborne.selenide.commands.GetSelectedValue
+   * @return null if the selected option doesn't have "value" attribute
    */
   @CheckReturnValue
   @Nullable
@@ -774,7 +775,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.GetSelectedText
    */
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   String getSelectedText();
 
   /**
@@ -1001,10 +1002,11 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Execute custom implemented command
    *
    * @param command custom command
-   * @return this element
+   * @return whatever the command returns
    * @see com.codeborne.selenide.commands.Execute
    * @see com.codeborne.selenide.Command
    */
+  @Nullable
   <ReturnType> ReturnType execute(Command<ReturnType> command);
 
   /**
@@ -1020,6 +1022,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * Take screenshot of this element
    *
    * @return file with screenshot (*.png)
+   * or null if Selenide failed to take a screenshot (due to some technical problem)
    * @see com.codeborne.selenide.commands.TakeScreenshot
    */
   @Nullable

--- a/src/main/java/com/codeborne/selenide/commands/GetAttribute.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetAttribute.java
@@ -4,8 +4,11 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 
+import javax.annotation.Nullable;
+
 public class GetAttribute implements Command<String> {
   @Override
+  @Nullable
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     return locator.getWebElement().getAttribute((String) args[0]);
   }

--- a/src/main/java/com/codeborne/selenide/commands/GetDataAttribute.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetDataAttribute.java
@@ -4,8 +4,11 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 
+import javax.annotation.Nullable;
+
 public class GetDataAttribute implements Command<String> {
   @Override
+  @Nullable
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     return locator.getWebElement().getAttribute("data-" + args[0]);
   }

--- a/src/main/java/com/codeborne/selenide/commands/GetInnerHtml.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetInnerHtml.java
@@ -5,8 +5,11 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+
 public class GetInnerHtml implements Command<String> {
   @Override
+  @Nonnull
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     WebElement element = locator.getWebElement();
     return element.getAttribute("innerHTML");

--- a/src/main/java/com/codeborne/selenide/commands/GetInnerText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetInnerText.java
@@ -5,8 +5,11 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+
 public class GetInnerText implements Command<String> {
   @Override
+  @Nonnull
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     WebElement element = locator.getWebElement();
     if (locator.driver().browser().isIE()) {

--- a/src/main/java/com/codeborne/selenide/commands/GetName.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetName.java
@@ -4,8 +4,11 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 
+import javax.annotation.Nullable;
+
 public class GetName implements Command<String> {
   @Override
+  @Nullable
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     return locator.getWebElement().getAttribute("name");
   }

--- a/src/main/java/com/codeborne/selenide/commands/GetSelectedOption.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSelectedOption.java
@@ -5,10 +5,13 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.support.ui.Select;
 
+import javax.annotation.Nonnull;
+
 import static com.codeborne.selenide.impl.WebElementWrapper.wrap;
 
 public class GetSelectedOption implements Command<SelenideElement> {
   @Override
+  @Nonnull
   public SelenideElement execute(SelenideElement proxy, WebElementSource selectElement, Object[] args) {
     return wrap(selectElement.driver(), new Select(selectElement.getWebElement()).getFirstSelectedOption());
   }

--- a/src/main/java/com/codeborne/selenide/commands/GetSelectedText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSelectedText.java
@@ -5,10 +5,12 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+
 public class GetSelectedText implements Command<String> {
   private final GetSelectedOption getSelectedOption;
 
-  public GetSelectedText(GetSelectedOption getSelectedOption) {
+  GetSelectedText(@Nonnull GetSelectedOption getSelectedOption) {
     this.getSelectedOption = getSelectedOption;
   }
 
@@ -17,8 +19,9 @@ public class GetSelectedText implements Command<String> {
   }
 
   @Override
+  @Nonnull
   public String execute(SelenideElement proxy, WebElementSource selectElement, Object[] args) {
     WebElement option = getSelectedOption.execute(proxy, selectElement, NO_ARGS);
-    return option == null ? null : option.getText();
+    return option.getText();
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/GetSelectedValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSelectedValue.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 public class GetSelectedValue implements Command<String> {
@@ -19,6 +20,7 @@ public class GetSelectedValue implements Command<String> {
   }
 
   @Override
+  @Nullable
   public String execute(SelenideElement proxy, WebElementSource selectElement, Object[] args) throws IOException {
     WebElement option = getSelectedOption.execute(proxy, selectElement, args);
     return option == null ? null : option.getAttribute("value");

--- a/src/main/java/com/codeborne/selenide/commands/GetText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetText.java
@@ -5,6 +5,8 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+
 public class GetText implements Command<String> {
   private final GetSelectedText getSelectedText;
 
@@ -17,6 +19,7 @@ public class GetText implements Command<String> {
   }
 
   @Override
+  @Nonnull
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     WebElement element = locator.getWebElement();
     return "select".equalsIgnoreCase(element.getTagName()) ?

--- a/src/main/java/com/codeborne/selenide/commands/GetValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetValue.java
@@ -4,8 +4,11 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 
+import javax.annotation.Nullable;
+
 public class GetValue implements Command<String> {
   @Override
+  @Nullable
   public String execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     return locator.getWebElement().getAttribute("value");
   }

--- a/src/main/java/com/codeborne/selenide/commands/TakeScreenshot.java
+++ b/src/main/java/com/codeborne/selenide/commands/TakeScreenshot.java
@@ -5,10 +5,12 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.ScreenShotLaboratory;
 import com.codeborne.selenide.impl.WebElementSource;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 public class TakeScreenshot implements Command<File> {
   @Override
+  @Nullable
   public File execute(SelenideElement proxy, WebElementSource element, Object[] args) {
     return ScreenShotLaboratory.getInstance().takeScreenshot(element.driver(), element.getWebElement());
   }

--- a/src/main/java/com/codeborne/selenide/commands/TakeScreenshotAsImage.java
+++ b/src/main/java/com/codeborne/selenide/commands/TakeScreenshotAsImage.java
@@ -5,10 +5,12 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.ScreenShotLaboratory;
 import com.codeborne.selenide.impl.WebElementSource;
 
+import javax.annotation.Nullable;
 import java.awt.image.BufferedImage;
 
 public class TakeScreenshotAsImage implements Command<BufferedImage> {
   @Override
+  @Nullable
   public BufferedImage execute(SelenideElement proxy, WebElementSource element, Object[] args) {
     return ScreenShotLaboratory.getInstance().takeScreenshotAsImage(element.driver(), element.getWebElement());
   }

--- a/src/main/java/com/codeborne/selenide/commands/Val.java
+++ b/src/main/java/com/codeborne/selenide/commands/Val.java
@@ -4,6 +4,8 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 
+import javax.annotation.Nullable;
+
 public class Val implements Command<Object> {
   private final GetValue getValue;
   private final SetValue setValue;
@@ -19,6 +21,7 @@ public class Val implements Command<Object> {
   }
 
   @Override
+  @Nullable
   public Object execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
     if (args == null || args.length == 0) {
       return getValue.execute(proxy, locator, NO_ARGS);

--- a/src/main/java/com/codeborne/selenide/impl/PageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/PageSourceExtractor.java
@@ -8,6 +8,8 @@ import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +18,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+@ParametersAreNonnullByDefault
 public class PageSourceExtractor {
   private static final Logger log = LoggerFactory.getLogger(PageSourceExtractor.class);
   protected Set<String> printedErrors = new ConcurrentSkipListSet<>();
@@ -29,6 +32,7 @@ public class PageSourceExtractor {
     this.fileName = fileName;
   }
 
+  @Nonnull
   protected File extract(boolean retryIfAlert) {
     File pageSource = new File(config.reportsFolder(), fileName + ".html");
     try {
@@ -49,7 +53,6 @@ public class PageSourceExtractor {
     }
     return pageSource;
   }
-
 
   protected void writeToFile(String content, File targetFile) {
     try (ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes(UTF_8))) {

--- a/src/test/java/com/codeborne/selenide/commands/GetSelectedTextCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSelectedTextCommandTest.java
@@ -1,52 +1,27 @@
 package com.codeborne.selenide.commands;
 
-import java.lang.reflect.Field;
-
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static org.mockito.Mockito.*;
 
 class GetSelectedTextCommandTest implements WithAssertions {
-  private SelenideElement proxy = mock(SelenideElement.class);
-  private WebElementSource selectElement = mock(WebElementSource.class);
-  private SelenideElement mockedElement = mock(SelenideElement.class);
-  private GetSelectedText getSelectedTextCommand;
-  private GetSelectedOption getSelectedOptionCommand = mock(GetSelectedOption.class);
-
-  @BeforeEach
-  void setup() {
-    getSelectedTextCommand = new GetSelectedText(getSelectedOptionCommand);
-  }
+  private final SelenideElement proxy = mock(SelenideElement.class);
+  private final WebElementSource selectElement = mock(WebElementSource.class);
+  private final GetSelectedOption getSelectedOptionCommand = mock(GetSelectedOption.class);
+  private final GetSelectedText command = new GetSelectedText(getSelectedOptionCommand);
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    GetSelectedText getSelectedText = new GetSelectedText();
-    Field getSelectedOptionField = getSelectedText.getClass().getDeclaredField("getSelectedOption");
-    getSelectedOptionField.setAccessible(true);
-    GetSelectedOption getSelectedOption = (GetSelectedOption) getSelectedOptionField.get(getSelectedText);
-    assertThat(getSelectedOption)
-      .isNotNull();
-  }
+  void returnsTextOfSelectedOption() {
+    SelenideElement option = mockElement("option", "Option text");
+    when(getSelectedOptionCommand.execute(any(), any(), any())).thenReturn(option);
 
-  @Test
-  void testExecuteMethodWhenSelectedOptionReturnsNothing() {
-    when(getSelectedOptionCommand.execute(proxy, selectElement, Command.NO_ARGS)).thenReturn(null);
-    assertThat(getSelectedTextCommand.execute(proxy, selectElement, new Object[]{"something more"}))
-      .isNullOrEmpty();
-  }
+    assertThat(command.execute(proxy, selectElement, null)).isEqualTo("Option text");
 
-  @Test
-  void testExecuteMethodWhenSelectedOptionReturnsElement() {
-    when(getSelectedOptionCommand.execute(proxy, selectElement, Command.NO_ARGS)).thenReturn(mockedElement);
-    String elementText = "Element text";
-    when(mockedElement.getText()).thenReturn(elementText);
-    assertThat(getSelectedTextCommand.execute(proxy, selectElement, new Object[]{"something more"}))
-      .isEqualTo(elementText);
+    verify(getSelectedOptionCommand).execute(proxy, selectElement, Command.NO_ARGS);
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.chrome.ChromeDriver;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.List;
 
@@ -23,7 +24,7 @@ class ScreenShotLaboratoryTest implements WithAssertions {
 
   private final ScreenShotLaboratory screenshots = new ScreenShotLaboratory() {
     @Override
-    public String takeScreenShot(Driver driver, String fileName) {
+    public String takeScreenShot(@Nonnull Driver driver, @Nonnull String fileName) {
       addToHistory(new File(fileName));
       return fileName;
     }
@@ -234,5 +235,10 @@ class ScreenShotLaboratoryTest implements WithAssertions {
 
     assertThat(screenShotPath)
       .contains("http://ci.org/path%20with%spaces/");
+  }
+
+  @Test
+  void encodePath() {
+    assertThat(screenshots.encodePath("/foo bar/boom room/pdf")).isEqualTo("/foo%20bar/boom%20room/pdf");
   }
 }

--- a/src/test/java/integration/AttributeTest.java
+++ b/src/test/java/integration/AttributeTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.codeborne.selenide.SelenideElement;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,14 +59,16 @@ public class AttributeTest extends ITest {
 
   @Test
   void userCanGetAttr() {
-    assertThat($(by("readonly", "readonly")).attr("name"))
-      .isEqualTo("username");
+    SelenideElement element = $(by("readonly", "readonly"));
+    assertThat(element.attr("name")).isEqualTo("username");
+    assertThat(element.attr("value")).isEqualTo("");
+    assertThat(element.attr("foo")).isNull();
   }
 
   @Test
   void userCanGetNameAttribute() {
-    assertThat($(by("readonly", "readonly")).name())
-      .isEqualTo("username");
+    assertThat($(by("readonly", "readonly")).name()).isEqualTo("username");
+    assertThat($("h2").name()).isNull();
   }
 
   @Test

--- a/src/test/resources/page_with_selects_without_jquery.html
+++ b/src/test/resources/page_with_selects_without_jquery.html
@@ -80,6 +80,15 @@
   </select>
 </div>
 
+<div id="empty" class="container">
+  <h2><a href="#">Select with an empty default option</a></h2>
+  <select id="gender">
+    <option value=""></option>
+    <option value="male">Male</option>
+    <option value="female">Female</option>
+  </select>
+</div>
+
 <div id="radioButtons">
   <h2>Radio buttons</h2>
   <input type="radio" name="me" value="master">Мастер</input>

--- a/src/test/resources/page_with_selects_without_jquery.html
+++ b/src/test/resources/page_with_selects_without_jquery.html
@@ -80,15 +80,6 @@
   </select>
 </div>
 
-<div id="empty" class="container">
-  <h2><a href="#">Select with an empty default option</a></h2>
-  <select id="gender">
-    <option value=""></option>
-    <option value="male">Male</option>
-    <option value="female">Female</option>
-  </select>
-</div>
-
 <div id="radioButtons">
   <h2>Radio buttons</h2>
   <input type="radio" name="me" value="master">Мастер</input>
@@ -114,6 +105,15 @@
   </tr>
   </tbody>
 </table>
+
+<div id="empty" class="container">
+  <h3><a href="#">Select with an empty default option</a></h3>
+  <select id="gender">
+    <option value=""></option>
+    <option value="male">Male</option>
+    <option value="female">Female</option>
+  </select>
+</div>
 
 <div id="status">
   Username: <span class="name">Bob Smith</span>&nbsp;Last login: <span class="last-login">01.01.1970</span>

--- a/src/test/resources/page_with_selects_without_jquery.html
+++ b/src/test/resources/page_with_selects_without_jquery.html
@@ -106,15 +106,6 @@
   </tbody>
 </table>
 
-<div id="empty" class="container">
-  <h3><a href="#">Select with an empty default option</a></h3>
-  <select id="gender">
-    <option value=""></option>
-    <option value="male">Male</option>
-    <option value="female">Female</option>
-  </select>
-</div>
-
 <div id="status">
   Username: <span class="name">Bob Smith</span>&nbsp;Last login: <span class="last-login">01.01.1970</span>
 </div>
@@ -202,5 +193,15 @@
      ng-class="widget"
      ng-click="none">Суслик
 </div>
+
+<div id="empty" class="container">
+  <h3><a href="#">Select with an empty default option</a></h3>
+  <select id="gender">
+    <option value=""></option>
+    <option value="male">Male</option>
+    <option value="female">Female</option>
+  </select>
+</div>
+
 </body>
 </html>

--- a/statics/src/main/java/com/codeborne/selenide/Screenshots.java
+++ b/statics/src/main/java/com/codeborne/selenide/Screenshots.java
@@ -3,6 +3,9 @@ package com.codeborne.selenide;
 import com.codeborne.selenide.impl.ScreenShotLaboratory;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.List;
@@ -10,9 +13,11 @@ import java.util.Optional;
 
 import static com.codeborne.selenide.WebDriverRunner.driver;
 
+@ParametersAreNonnullByDefault
 public class Screenshots {
   public static ScreenShotLaboratory screenshots = ScreenShotLaboratory.getInstance();
 
+  @Nullable
   public static String takeScreenShot(String className, String methodName) {
     return screenshots.takeScreenShot(driver(), className, methodName);
   }
@@ -20,8 +25,9 @@ public class Screenshots {
   /**
    * Take screenshot and give it filename
    *
-   * @return absolute path of the screenshot taken
+   * @return absolute path of the screenshot taken or null if failed to create screenshot
    */
+  @Nullable
   public static String takeScreenShot(String fileName) {
     return screenshots.takeScreenShot(driver(), fileName);
   }
@@ -30,6 +36,7 @@ public class Screenshots {
    * Take screenshot and return as a file
    * @return a temporary file, not guaranteed to be stored after tests complete.
    */
+  @Nullable
   public static File takeScreenShotAsFile() {
     return screenshots.takeScreenShotAsFile(driver());
   }
@@ -38,6 +45,7 @@ public class Screenshots {
    * Take screenshot of the WebElement/SelenideElement
    * @return a temporary file, not guaranteed to be stored after tests complete.
    */
+  @Nullable
   public static File takeScreenShot(WebElement element) {
     return screenshots.takeScreenshot(driver(), element);
   }
@@ -47,6 +55,7 @@ public class Screenshots {
    * for partially visible WebElement/Selenide horizontal scroll bar will be present
    * @return a temporary file, not guaranteed to be stored after tests complete.
    */
+  @Nullable
   public static File takeScreenShot(WebElement iframe, WebElement element) {
     return screenshots.takeScreenshot(driver(), iframe, element);
   }
@@ -56,6 +65,7 @@ public class Screenshots {
    * for partially visible WebElement/Selenide horizontal scroll bar will be present
    * @return buffered image
    */
+  @Nullable
   public static BufferedImage takeScreenShotAsImage(WebElement iframe, WebElement element) {
     return screenshots.takeScreenshotAsImage(driver(), iframe, element);
   }
@@ -64,6 +74,7 @@ public class Screenshots {
    * Take screenshot of the WebElement/SelenideElement
    * @return buffered image
    */
+  @Nullable
   public static BufferedImage takeScreenShotAsImage(WebElement element) {
     return screenshots.takeScreenshotAsImage(driver(), element);
   }
@@ -72,6 +83,7 @@ public class Screenshots {
     screenshots.startContext(className, methodName);
   }
 
+  @Nonnull
   public static List<File> finishContext() {
     return screenshots.finishContext();
   }
@@ -81,6 +93,7 @@ public class Screenshots {
    *
    * @return null if there were no any screenshots taken
    */
+  @Nullable
   public static File getLastScreenshot() {
     return screenshots.getLastScreenshot();
   }
@@ -91,6 +104,7 @@ public class Screenshots {
    * @return {@link java.util.Optional} with screenshot of current thread,
    * or an empty Optional if there were no any screenshots taken.
    */
+  @Nonnull
   public static Optional<File> getLastThreadScreenshot() {
     return screenshots.getLastThreadScreenshot();
   }
@@ -101,6 +115,7 @@ public class Screenshots {
    * @return {@link java.util.Optional} with screenshot of current {@code context} thread,
    * or an empty Optional if there were no any screenshots taken.
    */
+  @Nonnull
   public static Optional<File> getLastContextScreenshot() {
     return screenshots.getLastContextScreenshot();
   }

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -140,6 +140,18 @@ class SelectsTest extends IntegrationTest {
   }
 
   @Test
+  void getSelectedText_cannotBeNull() {
+    SelenideElement select = $("select#gender");
+    assertThat(select.getSelectedText()).isEqualTo("");
+
+    select.selectOptionContainingText("emal");
+    assertThat(select.getSelectedText()).isEqualTo("Female");
+
+    assertThatThrownBy(() -> $("select#missing").getSelectedText())
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
   void getTextReturnsTextsOfSelectedOptions() {
     assertThat($("#hero").getText())
       .isEqualTo("-- Select your hero --");

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -149,10 +149,40 @@ class SelenideMethodsTest extends IntegrationTest {
   }
 
   @Test
-  void userCanSetValueToTextfield() {
+  void innerText_cannotBeNull() {
+    assertThat($("br").innerHtml()).isEqualTo("");
+    assertThatThrownBy(() -> $("#missing").innerHtml())
+      .isInstanceOf(ElementNotFound.class);
+
+    assertThat($("br").innerText()).isEqualTo("");
+    assertThatThrownBy(() -> $("#missing").innerText())
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void getValue_canBeEmpty() {
+    assertThat($(By.name("password")).val()).isEqualTo("");
+    assertThat($(By.name("password")).getValue()).isEqualTo("");
+  }
+
+  @Test
+  void getValue_canBeNull() {
+    assertThat($("h2").val()).isNull();
+    assertThat($("h2").getValue()).isNull();
+  }
+
+  @Test
+  void getValue_throwsError_ifElementNotFound() {
+    assertThatThrownBy(() -> $("#missing").val())
+      .isInstanceOf(ElementNotFound.class);
+    assertThatThrownBy(() -> $("#missing").getValue())
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void userCanSetValueToTextField() {
     $(By.name("password")).setValue("john");
     $(By.name("password")).val("sherlyn");
-//    $(By.name("password")).shouldBe(focused);
     $(By.name("password")).shouldHave(value("sherlyn"));
     $(By.name("password")).waitUntil(value("sherlyn"), 1000);
     assertThat($(By.name("password")).val())
@@ -562,13 +592,13 @@ class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void canExecuteJavascript() {
-    long value = (Long) Selenide.executeJavaScript("return 10;");
+    Long value = Selenide.executeJavaScript("return 10;");
     assertThat(value).isEqualTo(10);
   }
 
   @Test
   void canExecuteAsyncJavascript() {
-    long value = Selenide.executeAsyncJavaScript(
+    Long value = Selenide.executeAsyncJavaScript(
       "var callback = arguments[arguments.length - 1]; setTimeout(function() { callback(10); }, 50);"
     );
     assertThat(value).isEqualTo(10);

--- a/statics/src/test/java/integration/errormessages/ErrorMsgWithScreenshotsTest.java
+++ b/statics/src/test/java/integration/errormessages/ErrorMsgWithScreenshotsTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 
 import static com.codeborne.selenide.Condition.cssClass;
@@ -40,7 +41,7 @@ class ErrorMsgWithScreenshotsTest extends IntegrationTest {
     Configuration.reportsUrl = "http://ci.org/";
     Screenshots.screenshots = new ScreenShotLaboratory() {
       @Override
-      public String takeScreenShot(Driver driver) {
+      public String takeScreenShot(@Nonnull Driver driver) {
         return new File(reportsFolder, "1.jpg").getAbsolutePath();
       }
     };


### PR DESCRIPTION
…getSelectedText()

* getSelectedOption() is non-nullable: if there is no selected option, it will throw an exception
* any methods using WebElement.getAttribute() are nullable
* unfortunately, all screenshots-related methods are nullable: taking a screenshot may fail at any moment

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
