### PR TITLE
#1220 delete empty downloads folders

### DIFF
--- a/src/main/java/com/codeborne/selenide/drivercommands/CloseDriverCommand.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/CloseDriverCommand.java
@@ -11,12 +11,16 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
+
+import static com.codeborne.selenide.impl.FileHelper.deleteFolderIfEmpty;
 
 @ParametersAreNonnullByDefault
 public class CloseDriverCommand {
   private static final Logger log = LoggerFactory.getLogger(CloseDriverCommand.class);
 
-  public void closeAsync(Config config, @Nullable WebDriver webDriver, @Nullable SelenideProxyServer selenideProxyServer) {
+  public void closeAsync(Config config, @Nullable WebDriver webDriver,
+                         @Nullable SelenideProxyServer selenideProxyServer, @Nullable File browserDownloadsFolder) {
     long threadId = Thread.currentThread().getId();
     if (config.holdBrowserOpen()) {
       log.info("Hold browser and proxy open: {} -> {}, {}", threadId, webDriver, selenideProxyServer);
@@ -29,7 +33,7 @@ public class CloseDriverCommand {
 
       long start = System.currentTimeMillis();
 
-      Thread t = new Thread(() -> close(webDriver, selenideProxyServer));
+      Thread t = new Thread(() -> close(webDriver, selenideProxyServer, browserDownloadsFolder));
       t.setDaemon(true);
       t.start();
 
@@ -49,7 +53,7 @@ public class CloseDriverCommand {
     }
   }
 
-  private void close(WebDriver webdriver, @Nullable SelenideProxyServer proxy) {
+  private void close(WebDriver webdriver, @Nullable SelenideProxyServer proxy, @Nullable File browserDownloadsFolder) {
     try {
       log.info("Trying to close the browser {} ...", webdriver.getClass().getSimpleName());
       webdriver.quit();
@@ -66,5 +70,7 @@ public class CloseDriverCommand {
       log.info("Trying to shutdown {} ...", proxy);
       proxy.shutdown();
     }
+
+    deleteFolderIfEmpty(browserDownloadsFolder);
   }
 }

--- a/src/main/java/com/codeborne/selenide/drivercommands/CreateDriverCommand.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/CreateDriverCommand.java
@@ -68,7 +68,7 @@ public class CreateDriverCommand {
 
     WebDriver webDriver = addListeners(webdriver, listeners);
     Runtime.getRuntime().addShutdownHook(
-      new Thread(new SelenideDriverFinalCleanupThread(config, webDriver, selenideProxyServer))
+      new Thread(new SelenideDriverFinalCleanupThread(config, webDriver, selenideProxyServer, browserDownloadsFolder))
     );
     return new Result(webDriver, selenideProxyServer, browserDownloadsFolder);
   }

--- a/src/main/java/com/codeborne/selenide/drivercommands/LazyDriver.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/LazyDriver.java
@@ -126,7 +126,7 @@ public class LazyDriver implements Driver {
 
   @Override
   public void close() {
-    closeDriverCommand.closeAsync(config, webDriver, selenideProxyServer);
+    closeDriverCommand.closeAsync(config, webDriver, selenideProxyServer, browserDownloadsFolder);
     webDriver = null;
     selenideProxyServer = null;
     browserDownloadsFolder = null;

--- a/src/main/java/com/codeborne/selenide/drivercommands/SelenideDriverFinalCleanupThread.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/SelenideDriverFinalCleanupThread.java
@@ -6,28 +6,31 @@ import org.openqa.selenium.WebDriver;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.File;
 
 @ParametersAreNonnullByDefault
 public class SelenideDriverFinalCleanupThread implements Runnable {
   private final Config config;
   private final WebDriver driver;
   private final SelenideProxyServer proxy;
+  private final File browserDownloadsFolder;
   private final CloseDriverCommand closeDriverCommand;
 
-  SelenideDriverFinalCleanupThread(Config config, WebDriver driver, @Nullable SelenideProxyServer proxy) {
-    this(config, driver, proxy, new CloseDriverCommand());
+  SelenideDriverFinalCleanupThread(Config config, WebDriver driver, @Nullable SelenideProxyServer proxy, File browserDownloadsFolder) {
+    this(config, driver, proxy, browserDownloadsFolder, new CloseDriverCommand());
   }
 
-  SelenideDriverFinalCleanupThread(Config config, WebDriver driver, @Nullable SelenideProxyServer proxy,
+  SelenideDriverFinalCleanupThread(Config config, WebDriver driver, @Nullable SelenideProxyServer proxy, File browserDownloadsFolder,
                                    CloseDriverCommand closeDriverCommand) {
     this.config = config;
     this.driver = driver;
     this.proxy = proxy;
+    this.browserDownloadsFolder = browserDownloadsFolder;
     this.closeDriverCommand = closeDriverCommand;
   }
 
   @Override
   public void run() {
-    closeDriverCommand.closeAsync(config, driver, proxy);
+    closeDriverCommand.closeAsync(config, driver, proxy, browserDownloadsFolder);
   }
 }

--- a/src/main/java/com/codeborne/selenide/drivercommands/WebDriverWrapper.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/WebDriverWrapper.java
@@ -104,6 +104,6 @@ public class WebDriverWrapper implements Driver {
    */
   @Override
   public void close() {
-    closeDriverCommand.closeAsync(config, webDriver, selenideProxy);
+    closeDriverCommand.closeAsync(config, webDriver, selenideProxy, browserDownloadsFolder);
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/FileHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileHelper.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 import java.io.FileInputStream;
@@ -56,6 +57,19 @@ public final class FileHelper {
   public static void cleanupFolder(File folder) throws IOException {
     if (folder.isDirectory()) {
       cleanDirectory(folder);
+    }
+  }
+
+  public static void deleteFolderIfEmpty(@Nullable File folder) {
+    if (folder != null && folder.isDirectory()) {
+      File[] files = folder.listFiles();
+      if (files == null || files.length == 0) {
+        if (folder.delete()) {
+          log.info("Deleted empty downloads folder: {}", folder.getAbsolutePath());
+        } else {
+          log.error("Failed to delete empty downloads folder: {}", folder.getAbsolutePath());
+        }
+      }
     }
   }
 }

--- a/src/test/java/com/codeborne/selenide/drivercommands/SelenideDriverFinalCleanupThreadTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/SelenideDriverFinalCleanupThreadTest.java
@@ -5,6 +5,8 @@ import com.codeborne.selenide.proxy.SelenideProxyServer;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
 
+import java.io.File;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -16,11 +18,12 @@ class SelenideDriverFinalCleanupThreadTest {
     Config config = mock(Config.class);
     WebDriver driver = mock(WebDriver.class);
     SelenideProxyServer proxy = mock(SelenideProxyServer.class);
+    File browserDownloadsFolder = mock(File.class);
     CloseDriverCommand closeDriverCommand = mock(CloseDriverCommand.class);
 
-    new SelenideDriverFinalCleanupThread(config, driver, proxy, closeDriverCommand).run();
+    new SelenideDriverFinalCleanupThread(config, driver, proxy, browserDownloadsFolder, closeDriverCommand).run();
 
-    verify(closeDriverCommand).closeAsync(config, driver, proxy);
+    verify(closeDriverCommand).closeAsync(config, driver, proxy, browserDownloadsFolder);
     verifyNoMoreInteractions(closeDriverCommand);
     verifyNoInteractions(config);
     verifyNoInteractions(driver);

--- a/src/test/java/com/codeborne/selenide/drivercommands/WebDriverWrapperTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/WebDriverWrapperTest.java
@@ -1,25 +1,51 @@
 package com.codeborne.selenide.drivercommands;
 
 import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
 
 import java.io.File;
+import java.io.IOException;
 
+import static java.nio.file.Files.createTempDirectory;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class WebDriverWrapperTest {
+  private File downloadsFolder;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    downloadsFolder = createTempDirectory("WebDriverWrapperTest").toFile();
+  }
 
   @Test
   void close_closesTheBrowser() {
     WebDriver webDriver = mock(WebDriver.class);
-    WebDriverWrapper driver = new WebDriverWrapper(new SelenideConfig(), webDriver, null, new File("build/downloads/135"));
+    WebDriverWrapper driver = new WebDriverWrapper(new SelenideConfig(), webDriver, null, downloadsFolder);
 
     driver.close();
 
     verify(webDriver).quit();
     verifyNoMoreInteractions(webDriver);
+    assertThat(downloadsFolder).doesNotExist();
+  }
+
+  @Test
+  void close_closesTheBrowser_withProxy() {
+    WebDriver webDriver = mock(WebDriver.class);
+    SelenideProxyServer proxy = mock(SelenideProxyServer.class);
+    WebDriverWrapper driver = new WebDriverWrapper(new SelenideConfig(), webDriver, proxy, downloadsFolder);
+
+    driver.close();
+
+    verify(webDriver).quit();
+    verify(proxy).shutdown();
+    verifyNoMoreInteractions(webDriver, proxy);
+    assertThat(downloadsFolder).doesNotExist();
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/FileHelperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/FileHelperTest.java
@@ -1,0 +1,59 @@
+package com.codeborne.selenide.impl;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.codeborne.selenide.impl.FileHelper.cleanupFolder;
+import static com.codeborne.selenide.impl.FileHelper.deleteFolderIfEmpty;
+import static java.nio.file.Files.createTempDirectory;
+import static org.apache.commons.io.FileUtils.deleteDirectory;
+import static org.apache.commons.io.FileUtils.touch;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileHelperTest {
+  private File folder;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    folder = createTempDirectory("FileHelperTest").toFile();
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    deleteDirectory(folder);
+  }
+
+  @Test
+  void cleanupFolder_deletesAllFilesFromFolder() throws IOException {
+    touch(new File(folder, "file1"));
+    touch(new File(folder, "file2"));
+
+    cleanupFolder(folder);
+
+    assertThat(folder).exists();
+    assertThat(new File(folder, "file1")).doesNotExist();
+    assertThat(new File(folder, "file2")).doesNotExist();
+  }
+
+  @Test
+  void deletesFolderIfItIsEmpty() {
+    deleteFolderIfEmpty(folder);
+    assertThat(folder).doesNotExist();
+  }
+
+  @Test
+  void ignoresNullParameter() {
+    deleteFolderIfEmpty(null);
+  }
+
+  @Test
+  void ignoresFolderWhichContainsFiles() throws IOException {
+    touch(new File(folder, "file1"));
+    deleteFolderIfEmpty(folder);
+    assertThat(folder).exists();
+  }
+}

--- a/statics/src/main/java/com/codeborne/selenide/impl/UnusedWebdriversCleanupThread.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/UnusedWebdriversCleanupThread.java
@@ -9,6 +9,8 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 
+import static com.codeborne.selenide.impl.FileHelper.deleteFolderIfEmpty;
+
 class UnusedWebdriversCleanupThread extends Thread {
   private static final Logger log = LoggerFactory.getLogger(UnusedWebdriversCleanupThread.class);
 
@@ -68,7 +70,8 @@ class UnusedWebdriversCleanupThread extends Thread {
       proxy.shutdown();
     }
 
-    threadDownloadsFolder.remove(thread.getId());
+    File downloadsFolder = threadDownloadsFolder.remove(thread.getId());
+    deleteFolderIfEmpty(downloadsFolder);
   }
 }
 

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -186,7 +186,8 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
     long threadId = currentThread().getId();
     WebDriver driver = threadWebDriver.get(threadId);
     SelenideProxyServer proxy = threadProxyServer.get(threadId);
-    closeDriverCommand.closeAsync(config, driver, proxy);
+    File downloadsFolder = threadDownloadsFolder.get(threadId);
+    closeDriverCommand.closeAsync(config, driver, proxy, downloadsFolder);
 
     resetWebDriver();
   }


### PR DESCRIPTION
... to avoid creating tons of empty subfolders in "build/downloads"

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
