### PR TITLE
Fix int method arguments displaying in selenide report(log)

### DIFF
--- a/src/main/java/com/codeborne/selenide/logevents/SelenideLogger.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SelenideLogger.java
@@ -54,14 +54,30 @@ public class SelenideLogger {
   @CheckReturnValue
   @Nonnull
   static String readableArguments(@Nullable Object... args) {
-    return args == null ? "" :
-        (args[0] instanceof Object[]) ? arrayToString((Object[]) args[0]) :
-            arrayToString(args);
+    if (args == null) {
+      return "";
+    }
+
+    if (args[0] instanceof Object[]) {
+      return arrayToString((Object[]) args[0]);
+    }
+
+    if (args[0] instanceof int[]) {
+      return arrayToString((int[]) args[0]);
+    }
+
+    return arrayToString(args);
   }
 
   @CheckReturnValue
   @Nonnull
   private static String arrayToString(Object[] args) {
+    return args.length == 1 ? String.valueOf(args[0]) : Arrays.toString(args);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  private static String arrayToString(int[] args) {
     return args.length == 1 ? String.valueOf(args[0]) : Arrays.toString(args);
   }
 

--- a/src/test/java/com/codeborne/selenide/logevents/SelenideLoggerTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/SelenideLoggerTest.java
@@ -56,6 +56,10 @@ final class SelenideLoggerTest implements WithAssertions {
       .isEqualTo("null");
     assertThat(SelenideLogger.readableArguments((Object[]) new String[]{null, "a", null}))
       .isEqualTo("[null, a, null]");
+    assertThat(SelenideLogger.readableArguments((Object) new int[]{1}))
+      .isEqualTo("1");
+    assertThat(SelenideLogger.readableArguments((Object) new int[]{1, 2}))
+      .isEqualTo("[1, 2]");
   }
 
   @Test


### PR DESCRIPTION
E.g.
SelenideElement.selectOption(int... index) method call

before fix: "select option([I@32057e6)"
after fix: "select option(1)"

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
