### PR TITLE
Add new shadow root selector 'shadowRoot([shadowHost], [cssSelector])'

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selectors.java
+++ b/src/main/java/com/codeborne/selenide/Selectors.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.selector.ByShadow;
+import com.codeborne.selenide.selector.ByShadowRoot;
 import javax.annotation.CheckReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.Quotes;
@@ -86,6 +87,16 @@ public class Selectors {
   @Nonnull
   public static By shadowCss(String target, String shadowHost, String... innerShadowHosts) {
     return ByShadow.cssSelector(target, shadowHost, innerShadowHosts);
+  }
+
+  /**
+   * @see ByShadowRoot#cssSelector(java.lang.String, java.lang.String)
+   * @since 5.13
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static By shadowRoot(String shadowHost, String target) {
+    return ByShadowRoot.cssSelector(shadowHost, target);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/selector/ByShadowRoot.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByShadowRoot.java
@@ -67,13 +67,13 @@ public class ByShadowRoot {
         final List<WebElement> hosts = getShadowRoots(root, shadowHost, -1);
         final WebElement targetWebElement = getElementInsideShadowTree(hosts, target);
         if (targetWebElement == null) {
-          throw new NoSuchElementException("The element was not found: " + toString());
+          throw new NoSuchElementException("The element was not found: {" + getSelectorString() + "}");
         }
         return targetWebElement;
       }
       final List<WebElement> hosts = getShadowRoots(root, shadowHost, 1);
       if (0 == hosts.size()) {
-        throw new NoSuchElementException("The element was not found: " + toString());
+        throw new NoSuchElementException("The element was not found: {" + getSelectorString() + "}");
       }
       return hosts.get(0);
     }
@@ -165,8 +165,21 @@ public class ByShadowRoot {
     @CheckReturnValue
     @Nonnull
     public String toString() {
-      final StringBuilder sb = new StringBuilder("By.ByShadowRoot: ");
-      sb.append(null != shadowHost ? shadowHost : "null").append(" ").append(null != target ? target : "null");
+      final StringBuilder sb = new StringBuilder("By.cssSelector: ");
+      sb.append(getSelectorString());
+      return sb.toString();
+    }
+    private String getSelectorString() {
+      final StringBuilder sb = new StringBuilder();
+      if (null != shadowHost) {
+        sb.append("[");
+        sb.append(shadowHost);
+        sb.append("]");
+      }
+      if (null != target) {
+        sb.append(" ");
+        sb.append(target);
+      }
       return sb.toString();
     }
   }

--- a/src/main/java/com/codeborne/selenide/selector/ByShadowRoot.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByShadowRoot.java
@@ -1,0 +1,173 @@
+package com.codeborne.selenide.selector;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@ParametersAreNonnullByDefault
+public class ByShadowRoot {
+
+  /**
+   * Find target elements inside shadow-root that attached to shadow-host.
+   * <br/> Supports inner shadow-hosts.
+   *
+   * <br/> For example: shadow-host &gt; target-element
+   * <pre>
+   * ex1) find all shadow-host
+   *   //*
+   * ex2) find shadow-host chidlens and tagName is div
+   *   div
+   * ex3) find all shadow-host and tagName is span in div shadow-host
+   *   div//span
+   * ex4) find shadow-host chidlens and tagName is span in div shadow-host
+   *   div/span
+   * ex5) find current shadow-host
+   *   null or ""
+   * </pre>
+   *
+   * @param shadowHost       CSS expression of the shadow-host with attached shadow-root and shadow-host tree split is "/" or "//".
+   * @param target           CSS expression of target element
+   * @return A By which locates elements by CSS inside shadow-root.
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static By cssSelector(final String shadowHost, final String target) {
+    return new ByShadowRootCss(shadowHost, target);
+  }
+
+  @ParametersAreNonnullByDefault
+  public static class ByShadowRootCss extends By implements Serializable {
+    private static final long serialVersionUID = -1230258723099459238L;
+
+    private final String shadowHost;
+    private final String target;
+
+    ByShadowRootCss(final String shadowHost, final String target) {
+      this.shadowHost = shadowHost;
+      this.target = target;
+    }
+
+    @Override
+    @CheckReturnValue
+    @Nonnull
+    public WebElement findElement(final SearchContext context) {
+      final SearchContext root = context instanceof JavascriptExecutor ? context.findElement(By.xpath("/*")) : context;
+      if (null != this.target && 0 < this.target.length()) {
+        final List<WebElement> hosts = getShadowRoots(root, shadowHost, -1);
+        final WebElement targetWebElement = getElementInsideShadowTree(hosts, target);
+        if (targetWebElement == null) {
+          throw new NoSuchElementException("The element was not found: " + toString());
+        }
+        return targetWebElement;
+      }
+      final List<WebElement> hosts = getShadowRoots(root, shadowHost, 1);
+      if (0 == hosts.size()) {
+        throw new NoSuchElementException("The element was not found: " + toString());
+      }
+      return hosts.get(0);
+    }
+
+    @Override
+    @CheckReturnValue
+    @Nonnull
+    public List<WebElement> findElements(final SearchContext context) {
+      final SearchContext root = context instanceof JavascriptExecutor ? context.findElement(By.xpath("/*")) : context;
+      final List<WebElement> hosts = getShadowRoots(root, shadowHost, -1);
+      if (null != this.target && 0 < this.target.length()) {
+        return getElementsInsideShadowTree(hosts, target);
+      }
+      return hosts;
+    }
+
+    private WebElement getElementInsideShadowTree(final List<WebElement> hosts, final String target) {
+      WebElement targetWebElement = null;
+      for (final WebElement host : hosts) {
+        targetWebElement = (WebElement) getJavascriptExecutor(host)
+          .executeScript("return arguments[0].shadowRoot.querySelector(arguments[1])", host, target);
+        if (targetWebElement != null) break;
+      }
+      return targetWebElement;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<WebElement> getElementsInsideShadowTree(final List<WebElement> hosts, final String target) {
+      final List<WebElement> elems = new ArrayList<WebElement>();
+      hosts.forEach(host -> {
+        elems.addAll((List<WebElement>) getJavascriptExecutor(host)
+          .executeScript("return arguments[0].shadowRoot.querySelectorAll(arguments[1])", host, target));
+      });
+      return elems;
+    }
+
+    private JavascriptExecutor getJavascriptExecutor(final SearchContext context) {
+      JavascriptExecutor jsExecutor;
+      if (context instanceof JavascriptExecutor) {
+        jsExecutor = (JavascriptExecutor) context;
+      } else {
+        jsExecutor = (JavascriptExecutor) ((WrapsDriver) context).getWrappedDriver();
+      }
+      return jsExecutor;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<WebElement> getShadowRoots(final SearchContext host, String sh, final int limit) {
+      /*
+      console.info((function(){
+          const sh=arguments[1].replace(/\/{3,}/g,'//').replace(/^\/([^\/])/,'$1').replace(/^\/+/,'/'),
+          ptn=/(^[^\/]*)\/?(.*$)/,es=[],doc=arguments[0],lmt=arguments[2],f1=function(e,s){
+            const rt=e.shadowRoot;
+            if(rt&&(0>=lmt||lmt>es.length))0==s.length?(es[es.length]=e):f2(rt,s);
+          },f2=function(rt,s){
+            const p1=s.match(ptn),p2=p1[2].match(ptn);
+            if(''==p1[1]){
+              rt.querySelectorAll(p2[1]).forEach(function(c){f1(c,p2[2])});
+              rt.querySelectorAll('*').forEach(function(c){f1(c,s)});
+            }else{
+              rt.querySelectorAll(p1[1]).forEach(function(c){f1(c,p1[2])});
+            }
+          };
+          (doc.shadowRoot?f1:f2)(doc,sh);
+          return es;
+      })(document, '*', -1));
+      */
+      if (null == sh) sh = "";
+      final StringBuilder sb = new StringBuilder();
+      sb.append("const sh=arguments[1].replace(/\\/{3,}/g,'//').replace(/^\\/([^\\/])/,'$1').replace(/^\\/+/,'/'),");
+      sb.append("ptn=/(^[^\\/]*)\\/?(.*$)/,es=[],doc=arguments[0],lmt=arguments[2],f1=function(e,s){");
+      sb.append("  const rt=e.shadowRoot;");
+      sb.append("  if(rt&&(0>=lmt||lmt>es.length))0==s.length?(es[es.length]=e):f2(rt,s);");
+      sb.append("},f2=function(rt,s){");
+      sb.append("  const p1=s.match(ptn),p2=p1[2].match(ptn);");
+      sb.append("  if(''==p1[1]){");
+      sb.append("    rt.querySelectorAll(p2[1]).forEach(function(c){f1(c,p2[2])});");
+      sb.append("    rt.querySelectorAll('*').forEach(function(c){f1(c,s)});");
+      sb.append("  }else{");
+      sb.append("    rt.querySelectorAll(p1[1]).forEach(function(c){f1(c,p1[2])});");
+      sb.append("  }");
+      sb.append("};");
+      sb.append("(doc.shadowRoot?f1:f2)(doc,sh);");
+      sb.append("return es;");
+      return (List<WebElement>) getJavascriptExecutor(host).executeScript(sb.toString(), host, sh, limit);
+    }
+
+    @Override
+    @CheckReturnValue
+    @Nonnull
+    public String toString() {
+      final StringBuilder sb = new StringBuilder("By.ByShadowRoot: ");
+      sb.append(null != shadowHost ? shadowHost : "null").append(" ").append(null != target ? target : "null");
+      return sb.toString();
+    }
+  }
+}

--- a/src/test/java/integration/ShadowRootElementTest.java
+++ b/src/test/java/integration/ShadowRootElementTest.java
@@ -1,0 +1,84 @@
+package integration;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchElementException;
+
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selectors.shadowRoot;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ShadowRootElementTest extends ITest {
+  @BeforeEach
+  void openTestPage() {
+    openFile("page_with_shadow_dom.html");
+  }
+
+  @Test
+  void clickInsideShadowHost() {
+    SelenideElement button = $(shadowRoot("#shadow-host", "#anyButton"));
+    button.click();
+    button.shouldHave(text("Changed text"));
+  }
+
+  @Test
+  void getTargetElementViaShadowHost() {
+    $(shadowRoot("#shadow-host", "p"))
+      .shouldHave(text("Inside Shadow-DOM"));
+  }
+
+  @Test
+  void getElementInsideInnerShadowHost() {
+    $(shadowRoot("#shadow-host/#inner-shadow-host", "p"))
+      .shouldHave(text("The Shadow-DOM inside another shadow tree"));
+  }
+
+  @Test
+  void throwErrorWhenGetNonExistingTargetInsideShadowRoot() {
+    assertThatThrownBy(() -> $(shadowRoot("#shadow-host", "#nonexistent")).text())
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void throwErrorWhenBypassingShadowHost() {
+    assertThatThrownBy(() -> $("p").text())
+      .isInstanceOf(ElementNotFound.class);
+  }
+
+  @Test
+  void throwErrorWhenShadowHostDoesNotHaveShadowRoot() {
+    assertThatThrownBy(() -> $(shadowRoot("h1", "p")).text())
+      .isInstanceOf(ElementNotFound.class)
+      .hasCauseInstanceOf(NoSuchElementException.class)
+      .hasMessageContaining("The element is not a shadow host or has 'closed' shadow-dom mode:");
+  }
+
+  @Test
+  void throwErrorWhenInnerShadowHostAbsent() {
+    assertThatThrownBy(() -> $(shadowRoot("#shadow-host/#nonexistent", "p")).text())
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageContaining("Element not found {#shadow-host [#nonexistent] p}")
+      .hasCauseInstanceOf(NoSuchElementException.class)
+      .hasMessageContaining("The element was not found: #nonexistent");
+  }
+
+  @Test
+  void getTargetElementsViaShadowHost() {
+    $$(shadowRoot("#shadow-host", "div.test-class"))
+      .shouldHaveSize(2);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost() {
+    $$(shadowRoot("#shadow-host/#inner-shadow-host", "p"))
+      .shouldHaveSize(1);
+  }
+
+  @Test
+  void getNonExistingTargetElementsInsideShadowHost() {
+    $$(shadowRoot("#shadow-host", "#nonexistent"))
+      .shouldHaveSize(0);
+  }
+}

--- a/src/test/java/integration/ShadowRootElementTest.java
+++ b/src/test/java/integration/ShadowRootElementTest.java
@@ -52,16 +52,16 @@ public class ShadowRootElementTest extends ITest {
     assertThatThrownBy(() -> $(shadowRoot("h1", "p")).text())
       .isInstanceOf(ElementNotFound.class)
       .hasCauseInstanceOf(NoSuchElementException.class)
-      .hasMessageContaining("The element is not a shadow host or has 'closed' shadow-dom mode:");
+      .hasMessageContaining("The element was not found: {[h1] p}");
   }
 
   @Test
   void throwErrorWhenInnerShadowHostAbsent() {
     assertThatThrownBy(() -> $(shadowRoot("#shadow-host/#nonexistent", "p")).text())
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("Element not found {#shadow-host [#nonexistent] p}")
+      .hasMessageContaining("Element not found {[#shadow-host/#nonexistent] p}")
       .hasCauseInstanceOf(NoSuchElementException.class)
-      .hasMessageContaining("The element was not found: #nonexistent");
+      .hasMessageContaining("The element was not found: {[#shadow-host/#nonexistent] p}");
   }
 
   @Test
@@ -80,5 +80,53 @@ public class ShadowRootElementTest extends ITest {
   void getNonExistingTargetElementsInsideShadowHost() {
     $$(shadowRoot("#shadow-host", "#nonexistent"))
       .shouldHaveSize(0);
+  }
+
+  @Test
+  void getAllShadowHost() {
+    $$(shadowRoot("//*", null))
+      .shouldHaveSize(14);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost2() {
+    $$(shadowRoot("//*", "h2"))
+      .shouldHaveSize(15);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost3() {
+    $$(shadowRoot("//*", "p"))
+      .shouldHaveSize(32);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost4() {
+    $$(shadowRoot("#next-shadow-host/div", "h2"))
+      .shouldHaveSize(5);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost5() {
+    $$(shadowRoot("#next-shadow-host/div.fourth-shadow-host", "p"))
+      .shouldHaveSize(0);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost6() {
+    $$(shadowRoot("#next-shadow-host//div.fourth-shadow-host", "p"))
+      .shouldHaveSize(30);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost7() {
+    $$(shadowRoot("#next-shadow-host/div/div.fourth-shadow-host", "p"))
+      .shouldHaveSize(30);
+  }
+
+  @Test
+  void getElementsInsideInnerShadowHost8() {
+    $(shadowRoot("//div.fourth-shadow-host", null)).$$(shadowRoot(null, "p"))
+      .shouldHaveSize(3);
   }
 }

--- a/src/test/java/integration/ShadowRootElementTest.java
+++ b/src/test/java/integration/ShadowRootElementTest.java
@@ -31,7 +31,7 @@ public class ShadowRootElementTest extends ITest {
 
   @Test
   void getElementInsideInnerShadowHost() {
-    $(shadowRoot("#shadow-host/#inner-shadow-host", "p"))
+    $(shadowRoot("#shadow-host (>) #inner-shadow-host", "p"))
       .shouldHave(text("The Shadow-DOM inside another shadow tree"));
   }
 
@@ -57,11 +57,11 @@ public class ShadowRootElementTest extends ITest {
 
   @Test
   void throwErrorWhenInnerShadowHostAbsent() {
-    assertThatThrownBy(() -> $(shadowRoot("#shadow-host/#nonexistent", "p")).text())
+    assertThatThrownBy(() -> $(shadowRoot("#shadow-host (>) #nonexistent", "p")).text())
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("Element not found {[#shadow-host/#nonexistent] p}")
+      .hasMessageContaining("Element not found {[#shadow-host (>) #nonexistent] p}")
       .hasCauseInstanceOf(NoSuchElementException.class)
-      .hasMessageContaining("The element was not found: {[#shadow-host/#nonexistent] p}");
+      .hasMessageContaining("The element was not found: {[#shadow-host (>) #nonexistent] p}");
   }
 
   @Test
@@ -72,7 +72,7 @@ public class ShadowRootElementTest extends ITest {
 
   @Test
   void getElementsInsideInnerShadowHost() {
-    $$(shadowRoot("#shadow-host/#inner-shadow-host", "p"))
+    $$(shadowRoot("#shadow-host (>) #inner-shadow-host", "p"))
       .shouldHaveSize(1);
   }
 
@@ -84,49 +84,49 @@ public class ShadowRootElementTest extends ITest {
 
   @Test
   void getAllShadowHost() {
-    $$(shadowRoot("//*", null))
+    $$(shadowRoot("(>>) *", null))
       .shouldHaveSize(14);
   }
 
   @Test
   void getElementsInsideInnerShadowHost2() {
-    $$(shadowRoot("//*", "h2"))
+    $$(shadowRoot("(>>) *", "h2"))
       .shouldHaveSize(15);
   }
 
   @Test
   void getElementsInsideInnerShadowHost3() {
-    $$(shadowRoot("//*", "p"))
+    $$(shadowRoot("(>>) *", "p"))
       .shouldHaveSize(32);
   }
 
   @Test
   void getElementsInsideInnerShadowHost4() {
-    $$(shadowRoot("#next-shadow-host/div", "h2"))
+    $$(shadowRoot("#next-shadow-host (>) div", "h2"))
       .shouldHaveSize(5);
   }
 
   @Test
   void getElementsInsideInnerShadowHost5() {
-    $$(shadowRoot("#next-shadow-host/div.fourth-shadow-host", "p"))
+    $$(shadowRoot("#next-shadow-host (>) div.fourth-shadow-host", "p"))
       .shouldHaveSize(0);
   }
 
   @Test
   void getElementsInsideInnerShadowHost6() {
-    $$(shadowRoot("#next-shadow-host//div.fourth-shadow-host", "p"))
+    $$(shadowRoot("#next-shadow-host (>>) div.fourth-shadow-host", "p"))
       .shouldHaveSize(30);
   }
 
   @Test
   void getElementsInsideInnerShadowHost7() {
-    $$(shadowRoot("#next-shadow-host/div/div.fourth-shadow-host", "p"))
+    $$(shadowRoot("#next-shadow-host (>) div (>) div.fourth-shadow-host", "p"))
       .shouldHaveSize(30);
   }
 
   @Test
   void getElementsInsideInnerShadowHost8() {
-    $(shadowRoot("//div.fourth-shadow-host", null)).$$(shadowRoot(null, "p"))
+    $(shadowRoot("(>>) div.fourth-shadow-host", null)).$$(shadowRoot(null, "p"))
       .shouldHaveSize(3);
   }
 }

--- a/src/test/resources/page_with_shadow_dom.html
+++ b/src/test/resources/page_with_shadow_dom.html
@@ -39,7 +39,24 @@
       p2.appendChild(text2);
       shadow2.appendChild(p2);
     });
-
+    $(function () {
+      let shadow = document.getElementById('next-shadow-host').attachShadow( { mode: "open" } );
+      let div = document.createElement("div");
+      shadow.appendChild(div);
+      let shadow2 = div.attachShadow( { mode: "open" } );
+      let div2 = document.createElement("div");
+      shadow2.appendChild(div2);
+      for(let i=0;i<5;i++){
+        $(div2).append('<div class="third-shadow-host"><h2>--therd:'+(i+1)+'</h2><div class="fourth-shadow-host" /><div class="fourth-shadow-host" /></div>');
+      }
+      $(div2).find("div.fourth-shadow-host").each(function(i){
+        let shadow = this.attachShadow( { mode: "open" } );
+        shadow.appendChild($('<h2>----fourth:'+(i+1)+'</h2>')[0]);
+        shadow.appendChild($('<p>line 1</p>')[0]);
+        shadow.appendChild($('<p>line 2</p>')[0]);
+        shadow.appendChild($('<p>line 3</p>')[0]);
+      });
+    });
 
 
   </script>
@@ -50,5 +67,6 @@
 <div id="shadow-host">
 </div>
 
+<div id="next-shadow-host">
 </body>
 </html>

--- a/statics/src/test/java/integration/ShadowDomInsideIFrameTest2.java
+++ b/statics/src/test/java/integration/ShadowDomInsideIFrameTest2.java
@@ -1,0 +1,43 @@
+package integration;
+
+import com.codeborne.selenide.Configuration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.value;
+import static com.codeborne.selenide.Selectors.shadowRoot;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.switchTo;
+import static com.codeborne.selenide.WebDriverRunner.isFirefox;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+class ShadowDomInsideIFrameTest2 extends IntegrationTest {
+  @BeforeEach
+  void setUp() {
+    openFile("page_with_shadow_dom_inside_iframe.html");
+  }
+
+  @Test
+  void getTargetElementViaShadowHostInsideIFrame() {
+    switchTo().frame("iframe_page");
+    $(shadowRoot("#shadow-host", "p"))
+      .shouldHave(text("Inside Shadow-DOM"));
+  }
+
+  @Test
+  void setValueViaShadowDomInsideIFrame() {
+    // Firefox says that the input is "not reachable by keyboard" (inside shadow-dom)
+    assumeFalse(isFirefox());
+    switchTo().frame("iframe_page");
+    Configuration.fastSetValue = false;
+    $(shadowRoot("#shadow-host", "input")).setValue("test").shouldHave(value("test"));
+  }
+
+  @Test
+  void setFastValueViaShadowDomInsideIFrame() {
+    switchTo().frame("iframe_page");
+    Configuration.fastSetValue = true;
+    $(shadowRoot("#shadow-host", "input")).setValue("test").shouldHave(value("test"));
+  }
+}


### PR DESCRIPTION
## Proposed changes
### I want to improve the selector of shadowCss.
- current style
shadowCss("p", "host1", "host2", "host3", "host4")
- new style
shadowRoot("host1//host4", "p")

### Support shadow-root elements
ex) shadow-root tree
```
host1
  + host2
     +p
  + host2
     +p
     +p
  + host2
     +p
```
$$(shadowRoot("host1/host2", "p")).shouldHaveSize(4);  

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
