### PR TITLE
Improve toString for NOT condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 5.16.0 (planned to 2x.10.2020)
+* Improve NOT condition description
 * Improve AND condition description
 * #1051 Selenide plugins system
 * #1261 Add actual own text to error message (when one of checks `ownText`, `exactOwnText` fails)

--- a/src/main/java/com/codeborne/selenide/conditions/Not.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Not.java
@@ -24,4 +24,9 @@ public class Not extends Condition {
   public String actualValue(Driver driver, WebElement element) {
     return condition.actualValue(driver, element);
   }
+
+  @Override
+  public String toString() {
+    return "not " + condition.toString();
+  }
 }

--- a/src/test/java/com/codeborne/selenide/conditions/ExplainedConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/ExplainedConditionTest.java
@@ -1,7 +1,6 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Condition;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,7 +52,7 @@ final class ExplainedConditionTest {
     assertThat(hidden.negate().toString()).isEqualTo("not hidden (because I don't see it)");
   }
 
-  @Test @Disabled
+  @Test
   void toString_haveText() {
     assertThat(text.toString()).isEqualTo("text 'blah' (because I typed it)");
     assertThat(text.negate().toString()).isEqualTo("not text 'blah' (because I typed it)");

--- a/src/test/java/com/codeborne/selenide/conditions/NotTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/NotTest.java
@@ -1,0 +1,78 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Driver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openqa.selenium.WebElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotTest {
+  Condition originalCondition = mock(Condition.class);
+  Not notCondition;
+
+  @BeforeEach
+  void commonMockCalls() {
+    // constructor call
+    when(originalCondition.getName()).thenReturn("original condition name");
+    notCondition = new Not(originalCondition, false);
+  }
+
+  @AfterEach
+  void verifyNoMoreInteractions() {
+    // constructor call
+    verify(originalCondition).getName();
+    Mockito.verifyNoMoreInteractions(originalCondition);
+  }
+
+  @Test
+  void getName() {
+    assertThat(notCondition.getName()).isEqualTo("not original condition name");
+  }
+
+  @Test
+  void actualValue() {
+    Driver driver = mock(Driver.class);
+    WebElement webElement = mock(WebElement.class);
+    when(originalCondition.actualValue(any(Driver.class), any(WebElement.class)))
+      .thenReturn("original condition actual value");
+
+
+    assertThat(notCondition.actualValue(driver, webElement)).isEqualTo("original condition actual value");
+    verify(originalCondition).actualValue(driver, webElement);
+  }
+
+  @Test
+  void applyFalse() {
+    Driver driver = mock(Driver.class);
+    WebElement webElement = mock(WebElement.class);
+    when(originalCondition.apply(any(Driver.class), any(WebElement.class))).thenReturn(true);
+
+    assertThat(notCondition.apply(driver, webElement)).isFalse();
+    verify(originalCondition).apply(driver, webElement);
+  }
+
+  @Test
+  void applyTrue() {
+    Driver driver = mock(Driver.class);
+    WebElement webElement = mock(WebElement.class);
+    when(originalCondition.apply(any(Driver.class), any(WebElement.class))).thenReturn(false);
+
+    assertThat(notCondition.apply(driver, webElement)).isTrue();
+    verify(originalCondition).apply(driver, webElement);
+  }
+
+  @Test
+  void hasToString() {
+    when(originalCondition.toString()).thenReturn("original condition toString");
+
+    assertThat(notCondition).hasToString("not original condition toString");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/conditions/TextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/TextTest.java
@@ -34,6 +34,16 @@ final class TextTest implements WithAssertions {
     assertThat(new Text("Hello World").apply(driver, select("Hello", " World"))).isTrue();
   }
 
+  @Test
+  void to_string() {
+    assertThat(new Text("Hello World")).hasToString("text 'Hello World'");
+  }
+
+  @Test
+  void negate_to_string() {
+    assertThat(new Text("Hello World").negate()).hasToString("not text 'Hello World'");
+  }
+
   private WebElement elementWithText(String text) {
     WebElement webElement = mock(WebElement.class);
     when(webElement.getText()).thenReturn(text);


### PR DESCRIPTION
NOT(negate) does not provide all details if use it for condition with overridden toString method (e.g. Text)

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
