### PR TITLE
#1013 improve error message when Selenide fails to describe an element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * #1241 make $.toString() more safe  --  see PR #1245
 * upgraded to WebDriverManager 4.1.0
 * #434 support working Sizzle together with Dojo.js, troop.js and JQuery  --  see PR #1242
+* #1013 improve error message when Selenide fails to describe an element  --  see PR #1239
 
 ## 5.13.1 (released 31.07.2020)
 * #1235 escape downloads path on Windows

--- a/src/main/java/com/codeborne/selenide/impl/Describe.java
+++ b/src/main/java/com/codeborne/selenide/impl/Describe.java
@@ -31,7 +31,7 @@ public class Describe {
   private Describe(Driver driver, WebElement element) {
     this.driver = driver;
     this.element = element;
-    sb.append('<').append(safeCall("tagName", element::getTagName));
+    sb.append('<').append(element.getTagName());
   }
 
   private Describe appendAttributes() {
@@ -147,10 +147,10 @@ public class Describe {
           .isDisplayed(element)
           .serialize();
     } catch (WebDriverException elementDoesNotExist) {
-      return Cleanup.of.webdriverExceptionMessage(elementDoesNotExist);
+      return failedToDescribe(Cleanup.of.webdriverExceptionMessage(elementDoesNotExist));
     }
-    catch (IndexOutOfBoundsException e) {
-      return e.toString();
+    catch (RuntimeException e) {
+      return failedToDescribe(e.toString());
     }
   }
 
@@ -166,11 +166,16 @@ public class Describe {
       }
       return new Describe(driver, element).attr("id").attr("name").flush();
     } catch (WebDriverException elementDoesNotExist) {
-      return Cleanup.of.webdriverExceptionMessage(elementDoesNotExist);
+      return failedToDescribe(Cleanup.of.webdriverExceptionMessage(elementDoesNotExist));
     }
-    catch (IndexOutOfBoundsException e) {
-      return e.toString();
+    catch (RuntimeException e) {
+      return failedToDescribe(e.toString());
     }
+  }
+
+  @Nonnull
+  private static String failedToDescribe(String s2) {
+    return "Ups, failed to described the element [caused by: " + s2 + ']';
   }
 
   private Describe isSelected(WebElement element) {

--- a/src/test/java/com/codeborne/selenide/impl/DescribeTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DescribeTest.java
@@ -41,7 +41,7 @@ class DescribeTest implements WithAssertions {
     doThrow(new ElementShould(driver, null, null, visible, webElement, null)).when(selenideElement).getTagName();
 
     assertThat(Describe.shortly(driver, selenideElement))
-      .isEqualTo("<StaleElementReferenceException: disappeared>");
+      .isEqualTo("Ups, failed to described the element [caused by: StaleElementReferenceException: disappeared]");
   }
 
   @Test
@@ -53,11 +53,31 @@ class DescribeTest implements WithAssertions {
   }
 
   @Test
-  void attribute_with_empty_value() {
+  void describe_attribute_with_empty_value() {
     Driver driver = mock(Driver.class);
     SelenideElement selenideElement = element("input", "readonly", "");
 
     assertThat(Describe.describe(driver, selenideElement)).isEqualTo("<input readonly>Hello yo</input>");
+  }
+
+  @Test
+  void describe_elementHasDisappeared() {
+    Driver driver = mock(Driver.class);
+    SelenideElement selenideElement = element("input", "readonly", "");
+    doThrow(new StaleElementReferenceException("Booo")).when(selenideElement).getTagName();
+
+    assertThat(Describe.describe(driver, selenideElement))
+      .isEqualTo("Ups, failed to described the element [caused by: StaleElementReferenceException: Booo]");
+  }
+
+  @Test
+  void describe_collectionHasResized() {
+    Driver driver = mock(Driver.class);
+    SelenideElement selenideElement = element("input", "readonly", "");
+    doThrow(new IndexOutOfBoundsException("Fooo")).when(selenideElement).getTagName();
+
+    assertThat(Describe.describe(driver, selenideElement))
+      .isEqualTo("Ups, failed to described the element [caused by: java.lang.IndexOutOfBoundsException: Fooo]");
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes
Fix for https://github.com/selenide/selenide/issues/1013

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
