### PR TITLE
Commands should return SelenideElement type instead of WebElement

### DIFF
--- a/src/main/java/com/codeborne/selenide/commands/Append.java
+++ b/src/main/java/com/codeborne/selenide/commands/Append.java
@@ -12,10 +12,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static com.codeborne.selenide.commands.Util.firstOf;
 
 @ParametersAreNonnullByDefault
-public class Append implements Command<WebElement> {
+public class Append implements Command<SelenideElement> {
   @Override
   @Nonnull
-  public WebElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     WebElement input = locator.getWebElement();
     input.sendKeys((String) firstOf(args));
     return proxy;

--- a/src/main/java/com/codeborne/selenide/commands/PressEnter.java
+++ b/src/main/java/com/codeborne/selenide/commands/PressEnter.java
@@ -4,17 +4,16 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class PressEnter implements Command<WebElement> {
+public class PressEnter implements Command<SelenideElement> {
   @Override
   @Nonnull
-  public WebElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     locator.findAndAssertElementIsInteractable().sendKeys(Keys.ENTER);
     return proxy;
   }

--- a/src/main/java/com/codeborne/selenide/commands/PressEscape.java
+++ b/src/main/java/com/codeborne/selenide/commands/PressEscape.java
@@ -4,17 +4,16 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class PressEscape implements Command<WebElement> {
+public class PressEscape implements Command<SelenideElement> {
   @Override
   @Nonnull
-  public WebElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     locator.findAndAssertElementIsInteractable().sendKeys(Keys.ESCAPE);
     return proxy;
   }

--- a/src/main/java/com/codeborne/selenide/commands/PressTab.java
+++ b/src/main/java/com/codeborne/selenide/commands/PressTab.java
@@ -4,17 +4,16 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class PressTab implements Command<WebElement> {
+public class PressTab implements Command<SelenideElement> {
   @Override
   @Nonnull
-  public WebElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     locator.findAndAssertElementIsInteractable().sendKeys(Keys.TAB);
     return proxy;
   }

--- a/src/main/java/com/codeborne/selenide/commands/ScrollIntoView.java
+++ b/src/main/java/com/codeborne/selenide/commands/ScrollIntoView.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -12,10 +11,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static com.codeborne.selenide.commands.Util.firstOf;
 
 @ParametersAreNonnullByDefault
-public class ScrollIntoView implements Command<WebElement> {
+public class ScrollIntoView implements Command<SelenideElement> {
   @Override
   @Nonnull
-  public WebElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     Object param = firstOf(args);
     locator.driver().executeJavaScript("arguments[0].scrollIntoView(" + param + ")", proxy);
     return proxy;

--- a/src/main/java/com/codeborne/selenide/commands/ScrollTo.java
+++ b/src/main/java/com/codeborne/selenide/commands/ScrollTo.java
@@ -4,17 +4,16 @@ import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.Point;
-import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class ScrollTo implements Command<WebElement> {
+public class ScrollTo implements Command<SelenideElement> {
   @Override
   @Nonnull
-  public WebElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     Point location = locator.getWebElement().getLocation();
     locator.driver().executeJavaScript("window.scrollTo(" + location.getX() + ", " + location.getY() + ')');
     return proxy;

--- a/src/main/java/com/codeborne/selenide/commands/SetSelected.java
+++ b/src/main/java/com/codeborne/selenide/commands/SetSelected.java
@@ -13,7 +13,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static com.codeborne.selenide.commands.Util.firstOf;
 
 @ParametersAreNonnullByDefault
-public class SetSelected implements Command<WebElement> {
+public class SetSelected implements Command<SelenideElement> {
   private final Click click;
 
   public SetSelected() {
@@ -26,7 +26,7 @@ public class SetSelected implements Command<WebElement> {
 
   @Override
   @Nonnull
-  public WebElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     boolean selected = firstOf(args);
     WebElement element = locator.getWebElement();
     if (!element.isDisplayed()) {

--- a/src/main/java/com/codeborne/selenide/commands/SetValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SetValue.java
@@ -15,7 +15,7 @@ import static com.codeborne.selenide.commands.Util.firstOf;
 import static com.codeborne.selenide.impl.Events.events;
 
 @ParametersAreNonnullByDefault
-public class SetValue implements Command<WebElement> {
+public class SetValue implements Command<SelenideElement> {
   private final SelectOptionByValue selectOptionByValue;
   private final SelectRadio selectRadio;
 
@@ -31,7 +31,7 @@ public class SetValue implements Command<WebElement> {
 
   @Override
   @Nonnull
-  public WebElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     String text = firstOf(args);
     WebElement element = locator.findAndAssertElementIsInteractable();
 


### PR DESCRIPTION
Useful when you want things like this:

```
class ScrollToCenter extends ScrollIntoView {
    @Override
    public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
        return super.execute(proxy, locator, new Object[] {"{block: \"center\"}"});
    }
}
```
...

```
$(".lupa").execute(new ScrollToCenter()).$(".pupa").click()
```
