### PR TITLE
Ability to access LocalStorage

### DIFF
--- a/src/main/java/com/codeborne/selenide/LocalStorage.java
+++ b/src/main/java/com/codeborne/selenide/LocalStorage.java
@@ -1,0 +1,35 @@
+package com.codeborne.selenide;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+
+public class LocalStorage {
+  private final Driver driver;
+
+  LocalStorage(Driver driver) {
+    this.driver = driver;
+  }
+
+  @CheckReturnValue
+  @Nullable
+  public String getItem(String key) {
+    return driver.executeJavaScript("return localStorage.getItem(arguments[0])", key);
+  }
+
+  public void setItem(String key, String value) {
+    driver.executeJavaScript("localStorage.setItem(arguments[0], arguments[1])", key, value);
+  }
+
+  public void removeItem(String key) {
+    driver.executeJavaScript("localStorage.removeItem(arguments[0])", key);
+  }
+
+  public void clear() {
+    driver.executeJavaScript("localStorage.clear()");
+  }
+
+  public int size() {
+    long size = driver.executeJavaScript("return localStorage.length");
+    return (int) size;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -423,6 +423,12 @@ public class SelenideDriver {
     return downloadFileWithHttpRequest().download(driver(), url, timeoutMs, none());
   }
 
+  @CheckReturnValue
+  @Nonnull
+  public LocalStorage getLocalStorage() {
+    return new LocalStorage(driver());
+  }
+
   private static SelenidePageFactory pageFactory;
   private static DownloadFileWithHttpRequest downloadFileWithHttpRequest;
 

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -977,4 +977,15 @@ public class Selenide {
   public static File download(String url, long timeoutMs) throws IOException, URISyntaxException {
     return getSelenideDriver().download(new URI(url), timeoutMs);
   }
+
+  /**
+   * Access browser's local storage.
+   * Allows setting, getting, removing items as well as getting the size and clear the storage.
+   *
+   * @return LocalStorage
+   */
+  @Nonnull
+  public static LocalStorage localStorage() {
+    return getSelenideDriver().getLocalStorage();
+  }
 }

--- a/statics/src/test/java/integration/LocalStorageTest.java
+++ b/statics/src/test/java/integration/LocalStorageTest.java
@@ -1,0 +1,49 @@
+package integration;
+
+import com.codeborne.selenide.Selenide;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Selenide.closeWebDriver;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalStorageTest extends IntegrationTest {
+  @AfterAll
+  static void tearDown() {
+    closeWebDriver();
+  }
+
+  @BeforeEach
+  void openTestPage() {
+    openFile("empty.html");
+  }
+
+  @Test
+  void setAndGetItem() {
+    Selenide.localStorage().setItem("cat", "Tom");
+    Selenide.localStorage().setItem("mouse", "Jerry");
+
+    String cat = Selenide.localStorage().getItem("cat");
+    String mouse = Selenide.localStorage().getItem("mouse");
+
+    assertThat(cat).isEqualTo("Tom");
+    assertThat(mouse).isEqualTo("Jerry");
+  }
+
+  @Test
+  void removeItem() {
+    Selenide.localStorage().setItem("cat", "Tom");
+    Selenide.localStorage().removeItem("cat");
+    String cat = Selenide.localStorage().getItem("cat");
+    assertThat(cat).isEqualTo(null);
+  }
+
+  @Test
+  void clearAndSizeLocalStorage() {
+    Selenide.localStorage().setItem("cat", "Tom");
+    Selenide.localStorage().setItem("mouse", "Jerry");
+    Selenide.localStorage().clear();
+    assertThat(Selenide.localStorage().size()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
## Proposed changes
Hello. Added ability to work with local storage via Selenide. 
Docs: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
