### PR TITLE
#1360 extract interface PageObjectFactory from SelenidePageFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.17.3 (released 11.01.2021)
+* #1361 Fix int method arguments displaying in selenide report(log)  --  thanks to Pavel Fokin @fokinp
+* #1360 extract interface PageObjectFactory from SelenidePageFactory
+* #1360 move usages of o.o.s.s.pagefactory.Annotations to SelenidePageFactory.findSelector()  -  make it customizable
+
 ## 5.17.2 (released 30.12.2020)
 * #1355 make Commands return SelenideElement instead of WebElement  --  thanks to Boris Osipov
 * #1356 fix method $.setValue(null)  --  thanks to Dmitriy Zemlyanitsyn for PR #1357

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -5,8 +5,8 @@ import com.codeborne.selenide.drivercommands.Navigator;
 import com.codeborne.selenide.drivercommands.WebDriverWrapper;
 import com.codeborne.selenide.impl.DownloadFileWithHttpRequest;
 import com.codeborne.selenide.impl.ElementFinder;
+import com.codeborne.selenide.impl.PageObjectFactory;
 import com.codeborne.selenide.impl.ScreenShotLaboratory;
-import com.codeborne.selenide.impl.SelenidePageFactory;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
 import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.codeborne.selenide.files.FileFilters.none;
+import static com.codeborne.selenide.impl.Plugins.inject;
 import static com.codeborne.selenide.impl.WebElementWrapper.wrap;
 import static java.util.Collections.emptyList;
 
@@ -134,13 +135,13 @@ public class SelenideDriver {
   @CheckReturnValue
   @Nonnull
   public <PageObjectClass> PageObjectClass page(Class<PageObjectClass> pageObjectClass) {
-    return pageFactory().page(driver(), pageObjectClass);
+    return pageFactory.page(driver(), pageObjectClass);
   }
 
   @CheckReturnValue
   @Nonnull
   public <PageObjectClass, T extends PageObjectClass> PageObjectClass page(T pageObject) {
-    return pageFactory().page(driver(), pageObject);
+    return pageFactory.page(driver(), pageObject);
   }
 
   public void refresh() {
@@ -429,13 +430,8 @@ public class SelenideDriver {
     return new LocalStorage(driver());
   }
 
-  private static SelenidePageFactory pageFactory;
+  private static final PageObjectFactory pageFactory = inject(PageObjectFactory.class);
   private static DownloadFileWithHttpRequest downloadFileWithHttpRequest;
-
-  private static synchronized SelenidePageFactory pageFactory() {
-    if (pageFactory == null) pageFactory = new SelenidePageFactory();
-    return pageFactory;
-  }
 
   private static synchronized DownloadFileWithHttpRequest downloadFileWithHttpRequest() {
     if (downloadFileWithHttpRequest == null) downloadFileWithHttpRequest = new DownloadFileWithHttpRequest();

--- a/src/main/java/com/codeborne/selenide/impl/ElementsContainerCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementsContainerCollection.java
@@ -20,7 +20,7 @@ import static com.codeborne.selenide.Condition.exist;
 
 @ParametersAreNonnullByDefault
 class ElementsContainerCollection extends AbstractList<ElementsContainer> {
-  private final SelenidePageFactory pageFactory;
+  private final PageObjectFactory pageFactory;
   private final Driver driver;
   private final SearchContext parent;
   private final Field field;
@@ -28,7 +28,7 @@ class ElementsContainerCollection extends AbstractList<ElementsContainer> {
   private final Type[] genericTypes;
   private final By selector;
 
-  ElementsContainerCollection(SelenidePageFactory pageFactory, Driver driver, SearchContext parent,
+  ElementsContainerCollection(PageObjectFactory pageFactory, Driver driver, SearchContext parent,
                               Field field, Class<?> listType, Type[] genericTypes, By selector) {
     this.pageFactory = pageFactory;
     this.driver = driver;

--- a/src/main/java/com/codeborne/selenide/impl/PageObjectFactory.java
+++ b/src/main/java/com/codeborne/selenide/impl/PageObjectFactory.java
@@ -1,0 +1,26 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.ElementsContainer;
+import com.codeborne.selenide.SelenideElement;
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+@ParametersAreNonnullByDefault
+public interface PageObjectFactory {
+  <PageObjectClass> PageObjectClass page(Driver driver, Class<PageObjectClass> pageObjectClass);
+
+  <PageObjectClass, T extends PageObjectClass> PageObjectClass page(Driver driver, T pageObject);
+
+  ElementsContainer createElementsContainer(Driver driver, SearchContext searchContext, Field field, By selector);
+
+  ElementsContainer initElementsContainer(Driver driver,
+                                          Field field,
+                                          SelenideElement self,
+                                          Class<?> type,
+                                          Type[] genericTypes) throws ReflectiveOperationException;
+}

--- a/src/main/java/com/codeborne/selenide/impl/SelenideFieldDecorator.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideFieldDecorator.java
@@ -9,7 +9,6 @@ import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.FindBys;
-import org.openqa.selenium.support.pagefactory.Annotations;
 import org.openqa.selenium.support.pagefactory.DefaultElementLocatorFactory;
 import org.openqa.selenium.support.pagefactory.DefaultFieldDecorator;
 import org.openqa.selenium.support.pagefactory.FieldDecorator;
@@ -31,11 +30,11 @@ import java.util.List;
 class SelenideFieldDecorator {
   private static final Logger logger = LoggerFactory.getLogger(SelenideFieldDecorator.class);
   private final FieldDecorator defaultFieldDecorator;
-  private final SelenidePageFactory pageFactory;
+  private final PageObjectFactory pageFactory;
   private final Driver driver;
   private final SearchContext searchContext;
 
-  SelenideFieldDecorator(SelenidePageFactory pageFactory, Driver driver, SearchContext searchContext) {
+  SelenideFieldDecorator(PageObjectFactory pageFactory, Driver driver, SearchContext searchContext) {
     defaultFieldDecorator = new DefaultFieldDecorator(new DefaultElementLocatorFactory(searchContext));
     this.pageFactory = pageFactory;
     this.driver = driver;
@@ -44,14 +43,14 @@ class SelenideFieldDecorator {
 
   @CheckReturnValue
   @Nullable
-  public final Object decorate(ClassLoader loader, Field field) {
+  public final Object decorate(ClassLoader loader, Field field, By selector) {
     Type[] classGenericTypes = field.getDeclaringClass().getGenericInterfaces();
-    return decorate(loader, field, classGenericTypes);
+    return decorate(loader, field, selector, classGenericTypes);
   }
 
   @CheckReturnValue
   @Nullable
-  public final Object decorate(ClassLoader loader, Field field, Type[] genericTypes) {
+  public final Object decorate(ClassLoader loader, Field field, By selector, Type[] genericTypes) {
     if (ElementsContainer.class.equals(field.getDeclaringClass()) && "self".equals(field.getName())) {
       if (searchContext instanceof SelenideElement) {
         return searchContext;
@@ -61,7 +60,6 @@ class SelenideFieldDecorator {
         return null;
       }
     }
-    By selector = new Annotations(field).buildBy();
     if (WebElement.class.isAssignableFrom(field.getType())) {
       return ElementFinder.wrap(driver, searchContext, selector, 0);
     }

--- a/src/main/resources/META-INF/defaultservices/com.codeborne.selenide.impl.PageObjectFactory
+++ b/src/main/resources/META-INF/defaultservices/com.codeborne.selenide.impl.PageObjectFactory
@@ -1,0 +1,1 @@
+com.codeborne.selenide.impl.SelenidePageFactory

--- a/src/test/java/com/codeborne/selenide/impl/SelenideFieldDecoratorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideFieldDecoratorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ByIdOrName;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.pagefactory.DefaultElementLocatorFactory;
 import org.openqa.selenium.support.pagefactory.FieldDecorator;
@@ -34,7 +35,7 @@ final class SelenideFieldDecoratorTest implements WithAssertions {
   private final Config config = new SelenideConfig();
   private final WebDriver webDriver = mock(WebDriver.class);
   private final Driver driver = new DriverStub(config, null, webDriver, null);
-  private final SelenidePageFactory pageFactory = new SelenidePageFactory();
+  private final PageObjectFactory pageFactory = new SelenidePageFactory();
   private final SelenideFieldDecorator fieldDecorator = new SelenideFieldDecorator(pageFactory, driver, webDriver);
 
   @Test
@@ -50,7 +51,7 @@ final class SelenideFieldDecoratorTest implements WithAssertions {
 
   @Test
   void decoratesSelenideElement() throws NoSuchFieldException {
-    assertThat(fieldDecorator.decorate(getClass().getClassLoader(), getField("username")))
+    assertThat(fieldDecorator.decorate(getClass().getClassLoader(), getField("username"), new ByIdOrName("username")))
       .isInstanceOf(SelenideElement.class);
   }
 
@@ -66,7 +67,8 @@ final class SelenideFieldDecoratorTest implements WithAssertions {
   void decoratesElementsCollection() throws NoSuchFieldException {
     TestPageWithElementsCollection page = new TestPageWithElementsCollection();
 
-    Object decoratedField = fieldDecorator.decorate(getClass().getClassLoader(), getField(page, "rows"));
+    Object decoratedField = fieldDecorator.decorate(getClass().getClassLoader(),
+      getField(page, "rows"), By.cssSelector("table tbody tr"));
 
     assertThat(decoratedField).isInstanceOf(ElementsCollection.class);
     verifyNoMoreInteractions(webDriver);
@@ -78,7 +80,7 @@ final class SelenideFieldDecoratorTest implements WithAssertions {
     WebElement element2 = mock(WebElement.class);
     when(webDriver.findElements(any(By.class))).thenReturn(asList(element1, element2));
 
-    Object decoratedField = fieldDecorator.decorate(getClass().getClassLoader(), getField("rows"));
+    Object decoratedField = fieldDecorator.decorate(getClass().getClassLoader(), getField("rows"), By.cssSelector("table tbody tr"));
     assertThat(decoratedField).isInstanceOf(ElementsCollection.class);
     verifyNoMoreInteractions(webDriver);
 
@@ -92,7 +94,7 @@ final class SelenideFieldDecoratorTest implements WithAssertions {
 
   @Test
   void decoratesVanillaWebElements() throws NoSuchFieldException {
-    final Object someDiv = fieldDecorator.decorate(getClass().getClassLoader(), getField("someDiv"));
+    final Object someDiv = fieldDecorator.decorate(getClass().getClassLoader(), getField("someDiv"), new ByIdOrName("someDiv"));
     assertThat(someDiv).isNotNull();
     assertThat(someDiv)
       .withFailMessage("someDiv should be instance of SelenideElement. Actual class: " + someDiv.getClass())
@@ -106,7 +108,8 @@ final class SelenideFieldDecoratorTest implements WithAssertions {
     WebElement element2 = mock(WebElement.class);
     when(webDriver.findElements(any(By.class))).thenReturn(asList(element1, element2));
 
-    List<WebElement> elements = (List<WebElement>) fieldDecorator.decorate(getClass().getClassLoader(), getField("data"));
+    List<WebElement> elements = (List<WebElement>) fieldDecorator.decorate(getClass().getClassLoader(),
+      getField("data"), By.cssSelector("table tbody tr"));
 
     assertThat(elements).hasSize(2);
     verify(webDriver).findElements(By.cssSelector("table tbody tr"));
@@ -116,13 +119,13 @@ final class SelenideFieldDecoratorTest implements WithAssertions {
 
   @Test
   void ignoresUnknownTypes() throws NoSuchFieldException {
-    assertThat(fieldDecorator.decorate(getClass().getClassLoader(), getField("unsupportedField")))
+    assertThat(fieldDecorator.decorate(getClass().getClassLoader(), getField("unsupportedField"), new ByIdOrName("unsupportedField")))
       .isNull();
   }
 
   @Test
   void decoratesElementsContainerWithItsSubElements() throws NoSuchFieldException {
-    StatusBlock status = (StatusBlock) fieldDecorator.decorate(getClass().getClassLoader(), getField("status"));
+    StatusBlock status = (StatusBlock) fieldDecorator.decorate(getClass().getClassLoader(), getField("status"), By.id("status"));
     WebElement statusElement = mockWebElement("div", "the status");
     WebElement lastLogin = mockWebElement("div", "03.03.2003");
     WebElement name = mockWebElement("div", "lena");
@@ -161,7 +164,8 @@ final class SelenideFieldDecoratorTest implements WithAssertions {
     WebElement name2 = mockWebElement("div", "katie");
     when(statusElement2.findElement(By.className("name"))).thenReturn(name2);
 
-    Object decoratedField = fieldDecorator.decorate(getClass().getClassLoader(), getField("statusHistory"));
+    Object decoratedField = fieldDecorator.decorate(getClass().getClassLoader(),
+      getField("statusHistory"), By.cssSelector("table.history tr.status"));
 
     assertThat(decoratedField).isInstanceOf(List.class);
     List<StatusBlock> statusHistory = (List<StatusBlock>) decoratedField;

--- a/statics/src/test/java/integration/pageobjects/FieldOfGenericTypeTest.java
+++ b/statics/src/test/java/integration/pageobjects/FieldOfGenericTypeTest.java
@@ -26,6 +26,7 @@ public class FieldOfGenericTypeTest extends IntegrationTest {
     DummyPage page = page(DummyPage.class);
     assertThat(page).isInstanceOf(DummyPage.class);
     assertThat(page.body).isInstanceOf(DummyTypedElement.class);
+    assertThat(page.body.names).isNull();
     assertThat(page.body.selects).isInstanceOf(List.class);
     assertThat(page.body.selects).hasSize(3);
     assertThat(page.body.getSelf()).isEqualTo($("body"));


### PR DESCRIPTION
this PR fixes https://github.com/selenide/selenide/issues/1360

## Proposed changes
* Make `SelenidePageFactory` overridable (injectable via plugins system)
* Extract usages of `o.o.s.s.pagefactory.Annotations` to a separate `protected` method thus making it possible to use another Annotations. 