### PR TITLE
Return all shadow dom elements

### DIFF
--- a/src/main/java/com/codeborne/selenide/selector/ByShadow.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByShadow.java
@@ -84,12 +84,12 @@ public class ByShadow {
       List<String> hostSelectors = innerHostSelectors;
       while (!hostSelectors.isEmpty()) {
         final List<WebElement> innerHosts = new ArrayList<>();
-        final String innerHostSelector = innerHostSelectors.get(0);
+        final String hostSelector = hostSelectors.get(0);
         for (final WebElement host : hosts) {
-          innerHosts.addAll(getElementsInsideShadowTree(host, innerHostSelector));
+          innerHosts.addAll(getElementsInsideShadowTree(host, hostSelector));
         }
         hosts = innerHosts;
-        hostSelectors = innerHostSelectors.subList(1, innerHostSelectors.size());
+        hostSelectors = hostSelectors.subList(1, hostSelectors.size());
       }
 
       return hosts;

--- a/src/main/java/com/codeborne/selenide/selector/ByShadow.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByShadow.java
@@ -11,8 +11,10 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @ParametersAreNonnullByDefault
 public class ByShadow {
@@ -66,13 +68,31 @@ public class ByShadow {
     @Override
     @CheckReturnValue
     @Nonnull
-    public List<WebElement> findElements(SearchContext context) {
-      WebElement host = context.findElement(By.cssSelector(shadowHost));
-      for (String innerHost : innerShadowHosts) {
-        host = getElementInsideShadowTree(host, innerHost);
+    public List<WebElement> findElements(final SearchContext context) {
+      final List<WebElement> hosts = context.findElements(By.cssSelector(shadowHost));
+
+      final List<WebElement> innerHosts = findInnerShadowHosts(hosts, Arrays.asList(this.innerShadowHosts));
+
+      return innerHosts.stream()
+        .flatMap(host -> getElementsInsideShadowTree(host, this.target).stream())
+        .collect(Collectors.toList());
+    }
+
+    private List<WebElement> findInnerShadowHosts(final List<WebElement> shadowHosts,
+                                                  final List<String> innerHostSelectors) {
+      List<WebElement> hosts = shadowHosts;
+      List<String> hostSelectors = innerHostSelectors;
+      while (!hostSelectors.isEmpty()) {
+        final List<WebElement> innerHosts = new ArrayList<>();
+        final String innerHostSelector = innerHostSelectors.get(0);
+        for (final WebElement host : hosts) {
+          innerHosts.addAll(getElementsInsideShadowTree(host, innerHostSelector));
+        }
+        hosts = innerHosts;
+        hostSelectors = innerHostSelectors.subList(1, innerHostSelectors.size());
       }
 
-      return getElementsInsideShadowTree(host, target);
+      return hosts;
     }
 
     private WebElement getElementInsideShadowTree(WebElement host, String target) {

--- a/src/test/java/integration/ShadowElementTest.java
+++ b/src/test/java/integration/ShadowElementTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +9,7 @@ import org.openqa.selenium.NoSuchElementException;
 
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selectors.shadowCss;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class ShadowElementTest extends ITest {
@@ -80,5 +82,12 @@ final class ShadowElementTest extends ITest {
   void getNonExistingTargetElementsInsideShadowHost() {
     $$(shadowCss("#nonexistent", "#shadow-host"))
       .shouldHaveSize(0);
+  }
+
+  @Test
+  void getAllElementsInAllNestedShadowHosts() {
+    final ElementsCollection elements = $$(shadowCss(".shadow-container-child-item", "#shadow-container", ".shadow-container-child"));
+    elements.shouldHaveSize(3);
+    assertThat(elements.get(0).getText()).isEqualTo("shadowContainerChildHost1").as("Mismatch in name of first child container");
   }
 }

--- a/src/test/java/integration/ShadowElementTest.java
+++ b/src/test/java/integration/ShadowElementTest.java
@@ -86,8 +86,10 @@ final class ShadowElementTest extends ITest {
 
   @Test
   void getAllElementsInAllNestedShadowHosts() {
-    final ElementsCollection elements = $$(shadowCss(".shadow-container-child-item", "#shadow-container", ".shadow-container-child"));
+    final ElementsCollection elements = $$(shadowCss(".shadow-container-child-child-item",
+      "#shadow-container", ".shadow-container-child", ".shadow-container-child-child"));
     elements.shouldHaveSize(3);
-    assertThat(elements.get(0).getText()).isEqualTo("shadowContainerChildHost1").as("Mismatch in name of first child container");
+    assertThat(elements.get(0).getText()).isEqualTo("shadowContainerChildChild1Host1").as("Mismatch in name of first child container");
+    assertThat(elements.get(2).getText()).isEqualTo("shadowContainerChildChild1Host3").as("Mismatch in name of last child container");
   }
 }

--- a/src/test/resources/page_with_shadow_dom.html
+++ b/src/test/resources/page_with_shadow_dom.html
@@ -7,19 +7,21 @@
   <script type="text/javascript" src="jquery.min.js"></script>
   <script type="text/javascript">
 
-    function appendChildItem(shadowContainer, text) {
+    function appendChildItem(shadowContainer, clazz, text) {
       var shadowContainerChildHost = document.createElement("div");
-      shadowContainerChildHost.setAttribute('class', 'shadow-container-child');
+      shadowContainerChildHost.setAttribute('class', clazz);
       var shadowContainerChild = shadowContainerChildHost.attachShadow( { mode: "open" } );
 
       var shadowContainerChildItem = document.createElement("div");
-      shadowContainerChildItem.setAttribute('class', 'shadow-container-child-item');
+      shadowContainerChildItem.setAttribute('class', clazz + '-item');
       let p = document.createElement("p");
       p.appendChild(document.createTextNode(text));
       shadowContainerChildItem.appendChild(p);
       shadowContainerChild.appendChild(shadowContainerChildItem);
 
       shadowContainer.appendChild(shadowContainerChildHost);
+
+      return shadowContainerChild;
     }
 
     $(function () {
@@ -55,9 +57,13 @@
       shadow2.appendChild(p2);
 
       var shadowContainer = document.getElementById('shadow-container').attachShadow( { mode: "open" } )
-      appendChildItem(shadowContainer, "shadowContainerChildHost1");
-      appendChildItem(shadowContainer, "shadowContainerChildHost2");
-      appendChildItem(shadowContainer, "shadowContainerChildHost3");
+      shadowContainerChild1 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost1');
+      shadowContainerChild2 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost2');
+      shadowContainerChild3 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost3');
+
+      appendChildItem(shadowContainerChild1, 'shadow-container-child-child', 'shadowContainerChildChild1Host1')
+      appendChildItem(shadowContainerChild1, 'shadow-container-child-child', 'shadowContainerChildChild2Host1')
+      appendChildItem(shadowContainerChild3, 'shadow-container-child-child', 'shadowContainerChildChild1Host3')
     });
 
   </script>

--- a/src/test/resources/page_with_shadow_dom.html
+++ b/src/test/resources/page_with_shadow_dom.html
@@ -7,6 +7,21 @@
   <script type="text/javascript" src="jquery.min.js"></script>
   <script type="text/javascript">
 
+    function appendChildItem(shadowContainer, text) {
+      var shadowContainerChildHost = document.createElement("div");
+      shadowContainerChildHost.setAttribute('class', 'shadow-container-child');
+      var shadowContainerChild = shadowContainerChildHost.attachShadow( { mode: "open" } );
+
+      var shadowContainerChildItem = document.createElement("div");
+      shadowContainerChildItem.setAttribute('class', 'shadow-container-child-item');
+      let p = document.createElement("p");
+      p.appendChild(document.createTextNode(text));
+      shadowContainerChildItem.appendChild(p);
+      shadowContainerChild.appendChild(shadowContainerChildItem);
+
+      shadowContainer.appendChild(shadowContainerChildHost);
+    }
+
     $(function () {
       var shadow = document.getElementById('shadow-host').attachShadow( { mode: "open" } )
 
@@ -38,17 +53,23 @@
       var text2 = document.createTextNode("The Shadow-DOM inside another shadow tree");
       p2.appendChild(text2);
       shadow2.appendChild(p2);
+
+      var shadowContainer = document.getElementById('shadow-container').attachShadow( { mode: "open" } )
+      appendChildItem(shadowContainer, "shadowContainerChildHost1");
+      appendChildItem(shadowContainer, "shadowContainerChildHost2");
+      appendChildItem(shadowContainer, "shadowContainerChildHost3");
     });
-
-
 
   </script>
 </head>
 <body>
 <h1>Page with Shadow DOM</h1>
 
-<div id="shadow-host">
-</div>
+<h2>Nested Shadow DOM</h2>
+<div id="shadow-host"></div>
+
+<h2>Multiple nested Shadow hosts</h2>
+<div id="shadow-container"></div>
 
 </body>
 </html>


### PR DESCRIPTION
## Proposed changes
As described in #1346 `ByShadowCss.findElements` should return all matching child elements of all matching inner shadow hosts but currently returns the children of the first inner hosts only.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
