### PR TITLE
Apply chrome headless arguments from puppeteer config

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -92,6 +92,30 @@ public class ChromeDriverFactory extends AbstractDriverFactory {
     arguments.add("--disable-dev-shm-usage");
     arguments.add("--no-sandbox");
     arguments.addAll(parseArguments(System.getProperty("chromeoptions.args")));
+    if (config.headless()) {
+      arguments.add("--disable-background-networking");
+      arguments.add("--enable-features=NetworkService,NetworkServiceInProcess");
+      arguments.add("--disable-background-timer-throttling");
+      arguments.add("--disable-backgrounding-occluded-windows");
+      arguments.add("--disable-breakpad");
+      arguments.add("--disable-client-side-phishing-detection");
+      arguments.add("--disable-component-extensions-with-background-pages");
+      arguments.add("--disable-default-apps");
+      arguments.add("--disable-features=TranslateUI");
+      arguments.add("--disable-hang-monitor");
+      arguments.add("--disable-ipc-flooding-protection");
+      arguments.add("--disable-popup-blocking");
+      arguments.add("--disable-prompt-on-repost");
+      arguments.add("--disable-renderer-backgrounding");
+      arguments.add("--disable-sync");
+      arguments.add("--force-color-profile=srgb");
+      arguments.add("--metrics-recording-only");
+      arguments.add("--no-first-run");
+      arguments.add("--password-store=basic");
+      arguments.add("--use-mock-keychain");
+      arguments.add("--hide-scrollbars");
+      arguments.add("--mute-audio");
+    }
     return arguments;
   }
 

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -92,6 +92,14 @@ public class ChromeDriverFactory extends AbstractDriverFactory {
     arguments.add("--disable-dev-shm-usage");
     arguments.add("--no-sandbox");
     arguments.addAll(parseArguments(System.getProperty("chromeoptions.args")));
+    arguments.addAll(createHeadlessArguments(config));
+    return arguments;
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  protected List<String> createHeadlessArguments(Config config) {
+    List<String> arguments = new ArrayList<>();
     if (config.headless()) {
       arguments.add("--disable-background-networking");
       arguments.add("--enable-features=NetworkService,NetworkServiceInProcess");


### PR DESCRIPTION
## Proposed changes
Apply chrome headless arguments from puppeteer [config](https://github.com/puppeteer/puppeteer/blob/7a2a41f2087b07e8ef1feaf3881bdcc3fd4922ca/src/Launcher.js#L261)

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
