### PR TITLE
#1220 cleanup downloads folder before every `$.download()` call

### DIFF
--- a/src/main/java/com/codeborne/selenide/Driver.java
+++ b/src/main/java/com/codeborne/selenide/Driver.java
@@ -17,6 +17,10 @@ public interface Driver {
   File browserDownloadsFolder();
   void close();
 
+  default boolean isDownloadsFolderUnique() {
+    return false;
+  }
+
   default boolean supportsJavascript() {
     return hasWebDriverStarted() && getWebDriver() instanceof JavascriptExecutor;
   }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.function.Predicate;
 
 @ParametersAreNonnullByDefault
@@ -36,7 +37,7 @@ public class DownloadFileWithProxyServer {
   @Nonnull
   public File download(WebElementSource anyClickableElement,
                        WebElement clickable, long timeout,
-                       FileFilter fileFilter) throws FileNotFoundException {
+                       FileFilter fileFilter) throws IOException {
 
     WebDriver webDriver = anyClickableElement.driver().getWebDriver();
     return windowsCloser.runAndCloseArisedWindows(webDriver, () ->

--- a/src/main/java/com/codeborne/selenide/impl/Downloader.java
+++ b/src/main/java/com/codeborne/selenide/impl/Downloader.java
@@ -30,11 +30,17 @@ public class Downloader {
   @CheckReturnValue
   @Nonnull
   public File prepareTargetFile(Config config, String fileName) {
+    File uniqueFolder = prepareTargetFolder(config);
+    return new File(uniqueFolder, fileName);
+  }
+
+  @Nonnull
+  public File prepareTargetFolder(Config config) {
     File uniqueFolder = new File(config.downloadsFolder(), random.text());
     if (uniqueFolder.exists()) {
       throw new IllegalStateException("Unbelievable! Unique folder already exists: " + uniqueFolder.getAbsolutePath());
     }
     ensureFolderExists(uniqueFolder);
-    return new File(uniqueFolder, fileName);
+    return uniqueFolder;
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/FileHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileHelper.java
@@ -53,9 +53,14 @@ public final class FileHelper {
     return folder;
   }
 
-  public static void cleanupFolder(File folder) throws IOException {
-    if (folder.isDirectory()) {
-      cleanDirectory(folder);
+  public static void cleanupFolder(File folder) {
+    try {
+      if (folder.isDirectory()) {
+        cleanDirectory(folder);
+      }
+    }
+    catch (IOException e) {
+      throw new IllegalStateException("Failed to cleanup folder " + folder.getAbsolutePath(), e);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/WindowsCloser.java
+++ b/src/main/java/com/codeborne/selenide/impl/WindowsCloser.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,7 +17,7 @@ public class WindowsCloser {
   private static final Logger log = LoggerFactory.getLogger(WindowsCloser.class);
 
   @CheckReturnValue
-  public <T> T runAndCloseArisedWindows(WebDriver webDriver, SupplierWithException<T> lambda) throws FileNotFoundException {
+  public <T> T runAndCloseArisedWindows(WebDriver webDriver, SupplierWithException<T> lambda) throws IOException {
     String originalWindowHandle = webDriver.getWindowHandle();
     Set<String> windowsBefore = webDriver.getWindowHandles();
 
@@ -71,6 +71,6 @@ public class WindowsCloser {
 
   @FunctionalInterface
   interface SupplierWithException<T> {
-    T get() throws FileNotFoundException;
+    T get() throws IOException;
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileToFolderTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileToFolderTest.java
@@ -24,9 +24,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 class DownloadFileToFolderTest {
+  private final Downloader downloader = new Downloader();
   private final Waiter waiter = new DummyWaiter();
   private final WindowsCloser windowsCloser = spy(new DummyWindowsCloser());
-  private final DownloadFileToFolder command = new DownloadFileToFolder(waiter, windowsCloser);
+  private final DownloadFileToFolder command = new DownloadFileToFolder(downloader, waiter, windowsCloser);
   private final SelenideConfig config = new SelenideConfig();
   private final WebDriver webdriver = mock(WebDriver.class);
   private final WebElementSource linkWithHref = mock(WebElementSource.class);
@@ -51,7 +52,7 @@ class DownloadFileToFolderTest {
     File downloadedFile = command.download(linkWithHref, link, 3000, FileFilters.none());
 
     assertThat(downloadedFile.getName()).isEqualTo(newFileName);
-    assertThat(downloadedFile.getParentFile().getAbsolutePath()).isEqualTo(driver.browserDownloadsFolder().getAbsolutePath());
+    assertThat(downloadedFile.getParentFile().getAbsolutePath()).isNotEqualTo(driver.browserDownloadsFolder().getAbsolutePath());
     assertThat(readFileToString(downloadedFile, UTF_8)).isEqualTo("Hello Bingo-Bongo");
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/DummyWindowsCloser.java
+++ b/src/test/java/com/codeborne/selenide/impl/DummyWindowsCloser.java
@@ -3,12 +3,12 @@ package com.codeborne.selenide.impl;
 import org.openqa.selenium.WebDriver;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 
 @ParametersAreNonnullByDefault
 public class DummyWindowsCloser extends WindowsCloser {
   @Override
-  public <T> T runAndCloseArisedWindows(WebDriver webDriver, SupplierWithException<T> lambda) throws FileNotFoundException {
+  public <T> T runAndCloseArisedWindows(WebDriver webDriver, SupplierWithException<T> lambda) throws IOException {
     return lambda.get();
   }
 }

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticDriver.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticDriver.java
@@ -68,6 +68,11 @@ public class StaticDriver implements Driver {
   }
 
   @Override
+  public boolean isDownloadsFolderUnique() {
+    return true;
+  }
+
+  @Override
   public void close() {
     WebDriverRunner.closeWebDriver();
   }

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -29,7 +29,7 @@ public class FileDownloadToFolderTest  extends IntegrationTest {
   private final File folder = new File(downloadsFolder);
 
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() {
     Configuration.fileDownload = FileDownloadMode.FOLDER;
     openFile("page_with_uploads.html");
     timeout = 4000;


### PR DESCRIPTION
NB! We can do it only for folders created by Selenide (aka "unique"). In case of folders provided by user, we cannot cleanup them.
