### PR TITLE
Add new collection condition - exactTextsCaseSensitiveInAnyOrder

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -3,6 +3,8 @@ package com.codeborne.selenide;
 import com.codeborne.selenide.collections.AllMatch;
 import com.codeborne.selenide.collections.AnyMatch;
 import com.codeborne.selenide.collections.ExactTexts;
+import com.codeborne.selenide.collections.ExactTextsCaseSensitiveInAnyOrder;
+import com.codeborne.selenide.collections.ItemWithText;
 import com.codeborne.selenide.collections.ListSize;
 import com.codeborne.selenide.collections.NoneMatch;
 import com.codeborne.selenide.collections.SizeGreaterThan;
@@ -12,15 +14,16 @@ import com.codeborne.selenide.collections.SizeLessThanOrEqual;
 import com.codeborne.selenide.collections.SizeNotEqual;
 import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.collections.TextsInAnyOrder;
-import com.codeborne.selenide.collections.ItemWithText;
 import com.codeborne.selenide.impl.WebElementsCollection;
+
 import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.function.Predicate;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.List;
-import java.util.function.Predicate;
 
 @ParametersAreNonnullByDefault
 public abstract class CollectionCondition implements Predicate<List<WebElement>> {
@@ -168,6 +171,30 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
   @CheckReturnValue
   public static CollectionCondition itemWithText(String expectedText) {
     return new ItemWithText(expectedText);
+  }
+
+  /**
+   * Checks that given collection has given texts in any order (each collection element EQUALS TO corresponding text)
+   *
+   * <p>NB! Case sensitive</p>
+   *
+   * @param expectedTexts Expected texts in any order in the collection
+   */
+  @CheckReturnValue
+  public static CollectionCondition exactTextsCaseSensitiveInAnyOrder(List<String> expectedTexts) {
+    return new ExactTextsCaseSensitiveInAnyOrder(expectedTexts);
+  }
+
+  /**
+   * Checks that given collection has given texts in any order (each collection element EQUALS TO corresponding text)
+   *
+   * <p>NB! Case sensitive</p>
+   *
+   * @param expectedTexts Expected texts in any order in the collection
+   */
+  @CheckReturnValue
+  public static CollectionCondition exactTextsCaseSensitiveInAnyOrder(String... expectedTexts) {
+    return new ExactTextsCaseSensitiveInAnyOrder(expectedTexts);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrder.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrder.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ExactTextsCaseSensitiveInAnyOrder extends ExactTexts {
 
@@ -22,10 +23,12 @@ public class ExactTextsCaseSensitiveInAnyOrder extends ExactTexts {
       return false;
     }
 
+    List<String> elementsTexts = elements.stream().map(WebElement::getText).collect(Collectors.toList());
+
     for (String expectedText : expectedTexts) {
       boolean found = false;
-      for (WebElement element : elements) {
-        if (Html.text.equalsCaseSensitive(element.getText(), expectedText)) {
+      for (String elementText : elementsTexts) {
+        if (Html.text.equalsCaseSensitive(elementText, expectedText)) {
           found = true;
         }
       }

--- a/src/main/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrder.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrder.java
@@ -1,0 +1,43 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.impl.Html;
+
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+public class ExactTextsCaseSensitiveInAnyOrder extends ExactTexts {
+
+  public ExactTextsCaseSensitiveInAnyOrder(String... exactTexts) {
+    super(exactTexts);
+  }
+
+  public ExactTextsCaseSensitiveInAnyOrder(List<String> exactTexts) {
+    super(exactTexts);
+  }
+
+  @Override
+  public boolean test(List<WebElement> elements) {
+    if (elements.size() != expectedTexts.size()) {
+      return false;
+    }
+
+    for (String expectedText : expectedTexts) {
+      boolean found = false;
+      for (WebElement element : elements) {
+        if (Html.text.equalsCaseSensitive(element.getText(), expectedText)) {
+          found = true;
+        }
+      }
+      if (!found) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "Exact texts case sensitive in any order " + expectedTexts;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/collections/TextsInAnyOrder.java
+++ b/src/main/java/com/codeborne/selenide/collections/TextsInAnyOrder.java
@@ -1,10 +1,13 @@
 package com.codeborne.selenide.collections;
 
 import com.codeborne.selenide.impl.Html;
+
 import org.openqa.selenium.WebElement;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class TextsInAnyOrder extends ExactTexts {
@@ -22,10 +25,12 @@ public class TextsInAnyOrder extends ExactTexts {
       return false;
     }
 
+    List<String> elementsTexts = elements.stream().map(WebElement::getText).collect(Collectors.toList());
+
     for (String expectedText : expectedTexts) {
       boolean found = false;
-      for (WebElement element : elements) {
-        if (Html.text.contains(element.getText(), expectedText)) {
+      for (String elementText : elementsTexts) {
+        if (Html.text.contains(elementText, expectedText)) {
           found = true;
         }
       }

--- a/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.collections.ExactTexts;
+import com.codeborne.selenide.collections.ExactTextsCaseSensitiveInAnyOrder;
 import com.codeborne.selenide.collections.ListSize;
 import com.codeborne.selenide.collections.SizeGreaterThan;
 import com.codeborne.selenide.collections.SizeGreaterThanOrEqual;
@@ -9,6 +10,7 @@ import com.codeborne.selenide.collections.SizeLessThanOrEqual;
 import com.codeborne.selenide.collections.SizeNotEqual;
 import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.collections.TextsInAnyOrder;
+
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
@@ -123,5 +125,17 @@ final class CollectionConditionTest implements WithAssertions {
     assertThat(collectionCondition)
       .as("Should contain explanation")
       .hasToString("texts [One] (because should be)");
+  }
+
+  @Test
+  void testExactTextsCaseSensitiveInAnyOrderWithList() {
+    CollectionCondition condition = CollectionCondition.exactTextsCaseSensitiveInAnyOrder(asList("One", "Two"));
+    assertThat(condition).isInstanceOf(ExactTextsCaseSensitiveInAnyOrder.class);
+  }
+
+  @Test
+  void testExactTextsCaseSensitiveInAnyOrderWithVarargs() {
+    CollectionCondition condition = CollectionCondition.exactTextsCaseSensitiveInAnyOrder("One", "Two");
+    assertThat(condition).isInstanceOf(ExactTextsCaseSensitiveInAnyOrder.class);
   }
 }

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrderTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrderTest.java
@@ -8,7 +8,7 @@ import static java.util.Arrays.asList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class ExactTextsInAnyOrderTest implements WithAssertions {
+class ExactTextsCaseSensitiveInAnyOrderTest implements WithAssertions {
 
   @Test
   void shouldMatchWithSameOrder() {

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsInAnyOrderTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsInAnyOrderTest.java
@@ -1,0 +1,67 @@
+package com.codeborne.selenide.collections;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ExactTextsInAnyOrderTest implements WithAssertions {
+
+  @Test
+  void shouldMatchWithSameOrder() {
+    ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder(asList("One", "Two", "Three"));
+    testApplyMethod(true, texts);
+  }
+
+  private void testApplyMethod(boolean shouldMatch, ExactTextsCaseSensitiveInAnyOrder texts) {
+    WebElement mockElement1 = mock(WebElement.class);
+    WebElement mockElement2 = mock(WebElement.class);
+    WebElement mockElement3 = mock(WebElement.class);
+
+    when(mockElement1.getText()).thenReturn("One");
+    when(mockElement2.getText()).thenReturn("Two");
+    when(mockElement3.getText()).thenReturn("Three");
+    assertThat(texts.test(asList(mockElement1, mockElement2, mockElement3)))
+      .isEqualTo(shouldMatch);
+  }
+
+  @Test
+  void shouldMatchWithDifferentOrder() {
+    ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder(asList("One", "Three", "Two"));
+    testApplyMethod(true, texts);
+  }
+
+  @Test
+  void shouldNotMatchWithSameOrderAndDifferentCase() {
+    ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder("one", "two", "three");
+    testApplyMethod(false, texts);
+  }
+
+  @Test
+  void shouldNotMatchWithDifferentOrderAndDifferentCase() {
+    ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder("one", "three", "two");
+    testApplyMethod(false, texts);
+  }
+
+  @Test
+  void shouldNotMatchWithSmallerListSize() {
+    ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder("One", "Two");
+    testApplyMethod(false, texts);
+  }
+
+  @Test
+  void shouldNotMatchWithBiggerListSize() {
+    ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder("One", "Two", "Three", "four");
+    testApplyMethod(false, texts);
+  }
+
+  @Test
+  void shouldHaveCorrectToString() {
+    assertThat(new ExactTextsCaseSensitiveInAnyOrder("One", "Two"))
+      .hasToString("Exact texts case sensitive in any order [One, Two]");
+  }
+
+}

--- a/src/test/java/com/codeborne/selenide/conditions/ExactTextCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/ExactTextCaseSensitiveTest.java
@@ -1,0 +1,43 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ExactTextCaseSensitiveTest {
+
+  private final Driver driver = mock(Driver.class);
+  private final WebElement element = mock(WebElement.class);
+
+  @BeforeEach
+  void setUp() {
+    when(element.getText()).thenReturn("One");
+  }
+
+  @Test
+  void shouldMatchExpectedTextWithSameCase() {
+    assertThat(new ExactTextCaseSensitive("One").apply(driver, element)).isEqualTo(true);
+  }
+
+  @Test
+  void shouldNotMatchExpectedTextWithDifferentCase() {
+    assertThat(new ExactTextCaseSensitive("one").apply(driver, element)).isEqualTo(false);
+  }
+
+  @Test
+  void shouldNotMatchDifferentExpectedText() {
+    assertThat(new ExactTextCaseSensitive("Two").apply(driver, element)).isEqualTo(false);
+  }
+
+  @Test
+  void shouldHaveCorrectToString() {
+    assertThat(new ExactTextCaseSensitive("One")).hasToString("exact text case sensitive 'One'");
+  }
+
+}

--- a/src/test/resources/page_with_list_of_elements.html
+++ b/src/test/resources/page_with_list_of_elements.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+<h1>List of elements</h1>
+<div class="element">One</div>
+<div class="element">Two</div>
+<div class="element">Three</div>
+</body>
+</html>

--- a/statics/src/test/java/integration/ElementsCollectionTextsTest.java
+++ b/statics/src/test/java/integration/ElementsCollectionTextsTest.java
@@ -1,0 +1,40 @@
+package integration;
+
+import com.codeborne.selenide.ex.TextsMismatch;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.codeborne.selenide.CollectionCondition.exactTextsCaseSensitiveInAnyOrder;
+import static com.codeborne.selenide.Selenide.$$;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ElementsCollectionTextsTest extends IntegrationTest {
+
+  @BeforeEach
+  void setUp() {
+    openFile("page_with_list_of_elements.html");
+  }
+
+  @Test
+  void shouldMatchTextsOfElementsWithSameOrder() {
+    List<String> expectedTexts = Arrays.asList("One", "Two", "Three");
+    $$(".element").shouldHave(exactTextsCaseSensitiveInAnyOrder(expectedTexts));
+  }
+
+  @Test
+  void shouldMatchTextsOfElementsWithDifferentOrder() {
+    List<String> expectedTexts = Arrays.asList("One", "Three", "Two");
+    $$(".element").shouldHave(exactTextsCaseSensitiveInAnyOrder(expectedTexts));
+  }
+
+  @Test
+  void shouldFailWithExpectedTextsWithDifferentCase() {
+    List<String> expectedTexts = Arrays.asList("one", "Three", "Two");
+    assertThrows(TextsMismatch.class, () ->
+      $$(".element").shouldHave(exactTextsCaseSensitiveInAnyOrder(expectedTexts)));
+  }
+}


### PR DESCRIPTION
## Proposed changes
Add new collection condition `exactTextsCaseSensitiveInAnyOrder`. There's already a condition to check that a given elements collection contains expected texts in any order. But it doesn't check for the exact text and case. The proposed condition uses `equalsCaseSensitive` comparison.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
