### PR TITLE
adding Item With Text collection condition

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -12,6 +12,7 @@ import com.codeborne.selenide.collections.SizeLessThanOrEqual;
 import com.codeborne.selenide.collections.SizeNotEqual;
 import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.collections.TextsInAnyOrder;
+import com.codeborne.selenide.collections.ItemWithText;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.openqa.selenium.WebElement;
 
@@ -156,6 +157,16 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
   @CheckReturnValue
   public static CollectionCondition noneMatch(String description, java.util.function.Predicate<WebElement> predicate) {
     return new NoneMatch(description, predicate);
+  }
+
+  /**
+   * Checks if given collection has given text
+   *
+   * @param expectedText The expected text in the collection
+   */
+  @CheckReturnValue
+  public static CollectionCondition itemWithText(String expectedText) {
+    return new ItemWithText(expectedText);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
+++ b/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.collections;
 import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.ex.ElementWithTextNotFound;
-import com.codeborne.selenide.ex.TextsMismatch;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.openqa.selenium.WebElement;
 

--- a/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
+++ b/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.collections;
 
 import com.codeborne.selenide.CollectionCondition;
 import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.ex.ElementWithTextNotFound;
 import com.codeborne.selenide.ex.TextsMismatch;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.openqa.selenium.WebElement;
@@ -26,7 +27,7 @@ public class ItemWithText extends CollectionCondition {
 
   @Override
   public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
-    throw new TextsMismatch(
+    throw new ElementWithTextNotFound(
       collection, ElementsCollection.texts(elements), Collections.singletonList(expectedText), explanation, timeoutMs);
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
+++ b/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
@@ -1,0 +1,41 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.openqa.selenium.WebElement;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ItemWithText extends CollectionCondition {
+
+  private final String expectedText;
+
+  public ItemWithText(String expectedText) {
+    this.expectedText = expectedText;
+  }
+
+  @Override
+  public boolean test(List<WebElement> elements) {
+    return ElementsCollection
+      .texts(elements)
+      .contains(expectedText);
+  }
+
+  @Override
+  public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
+    throw new TextsMismatch(collection, ElementsCollection.texts(elements), Collections.singletonList(expectedText), explanation, timeoutMs);
+  }
+
+  @Override
+  public boolean applyNull() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "Text " + expectedText;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
+++ b/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
@@ -26,7 +26,8 @@ public class ItemWithText extends CollectionCondition {
 
   @Override
   public void fail(WebElementsCollection collection, List<WebElement> elements, Exception lastError, long timeoutMs) {
-    throw new TextsMismatch(collection, ElementsCollection.texts(elements), Collections.singletonList(expectedText), explanation, timeoutMs);
+    throw new TextsMismatch(
+      collection, ElementsCollection.texts(elements), Collections.singletonList(expectedText), explanation, timeoutMs);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/ex/ElementWithTextNotFound.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementWithTextNotFound.java
@@ -1,0 +1,21 @@
+package com.codeborne.selenide.ex;
+
+import com.codeborne.selenide.impl.WebElementsCollection;
+
+import java.util.List;
+
+import static java.lang.System.lineSeparator;
+
+public class ElementWithTextNotFound extends UIAssertionError {
+
+  public ElementWithTextNotFound(WebElementsCollection collection, List<String> actualTexts,
+                                 List<String> expectedTexts, String explanation, long timeoutMs) {
+    super(collection.driver(),
+      "Element with text not found" +
+        lineSeparator() + "Actual: " + actualTexts +
+        lineSeparator() + "Expected: " + expectedTexts +
+        (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
+        lineSeparator() + "Collection: " + collection.description());
+    super.timeoutMs = timeoutMs;
+  }
+}

--- a/src/test/java/com/codeborne/selenide/collections/ItemWithTextTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ItemWithTextTest.java
@@ -1,0 +1,61 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.impl.WebElementsCollection;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static com.codeborne.selenide.Mocks.mockElement;
+
+class ItemWithTextTest implements WithAssertions {
+  private SelenideElement element1 = mockElement("Test-One");
+  private SelenideElement element2 = mockElement("Test-Two");
+  private SelenideElement element3 = mockElement("Test-Three");
+  private WebElementsCollection collection = mockCollection("Collection description", element1, element2, element3);
+
+  @Test
+  void applyOnCorrectElementText() {
+    assertThat(new ItemWithText("Test-One")
+      .test(collection.getElements()))
+      .isTrue();
+  }
+
+  @Test
+  void applyOnWrongElementText() {
+    assertThat(new ItemWithText("Test-X")
+      .test(collection.getElements()))
+      .isFalse();
+  }
+
+  @Test
+  void testToString() {
+    assertThat(new ItemWithText("Test-One"))
+      .hasToString("Text Test-One");
+  }
+
+  @Test
+  void testApplyWithEmptyList() {
+    WebElementsCollection emptyCollection = mockCollection("empty collection");
+    assertThat(new ItemWithText("Test-X")
+      .test(emptyCollection.getElements()))
+      .isFalse();
+  }
+
+  @Test
+  void failOnMatcherError() {
+    String expectedText = "Won't exist";
+    assertThatThrownBy(() -> new ItemWithText(expectedText)
+      .fail(collection,
+        collection.getElements(),
+        new Exception("Exception message"), 10000)).isInstanceOf(TextsMismatch.class)
+      .hasMessageContaining(
+        String.format(String.format("Texts mismatch" +
+          "%nActual: %s" +
+          "%nExpected: %s", ElementsCollection.texts(collection.getElements()), Collections.singletonList(expectedText))));
+  }
+}

--- a/src/test/java/com/codeborne/selenide/collections/ItemWithTextTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ItemWithTextTest.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.collections;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementWithTextNotFound;
-import com.codeborne.selenide.ex.TextsMismatch;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/codeborne/selenide/collections/ItemWithTextTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ItemWithTextTest.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.collections;
 
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementWithTextNotFound;
 import com.codeborne.selenide.ex.TextsMismatch;
 import com.codeborne.selenide.impl.WebElementsCollection;
 import org.assertj.core.api.WithAssertions;
@@ -52,9 +53,9 @@ class ItemWithTextTest implements WithAssertions {
     assertThatThrownBy(() -> new ItemWithText(expectedText)
       .fail(collection,
         collection.getElements(),
-        new Exception("Exception message"), 10000)).isInstanceOf(TextsMismatch.class)
+        new Exception("Exception message"), 10000)).isInstanceOf(ElementWithTextNotFound.class)
       .hasMessageContaining(
-        String.format(String.format("Texts mismatch" +
+        String.format(String.format("Element with text not found" +
           "%nActual: %s" +
           "%nExpected: %s", ElementsCollection.texts(collection.getElements()), Collections.singletonList(expectedText))));
   }

--- a/src/test/java/com/codeborne/selenide/ex/ElementWithTextNotFoundTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementWithTextNotFoundTest.java
@@ -1,0 +1,46 @@
+package com.codeborne.selenide.ex;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static java.util.Arrays.asList;
+
+public class ElementWithTextNotFoundTest implements WithAssertions {
+  private final List<String> actualTexts = asList("Niff", "Naff", "Nuff");
+  private final List<String> expectedTexts = asList("Piff", "Paff", "Puff");
+
+  @Test
+  void errorMessage() {
+    ElementWithTextNotFound elementWithTextNotFound = new ElementWithTextNotFound(mockCollection(".characters"),
+      actualTexts,
+      expectedTexts,
+      null, 9000);
+
+    assertThat(elementWithTextNotFound).hasMessage(String.format("Element with text not found%n" +
+      "Actual: [Niff, Naff, Nuff]%n" +
+      "Expected: [Piff, Paff, Puff]%n" +
+      "Collection: .characters%n" +
+      "Screenshot: null%n" +
+      "Timeout: 9 s."));
+  }
+
+  @Test
+  void errorMessageWithExplanation() {
+    ElementWithTextNotFound elementWithTextNotFound = new ElementWithTextNotFound(mockCollection(".characters"),
+      actualTexts,
+      expectedTexts,
+      "we expect favorite characters", 9000);
+
+    assertThat(elementWithTextNotFound).hasMessage(String.format("Element with text not found%n" +
+      "Actual: [Niff, Naff, Nuff]%n" +
+      "Expected: [Piff, Paff, Puff]%n" +
+      "Because: we expect favorite characters%n" +
+      "Collection: .characters%n" +
+      "Screenshot: null%n" +
+      "Timeout: 9 s."));
+
+  }
+}

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -6,6 +6,7 @@ import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.MatcherError;
 import com.codeborne.selenide.ex.TextsMismatch;
 import com.codeborne.selenide.ex.TextsSizeMismatch;
+import com.codeborne.selenide.ex.ElementWithTextNotFound;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -473,17 +474,17 @@ class CollectionMethodsTest extends ITest {
 
   @Test
   void shouldItemWithText() {
-    $$("#user-table tbody tr  td.firstname")
+    $$("#user-table tbody tr td.firstname")
       .shouldBe(itemWithText("Bob"));
   }
 
   @Test
   void errorWhenItemWithTextNotMatchedButShouldBe() {
     String expectedText = "Luis";
-    assertThatThrownBy(()  -> $$("#user-table tbody tr  td.firstname").shouldBe(itemWithText(expectedText)))
-      .isInstanceOf(TextsMismatch.class)
+    assertThatThrownBy(()  -> $$("#user-table tbody tr td.firstname").shouldHave(itemWithText(expectedText)))
+      .isInstanceOf(ElementWithTextNotFound.class)
       .hasMessageContaining(
-        String.format(String.format("Texts mismatch" +
+        String.format(String.format("Element with text not found" +
           "%nActual: %s" +
           "%nExpected: %s", Arrays.asList("Bob", "John"), Collections.singletonList(expectedText))));
   }

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -15,12 +15,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static com.codeborne.selenide.CollectionCondition.allMatch;
 import static com.codeborne.selenide.CollectionCondition.anyMatch;
 import static com.codeborne.selenide.CollectionCondition.empty;
 import static com.codeborne.selenide.CollectionCondition.exactTexts;
 import static com.codeborne.selenide.CollectionCondition.noneMatch;
+import static com.codeborne.selenide.CollectionCondition.itemWithText;
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
@@ -388,6 +391,10 @@ class CollectionMethodsTest extends ITest {
     assertThatThrownBy(() -> elementsCollection.shouldHave(texts("any text")))
       .as(description, "texts").isInstanceOf(ElementNotFound.class)
       .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
+
+    assertThatThrownBy(() -> elementsCollection.shouldHave(itemWithText("any text")))
+      .as(description, "itemWithText").isInstanceOf(ElementNotFound.class)
+      .hasCauseExactlyInstanceOf(IndexOutOfBoundsException.class);
   }
 
   @Test
@@ -462,6 +469,23 @@ class CollectionMethodsTest extends ITest {
       .isInstanceOf(MatcherError.class)
       .hasMessageContaining(String.format("Collection matcher error" +
         "%nExpected: none of elements to match [value==cat] predicate"));
+  }
+
+  @Test
+  void shouldItemWithText() {
+    $$("#user-table tbody tr  td.firstname")
+      .shouldBe(itemWithText("Bob"));
+  }
+
+  @Test
+  void errorWhenItemWithTextNotMatchedButShouldBe() {
+    String expectedText = "Luis";
+    assertThatThrownBy(()  -> $$("#user-table tbody tr  td.firstname").shouldBe(itemWithText(expectedText)))
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageContaining(
+        String.format(String.format("Texts mismatch" +
+          "%nActual: %s" +
+          "%nExpected: %s", Arrays.asList("Bob", "John"), Collections.singletonList(expectedText))));
   }
 
 }


### PR DESCRIPTION
## Proposed changes
Added new collection condition to match if an item from the collection has the expected text
Example:
`$$("#user-table tbody tr  td.firstname").shouldBe(itemWithText("Bob"));`

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
