### PR TITLE
#1206 write webdriver log to a file

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -8,10 +8,13 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.Integer.parseInt;
+import static java.lang.System.currentTimeMillis;
+import static java.lang.management.ManagementFactory.getRuntimeMXBean;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
@@ -24,6 +27,18 @@ public abstract class AbstractDriverFactory implements DriverFactory {
   private static final Logger log = LoggerFactory.getLogger(AbstractDriverFactory.class);
   private static final Pattern REGEX_SIGNED_INTEGER = Pattern.compile("^-?\\d+$");
   private static final Pattern REGEX_VERSION = Pattern.compile("(\\d+)(\\..*)?");
+
+  protected File webdriverLog(Config config) {
+    String pid = getRuntimeMXBean().getName().replaceFirst("(.*)@.*", "$1");
+    File logFolder = new File(config.reportsFolder());
+    if (!logFolder.exists()) {
+      logFolder.mkdirs();
+    }
+    String logFileName = String.format("%sdriver.%s_%s.log", config.browser(), currentTimeMillis(), pid);
+    File logFile = new File(logFolder, logFileName);
+    log.info("Write webdriver logs to: {}", logFile.getAbsolutePath());
+    return logFile;
+  }
 
   protected MutableCapabilities createCommonCapabilities(Config config, Browser browser, Proxy proxy) {
     DesiredCapabilities capabilities = new DesiredCapabilities();

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -44,11 +44,13 @@ public class ChromeDriverFactory extends AbstractDriverFactory {
   public WebDriver create(Config config, Browser browser, Proxy proxy) {
     MutableCapabilities chromeOptions = createCapabilities(config, browser, proxy);
     log.debug("Chrome options: {}", chromeOptions);
-    return new ChromeDriver(buildService(), chromeOptions);
+    return new ChromeDriver(buildService(config), chromeOptions);
   }
 
-  protected ChromeDriverService buildService() {
-    return ChromeDriverService.createDefaultService();
+  protected ChromeDriverService buildService(Config config) {
+    return new ChromeDriverService.Builder()
+      .withLogFile(webdriverLog(config))
+      .build();
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeDriverService;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +31,13 @@ public class EdgeDriverFactory extends AbstractDriverFactory {
   @Override
   public WebDriver create(Config config, Browser browser, Proxy proxy) {
     EdgeOptions options = createCapabilities(config, browser, proxy);
-    return new EdgeDriver(options);
+    return new EdgeDriver(createDriverService(config), options);
+  }
+
+  private EdgeDriverService createDriverService(Config config) {
+    return new EdgeDriverService.Builder()
+      .withLogFile(webdriverLog(config))
+      .build();
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.firefox.GeckoDriverService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,9 +35,14 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
 
   @Override
   public WebDriver create(Config config, Browser browser, Proxy proxy) {
-    String logFilePath = System.getProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
-    System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, logFilePath);
-    return new FirefoxDriver(createCapabilities(config, browser, proxy));
+    return new FirefoxDriver(createDriverService(config), createCapabilities(config, browser, proxy));
+  }
+
+  protected GeckoDriverService createDriverService(Config config) {
+    File logFile = webdriverLog(config);
+    return new GeckoDriverService.Builder()
+      .withLogFile(logFile)
+      .build();
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.opera.OperaDriver;
+import org.openqa.selenium.opera.OperaDriverService;
 import org.openqa.selenium.opera.OperaOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +24,13 @@ public class OperaDriverFactory extends AbstractDriverFactory {
 
   @Override
   public WebDriver create(Config config, Browser browser, Proxy proxy) {
-    return new OperaDriver(createCapabilities(config, browser, proxy));
+    return new OperaDriver(createDriverService(config), createCapabilities(config, browser, proxy));
+  }
+
+  private OperaDriverService createDriverService(Config config) {
+    return new OperaDriverService.Builder()
+      .withLogFile(webdriverLog(config))
+      .build();
   }
 
   @Override

--- a/statics/src/test/java/integration/ChromeProfileByFactoryTest.java
+++ b/statics/src/test/java/integration/ChromeProfileByFactoryTest.java
@@ -66,7 +66,7 @@ class ChromeProfileByFactoryTest extends IntegrationTest {
 
   private static class MyFactory extends ChromeDriverFactory {
     @Override
-    protected ChromeDriverService buildService() {
+    protected ChromeDriverService buildService(Config config) {
       return new ChromeDriverService.Builder()
         .withLogFile(chromedriverLog)
         .withVerbose(true)


### PR DESCRIPTION
* by default, it's located in "build/reports/tests"  (see Configuration.reportsFolder)
* currently only chrome, firefox, edge, opera are supported

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
