### PR TITLE
Upgrade commons-compress to 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.14.1 (released 21.08.2020)
+* Upgrade commons-compress to 1.20 because previous versions have security issue https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-460507
+
 ## 5.14.0 (released 17.08.2020)
 * #1220 create a unique downloads folder for every browser instance  --  see PR #1221
 * #1194 added method `$$.shouldHave(itemWithText("any text"))`  --  thanks to Luis Serna for PR #1194

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 group = 'com.codeborne'
 archivesBaseName = 'selenide'
-version = '5.14.0'
+version = '5.14.1'
 
 ext {
   encoding = StandardCharsets.UTF_8.name()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -46,6 +46,12 @@ dependencies {
   implementation('org.slf4j:slf4j-api:1.7.30')
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testRuntimeOnly('org.slf4j:slf4j-simple:1.7.30')
+
+  constraints {
+    implementation('org.apache.commons:commons-compress:1.20') {
+      because 'versions 1.15-1.19 have a security bug SNYK-JAVA-ORGAPACHECOMMONS-460507'
+    }
+  }
 }
 
 task libsProd(type: Sync) {


### PR DESCRIPTION
... because previous versions have security issue https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-460507

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
