### PR TITLE
Add chrome option "--disable-dev-shm-usage" to avoid crashing Chrome …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * #1190 take screenshot if `switchTo(frame)` or `switchTo(window)` or `switchTo(alert)` failed  --  see PR #1240
 * #1241 make $.toString() more safe  --  see PR #1245
 * upgraded to WebDriverManager 4.1.0
+* Add chrome option "--disable-dev-shm-usage" to avoid crashing Chrome because of out of memory error
 * #434 support working Sizzle together with Dojo.js, troop.js and JQuery  --  see PR #1242
 
 ## 5.13.1 (released 31.07.2020)

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -85,6 +85,7 @@ public class ChromeDriverFactory extends AbstractDriverFactory {
   protected List<String> createChromeArguments(Config config, Browser browser) {
     List<String> arguments = new ArrayList<>();
     arguments.add("--proxy-bypass-list=<-loopback>");
+    arguments.add("--disable-dev-shm-usage");
     arguments.addAll(parseArguments(System.getProperty("chromeoptions.args")));
     return arguments;
   }

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -133,6 +133,14 @@ class ChromeDriverFactoryTest implements WithAssertions {
   }
 
   @Test
+  void disablesUsingDevSharedMemory() {
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
+    List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
+
+    assertThat(optionArguments).contains("--disable-dev-shm-usage");
+  }
+
+  @Test
   void parseCSV() {
     assertThat(factory.parseCSV("123")).isEqualTo(singletonList("123"));
     assertThat(factory.parseCSV("foo bar")).isEqualTo(singletonList("foo bar"));


### PR DESCRIPTION
…because of out of memory error

* By default, chrome uses /dev/shm for shared memory
* /dev/shm has a limited size and might cause "out of memory" error when rendering big webpages
* Option "--disable-dev-shm-usage" disables using /dev/shm for shared memory. Thus, the size of shared memory is not limited anymore.
