### PR TITLE
#217 report exact actual value

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -569,8 +569,25 @@ public abstract class Condition {
    *
    * @param element given WebElement
    * @return true if element matches condition
+   *
+   * @deprecated Implement {@link #apply(Driver, WebElement, Object)} instead.
    */
-  public abstract boolean apply(Driver driver, WebElement element);
+  @Deprecated
+  public boolean apply(Driver driver, WebElement element) {
+    throw new UnsupportedOperationException("Condition.apply is not implemented");
+  }
+
+  /**
+   * Check if given element matches this condition.
+   *
+   * @param driver Selenide Driver
+   * @param element given WebElement
+   * @param actualValue the actual value of this element (that this condition is supposed to check)
+   * @return true if element matches condition
+   */
+  public boolean apply(Driver driver, WebElement element, @Nullable Object actualValue) {
+    return apply(driver, element);
+  }
 
   public boolean applyNull() {
     return absentElementMatchesCondition;
@@ -584,9 +601,26 @@ public abstract class Condition {
    * @param driver given driver
    * @param element given WebElement
    * @return any string that needs to be appended to error message.
+   *
+   * @deprecated Implement method {@link #formatActualValue(Object)} instead.
    */
   @Nullable
+  @Deprecated
   public String actualValue(Driver driver, WebElement element) {
+    return null;
+  }
+
+  /**
+   * Print out the actual value
+   * @param actualValue the actual value previously received using method {@link #getActualValue(Driver, WebElement)}
+   * @return String representation for error message
+   */
+  public String formatActualValue(@Nullable Object actualValue) {
+    return String.valueOf(actualValue);
+  }
+
+  @Nullable
+  public Object getActualValue(Driver driver, WebElement element) {
     return null;
   }
 

--- a/src/main/java/com/codeborne/selenide/conditions/Visible.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Visible.java
@@ -6,7 +6,10 @@ import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+
+import static java.lang.Boolean.TRUE;
 
 @ParametersAreNonnullByDefault
 public class Visible extends Condition {
@@ -15,16 +18,21 @@ public class Visible extends Condition {
   }
 
   @Override
-  @CheckReturnValue
-  public boolean apply(Driver driver, WebElement element) {
+  public Boolean getActualValue(Driver driver, WebElement element) {
     return element.isDisplayed();
   }
 
   @Override
   @CheckReturnValue
+  public boolean apply(Driver driver, WebElement element, @Nullable Object actualVisibility) {
+    return actualVisibility == TRUE;
+  }
+
+  @Override
+  @CheckReturnValue
   @Nonnull
-  public String actualValue(Driver driver, WebElement element) {
-    return String.format("visible:%s", element.isDisplayed());
+  public String formatActualValue(@Nullable Object actualVisibility) {
+    return String.format("visible:%s", actualVisibility);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/ex/ElementShould.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShould.java
@@ -16,12 +16,12 @@ public class ElementShould extends UIAssertionError {
   private static final ElementDescriber describe = inject(ElementDescriber.class);
 
   public ElementShould(Driver driver, String searchCriteria, String prefix, Condition expectedCondition,
-                       WebElement element, @Nullable Throwable lastError) {
+                       WebElement element, @Nullable Object actualValue, @Nullable Throwable lastError) {
     super(driver,
       String.format("Element should %s%s {%s}%nElement: '%s'%s",
         prefix, expectedCondition, searchCriteria,
         describe.fully(driver, element),
-        actualValue(expectedCondition, driver, element)
+        actualValue(expectedCondition, driver, element, actualValue)
       ), lastError);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
@@ -17,12 +17,12 @@ public class ElementShouldNot extends UIAssertionError {
   private static final ElementDescriber describe = inject(ElementDescriber.class);
 
   public ElementShouldNot(Driver driver, String searchCriteria, String prefix, Condition expectedCondition,
-                          WebElement element, @Nullable Throwable lastError) {
+                          WebElement element, @Nullable Object actualValue, @Nullable Throwable lastError) {
     super(driver,
       String.format("Element should not %s%s {%s}%sElement: '%s'%s",
         prefix, expectedCondition, searchCriteria, lineSeparator(),
         describe.fully(driver, element),
-        actualValue(expectedCondition, driver, element)
+        actualValue(expectedCondition, driver, element, actualValue)
       ), lastError);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ErrorMessages.java
+++ b/src/main/java/com/codeborne/selenide/ex/ErrorMessages.java
@@ -44,6 +44,16 @@ public class ErrorMessages {
   }
 
   @CheckReturnValue
+  static String actualValue(Condition condition, Driver driver, @Nullable WebElement element, @Nullable Object actualValue) {
+    if (actualValue != null) {
+      String formatted = condition.formatActualValue(actualValue);
+      return String.format("%nActual value: %s", formatted);
+    }
+    // For old Conditions that don't implement `getActualValue()` yet
+    return actualValue(condition, driver, element);
+  }
+
+  @CheckReturnValue
   static String causedBy(@Nullable Throwable cause) {
     if (cause == null) {
       return "";

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -68,9 +68,11 @@ public abstract class WebElementSource {
 
     Throwable lastError = null;
     WebElement element = null;
+    Object actualValue = null;
     try {
       element = getWebElement();
-      if (check.apply(driver(), element)) {
+      actualValue = check.getActualValue(driver(), element);
+      if (check.apply(driver(), element, actualValue)) {
         return element;
       }
     }
@@ -88,10 +90,10 @@ public abstract class WebElementSource {
       }
     }
     else if (invert) {
-      throw new ElementShouldNot(driver(), getSearchCriteria(), prefix, condition, element, lastError);
+      throw new ElementShouldNot(driver(), getSearchCriteria(), prefix, condition, element, actualValue, lastError);
     }
     else {
-      throw new ElementShould(driver(), getSearchCriteria(), prefix, condition, element, lastError);
+      throw new ElementShould(driver(), getSearchCriteria(), prefix, condition, element, actualValue, lastError);
     }
     return null;
   }

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
@@ -16,7 +16,7 @@ final class ElementShouldNotTest implements WithAssertions {
   @Test
   void testToString() {
     ElementShouldNot elementShould = new ElementShouldNot(driver, "by.name: selenide", "be ", appear,
-      mock(WebElement.class), new Throwable("Error message"));
+      mock(WebElement.class), "visible:false", new Throwable("Error message"));
     assertThat(elementShould).hasMessage("Element should not be visible {by.name: selenide}" + lineSeparator() +
       "Element: '<null displayed:false></null>'" + lineSeparator() +
       "Actual value: visible:false" + lineSeparator() +

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
@@ -1,12 +1,12 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import static com.codeborne.selenide.Condition.appear;
 import static java.lang.System.lineSeparator;
 import static org.mockito.Mockito.mock;
 
@@ -18,7 +18,8 @@ final class ElementShouldTest implements WithAssertions {
     Driver driver = new DriverStub();
     WebElement webElementMock = mock(WebElement.class);
     Exception exception = new Exception("Error message");
-    ElementShould elementShould = new ElementShould(driver, searchCriteria, prefix, Condition.appear, webElementMock, exception);
+    ElementShould elementShould = new ElementShould(driver, searchCriteria, prefix, appear,
+      webElementMock, "visible:false", exception);
 
     assertThat(elementShould)
       .hasMessage("Element should be visible {by.name: selenide}" + lineSeparator() +

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementDescriberTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementDescriberTest.java
@@ -44,7 +44,7 @@ final class SelenideElementDescriberTest implements WithAssertions {
 
     SelenideElement selenideElement = mock(SelenideElement.class);
     when(selenideElement.toWebElement()).thenReturn(webElement);
-    doThrow(new ElementShould(driver, null, null, visible, webElement, null)).when(selenideElement).getTagName();
+    doThrow(new ElementShould(driver, null, null, visible, webElement, null, null)).when(selenideElement).getTagName();
 
     assertThat(describe.briefly(driver, selenideElement))
       .isEqualTo("Ups, failed to described the element [caused by: StaleElementReferenceException: disappeared]");


### PR DESCRIPTION
A draft solution for https://github.com/selenide/selenide/issues/217

The idea is:
1. All `Condition`s must implement method `getActualValue`
2. Instead of `apply(Driver driver, WebElement element)`, all `Condition`s must implement `apply(Driver driver, WebElement element, @Nullable Object actualValue)`. 
3. Now look into `WebElementSource.checkCondition` 

### Pros:
Now error message contains the actual value (visibility, text etc) at the moment of last (failed) check. 

### Cons:
We need to refactor all conditions (though, it's rather a small and simple refactoring). 

See `Visible` for example (it's the only updated condition by the moment).