### PR TITLE
Override toString for FileFilter classes

### DIFF
--- a/src/main/java/com/codeborne/selenide/DownloadOptions.java
+++ b/src/main/java/com/codeborne/selenide/DownloadOptions.java
@@ -44,11 +44,11 @@ public class DownloadOptions {
   @Override
   public String toString() {
     if (hasSpecifiedTimed() && !filter.isEmpty())
-      return String.format("method: %s, timeout: %s ms, filter:%s", method, timeout, filter.description());
+      return String.format("method: %s, timeout: %s ms, filter: %s", method, timeout, filter.description());
     else if (hasSpecifiedTimed())
       return String.format("method: %s, timeout: %s ms", method, timeout);
     else if (!filter.isEmpty())
-      return String.format("method: %s, filter:%s", method, filter.description());
+      return String.format("method: %s, filter: %s", method, filter.description());
     else
       return String.format("method: %s", method);
   }

--- a/src/main/java/com/codeborne/selenide/files/EmptyFileFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/EmptyFileFilter.java
@@ -15,4 +15,9 @@ class EmptyFileFilter implements FileFilter {
   public boolean isEmpty() {
     return true;
   }
+
+  @Override
+  public String toString() {
+    return description();
+  }
 }

--- a/src/main/java/com/codeborne/selenide/files/ExtensionFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/ExtensionFilter.java
@@ -14,6 +14,10 @@ class ExtensionFilter implements FileFilter {
   }
 
   @Override public String description() {
-    return " with extension \"" + extension + "\"";
+    return "with extension \"" + extension + "\"";
+  }
+
+  @Override public String toString() {
+    return description();
   }
 }

--- a/src/main/java/com/codeborne/selenide/files/FilenameFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/FilenameFilter.java
@@ -12,6 +12,10 @@ class FilenameFilter implements FileFilter {
   }
 
   @Override public String description() {
-    return " with file name \"" + fileName + "\"";
+    return "with file name \"" + fileName + "\"";
+  }
+
+  @Override public String toString() {
+    return description();
   }
 }

--- a/src/main/java/com/codeborne/selenide/files/FilenameRegexFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/FilenameRegexFilter.java
@@ -14,6 +14,10 @@ class FilenameRegexFilter implements FileFilter {
   }
 
   @Override public String description() {
-    return " with file name matching \"" + fileNameRegex + "\"";
+    return "with file name matching \"" + fileNameRegex + "\"";
+  }
+
+  @Override public String toString() {
+    return description();
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
@@ -101,7 +101,7 @@ public class DownloadFileWithHttpRequest {
     saveContentToFile(response, downloadedFile);
 
     if (!fileFilter.match(new DownloadedFile(downloadedFile, emptyMap()))) {
-      throw new FileNotFoundException(String.format("Failed to download file from %s in %d ms.%s %n; actually downloaded: %s",
+      throw new FileNotFoundException(String.format("Failed to download file from %s in %d ms. %s;%n actually downloaded: %s",
         relativeOrAbsoluteUrl, timeout, fileFilter.description(), downloadedFile.getAbsolutePath())
       );
     }

--- a/src/test/java/com/codeborne/selenide/files/EmptyFileFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/EmptyFileFilterTest.java
@@ -8,6 +8,7 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class EmptyFileFilterTest {
+  private static final String FILTER_DESCRIPTION = "";
   private final FileFilter filter = new EmptyFileFilter();
 
   @Test
@@ -21,7 +22,12 @@ final class EmptyFileFilterTest {
 
   @Test
   void description() {
-    assertThat(filter.description()).isEqualTo("");
+    assertThat(filter.description()).isEqualTo(FILTER_DESCRIPTION);
+  }
+
+  @Test
+  void hasToString() {
+    assertThat(filter).hasToString(FILTER_DESCRIPTION);
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/files/ExtensionFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/ExtensionFilterTest.java
@@ -8,6 +8,7 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class ExtensionFilterTest {
+  private static final String FILTER_DESCRIPTION = "with extension \"pdf\"";
   private final FileFilter filter = new ExtensionFilter("pdf");
 
   @Test
@@ -24,7 +25,12 @@ final class ExtensionFilterTest {
 
   @Test
   void description() {
-    assertThat(filter.description()).isEqualTo(" with extension \"pdf\"");
+    assertThat(filter.description()).isEqualTo(FILTER_DESCRIPTION);
+  }
+
+  @Test
+  void hasToString() {
+    assertThat(filter).hasToString(FILTER_DESCRIPTION);
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/files/FilenameFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/FilenameFilterTest.java
@@ -8,6 +8,7 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class FilenameFilterTest {
+  private static final String FILTER_DESCRIPTION = "with file name \"cv.pdf\"";
   private final FileFilter filter = new FilenameFilter("cv.pdf");
 
   @Test
@@ -20,7 +21,12 @@ final class FilenameFilterTest {
 
   @Test
   void description() {
-    assertThat(filter.description()).isEqualTo(" with file name \"cv.pdf\"");
+    assertThat(filter.description()).isEqualTo(FILTER_DESCRIPTION);
+  }
+
+  @Test
+  void hasToString() {
+    assertThat(filter).hasToString(FILTER_DESCRIPTION);
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/files/FilenameRegexFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/FilenameRegexFilterTest.java
@@ -8,6 +8,7 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class FilenameRegexFilterTest {
+  private static final String FILTER_DESCRIPTION = "with file name matching \"cv-\\d+.pdf\"";
   private final FileFilter filter = new FilenameRegexFilter("cv-\\d+.pdf");
 
   @Test
@@ -20,7 +21,12 @@ final class FilenameRegexFilterTest {
 
   @Test
   void description() {
-    assertThat(filter.description()).isEqualTo(" with file name matching \"cv-\\d+.pdf\"");
+    assertThat(filter.description()).isEqualTo(FILTER_DESCRIPTION);
+  }
+
+  @Test
+  void hasToString() {
+    assertThat(filter).hasToString(FILTER_DESCRIPTION);
   }
 
   @Test

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -82,7 +82,7 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
     assertThatThrownBy(() -> $(byText("Download me")).download(withName("good_bye_world.txt")))
       .isInstanceOf(FileNotFoundException.class)
       .hasMessageMatching("Failed to download file from http.+/files/hello_world.txt in 1000 ms." +
-        " with file name \"good_bye_world.txt\" " + System.lineSeparator() + "; actually downloaded: .+hello_world.txt");
+        " with file name \"good_bye_world.txt\";" + System.lineSeparator() + " actually downloaded: .+hello_world.txt");
   }
 
   @Test


### PR DESCRIPTION
Use well defined string description (instead of default hashCode) in selenide report(log):
- SelenideElement.download(FileFilter fileFilter)
- SelenideElement.download(long timeout, FileFilter fileFilter)

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
