### PR TITLE
#1261 Add actual own text to error message (when one of checks `ownTe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.16.0 (planned to 2x.10.2020)
 * #1051 Selenide plugins system
+* #1261 Add actual own text to error message (when one of checks `ownText`, `exactOwnText` fails)
 
 ## 5.15.1 (released 03.10.2020)
 * Fix creating logs dir in parallel tests

--- a/src/main/java/com/codeborne/selenide/conditions/ExactOwnText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/ExactOwnText.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.commands.GetOwnText.getOwnText;
@@ -28,4 +29,9 @@ public class ExactOwnText extends Condition {
     return String.format("%s '%s'", getName(), expectedText);
   }
 
+  @Nullable
+  @Override
+  public String actualValue(Driver driver, WebElement element) {
+    return getOwnText(driver, element);
+  }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/OwnText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/OwnText.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.commands.GetOwnText.getOwnText;
@@ -33,4 +34,9 @@ public class OwnText extends Condition {
     return String.format("%s '%s'", getName(), expectedText);
   }
 
+  @Nullable
+  @Override
+  public String actualValue(Driver driver, WebElement element) {
+    return getOwnText(driver, element);
+  }
 }

--- a/statics/src/test/java/integration/ElementTextTest.java
+++ b/statics/src/test/java/integration/ElementTextTest.java
@@ -59,5 +59,6 @@ final class ElementTextTest extends IntegrationTest {
     $("#parent_div").shouldHave(exactOwnText("Big papa"));
     $("#parent_div").shouldNotHave(exactOwnText("papa"));
     $("#parent_div").shouldNotHave(exactOwnText("Son"));
-    $("#parent_div").shouldNotHave(exactOwnText("Daughter"));  }
+    $("#parent_div").shouldNotHave(exactOwnText("Daughter"));
+  }
 }


### PR DESCRIPTION
…xt`, `exactOwnText` fails)

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
