### PR TITLE
Unique downloads folder for every browser

### DIFF
--- a/.upload_reports.sh
+++ b/.upload_reports.sh
@@ -14,14 +14,14 @@ FAILURE_MESSAGE="\nBUILD FAILED. PLEASE READ CHECKSTYLE AND TEST RESULT REPORTS 
 SUCCESS_MESSAGE="\nYOU CAN FIND TEST RESULTS REPORTS ON THE LINK ABOVE\n"
 
 echo "COMPRESSING build artifacts."
-cd ${ARTIFACTS_DIR}
-tar -zcf ${ARTIFACTS_FILE} *
+cd "${ARTIFACTS_DIR}" || exit 2
+tar -zcf "${ARTIFACTS_FILE}" *
 
 echo "Uploading build artifacts"
-curl --upload-file ${ARTIFACTS_FILE} https://transfer.sh/
+curl -F "file=@${ARTIFACTS_FILE}" -s -w "\n"  https://file.io
 if [ $TRAVIS_TEST_RESULT -eq 0 ];
 then
-	echo -e ${SUCCESS_MESSAGE}
+	echo -e "${SUCCESS_MESSAGE}"
 else
-	echo -e ${FAILURE_MESSAGE}
+	echo -e "${FAILURE_MESSAGE}"
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 5.14.0
+* #1220 create a unique downloads folder for every browser instance  --  see PR #1221
 * #1194 added method `$$.shouldHave(itemWithText("any text"))`  --  thanks to Luis Serna for PR #1194
 * #1166 added method `SelenideDriver.screenshot(fileName)`  --  see PR #1227
 * #1224 added method `SelenideDriver.screenshot(OutputType)`  --  see PR #1231 

--- a/src/main/java/com/codeborne/selenide/Driver.java
+++ b/src/main/java/com/codeborne/selenide/Driver.java
@@ -5,6 +5,8 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
 
+import java.io.File;
+
 public interface Driver {
   Config config();
   Browser browser();
@@ -12,6 +14,7 @@ public interface Driver {
   WebDriver getWebDriver();
   SelenideProxyServer getProxy();
   WebDriver getAndCheckWebDriver();
+  File browserDownloadsFolder();
   void close();
 
   default boolean supportsJavascript() {

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -36,7 +36,7 @@ import static java.util.Collections.emptyList;
 @ParametersAreNonnullByDefault
 public class SelenideDriver {
   private static final Navigator navigator = new Navigator();
-  private static ScreenShotLaboratory screenshots = ScreenShotLaboratory.getInstance();
+  private static final ScreenShotLaboratory screenshots = ScreenShotLaboratory.getInstance();
 
   private final Config config;
   private final Driver driver;
@@ -56,7 +56,12 @@ public class SelenideDriver {
 
   public SelenideDriver(Config config, WebDriver webDriver, @Nullable SelenideProxyServer selenideProxy) {
     this.config = config;
-    this.driver = new WebDriverWrapper(config, webDriver, selenideProxy);
+    this.driver = new WebDriverWrapper(config, webDriver, selenideProxy, new File(config.downloadsFolder()));
+  }
+
+  public SelenideDriver(Config config, WebDriver webDriver, @Nullable SelenideProxyServer selenideProxy, File browserDownloadsFolder) {
+    this.config = config;
+    this.driver = new WebDriverWrapper(config, webDriver, selenideProxy, browserDownloadsFolder);
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/drivercommands/CreateDriverCommand.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/CreateDriverCommand.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.drivercommands;
 
 import com.codeborne.selenide.Config;
+import com.codeborne.selenide.impl.FileNamer;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
 import com.codeborne.selenide.webdriver.WebDriverFactory;
 import org.openqa.selenium.Proxy;
@@ -13,13 +14,24 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 import java.util.List;
 
+import static com.codeborne.selenide.impl.FileHelper.ensureFolderExists;
 import static java.lang.Thread.currentThread;
 
 @ParametersAreNonnullByDefault
 public class CreateDriverCommand {
   private static final Logger log = LoggerFactory.getLogger(CreateDriverCommand.class);
+  private final FileNamer fileNamer;
+
+  public CreateDriverCommand() {
+    this(new FileNamer());
+  }
+
+  CreateDriverCommand(FileNamer fileNamer) {
+    this.fileNamer = fileNamer;
+  }
 
   @Nonnull
   public Result createDriver(Config config,
@@ -47,7 +59,9 @@ public class CreateDriverCommand {
       }
     }
 
-    WebDriver webdriver = factory.createWebDriver(config, browserProxy);
+    File browserDownloadsFolder = ensureFolderExists(new File(config.downloadsFolder(), fileNamer.generateFileName()));
+
+    WebDriver webdriver = factory.createWebDriver(config, browserProxy, browserDownloadsFolder);
 
     log.info("Create webdriver in current thread {}: {} -> {}",
       currentThread().getId(), webdriver.getClass().getSimpleName(), webdriver);
@@ -56,7 +70,7 @@ public class CreateDriverCommand {
     Runtime.getRuntime().addShutdownHook(
       new Thread(new SelenideDriverFinalCleanupThread(config, webDriver, selenideProxyServer))
     );
-    return new Result(webDriver, selenideProxyServer);
+    return new Result(webDriver, selenideProxyServer, browserDownloadsFolder);
   }
 
   @Nonnull
@@ -76,10 +90,12 @@ public class CreateDriverCommand {
   public static class Result {
     public final WebDriver webDriver;
     public final SelenideProxyServer selenideProxyServer;
+    public final File browserDownloadsFolder;
 
-    public Result(WebDriver webDriver, @Nullable SelenideProxyServer selenideProxyServer) {
+    public Result(WebDriver webDriver, @Nullable SelenideProxyServer selenideProxyServer, File browserDownloadsFolder) {
       this.webDriver = webDriver;
       this.selenideProxyServer = selenideProxyServer;
+      this.browserDownloadsFolder = browserDownloadsFolder;
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/drivercommands/LazyDriver.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/LazyDriver.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,6 +40,7 @@ public class LazyDriver implements Driver {
   private boolean closed;
   private WebDriver webDriver;
   private SelenideProxyServer selenideProxyServer;
+  private File browserDownloadsFolder;
 
   public LazyDriver(Config config, @Nullable Proxy userProvidedProxy, List<WebDriverEventListener> listeners) {
     this(config, userProvidedProxy, listeners, new WebDriverFactory(), new BrowserHealthChecker(),
@@ -109,10 +111,16 @@ public class LazyDriver implements Driver {
     return getWebDriver();
   }
 
+  @Override
+  public File browserDownloadsFolder() {
+    return browserDownloadsFolder;
+  }
+
   void createDriver() {
     CreateDriverCommand.Result result = createDriverCommand.createDriver(config, factory, userProvidedProxy, listeners);
     this.webDriver = result.webDriver;
     this.selenideProxyServer = result.selenideProxyServer;
+    this.browserDownloadsFolder = result.browserDownloadsFolder;
     this.closed = false;
   }
 
@@ -121,6 +129,7 @@ public class LazyDriver implements Driver {
     closeDriverCommand.closeAsync(config, webDriver, selenideProxyServer);
     webDriver = null;
     selenideProxyServer = null;
+    browserDownloadsFolder = null;
     closed = true;
   }
 }

--- a/src/main/java/com/codeborne/selenide/drivercommands/WebDriverWrapper.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/WebDriverWrapper.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 
 import static java.util.Objects.requireNonNull;
 
@@ -26,21 +27,25 @@ public class WebDriverWrapper implements Driver {
   private final Config config;
   private final WebDriver webDriver;
   private final SelenideProxyServer selenideProxy;
+  private final File browserDownloadsFolder;
   private final BrowserHealthChecker browserHealthChecker;
   private final CloseDriverCommand closeDriverCommand;
 
-  public WebDriverWrapper(Config config, WebDriver webDriver, @Nullable SelenideProxyServer selenideProxy) {
-    this(config, webDriver, selenideProxy, new BrowserHealthChecker(), new CloseDriverCommand());
+  public WebDriverWrapper(Config config, WebDriver webDriver,
+                          @Nullable SelenideProxyServer selenideProxy, File browserDownloadsFolder) {
+    this(config, webDriver, selenideProxy, browserDownloadsFolder, new BrowserHealthChecker(), new CloseDriverCommand());
   }
 
-  private WebDriverWrapper(Config config, WebDriver webDriver, @Nullable SelenideProxyServer selenideProxy,
-                   BrowserHealthChecker browserHealthChecker, CloseDriverCommand closeDriverCommand) {
+  private WebDriverWrapper(Config config, WebDriver webDriver,
+                           @Nullable SelenideProxyServer selenideProxy, File browserDownloadsFolder,
+                           BrowserHealthChecker browserHealthChecker, CloseDriverCommand closeDriverCommand) {
     requireNonNull(config, "config must not be null");
     requireNonNull(webDriver, "webDriver must not be null");
 
     this.config = config;
     this.webDriver = webDriver;
     this.selenideProxy = selenideProxy;
+    this.browserDownloadsFolder = browserDownloadsFolder;
     this.browserHealthChecker = browserHealthChecker;
     this.closeDriverCommand = closeDriverCommand;
   }
@@ -85,9 +90,14 @@ public class WebDriverWrapper implements Driver {
     return webDriver;
   }
 
+  @Override
+  public File browserDownloadsFolder() {
+    return browserDownloadsFolder;
+  }
+
   /**
    * Close the webdriver.
-   *
+   * <p>
    * NB! The behaviour was changed in Selenide 5.4.0
    * Even if webdriver was created by user - it will be closed.
    * It may hurt if you try to use this browser after closing.

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Config;
+import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.files.FileFilter;
 import com.codeborne.selenide.proxy.DownloadedFile;
 import org.openqa.selenium.WebDriver;
@@ -55,8 +56,9 @@ public class DownloadFileToFolder {
   private File clickAndWaitForNewFilesInDownloadsFolder(WebElementSource anyClickableElement, WebElement clickable,
                                                         long timeout,
                                                         FileFilter fileFilter) throws FileNotFoundException {
-    Config config = anyClickableElement.driver().config();
-    File folder = new File(config.downloadsFolder());
+    Driver driver = anyClickableElement.driver();
+    Config config = driver.config();
+    File folder = driver.browserDownloadsFolder();
 
     PreviousDownloadsCompleted previousFiles = new PreviousDownloadsCompleted();
     waiter.wait(folder, previousFiles, timeout, config.pollingInterval());

--- a/src/main/java/com/codeborne/selenide/impl/Downloader.java
+++ b/src/main/java/com/codeborne/selenide/impl/Downloader.java
@@ -7,6 +7,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 
+import static com.codeborne.selenide.impl.FileHelper.ensureFolderExists;
+
 @ParametersAreNonnullByDefault
 public class Downloader {
   private final Randomizer random;
@@ -32,10 +34,7 @@ public class Downloader {
     if (uniqueFolder.exists()) {
       throw new IllegalStateException("Unbelievable! Unique folder already exists: " + uniqueFolder.getAbsolutePath());
     }
-    if (!uniqueFolder.mkdirs()) {
-      throw new RuntimeException("Failed to create folder " + uniqueFolder.getAbsolutePath());
-    }
-
+    ensureFolderExists(uniqueFolder);
     return new File(uniqueFolder, fileName);
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/FileHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileHelper.java
@@ -3,12 +3,15 @@ package com.codeborne.selenide.impl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
+import static org.apache.commons.io.FileUtils.cleanDirectory;
 
 @ParametersAreNonnullByDefault
 public final class FileHelper {
@@ -24,7 +27,7 @@ public final class FileHelper {
   }
 
   public static void copyFile(InputStream in, File targetFile) throws IOException {
-    ensureFolderExists(targetFile);
+    ensureParentFolderExists(targetFile);
 
     try (FileOutputStream out = new FileOutputStream(targetFile)) {
       byte[] buffer = new byte[1024];
@@ -35,13 +38,24 @@ public final class FileHelper {
     }
   }
 
-  private static void ensureFolderExists(File targetFile) {
-    File folder = targetFile.getParentFile();
+  public static void ensureParentFolderExists(File targetFile) {
+    ensureFolderExists(targetFile.getParentFile());
+  }
+
+  @Nonnull
+  public static File ensureFolderExists(File folder) {
     if (!folder.exists()) {
-      log.info("Creating folder: {}", folder);
+      log.info("Creating folder: {}", folder.getAbsolutePath());
       if (!folder.mkdirs()) {
-        log.error("Failed to create {}", folder);
+        log.error("Failed to create folder: {}", folder.getAbsolutePath());
       }
+    }
+    return folder;
+  }
+
+  public static void cleanupFolder(File folder) throws IOException {
+    if (folder.isDirectory()) {
+      cleanDirectory(folder);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/FileNamer.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileNamer.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.impl;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import java.util.regex.Pattern;
+
+import static java.lang.Thread.currentThread;
+import static java.lang.management.ManagementFactory.getRuntimeMXBean;
+
+public class FileNamer {
+  private static final Pattern REGEX_MXBEAN_NAME = Pattern.compile("(.*)@.*");
+
+  /**
+   * Creates a unique name for a file (to some extent).
+   * Name starts with a current time, making it (more or less) easy to sort those files and find something.
+   */
+  @CheckReturnValue
+  @Nonnull
+  public String generateFileName() {
+    return String.format("%s_%s_%s", System.currentTimeMillis(), pid(), currentThread().getId());
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  private String pid() {
+    return REGEX_MXBEAN_NAME.matcher(getRuntimeMXBean().getName()).replaceFirst("$1");
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+import static com.codeborne.selenide.impl.FileHelper.ensureParentFolderExists;
 import static java.io.File.separatorChar;
 import static java.lang.ThreadLocal.withInitial;
 import static java.util.Collections.emptyList;
@@ -186,16 +187,6 @@ public class ScreenShotLaboratory {
     return currentContext.get() + timestamp() + "." + screenshotCounter.getAndIncrement();
   }
 
-  protected void ensureFolderExists(File targetFile) {
-    File folder = targetFile.getParentFile();
-    if (!folder.exists()) {
-      log.info("Creating folder: {}", folder);
-      if (!folder.mkdirs()) {
-        log.error("Failed to create {}", folder);
-      }
-    }
-  }
-
   protected long timestamp() {
     return System.currentTimeMillis();
   }
@@ -218,7 +209,7 @@ public class ScreenShotLaboratory {
   @Nonnull
   private File writeToFile(Driver driver, BufferedImage destination) throws IOException {
     File screenshotOfElement = new File(driver.config().reportsFolder(), generateScreenshotFileName() + ".png");
-    ensureFolderExists(screenshotOfElement);
+    ensureParentFolderExists(screenshotOfElement);
     ImageIO.write(destination, "png", screenshotOfElement);
     return screenshotOfElement;
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.codeborne.selenide.impl.FileHelper.ensureFolderExists;
 import static java.lang.Integer.parseInt;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
@@ -36,13 +37,8 @@ public abstract class AbstractDriverFactory implements DriverFactory {
   @CheckReturnValue
   @Nonnull
   protected File webdriverLog(Config config) {
-    File logFolder = new File(config.reportsFolder());
-    if (!logFolder.exists()) {
-      if (!logFolder.mkdirs()) {
-        log.warn("Failed to create folder for webdriver logs: {}", logFolder.getAbsolutePath());
-      }
-    }
-    String logFileName = String.format("webdriver.%s_%s_%s.log", currentTimeMillis(), pid(), currentThread().getId());
+    File logFolder = ensureFolderExists(new File(config.reportsFolder()));
+    String logFileName = String.format("webdriver.%s.log", fileNamer.generateFileName());
     File logFile = new File(logFolder, logFileName);
     log.info("Write webdriver logs to: {}", logFile.getAbsolutePath());
     return logFile;

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Config;
+import com.codeborne.selenide.impl.FileNamer;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -17,9 +18,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.Integer.parseInt;
-import static java.lang.System.currentTimeMillis;
-import static java.lang.Thread.currentThread;
-import static java.lang.management.ManagementFactory.getRuntimeMXBean;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
@@ -33,7 +31,7 @@ public abstract class AbstractDriverFactory implements DriverFactory {
   private static final Logger log = LoggerFactory.getLogger(AbstractDriverFactory.class);
   private static final Pattern REGEX_SIGNED_INTEGER = Pattern.compile("^-?\\d+$");
   private static final Pattern REGEX_VERSION = Pattern.compile("(\\d+)(\\..*)?");
-  private static final Pattern REGEX_MXBEAN_NAME = Pattern.compile("(.*)@.*");
+  private final FileNamer fileNamer = new FileNamer();
 
   @CheckReturnValue
   @Nonnull
@@ -72,12 +70,6 @@ public abstract class AbstractDriverFactory implements DriverFactory {
 
     transferCapabilitiesFromSystemProperties(capabilities);
     return new MergeableCapabilities(capabilities, config.browserCapabilities());
-  }
-
-  @CheckReturnValue
-  @Nonnull
-  protected String downloadsFolder(Config config) {
-    return new File(config.downloadsFolder()).getAbsolutePath();
   }
 
   protected void transferCapabilitiesFromSystemProperties(DesiredCapabilities currentBrowserCapabilities) {
@@ -131,11 +123,5 @@ public abstract class AbstractDriverFactory implements DriverFactory {
     if (isBlank(browserVersion)) return 0;
     Matcher matcher = REGEX_VERSION.matcher(browserVersion);
     return matcher.matches() ? parseInt(matcher.replaceFirst("$1")) : 0;
-  }
-
-  @CheckReturnValue
-  @Nonnull
-  protected String pid() {
-    return REGEX_MXBEAN_NAME.matcher(getRuntimeMXBean().getName()).replaceFirst("$1");
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/CdpClient.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/CdpClient.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
@@ -21,11 +22,11 @@ import java.net.URL;
 public class CdpClient {
   private static final Logger log = LoggerFactory.getLogger(CdpClient.class);
 
-  public void setDownloadsFolder(DriverService driverService, RemoteWebDriver driver, String downloadsFolder) {
+  public void setDownloadsFolder(DriverService driverService, RemoteWebDriver driver, File downloadsFolder) {
     setDownloadsFolder(driverService.getUrl(), driver.getSessionId(), downloadsFolder);
   }
 
-  public void setDownloadsFolder(URL remoteDriverUrl, SessionId driverSessionId, String downloadsFolder) {
+  public void setDownloadsFolder(URL remoteDriverUrl, SessionId driverSessionId, File downloadsFolder) {
     try {
       String command = command(downloadsFolder);
       post(remoteDriverUrl, driverSessionId, command);
@@ -39,12 +40,12 @@ public class CdpClient {
 
   @CheckReturnValue
   @Nonnull
-  private String command(String downloadsFolder) {
+  private String command(File downloadsFolder) {
     return "{" +
         "  \"cmd\": \"Page.setDownloadBehavior\",\n" +
         "  \"params\": {\n" +
         "    \"behavior\": \"allow\", \n" +
-        "    \"downloadPath\": \"" + escapeForJson(downloadsFolder) + "\"\n" +
+        "    \"downloadPath\": \"" + escapeForJson(downloadsFolder.getAbsolutePath()) + "\"\n" +
         "  }\n" +
         "}";
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/DefaultDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/DefaultDriverFactory.java
@@ -13,6 +13,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
@@ -25,15 +26,16 @@ public class DefaultDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy) {
-    return createInstanceOf(config.browser(), config, browser, proxy);
+  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
+    return createInstanceOf(config.browser(), config, browser, proxy, browserDownloadsFolder);
   }
 
   @CheckReturnValue
   @Nonnull
-  private WebDriver createInstanceOf(String className, Config config, Browser browser, @Nullable Proxy proxy) {
+  private WebDriver createInstanceOf(String className, Config config, Browser browser,
+                                     @Nullable Proxy proxy, File browserDownloadsFolder) {
     try {
-      Capabilities capabilities = createCapabilities(config, browser, proxy);
+      Capabilities capabilities = createCapabilities(config, browser, proxy, browserDownloadsFolder);
 
       Class<?> clazz = Class.forName(className);
       if (WebDriverProvider.class.isAssignableFrom(clazz)) {
@@ -44,7 +46,7 @@ public class DefaultDriverFactory extends AbstractDriverFactory {
         if (config.driverManagerEnabled()) {
           factory.setupWebdriverBinary();
         }
-        return factory.create(config, browser, proxy);
+        return factory.create(config, browser, proxy, browserDownloadsFolder);
       }
       else {
         Constructor<?> constructor = Class.forName(className).getConstructor(Capabilities.class);
@@ -60,7 +62,7 @@ public class DefaultDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public MutableCapabilities createCapabilities(Config config, Browser browser, @Nullable Proxy proxy) {
+  public MutableCapabilities createCapabilities(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
     return createCommonCapabilities(config, browser, proxy);
   }
 

--- a/src/main/java/com/codeborne/selenide/webdriver/DriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/DriverFactory.java
@@ -9,15 +9,16 @@ import org.openqa.selenium.WebDriver;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.File;
 
 public interface DriverFactory {
   void setupWebdriverBinary();
 
   @CheckReturnValue
   @Nonnull
-  MutableCapabilities createCapabilities(Config config, Browser browser, @Nullable Proxy proxy);
+  MutableCapabilities createCapabilities(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder);
 
   @CheckReturnValue
   @Nonnull
-  WebDriver create(Config config, Browser browser, @Nullable Proxy proxy);
+  WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder);
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -17,6 +17,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import java.io.File;
+
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 
 @ParametersAreNonnullByDefault
@@ -38,12 +40,12 @@ public class EdgeDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy) {
-    EdgeOptions options = createCapabilities(config, browser, proxy);
+  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
+    EdgeOptions options = createCapabilities(config, browser, proxy, browserDownloadsFolder);
     EdgeDriverService driverService = createDriverService(config);
     EdgeDriver driver = new EdgeDriver(driverService, options);
     if (isChromiumBased()) {
-      cdpClient.setDownloadsFolder(driverService, driver, downloadsFolder(config));
+      cdpClient.setDownloadsFolder(driverService, driver, browserDownloadsFolder);
     }
     return driver;
   }
@@ -57,7 +59,7 @@ public class EdgeDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public EdgeOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy) {
+  public EdgeOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
     MutableCapabilities capabilities = createCommonCapabilities(config, browser, proxy);
     if (isChromiumBased()) {
       capabilities.setCapability(ACCEPT_INSECURE_CERTS, true);

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -41,8 +41,8 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy) {
-    return new FirefoxDriver(createDriverService(config), createCapabilities(config, browser, proxy));
+  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
+    return new FirefoxDriver(createDriverService(config), createCapabilities(config, browser, proxy, browserDownloadsFolder));
   }
 
   @CheckReturnValue
@@ -57,14 +57,14 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public FirefoxOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy) {
+  public FirefoxOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
     FirefoxOptions firefoxOptions = new FirefoxOptions();
     firefoxOptions.setHeadless(config.headless());
     setupBrowserBinary(config, firefoxOptions);
     setupPreferences(firefoxOptions);
     firefoxOptions.merge(createCommonCapabilities(config, browser, proxy));
 
-    setupDownloadsFolder(config, firefoxOptions);
+    setupDownloadsFolder(config, firefoxOptions, browserDownloadsFolder);
 
     Map<String, String> ffProfile = collectFirefoxProfileFromSystemProperties();
     if (!ffProfile.isEmpty()) {
@@ -91,9 +91,9 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
     firefoxOptions.addPreference("network.proxy.allow_hijacking_localhost", true);
   }
 
-  protected void setupDownloadsFolder(Config config, FirefoxOptions firefoxOptions) {
+  protected void setupDownloadsFolder(Config config, FirefoxOptions firefoxOptions, File browserDownloadsFolder) {
     if (config.remote() == null) {
-      firefoxOptions.addPreference("browser.download.dir", new File(config.downloadsFolder()).getAbsolutePath());
+      firefoxOptions.addPreference("browser.download.dir", browserDownloadsFolder.getAbsolutePath());
     }
     firefoxOptions.addPreference("browser.helperApps.neverAsk.saveToDisk", popularContentTypes());
     firefoxOptions.addPreference("pdfjs.disabled", true);  // disable the built-in viewer

--- a/src/main/java/com/codeborne/selenide/webdriver/InternetExplorerDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/InternetExplorerDriverFactory.java
@@ -15,6 +15,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 
 @ParametersAreNonnullByDefault
 public class InternetExplorerDriverFactory extends AbstractDriverFactory {
@@ -30,15 +31,16 @@ public class InternetExplorerDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy) {
-    InternetExplorerOptions options = createCapabilities(config, browser, proxy);
+  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
+    InternetExplorerOptions options = createCapabilities(config, browser, proxy, browserDownloadsFolder);
     return new InternetExplorerDriver(options);
   }
 
   @Override
   @CheckReturnValue
   @Nonnull
-  public InternetExplorerOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy) {
+  public InternetExplorerOptions createCapabilities(Config config, Browser browser,
+                                                    @Nullable Proxy proxy, File browserDownloadsFolder) {
     Capabilities capabilities = createCommonCapabilities(config, browser, proxy);
     InternetExplorerOptions options = new InternetExplorerOptions(capabilities);
     if (!config.browserBinary().isEmpty()) {

--- a/src/main/java/com/codeborne/selenide/webdriver/LegacyFirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/LegacyFirefoxDriverFactory.java
@@ -9,6 +9,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 
 @ParametersAreNonnullByDefault
 public class LegacyFirefoxDriverFactory extends FirefoxDriverFactory {
@@ -20,8 +21,8 @@ public class LegacyFirefoxDriverFactory extends FirefoxDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public FirefoxOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy) {
-    FirefoxOptions firefoxOptions = super.createCapabilities(config, browser, proxy);
+  public FirefoxOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
+    FirefoxOptions firefoxOptions = super.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     firefoxOptions.setLegacy(true);
     return firefoxOptions;
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
@@ -16,6 +16,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 
 @ParametersAreNonnullByDefault
 public class OperaDriverFactory extends AbstractDriverFactory {
@@ -32,11 +33,11 @@ public class OperaDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy) {
+  public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
     OperaDriverService driverService = createDriverService(config);
-    OperaOptions capabilities = createCapabilities(config, browser, proxy);
+    OperaOptions capabilities = createCapabilities(config, browser, proxy, browserDownloadsFolder);
     OperaDriver driver = new OperaDriver(driverService, capabilities);
-    cdpClient.setDownloadsFolder(driverService, driver, downloadsFolder(config));
+    cdpClient.setDownloadsFolder(driverService, driver, browserDownloadsFolder);
     return driver;
   }
 
@@ -49,7 +50,7 @@ public class OperaDriverFactory extends AbstractDriverFactory {
   @Override
   @CheckReturnValue
   @Nonnull
-  public OperaOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy) {
+  public OperaOptions createCapabilities(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
     OperaOptions operaOptions = new OperaOptions();
     if (config.headless()) {
       throw new InvalidArgumentException("headless browser not supported in Opera. Set headless property to false.");

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,15 +44,16 @@ public class WebDriverFactory {
     return result;
   }
 
-  public WebDriver createWebDriver(Config config, Proxy proxy) {
+  public WebDriver createWebDriver(Config config, Proxy proxy, File browserDownloadsFolder) {
     log.debug("browser={}", config.browser());
     log.debug("browser.version={}", config.browserVersion());
     log.debug("remote={}", config.remote());
     log.debug("browserSize={}", config.browserSize());
     log.debug("startMaximized={}", config.startMaximized());
+    log.debug("downloadsFolder={}", browserDownloadsFolder.getAbsolutePath());
 
     Browser browser = new Browser(config.browser(), config.headless());
-    WebDriver webdriver = createWebDriverInstance(config, proxy, browser);
+    WebDriver webdriver = createWebDriverInstance(config, proxy, browser, browserDownloadsFolder);
 
     browserResizer.adjustBrowserSize(config, webdriver);
     browserResizer.adjustBrowserPosition(config, webdriver);
@@ -62,18 +64,18 @@ public class WebDriverFactory {
     return webdriver;
   }
 
-  private WebDriver createWebDriverInstance(Config config, Proxy proxy, Browser browser) {
+  private WebDriver createWebDriverInstance(Config config, Proxy proxy, Browser browser, File browserDownloadsFolder) {
     DriverFactory webdriverFactory = findFactory(browser);
 
     if (config.remote() != null) {
-      MutableCapabilities capabilities = webdriverFactory.createCapabilities(config, browser, proxy);
+      MutableCapabilities capabilities = webdriverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
       return remoteDriverFactory.create(config, browser, capabilities);
     }
     else {
       if (config.driverManagerEnabled()) {
         webdriverFactory.setupWebdriverBinary();
       }
-      return webdriverFactory.create(config, browser, proxy);
+      return webdriverFactory.create(config, browser, proxy, browserDownloadsFolder);
     }
   }
 

--- a/src/test/java/com/codeborne/selenide/DriverStub.java
+++ b/src/test/java/com/codeborne/selenide/DriverStub.java
@@ -5,6 +5,8 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
 
+import java.io.File;
+
 /**
  * A dummy `Driver` implementation used in tests.
  */
@@ -13,6 +15,7 @@ public class DriverStub implements Driver {
   private final Browser browser;
   private final WebDriver webDriver;
   private final SelenideProxyServer proxy;
+  private final File browserDownloadsFolder = new File("build/downloads/45");
 
   public DriverStub() {
     this("zopera");
@@ -57,6 +60,11 @@ public class DriverStub implements Driver {
   @Override
   public WebDriver getAndCheckWebDriver() {
     return webDriver;
+  }
+
+  @Override
+  public File browserDownloadsFolder() {
+    return browserDownloadsFolder;
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/drivercommands/LazyDriverTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/LazyDriverTest.java
@@ -1,12 +1,15 @@
 package com.codeborne.selenide.drivercommands;
 
 import com.codeborne.selenide.Config;
+import com.codeborne.selenide.impl.DummyFileNamer;
 import com.codeborne.selenide.webdriver.WebDriverFactory;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+
+import java.io.File;
 
 import static java.util.Collections.emptyList;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,16 +21,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class LazyDriverTest implements WithAssertions {
-  private Config config = mock(Config.class);
-  private WebDriver webdriver = mock(WebDriver.class);
-  private WebDriverFactory factory = mock(WebDriverFactory.class);
-  private BrowserHealthChecker browserHealthChecker = mock(BrowserHealthChecker.class);
-  private CreateDriverCommand createDriverCommand = new CreateDriverCommand();
-  private CloseDriverCommand closeDriverCommand = new CloseDriverCommand();
+  private final Config config = mock(Config.class);
+  private final WebDriver webdriver = mock(WebDriver.class);
+  private final WebDriverFactory factory = mock(WebDriverFactory.class);
+  private final BrowserHealthChecker browserHealthChecker = mock(BrowserHealthChecker.class);
+  private final CreateDriverCommand createDriverCommand = new CreateDriverCommand(new DummyFileNamer("123_456_78"));
+  private final CloseDriverCommand closeDriverCommand = new CloseDriverCommand();
   private LazyDriver driver;
 
   @BeforeEach
   void mockLogging() {
+    when(config.downloadsFolder()).thenReturn("build/down");
     when(config.reopenBrowserOnFail()).thenReturn(true);
     when(config.proxyEnabled()).thenReturn(true);
     driver = new LazyDriver(config, null, emptyList(), factory, browserHealthChecker, createDriverCommand, closeDriverCommand);
@@ -35,8 +39,8 @@ class LazyDriverTest implements WithAssertions {
 
   @BeforeEach
   void setUp() {
-    doReturn(webdriver).when(factory).createWebDriver(any(), any());
-    doReturn(webdriver).when(factory).createWebDriver(any(), isNull());
+    doReturn(webdriver).when(factory).createWebDriver(any(), any(), any());
+    doReturn(webdriver).when(factory).createWebDriver(any(), isNull(), any());
   }
 
   @Test
@@ -45,7 +49,7 @@ class LazyDriverTest implements WithAssertions {
 
     driver.createDriver();
 
-    verify(factory).createWebDriver(config, null);
+    verify(factory).createWebDriver(config, null, new File("build/down/123_456_78"));
   }
 
   @Test
@@ -55,7 +59,7 @@ class LazyDriverTest implements WithAssertions {
     driver.createDriver();
 
     assertThat(driver.getProxy()).isNotNull();
-    verify(factory).createWebDriver(config, driver.getProxy().createSeleniumProxy());
+    verify(factory).createWebDriver(config, driver.getProxy().createSeleniumProxy(), new File("build/down/123_456_78"));
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/drivercommands/WebDriverWrapperTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/WebDriverWrapperTest.java
@@ -4,6 +4,8 @@ import com.codeborne.selenide.SelenideConfig;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
 
+import java.io.File;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -13,7 +15,7 @@ class WebDriverWrapperTest {
   @Test
   void close_closesTheBrowser() {
     WebDriver webDriver = mock(WebDriver.class);
-    WebDriverWrapper driver = new WebDriverWrapper(new SelenideConfig(), webDriver, null);
+    WebDriverWrapper driver = new WebDriverWrapper(new SelenideConfig(), webDriver, null, new File("build/downloads/135"));
 
     driver.close();
 

--- a/src/test/java/com/codeborne/selenide/impl/BrowserHealthCheckerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/BrowserHealthCheckerTest.java
@@ -13,8 +13,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 class BrowserHealthCheckerTest implements WithAssertions {
-  private WebDriver webdriver = mock(WebDriver.class);
-  private BrowserHealthChecker checker = new BrowserHealthChecker();
+  private final WebDriver webdriver = mock(WebDriver.class);
+  private final BrowserHealthChecker checker = new BrowserHealthChecker();
 
   @Test
   void checksIfBrowserIsStillAlive_byCallingGetTitle() {
@@ -25,21 +25,21 @@ class BrowserHealthCheckerTest implements WithAssertions {
 
   @Test
   void isBrowserStillOpen_UnreachableBrowserException() {
-    doThrow(UnreachableBrowserException.class).when(webdriver).getTitle();
+    doThrow(new UnreachableBrowserException("oops")).when(webdriver).getTitle();
 
     assertThat(checker.isBrowserStillOpen(webdriver)).isFalse();
   }
 
   @Test
   void isBrowserStillOpen_NoSuchWindowException() {
-    doThrow(NoSuchWindowException.class).when(webdriver).getTitle();
+    doThrow(new NoSuchWindowException("oops")).when(webdriver).getTitle();
 
     assertThat(checker.isBrowserStillOpen(webdriver)).isFalse();
   }
 
   @Test
   void isBrowserStillOpen_NoSuchSessionException() {
-    doThrow(NoSuchSessionException.class).when(webdriver).getTitle();
+    doThrow(new NoSuchSessionException("oops")).when(webdriver).getTitle();
 
     assertThat(checker.isBrowserStillOpen(webdriver)).isFalse();
   }

--- a/src/test/java/com/codeborne/selenide/impl/DummyFileNamer.java
+++ b/src/test/java/com/codeborne/selenide/impl/DummyFileNamer.java
@@ -1,0 +1,21 @@
+package com.codeborne.selenide.impl;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class DummyFileNamer extends FileNamer {
+  private final String fileName;
+
+  public DummyFileNamer(String fileName) {
+    this.fileName = fileName;
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public String generateFileName() {
+    return fileName;
+  }
+}

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,7 +54,7 @@ class SelenideElementProxyTest implements WithAssertions {
     .screenshots(false)
     .timeout(3)
     .pollingInterval(1);
-  private final SelenideDriver driver = new SelenideDriver(config, webdriver, null);
+  private final SelenideDriver driver = new SelenideDriver(config, webdriver, null, new File("build/downloads/123"));
 
   @BeforeEach
   void mockWebDriver() {

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -27,7 +27,8 @@ class ChromeDriverFactoryTest implements WithAssertions {
   private static final String DOWNLOADS_FOLDER = Paths.get("blah", "downloads").toString();
 
   private final Proxy proxy = mock(Proxy.class);
-  private final SelenideConfig config = new SelenideConfig().downloadsFolder(DOWNLOADS_FOLDER);
+  private final SelenideConfig config = new SelenideConfig().downloadsFolder("build/should-not-be-used");
+  private final File browserDownloadsFolder = new File(DOWNLOADS_FOLDER);
   private final Browser browser = new Browser(config.browser(), config.headless());
   private final ChromeDriverFactory factory = new ChromeDriverFactory();
 
@@ -40,7 +41,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
 
   @Test
   void defaultChromeOptions() {
-    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy);
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap).hasSize(3);
@@ -54,7 +55,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   void shouldNotSetupDownloadFolder_forRemoteWebdriver() {
     config.remote("https://some.remote:1234/wd");
 
-    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy);
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
 
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
     assertThat(prefsMap).containsEntry("credentials_enable_service", false);
@@ -65,7 +66,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   void transferChromeOptionArgumentsFromSystemPropsToDriver() {
     System.setProperty(CHROME_OPTIONS_ARGS, "abdd,--abcd,\"snc,snc\",xcvcd=123,\"abc emd\"");
 
-    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy);
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments)
@@ -77,7 +78,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=stringval,key2=1,key3=false,key4=true," +
       "\"key5=abc,555\",key6=\"555 abc\"");
 
-    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy);
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap)
@@ -93,7 +94,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   void transferChromeOptionPreferencesFromSystemPropsToDriverNoAssignmentStatement() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=1,key2");
 
-    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy);
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap).containsEntry("key1", 1);
@@ -104,7 +105,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   void transferChromeOptionPreferencesFromSystemPropsToDriverTwoAssignmentStatement() {
     System.setProperty(CHROME_OPTIONS_PREFS, "key1=1,key2=1=false");
 
-    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy);
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(prefsMap).containsEntry("key1", 1);
@@ -115,7 +116,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   void browserBinaryCanBeSet() {
     config.browserBinary("c:/browser.exe");
 
-    Capabilities caps = factory.createCapabilities(config, browser, proxy);
+    Capabilities caps = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
 
     Map<String, Object> options = getChromeOptions(caps);
     assertThat(options.get("binary")).isEqualTo("c:/browser.exe");
@@ -125,7 +126,7 @@ class ChromeDriverFactoryTest implements WithAssertions {
   void headlessCanBeSet() {
     config.headless(true);
 
-    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy);
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 
     assertThat(optionArguments).contains("--headless");

--- a/src/test/java/com/codeborne/selenide/webdriver/CommonCapabilitiesTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/CommonCapabilitiesTest.java
@@ -15,6 +15,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 
 import static com.codeborne.selenide.Browsers.EDGE;
 import static com.codeborne.selenide.Browsers.IE;
@@ -89,14 +90,14 @@ public class CommonCapabilitiesTest implements WithAssertions {
     @Override
     @CheckReturnValue
     @Nonnull
-    public MutableCapabilities createCapabilities(Config config, Browser browser, @Nullable Proxy proxy) {
+    public MutableCapabilities createCapabilities(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
       return new DesiredCapabilities();
     }
 
     @Override
     @CheckReturnValue
     @Nonnull
-    public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy) {
+    public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
       return mock(WebDriver.class);
     }
   }

--- a/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
@@ -26,7 +26,8 @@ class FirefoxDriverFactoryTest implements WithAssertions {
 
   private final Proxy proxy = mock(Proxy.class);
   private final FirefoxDriverFactory driverFactory = new FirefoxDriverFactory();
-  private final SelenideConfig config = new SelenideConfig().downloadsFolder(DOWNLOADS_FOLDER);
+  private final SelenideConfig config = new SelenideConfig().downloadsFolder("build/should-not-be-used");
+  private final File browserDownloadsFolder = new File(DOWNLOADS_FOLDER);
   private final Browser browser = new Browser(config.browser(), config.headless());
   private final Set<String> systemProperties = new HashSet<>();
 
@@ -69,7 +70,7 @@ class FirefoxDriverFactoryTest implements WithAssertions {
     config.browserCapabilities(new DesiredCapabilities(firefoxOptions));
     givenSystemProperty("firefoxprofile.some.cap", "25");
 
-    FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy).getProfile();
+    FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder).getProfile();
 
     assertThat(profile.getIntegerPreference("some.cap", 0)).isEqualTo(25);
     assertThat(profile.getIntegerPreference("some.conf.cap", 0)).isEqualTo(42);
@@ -78,7 +79,7 @@ class FirefoxDriverFactoryTest implements WithAssertions {
   @Test
   void transferIntegerFirefoxProfilePreferencesFromSystemPropsToDriver() {
     givenSystemProperty("firefoxprofile.some.cap", "25");
-    FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy).getProfile();
+    FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder).getProfile();
     assertThat(profile.getIntegerPreference("some.cap", 0)).isEqualTo(25);
   }
 
@@ -86,7 +87,7 @@ class FirefoxDriverFactoryTest implements WithAssertions {
   void transferBooleanFirefoxProfilePreferencesFromSystemPropsToDriver() {
     givenSystemProperty("firefoxprofile.some.cap1", "faLSe");
     givenSystemProperty("firefoxprofile.some.cap2", "TRue");
-    FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy).getProfile();
+    FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder).getProfile();
     assertThat(profile.getBooleanPreference("some.cap1", true)).isEqualTo(false);
     assertThat(profile.getBooleanPreference("some.cap2", false)).isEqualTo(true);
   }
@@ -94,14 +95,14 @@ class FirefoxDriverFactoryTest implements WithAssertions {
   @Test
   void transferStringFirefoxProfilePreferencesFromSystemPropsToDriver() {
     givenSystemProperty("firefoxprofile.some.cap", "abdd");
-    FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy).getProfile();
+    FirefoxProfile profile = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder).getProfile();
     assertThat(profile.getStringPreference("some.cap", "sjlj")).isEqualTo("abdd");
   }
 
   @Test
   void browserBinaryCanBeSet() {
     config.browserBinary("c:/browser.exe");
-    Capabilities caps = driverFactory.createCapabilities(config, browser, proxy);
+    Capabilities caps = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     Map options = (Map) caps.asMap().get(FirefoxOptions.FIREFOX_OPTIONS);
     assertThat(options.get("binary")).isEqualTo("c:/browser.exe");
   }
@@ -109,14 +110,14 @@ class FirefoxDriverFactoryTest implements WithAssertions {
   @Test
   void headlessCanBeSet() {
     config.headless(true);
-    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy);
+    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     List<String> optionArguments = getBrowserLaunchArgs(FirefoxOptions.FIREFOX_OPTIONS, options);
     assertThat(optionArguments).contains("-headless");
   }
 
   @Test
   void enablesProxyForLocalAddresses() {
-    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy);
+    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
 
     Map<String, Object> prefs = prefs(options);
     assertThat(prefs.get("network.proxy.no_proxies_on")).isEqualTo("");
@@ -138,7 +139,7 @@ class FirefoxDriverFactoryTest implements WithAssertions {
   void configuresDownloadFolder() {
     config.headless(true);
 
-    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy);
+    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
 
     Map<String, Object> prefs = prefs(options);
     assertThat(prefs.get("browser.download.dir")).isEqualTo(new File(DOWNLOADS_FOLDER).getAbsolutePath());
@@ -153,7 +154,7 @@ class FirefoxDriverFactoryTest implements WithAssertions {
     config.headless(true);
     config.remote("https://some.remote.blah:1234/wd");
 
-    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy);
+    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
 
     Map<String, Object> prefs = prefs(options);
     assertThat(prefs.get("browser.download.dir")).isNull();

--- a/src/test/java/com/codeborne/selenide/webdriver/OperaDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/OperaDriverFactoryTest.java
@@ -9,19 +9,21 @@ import org.openqa.selenium.InvalidArgumentException;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.opera.OperaOptions;
 
+import java.io.File;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 
 class OperaDriverFactoryTest implements WithAssertions {
   private final Proxy proxy = mock(Proxy.class);
+  private final File browserDownloadsFolder = new File("build/downlao");
   private final SelenideConfig config = new SelenideConfig().headless(false);
   private final Browser browser = new Browser(config.browser(), config.headless());
 
   @Test
   void browserBinaryCanBeSet() {
     config.browserBinary("c:/browser.exe");
-    Capabilities caps = new OperaDriverFactory().createCapabilities(config, browser, proxy);
+    Capabilities caps = new OperaDriverFactory().createCapabilities(config, browser, proxy, browserDownloadsFolder);
     Map options = (Map) caps.asMap().get(OperaOptions.CAPABILITY);
     assertThat(options.get("binary"))
       .isEqualTo("c:/browser.exe");
@@ -30,7 +32,7 @@ class OperaDriverFactoryTest implements WithAssertions {
   @Test
   void headlessCanNotBeSet() {
     config.headless(true);
-    assertThatThrownBy(() -> new OperaDriverFactory().createCapabilities(config, browser, proxy))
+    assertThatThrownBy(() -> new OperaDriverFactory().createCapabilities(config, browser, proxy, browserDownloadsFolder))
       .isInstanceOf(InvalidArgumentException.class);
   }
 }

--- a/src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryHeadlessOptionsTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryHeadlessOptionsTest.java
@@ -8,19 +8,21 @@ import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 
+import java.io.File;
 import java.util.List;
 
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
 
 class RemoteDriverFactoryHeadlessOptionsTest implements WithAssertions {
   private final RemoteDriverFactory factory = new RemoteDriverFactory();
+  private final File browserDownloadsFolder = new File("build/downlao");
   private final SelenideConfig config = new SelenideConfig().headless(false);
 
   @Test
   void shouldAddChromeHeadlessOptions() {
     config.headless(true);
     config.browser("chrome");
-    MutableCapabilities chromeOptions = new ChromeDriverFactory().createCapabilities(config, browser(), null);
+    MutableCapabilities chromeOptions = new ChromeDriverFactory().createCapabilities(config, browser(), null, browserDownloadsFolder);
 
     factory.setupCapabilities(config, browser(), chromeOptions);
     List<String> launchArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
@@ -33,7 +35,7 @@ class RemoteDriverFactoryHeadlessOptionsTest implements WithAssertions {
   void shouldNotAddFirefoxHeadlessOptions() {
     config.headless(true);
     config.browser("firefox");
-    MutableCapabilities firefoxOptions = new FirefoxDriverFactory().createCapabilities(config, browser(), null);
+    MutableCapabilities firefoxOptions = new FirefoxDriverFactory().createCapabilities(config, browser(), null, browserDownloadsFolder);
 
     factory.setupCapabilities(config, browser(), firefoxOptions);
     List<String> launchArguments = getBrowserLaunchArgs(FirefoxOptions.FIREFOX_OPTIONS, firefoxOptions);
@@ -45,7 +47,7 @@ class RemoteDriverFactoryHeadlessOptionsTest implements WithAssertions {
   void shouldNotAddChromeHeadlessOptions() {
     config.browser("chrome");
     config.headless(false);
-    MutableCapabilities chromeOptions = new ChromeDriverFactory().createCapabilities(config, browser(), null);
+    MutableCapabilities chromeOptions = new ChromeDriverFactory().createCapabilities(config, browser(), null, browserDownloadsFolder);
 
     factory.setupCapabilities(config, browser(), chromeOptions);
     List<String> launchArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
@@ -58,7 +60,7 @@ class RemoteDriverFactoryHeadlessOptionsTest implements WithAssertions {
   void shouldAddFirefoxHeadlessOptions() {
     config.browser("firefox");
     config.headless(false);
-    MutableCapabilities firefoxOptions = new FirefoxDriverFactory().createCapabilities(config, browser(), null);
+    MutableCapabilities firefoxOptions = new FirefoxDriverFactory().createCapabilities(config, browser(), null, browserDownloadsFolder);
 
     factory.setupCapabilities(config, browser(), firefoxOptions);
     List<String> launchArguments = getBrowserLaunchArgs(FirefoxOptions.FIREFOX_OPTIONS, firefoxOptions);

--- a/src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/RemoteDriverFactoryTest.java
@@ -9,12 +9,14 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.BrowserType;
 
+import java.io.File;
 import java.util.Map;
 
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchPrefs;
 
 class RemoteDriverFactoryTest implements WithAssertions {
   private final RemoteDriverFactory factory = new RemoteDriverFactory();
+  private final File browserDownloadsFolder = new File("build/downlao");
   private final SelenideConfig config = new SelenideConfig().remote("https://some.grid:1234/wd/");
 
   @Test
@@ -62,7 +64,7 @@ class RemoteDriverFactoryTest implements WithAssertions {
   void browserBinaryCanBeSetForFirefox() {
     config.browser("firefox");
     config.browserBinary("c:/browser.exe");
-    MutableCapabilities firefoxOptions = new FirefoxDriverFactory().createCapabilities(config, browser(), null);
+    MutableCapabilities firefoxOptions = new FirefoxDriverFactory().createCapabilities(config, browser(), null, browserDownloadsFolder);
 
     factory.setupCapabilities(config, browser(), firefoxOptions);
 
@@ -75,7 +77,7 @@ class RemoteDriverFactoryTest implements WithAssertions {
   void browserBinaryCanBeSetForChrome() {
     config.browser("chrome");
     config.browserBinary("c:/browser.exe");
-    MutableCapabilities chromeOptions = new ChromeDriverFactory().createCapabilities(config, browser(), null);
+    MutableCapabilities chromeOptions = new ChromeDriverFactory().createCapabilities(config, browser(), null, browserDownloadsFolder);
 
     factory.setupCapabilities(config, browser(), chromeOptions);
 
@@ -87,7 +89,7 @@ class RemoteDriverFactoryTest implements WithAssertions {
   @Test
   void downloadsFolderShouldNotBeSetForChrome() {
     config.browser("chrome");
-    MutableCapabilities chromeOptions = new ChromeDriverFactory().createCapabilities(config, browser(), null);
+    MutableCapabilities chromeOptions = new ChromeDriverFactory().createCapabilities(config, browser(), null, browserDownloadsFolder);
 
     factory.setupCapabilities(config, browser(), chromeOptions);
 

--- a/src/test/java/integration/BaseIntegrationTest.java
+++ b/src/test/java/integration/BaseIntegrationTest.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 
 import static com.automation.remarks.video.enums.RecordingMode.ANNOTATED;
 import static com.codeborne.selenide.Browsers.FIREFOX;
+import static com.codeborne.selenide.impl.FileHelper.ensureFolderExists;
 import static java.lang.Boolean.parseBoolean;
 import static org.openqa.selenium.net.PortProber.findFreePort;
 
@@ -49,7 +50,7 @@ public abstract class BaseIntegrationTest {
 
   private static void setUpVideoRecorder() {
     File videoFolder = new File(System.getProperty("selenide.reportsFolder", "build/reports/tests"));
-    videoFolder.mkdirs();
+    ensureFolderExists(videoFolder);
     System.setProperty("video.folder", videoFolder.getAbsolutePath());
     System.setProperty("video.enabled", String.valueOf(!browser().isHeadless()));
     System.setProperty("video.mode", String.valueOf(ANNOTATED));

--- a/src/test/java/integration/FirefoxWithProfileTest.java
+++ b/src/test/java/integration/FirefoxWithProfileTest.java
@@ -41,7 +41,8 @@ class FirefoxWithProfileTest extends BaseIntegrationTest {
     if (browser().isHeadless()) options.setHeadless(true);
     WebDriver firefox = new FirefoxDriver(options);
 
-    customFirefox = new SelenideDriver(new SelenideConfig().browser("firefox").baseUrl(getBaseUrl()), firefox, null);
+    SelenideConfig config = new SelenideConfig().browser("firefox").baseUrl(getBaseUrl());
+    customFirefox = new SelenideDriver(config, firefox, null, new File("build/downloads/456"));
     customFirefox.open("/page_with_selects_without_jquery.html");
     customFirefox.$("#non-clickable-element").shouldBe(visible);
 

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.log.com.codeborne.selenide=debug

--- a/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -8,6 +8,8 @@ import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.events.WebDriverEventListener;
 
+import java.io.File;
+
 import static com.codeborne.selenide.Configuration.browser;
 import static com.codeborne.selenide.Configuration.headless;
 
@@ -104,6 +106,10 @@ public class WebDriverRunner implements Browsers {
 
   public static Driver driver() {
     return getSelenideDriver().driver();
+  }
+
+  public static File getBrowserDownloadsFolder() {
+    return webdriverContainer.getBrowserDownloadsFolder();
   }
 
   /**

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticDriver.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticDriver.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.WebDriver;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 
 /**
  * A `Driver` implementation which uses thread-local
@@ -59,6 +60,11 @@ public class StaticDriver implements Driver {
   @Override
   public WebDriver getAndCheckWebDriver() {
     return WebDriverRunner.getAndCheckWebDriver();
+  }
+
+  @Override
+  public File browserDownloadsFolder() {
+    return WebDriverRunner.getBrowserDownloadsFolder();
   }
 
   @Override

--- a/statics/src/main/java/com/codeborne/selenide/impl/UnusedWebdriversCleanupThread.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/UnusedWebdriversCleanupThread.java
@@ -5,6 +5,7 @@ import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 
@@ -14,12 +15,16 @@ class UnusedWebdriversCleanupThread extends Thread {
   private final Collection<Thread> allWebDriverThreads;
   private final Map<Long, WebDriver> threadWebDriver;
   private final Map<Long, SelenideProxyServer> threadProxyServer;
+  private final Map<Long, File> threadDownloadsFolder;
 
-  UnusedWebdriversCleanupThread(Collection<Thread> allWebDriverThreads, Map<Long, WebDriver> threadWebDriver,
-                                Map<Long, SelenideProxyServer> threadProxyServer) {
+  UnusedWebdriversCleanupThread(Collection<Thread> allWebDriverThreads,
+                                Map<Long, WebDriver> threadWebDriver,
+                                Map<Long, SelenideProxyServer> threadProxyServer,
+                                Map<Long, File> threadDownloadsFolder) {
     this.allWebDriverThreads = allWebDriverThreads;
     this.threadWebDriver = threadWebDriver;
     this.threadProxyServer = threadProxyServer;
+    this.threadDownloadsFolder = threadDownloadsFolder;
     setDaemon(true);
     setName("Webdrivers killer thread");
   }
@@ -62,6 +67,8 @@ class UnusedWebdriversCleanupThread extends Thread {
     if (proxy != null) {
       proxy.shutdown();
     }
+
+    threadDownloadsFolder.remove(thread.getId());
   }
 }
 

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
@@ -9,12 +9,14 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 
 @ParametersAreNonnullByDefault
 public interface WebDriverContainer {
   void addListener(WebDriverEventListener listener);
   void setWebDriver(WebDriver webDriver);
-  void setWebDriver(WebDriver webDriver, SelenideProxyServer selenideProxy);
+  void setWebDriver(WebDriver webDriver, @Nullable SelenideProxyServer selenideProxy);
+  void setWebDriver(WebDriver webDriver, @Nullable SelenideProxyServer selenideProxy, File browserDownloadsFolder);
   void resetWebDriver();
 
   @CheckReturnValue
@@ -30,6 +32,10 @@ public interface WebDriverContainer {
   @CheckReturnValue
   @Nonnull
   WebDriver getAndCheckWebDriver();
+
+  @CheckReturnValue
+  @Nonnull
+  File getBrowserDownloadsFolder();
 
   void closeWindow();
   void closeWebDriver();

--- a/statics/src/test/java/grid/CustomWebdriverFactoryWithRemoteBrowser.java
+++ b/statics/src/test/java/grid/CustomWebdriverFactoryWithRemoteBrowser.java
@@ -15,6 +15,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -37,7 +38,7 @@ public class CustomWebdriverFactoryWithRemoteBrowser extends AbstractGridTest {
     @Override
     @CheckReturnValue
     @Nonnull
-    public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy) {
+    public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, File browserDownloadsFolder) {
       ChromeOptions options = new ChromeOptions();
       options.setHeadless(true);
       addSslErrorIgnoreCapabilities(options);

--- a/statics/src/test/java/integration/BrowserLogsTest.java
+++ b/statics/src/test/java/integration/BrowserLogsTest.java
@@ -10,7 +10,6 @@ import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.getWebDriverLogs;
 import static com.codeborne.selenide.WebDriverRunner.hasWebDriverStarted;
-import static com.codeborne.selenide.WebDriverRunner.isChrome;
 import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -19,8 +18,9 @@ import static org.openqa.selenium.logging.LogType.BROWSER;
 class BrowserLogsTest extends IntegrationTest {
   @BeforeEach
   void setUp() {
-    // Firefox says `UnsupportedCommandException: POST /session/b493bc56.../log did not match a known command`
-    assumeFalse(isFirefox());
+    assumeFalse(isFirefox(),
+      "Firefox says `UnsupportedCommandException: POST /session/b493bc56.../log did not match a known command`"
+    );
 
     if (hasWebDriverStarted()) {
       getWebDriverLogs(BROWSER); // clear logs
@@ -30,7 +30,6 @@ class BrowserLogsTest extends IntegrationTest {
 
   @Test
   void canGetWebDriverBrowserConsoleLogEntry() {
-    assumeFalse(isChrome());
     $(byText("Generate JS Error")).click();
     List<String> webDriverLogs = getWebDriverLogs(BROWSER, Level.ALL);
 

--- a/statics/src/test/java/integration/ChromeProfileByFactoryTest.java
+++ b/statics/src/test/java/integration/ChromeProfileByFactoryTest.java
@@ -56,7 +56,7 @@ class ChromeProfileByFactoryTest extends IntegrationTest {
     assertThat(log).contains("\"excludeSwitches\": [ \"enable-automation\" ]");
     assertThat(log).contains("\"extensions\": [  ]");
     assertThat(log).contains("\"credentials_enable_service\": false");
-    assertThat(log).contains("\"download.default_directory\": \"" + downloadsFolder.getAbsolutePath() + "\"");
+    assertThat(log).contains("\"download.default_directory\": \"" + downloadsFolder.getAbsolutePath());
 
     String arguments = "\"--proxy-bypass-list=\\u003C-loopback>\", \"--no-sandbox\", \"--disable-3d-apis\"";
     if (Configuration.headless) {

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -16,24 +16,24 @@ import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.WebDriverRunner.getBrowserDownloadsFolder;
 import static com.codeborne.selenide.files.FileFilters.withExtension;
 import static com.codeborne.selenide.files.FileFilters.withName;
 import static com.codeborne.selenide.files.FileFilters.withNameMatching;
+import static com.codeborne.selenide.impl.FileHelper.cleanupFolder;
 import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FileDownloadToFolderTest  extends IntegrationTest {
-  private final File folder = new File(Configuration.downloadsFolder);
+  private final File folder = new File(downloadsFolder);
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws IOException {
     Configuration.fileDownload = FileDownloadMode.FOLDER;
     openFile("page_with_uploads.html");
     timeout = 4000;
-    new File(downloadsFolder, "hello_world.txt").delete();
-    new File(downloadsFolder, "some-file.txt").delete();
-    new File(downloadsFolder, "файл-с-русским-названием.txt").delete();
+    cleanupFolder(getBrowserDownloadsFolder());
   }
 
   @Test
@@ -107,15 +107,15 @@ public class FileDownloadToFolderTest  extends IntegrationTest {
   @Test
   void downloadsFilesToCustomFolder() throws IOException {
     closeWebDriver();
-    String downloadsFolder = "build/custom-folder";
-    Configuration.downloadsFolder = downloadsFolder;
+    String customDownloadsFolder = "build/custom-folder-" + System.currentTimeMillis();
+    downloadsFolder = customDownloadsFolder;
 
     try {
       openFile("page_with_uploads.html");
       File downloadedFile = $(byText("Download me")).download();
 
       assertThat(downloadedFile.getAbsolutePath())
-        .startsWith(new File(downloadsFolder).getAbsolutePath());
+        .startsWith(new File(customDownloadsFolder).getAbsolutePath());
     }
     finally {
       closeWebDriver();

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -41,6 +41,7 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     resetSettings();
   }
 
+  @BeforeEach
   @AfterEach
   public void restoreDefaultProperties() {
     timeout = 1;


### PR DESCRIPTION
## Proposed changes
Solve issue ##1220: generate a unique downloads folder for every browser instance.  

The main change is _the downloads folder_. 
* before: `build/downloads` (for all browser instances)
* after: `build/downloads/<timestamp>_<pid>_<thread_id>"`

## API changes
* `com.codeborne.selenide.SelenideDriver` constructor gets new parameter `File browserDownloadsFolder`
* `com.codeborne.selenide.Driver` gets new method `File browserDownloadsFolder()`
* In all subclasses of `com.codeborne.selenide.webdriver.AbstractDriverFactory` method `create` gets new parameter `File browserDownloadsFolder`. Some of them ignore it (Safari and IE) because those browsers doesn't support custom downloads folder.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
