### PR TITLE
add parent element to ElementFinder.getSearchCriteria

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
@@ -140,9 +140,18 @@ public class ElementFinder extends WebElementSource {
   @CheckReturnValue
   @Nonnull
   public String getSearchCriteria() {
+    return parent == null ?
+      elementCriteria() :
+      (parent instanceof SelenideElement) ?
+        ((SelenideElement) parent).getSearchCriteria() + "/" + elementCriteria() :
+        elementCriteria();
+  }
+
+  @Nonnull
+  private String elementCriteria() {
     return index == 0 ?
-        describe.selector(criteria) :
-        describe.selector(criteria) + '[' + index + ']';
+      describe.selector(criteria) :
+      describe.selector(criteria) + '[' + index + ']';
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/impl/ElementFinderTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ElementFinderTest.java
@@ -16,6 +16,7 @@ final class ElementFinderTest implements WithAssertions {
   void testToStringForFinderByCssSelectors() {
     SelenideElement parent = mock(SelenideElement.class);
     when(parent.toString()).thenReturn("table");
+    when(parent.getSearchCriteria()).thenReturn("table");
     when(parent.getTagName()).thenReturn("table");
 
     assertThat(new ElementFinder(driver, null, By.id("app"), 0))
@@ -23,14 +24,15 @@ final class ElementFinderTest implements WithAssertions {
     assertThat(new ElementFinder(driver, null, By.id("app"), 3))
       .hasToString("{By.id: app[3]}");
     assertThat(new ElementFinder(driver, parent, By.id("app"), 0))
-      .hasToString("{By.id: app}");
+      .hasToString("{table/By.id: app}");
     assertThat(new ElementFinder(driver, parent, By.id("app"), 3))
-      .hasToString("{By.id: app[3]}");
+      .hasToString("{table/By.id: app[3]}");
   }
 
   @Test
   void testToStringForFinderByXpathExpiration() {
     SelenideElement parent = mock(SelenideElement.class);
+    when(parent.getSearchCriteria()).thenReturn("By.xpath: //table");
     when(parent.toString()).thenReturn("table");
     when(parent.getTagName()).thenReturn("table");
 
@@ -39,8 +41,8 @@ final class ElementFinderTest implements WithAssertions {
     assertThat(new ElementFinder(driver, null, By.xpath("//*[@id='app']"), 3))
       .hasToString("{By.xpath: //*[@id='app'][3]}");
     assertThat(new ElementFinder(driver, parent, By.xpath("//*[@id='app']"), 0))
-      .hasToString("{By.xpath: //*[@id='app']}");
+      .hasToString("{By.xpath: //table/By.xpath: //*[@id='app']}");
     assertThat(new ElementFinder(driver, parent, By.xpath("//*[@id='app']"), 3))
-      .hasToString("{By.xpath: //*[@id='app'][3]}");
+      .hasToString("{By.xpath: //table/By.xpath: //*[@id='app'][3]}");
   }
 }

--- a/src/test/java/integration/LastChildTest.java
+++ b/src/test/java/integration/LastChildTest.java
@@ -31,7 +31,7 @@ final class LastChildTest extends ITest {
   void throwsExceptionWhenNoChildrenExist() {
     assertThatThrownBy(() -> $x("//span[@id='hello-world']").lastChild().should(be(visible)))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageStartingWith(String.format("Element not found {By.xpath: *[last()]}%nExpected: be visible"));
+      .hasMessageStartingWith(String.format("Element not found {By.xpath: //span[@id='hello-world']/By.xpath: *[last()]}%nExpected: be visible"));
   }
 
 }

--- a/src/test/java/integration/LastChildTest.java
+++ b/src/test/java/integration/LastChildTest.java
@@ -29,9 +29,11 @@ final class LastChildTest extends ITest {
 
   @Test
   void throwsExceptionWhenNoChildrenExist() {
+    String expectedError = String.format("Element not found {By.xpath: //span[@id='hello-world']" +
+      "/By.xpath: *[last()]}%nExpected: be visible");
     assertThatThrownBy(() -> $x("//span[@id='hello-world']").lastChild().should(be(visible)))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageStartingWith(String.format("Element not found {By.xpath: //span[@id='hello-world']/By.xpath: *[last()]}%nExpected: be visible"));
+      .hasMessageStartingWith(expectedError);
   }
 
 }

--- a/src/test/java/integration/SiblingTest.java
+++ b/src/test/java/integration/SiblingTest.java
@@ -30,7 +30,7 @@ final class SiblingTest extends ITest {
   void errorWhenSiblingAbsent() {
     assertThatThrownBy(() -> $("#multirowTableFirstRow").sibling(3).click())
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageStartingWith("Element not found {By.xpath: following-sibling::*[4]}");
+      .hasMessageStartingWith("Element not found {#multirowTableFirstRow/By.xpath: following-sibling::*[4]}");
   }
 
   @Test
@@ -48,6 +48,6 @@ final class SiblingTest extends ITest {
   void errorWhenPrecedingElementAbsent() {
     assertThatThrownBy(() -> $("#multirowTableSecondRow").preceding(3).click())
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageStartingWith("Element not found {By.xpath: preceding-sibling::*[4]}");
+      .hasMessageStartingWith("Element not found {#multirowTableSecondRow/By.xpath: preceding-sibling::*[4]}");
   }
 }

--- a/statics/src/test/java/integration/errormessages/ErrorMsgWithScreenshotsTest.java
+++ b/statics/src/test/java/integration/errormessages/ErrorMsgWithScreenshotsTest.java
@@ -80,7 +80,7 @@ final class ErrorMsgWithScreenshotsTest extends IntegrationTest {
         .shouldBe(visible)
     )
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("Element not found {thead}")
+      .hasMessageContaining("Element not found {#multirowTable/thead}")
       .matches(e -> {
         String path = "/integration/errormessages/ErrorMsgWithScreenshotsTest/reportWhichParentElementIsNotFound";
         return ((ElementNotFound) e).getScreenshot()
@@ -119,7 +119,7 @@ final class ErrorMsgWithScreenshotsTest extends IntegrationTest {
     }
     catch (ElementNotFound e) {
       assertThat(e)
-        .hasMessageContaining("Element not found {.second_row}");
+        .hasMessageContaining("Element not found {#multirowTable/tbody tr.findBy(text 'Norris')/.second_row}");
     }
   }
 

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnElementFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnElementFailsOnTest.java
@@ -209,7 +209,7 @@ final class MethodCalledOnElementFailsOnTest extends IntegrationTest {
       fail("Expected ElementNotFound");
     } catch (ElementNotFound expected) {
       assertThat(expected)
-        .hasMessageStartingWith("Element not found {.nonexistent}");
+        .hasMessageStartingWith("Element not found {ul/.nonexistent}");
       assertThat(expected)
         .hasMessageContaining("Expected: visible");
       assertScreenshot(expected);
@@ -228,7 +228,7 @@ final class MethodCalledOnElementFailsOnTest extends IntegrationTest {
       fail("Expected ElementNotFound");
     } catch (ElementNotFound expected) {
       assertThat(expected)
-        .hasMessageStartingWith("Element not found {.nonexistent}");
+        .hasMessageStartingWith("Element not found {ul/.nonexistent}");
       assertThat(expected)
         .hasMessageContaining("Expected: visible");
       assertScreenshot(expected);
@@ -307,7 +307,7 @@ final class MethodCalledOnElementFailsOnTest extends IntegrationTest {
       fail("Expected ElementNotFound");
     } catch (ElementNotFound expected) {
       assertThat(expected)
-        .hasMessageStartingWith("Element not found {.nonexistent}");
+        .hasMessageStartingWith("Element not found {ul li.filter(css class 'the-expanse').findBy(css class 'detective')/.nonexistent}");
       assertThat(expected)
         .hasMessageContaining("Expected: exact text 'detective'");
       assertScreenshot(expected);
@@ -386,7 +386,7 @@ final class MethodCalledOnElementFailsOnTest extends IntegrationTest {
       fail("Expected ElementNotFound");
     } catch (ElementNotFound expected) {
       assertThat(expected)
-        .hasMessageStartingWith("Element not found {.nonexistent}");
+        .hasMessageStartingWith("Element not found {ul li.filter(css class 'the-expanse')[0]/.nonexistent}");
       assertThat(expected)
         .hasMessageContaining("Expected: exact text 'detective'");
       assertScreenshot(expected);


### PR DESCRIPTION
## Proposed changes
In https://github.com/selenide/selenide/issues/61 i saw message about error format https://github.com/selenide/selenide/issues/61#issuecomment-642647647
but it format is not apply when we use element chain 
Example: $("div").$(".someClass").$("div")
if the latest element is not found  - we take message: Element not found {div}
Now it will checks and put all parent paths like as it works for ElementsCollection
## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
