### PR TITLE
fixes #1298 - href condition for encoded vals

### DIFF
--- a/src/main/java/com/codeborne/selenide/conditions/Href.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Href.java
@@ -19,9 +19,11 @@ public class Href extends AttributeWithValue {
   @CheckReturnValue
   @Override
   public boolean apply(Driver driver, WebElement element) {
-    String fullUrl = decode(getAttributeValue(element));
+    String href = getAttributeValue(element);
+    String fullUrl = decode(href);
     return fullUrl.endsWith(expectedAttributeValue) ||
-      fullUrl.endsWith(expectedAttributeValue + "/");
+      fullUrl.endsWith(expectedAttributeValue + "/") ||
+      href.endsWith(expectedAttributeValue);
   }
 
   String decode(String url) {

--- a/src/test/java/com/codeborne/selenide/conditions/HrefTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/HrefTest.java
@@ -39,6 +39,11 @@ final class HrefTest {
   }
 
   @Test
+  void hrefContainingEncodedSpace() {
+    assertThat(new Href("some%20file.pdf").apply(driver, link("https://dropbox.com/some%20file.pdf"))).isTrue();
+  }
+
+  @Test
   void decodesUrl() {
     Href condition = new Href("");
     assertThat(condition.decode("https://yandex.ee")).isEqualTo("https://yandex.ee");

--- a/src/test/resources/page_with_uploads.html
+++ b/src/test/resources/page_with_uploads.html
@@ -14,5 +14,6 @@
     <a href="/files/файл-с-запрещёнными-символами.txt">Download file with "forbidden" characters in name</a>
     <a href="/files/minimal.pdf">Download a PDF</a>
     <a href="/files/unexisting_file.png">Download missing file</a>
+    <a href="/files/unexisting%20file%20encoded.png">Check href value</a>
   </body>
 </html>

--- a/statics/src/test/java/integration/HrefTest.java
+++ b/statics/src/test/java/integration/HrefTest.java
@@ -33,5 +33,6 @@ final class HrefTest extends IntegrationTest {
     $("a", 1).shouldHave(href("/files/hello_world.txt?pause=2000"));
     $("a", 2).shouldHave(href("/files/файл-с-русским-названием.txt"));
     $("a", 3).shouldHave(href("/files/файл-с-запрещёнными-символами.txt"));
+    $(byText("Check href value")).shouldHave(href("unexisting%20file%20encoded.png"));
   }
 }


### PR DESCRIPTION


## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
