### PR TITLE
#1241 make $.toString() more safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * #1166 added method `SelenideDriver.screenshot(fileName)`  --  see PR #1227
 * #1224 added method `SelenideDriver.screenshot(OutputType)`  --  see PR #1231
 * #1190 take screenshot if `switchTo(frame)` or `switchTo(window)` or `switchTo(alert)` failed  --  see PR #1240
+* #1241 make $.toString() more safe  --  see PR #1245
 * upgraded to WebDriverManager 4.1.0
 * #434 support working Sizzle together with Dojo.js, troop.js and JQuery  --  see PR #1242
 

--- a/src/test/java/com/codeborne/selenide/impl/DescribeTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DescribeTest.java
@@ -41,7 +41,7 @@ class DescribeTest implements WithAssertions {
     doThrow(new ElementShould(driver, null, null, visible, webElement, null)).when(selenideElement).getTagName();
 
     assertThat(Describe.shortly(driver, selenideElement))
-      .isEqualTo("StaleElementReferenceException: disappeared");
+      .isEqualTo("<StaleElementReferenceException: disappeared>");
   }
 
   @Test


### PR DESCRIPTION
it seems that sometimes `RemoteWebElement::getText` can throw `ClassCastException` instead of `StaleElementException`...

Fix for https://github.com/selenide/selenide/issues/1241
