### PR TITLE
Method text("") fail if null or empty string is given

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -29,6 +29,7 @@ import com.codeborne.selenide.conditions.Text;
 import com.codeborne.selenide.conditions.Value;
 import com.codeborne.selenide.conditions.Visible;
 import javax.annotation.CheckReturnValue;
+import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
@@ -272,10 +273,15 @@ public abstract class Condition {
    * <p>NB! Ignores multiple whitespaces between words</p>
    *
    * @param text expected text of HTML element
+   *
+   * @throws IllegalArgumentException if given text is null or empty
    */
   @CheckReturnValue
   @Nonnull
   public static Condition text(String text) {
+    if (StringUtils.isBlank(text)) {
+      throw new IllegalArgumentException("No expected text given");
+    }
     return new Text(text);
   }
 

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -280,7 +280,7 @@ public abstract class Condition {
   @Nonnull
   public static Condition text(String text) {
     if (StringUtils.isBlank(text)) {
-      throw new IllegalArgumentException("No expected text given");
+      throw new IllegalArgumentException("Text condition must not be null or empty string");
     }
     return new Text(text);
   }

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.proxy.SelenideProxyServer;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
@@ -8,6 +9,8 @@ import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Condition.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -403,4 +406,15 @@ class ConditionTest {
     Condition condition = attribute("name").because("it's awesome");
     assertThat(condition).hasToString("attribute name (because it's awesome)");
   }
+
+  @Test
+  void shouldGetExceptionIfGivenTextIsNullOrEmpty() {
+    IllegalArgumentException exceptionWhenNull = assertThrows(IllegalArgumentException.class, () -> text(null));
+    IllegalArgumentException exceptionWhenEmpty = assertThrows(IllegalArgumentException.class, () -> text(StringUtils.EMPTY));
+    assertAll(() -> {
+      assertThat(exceptionWhenNull.getMessage()).hasToString("No expected text given");
+      assertThat(exceptionWhenEmpty.getMessage()).hasToString("No expected text given");
+    });
+  }
+
 }

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -9,11 +9,9 @@ import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Condition.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ConditionTest {
   private WebDriver webDriver = mock(WebDriver.class);
@@ -409,11 +407,14 @@ class ConditionTest {
 
   @Test
   void shouldGetExceptionIfGivenTextIsNullOrEmpty() {
-    IllegalArgumentException exceptionWhenNull = assertThrows(IllegalArgumentException.class, () -> text(null));
-    IllegalArgumentException exceptionWhenEmpty = assertThrows(IllegalArgumentException.class, () -> text(StringUtils.EMPTY));
     assertAll(() -> {
-      assertThat(exceptionWhenNull.getMessage()).hasToString("No expected text given");
-      assertThat(exceptionWhenEmpty.getMessage()).hasToString("No expected text given");
+      assertThatThrownBy(() -> text(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No expected text given");
+
+      assertThatThrownBy(() -> text(StringUtils.EMPTY))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No expected text given");
     });
   }
 

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -410,11 +410,11 @@ class ConditionTest {
     assertAll(() -> {
       assertThatThrownBy(() -> text(null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("No expected text given");
+        .hasMessage("Text condition must not be null or empty string");
 
       assertThatThrownBy(() -> text(StringUtils.EMPTY))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("No expected text given");
+        .hasMessage("Text condition must not be null or empty string");
     });
   }
 


### PR DESCRIPTION
## Proposed changes
Fix issue #1156. Method text("") fail if null or empty string is given

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
