### PR TITLE
Fix/1307 multiple download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Improve AND condition description
 * #1051 Selenide plugins system
 * #1261 Add actual own text to error message (when one of checks `ownText`, `exactOwnText` fails)
+* #1307 Allow Chrome to download multiple files in one request (set as default setting)
 
 ## 5.15.1 (released 03.10.2020)
 * Fix creating logs dir in parallel tests

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -117,6 +117,7 @@ public class ChromeDriverFactory extends AbstractDriverFactory {
     Map<String, Object> chromePreferences = new HashMap<>();
     chromePreferences.put("credentials_enable_service", false);
     chromePreferences.put("plugins.always_open_pdf_externally", true);
+    chromePreferences.put("profile.default_content_setting_values.automatic_downloads", 1);
 
     if (config.remote() == null) {
       chromePreferences.put("download.default_directory", browserDownloadsFolder.getAbsolutePath());

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -44,9 +44,10 @@ final class ChromeDriverFactoryTest implements WithAssertions {
     Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
-    assertThat(prefsMap).hasSize(3);
+    assertThat(prefsMap).hasSizeGreaterThanOrEqualTo(4);
     assertThat(prefsMap).containsEntry("credentials_enable_service", false);
     assertThat(prefsMap).containsEntry("plugins.always_open_pdf_externally", true);
+    assertThat(prefsMap).containsEntry("profile.default_content_setting_values.automatic_downloads", 1);
     assertThat(prefsMap).containsEntry("download.default_directory",
       new File(DOWNLOADS_FOLDER).getAbsolutePath());
   }

--- a/src/test/resources/downloadMultipleFiles.html
+++ b/src/test/resources/downloadMultipleFiles.html
@@ -1,0 +1,45 @@
+<html>
+  <body>
+    <button id="two-downloads" onclick="do_dl()">Download two files</button>
+  </body>
+  <script> function download_files(files) {
+      function download_next(i) {
+        if (i >= files.length) {
+          return;
+        }
+        var a = document.createElement('a');
+        a.href = files[i].download;
+        a.target = '_parent';
+    // Use a.download if available, it prevents plugins from opening.
+        if ('download' in a) {
+          a.download = files[i].filename;
+        }
+    // Add a to the doc for click to work.
+        (document.body || document.documentElement).appendChild(a);
+        if (a.click) {
+          a.click(); // The click method is supported by most browsers.
+        } else {
+          $(a).click(); // Backup using jquery
+        }
+    // Delete the temporary link.
+        a.parentNode.removeChild(a);
+    // Download the next file with a small timeout. The timeout is necessary
+    // for IE, which will otherwise only download the first file.
+        setTimeout(function () {
+          download_next(i + 1);
+        }, 500);
+      }
+
+    // Initiate the first download.
+      download_next(0);
+    }
+
+    function do_dl() {
+      download_files([
+        {download: "download.html", filename: "file1.txt"},
+        {download: "empty.html", filename: "file2.txt"},
+
+      ]);
+    };
+  </script>
+</html>

--- a/src/test/resources/downloadMultipleFiles.html
+++ b/src/test/resources/downloadMultipleFiles.html
@@ -1,45 +1,49 @@
-<html>
-  <body>
-    <button id="two-downloads" onclick="do_dl()">Download two files</button>
-  </body>
-  <script> function download_files(files) {
-      function download_next(i) {
-        if (i >= files.length) {
-          return;
-        }
-        var a = document.createElement('a');
-        a.href = files[i].download;
-        a.target = '_parent';
-    // Use a.download if available, it prevents plugins from opening.
-        if ('download' in a) {
-          a.download = files[i].filename;
-        }
-    // Add a to the doc for click to work.
-        (document.body || document.documentElement).appendChild(a);
-        if (a.click) {
-          a.click(); // The click method is supported by most browsers.
-        } else {
-          $(a).click(); // Backup using jquery
-        }
-    // Delete the temporary link.
-        a.parentNode.removeChild(a);
-    // Download the next file with a small timeout. The timeout is necessary
-    // for IE, which will otherwise only download the first file.
-        setTimeout(function () {
-          download_next(i + 1);
-        }, 500);
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Test::downloads::multiple files</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+</head>
+<body>
+<button id="multiple-downloads">Download three files</button>
+<script>
+  (function() {
+    function createLink(file) {
+      let link = document.createElement('a');
+      link.href = file.download;
+      link.target = '_parent';
+      if ('download' in link) {
+        // Use a.download if available, it prevents plugins from opening.
+        link.download = file.filename;
       }
-
-    // Initiate the first download.
-      download_next(0);
+      return link;
     }
 
-    function do_dl() {
-      download_files([
+    function downloadFile(file) {
+      let link = createLink(file);
+      (document.body || document.documentElement).appendChild(link);
+      link.click();
+      link.parentNode.removeChild(link);
+    }
+
+    function downloadFiles(files) {
+      files.forEach(function(file, index) {
+        // The timeout is necessary for IE, which will otherwise only download the first file.
+        setTimeout(function() {
+          downloadFile(file);
+        }, index);
+      });
+    }
+
+    document.getElementById('multiple-downloads').addEventListener('click', function() {
+      downloadFiles([
         {download: "download.html", filename: "file1.txt"},
         {download: "empty.html", filename: "file2.txt"},
-
+        {download: "hello_world.txt", filename: "file3.txt"},
       ]);
-    };
-  </script>
+    }, false);
+  })();
+</script>
+</body>
 </html>

--- a/statics/src/test/java/integration/proxy/MultipleDownloadsTest.java
+++ b/statics/src/test/java/integration/proxy/MultipleDownloadsTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MultipleDownloadsTest extends IntegrationTest {
   @BeforeEach
   void setUp() {
-    closeWebDriver();
     useProxy(true);
   }
 

--- a/statics/src/test/java/integration/proxy/MultipleDownloadsTest.java
+++ b/statics/src/test/java/integration/proxy/MultipleDownloadsTest.java
@@ -1,0 +1,27 @@
+package integration.proxy;
+
+import com.codeborne.selenide.files.FileFilters;
+import integration.IntegrationTest;
+import org.junit.jupiter.api.*;
+
+import java.io.*;
+
+import static com.codeborne.selenide.DownloadOptions.using;
+import static com.codeborne.selenide.FileDownloadMode.PROXY;
+import static com.codeborne.selenide.Selenide.*;
+
+public class MultipleDownloadsTest extends IntegrationTest {
+  @BeforeEach
+  void setUp() {
+    closeWebDriver();
+    useProxy(true);
+  }
+  @Test
+  void downloadMultipleFiles() throws FileNotFoundException {
+    open("/downloadMultipleFiles.html");
+    File text = $("#two-downloads").download(using(PROXY)
+      .withTimeout(6000).withFilter(FileFilters.withName("empty.html")));
+    Assertions.assertEquals("empty.html", text.getName());
+    Assertions.assertEquals(224, text.length());
+  }
+}

--- a/statics/src/test/java/integration/proxy/MultipleDownloadsTest.java
+++ b/statics/src/test/java/integration/proxy/MultipleDownloadsTest.java
@@ -1,14 +1,18 @@
 package integration.proxy;
 
-import com.codeborne.selenide.files.FileFilters;
 import integration.IntegrationTest;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
 
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
-import static com.codeborne.selenide.Selenide.*;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.files.FileFilters.withName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultipleDownloadsTest extends IntegrationTest {
   @BeforeEach
@@ -16,12 +20,16 @@ public class MultipleDownloadsTest extends IntegrationTest {
     closeWebDriver();
     useProxy(true);
   }
+
   @Test
   void downloadMultipleFiles() throws FileNotFoundException {
     open("/downloadMultipleFiles.html");
-    File text = $("#two-downloads").download(using(PROXY)
-      .withTimeout(6000).withFilter(FileFilters.withName("empty.html")));
-    Assertions.assertEquals("empty.html", text.getName());
-    Assertions.assertEquals(224, text.length());
+
+    File text = $("#multiple-downloads").download(
+      using(PROXY).withTimeout(4000).withFilter(withName("empty.html"))
+    );
+
+    assertEquals("empty.html", text.getName());
+    assertEquals(224, text.length());
   }
 }

--- a/statics/src/test/java/integration/proxy/ProxyServerUsageTest.java
+++ b/statics/src/test/java/integration/proxy/ProxyServerUsageTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.getSelenideProxy;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,7 +21,6 @@ final class ProxyServerUsageTest extends IntegrationTest {
   @BeforeEach
   @AfterEach
   void setUp() {
-    closeWebDriver();
     useProxy(true);
   }
 


### PR DESCRIPTION
## Proposed changes
This is a fix for #1307 which allows download multiple file by chrome as default setting

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

