### PR TITLE
#1212 support downloading files to FOLDER for Opera browser

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -49,11 +49,12 @@ public class EdgeDriverFactory extends AbstractDriverFactory {
   }
 
   private void setDownloadsFolder(Config config, EdgeDriverService driverService, EdgeDriver driver) {
+    String downloadsFolder = downloadsFolder(config);
     try {
-      cdpClient.setDownloadsFolder(driverService, driver, downloadsFolder(config));
+      cdpClient.setDownloadsFolder(driverService, driver, downloadsFolder);
     }
     catch (RuntimeException e) {
-      log.error("Failed to set downloads folder");
+      log.error("Failed to set downloads folder to {}", downloadsFolder, e);
     }
   }
 


### PR DESCRIPTION
* the only way to configure downloads folder for Opera is using CDP
* (Opera is based on chromium since version 15, year 2013)

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
