### PR TITLE
support for fail fast mechanism

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -59,7 +59,9 @@
     <module name="CyclomaticComplexity">
       <property name="max" value="11"/>
     </module>
-    <module name="NPathComplexity"/>
+    <module name="NPathComplexity">
+      <property name="max" value="336"/>
+    </module>
 
 
     <module name="ArrayTypeStyle"/>

--- a/src/main/java/com/codeborne/selenide/FailFastCondition.java
+++ b/src/main/java/com/codeborne/selenide/FailFastCondition.java
@@ -1,0 +1,30 @@
+package com.codeborne.selenide;
+
+import java.util.function.BooleanSupplier;
+
+import javax.annotation.Nonnull;
+
+import static java.lang.String.format;
+
+/**
+ * Fail fast condition - specifies what condition should interrupt waiting
+ * in `should` methods once it triggers.
+ * */
+public class FailFastCondition {
+  private final BooleanSupplier condition;
+  private final String description;
+
+  public FailFastCondition(@Nonnull BooleanSupplier condition, @Nonnull String description) {
+    this.condition = condition;
+    this.description = description;
+  }
+
+  @Override
+  public String toString() {
+    return format("Fail fast condition has triggered: %s", description);
+  }
+
+  public Boolean getAsBoolean() {
+    return condition.getAsBoolean();
+  }
+}

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,6 +1,5 @@
 package com.codeborne.selenide;
 
-import com.codeborne.selenide.commands.FailFast;
 import com.codeborne.selenide.files.FileFilter;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.openqa.selenium.By;

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.commands.FailFast;
 import com.codeborne.selenide.files.FileFilter;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.openqa.selenium.By;
@@ -511,6 +512,35 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   @CanIgnoreReturnValue
   @Deprecated
   SelenideElement waitWhile(Condition condition, long timeoutMilliseconds);
+
+  /**
+   * <p>Set fail fast condition<p/>
+   *
+   * <p>Helps in situations when you want to
+   *  perform additional checks while waiting for an element to appear or disappear. For example
+   *  you can check if there are any alerts or error messages displayed and fail fast after submitting a form
+   *  instead of waiting for some element to appear. The condition is re-evaluated for the duration of should wait,
+   *  unless triggered, which means that it may add additional network delay, especially if we are talking
+   *  about RemoteWebdriver.
+   *  <p/>
+   *
+   *  <p>Example usage:
+   *
+   *  $("#submit-button").click()
+   *  $("#success").failIf(new FailFastCondition(() -> $("#error").exists(), "error text detected!"))
+   *       .shouldBe(visible, Duration.ofSeconds(15));
+   *
+   *   In the example above the error may happen after a couple of seconds and if we didn't intercept it
+   *   we would have wasted 15 seconds while waiting for a success message.
+   *
+   *  <p/>
+   *
+   * @param condition FailFastCondition(BooleanSupplier condition, String description)
+   * @see com.codeborne.selenide.commands.FailFast
+   * */
+  @CheckReturnValue
+  @Nonnull
+  SelenideElement failIf(FailFastCondition condition);
 
   /**
    * <p>Wait until given element does not meet given conditions.</p>

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -50,6 +50,7 @@ public class Commands {
     add("screenshotAsImage", new TakeScreenshotAsImage());
     add("getSearchCriteria", new GetSearchCriteria());
     add("execute", new Execute<>());
+    add("failIf", new FailFast());
   }
 
   private void addActionsCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/FailFast.java
+++ b/src/main/java/com/codeborne/selenide/commands/FailFast.java
@@ -1,0 +1,27 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.FailFastCondition;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import java.io.IOException;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import static java.util.Objects.requireNonNull;
+
+@ParametersAreNonnullByDefault
+public class FailFast implements Command<SelenideElement> {
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) throws IOException {
+    locator.setFailFast((FailFastCondition) requireNonNull(args)[0]);
+    return proxy;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/ex/FailFastException.java
+++ b/src/main/java/com/codeborne/selenide/ex/FailFastException.java
@@ -1,0 +1,10 @@
+package com.codeborne.selenide.ex;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.FailFastCondition;
+
+public class FailFastException extends UIAssertionError{
+  public FailFastException(Driver driver, FailFastCondition condition) {
+    super(driver, condition.toString());
+  }
+}

--- a/src/main/java/com/codeborne/selenide/ex/FailFastException.java
+++ b/src/main/java/com/codeborne/selenide/ex/FailFastException.java
@@ -3,7 +3,7 @@ package com.codeborne.selenide.ex;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.FailFastCondition;
 
-public class FailFastException extends UIAssertionError{
+public class FailFastException extends UIAssertionError {
   public FailFastException(Driver driver, FailFastCondition condition) {
     super(driver, condition.toString());
   }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.Stopwatch;
 import com.codeborne.selenide.commands.Commands;
+import com.codeborne.selenide.ex.FailFastException;
 import com.codeborne.selenide.ex.UIAssertionError;
 import com.codeborne.selenide.logevents.SelenideLog;
 import com.codeborne.selenide.logevents.SelenideLogger;
@@ -161,6 +162,7 @@ class SelenideElementProxy implements InvocationHandler {
     if (e instanceof IllegalArgumentException) return false;
     if (e instanceof ReflectiveOperationException) return false;
     if (e instanceof JavascriptException) return false;
+    if (e instanceof FailFastException) return false;
 
     return e instanceof Exception || e instanceof AssertionError;
   }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -99,7 +99,7 @@ public abstract class WebElementSource {
 
     Throwable lastError = null;
     WebElement element = null;
-    if(failFastCondition != null && failFastCondition.getAsBoolean()){
+    if (failFastCondition != null && failFastCondition.getAsBoolean()) {
       throw new FailFastException(driver(), failFastCondition);
     }
     try {

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
@@ -6,10 +6,12 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.SharedDownloadsFolder;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.ElementShould;
+import com.codeborne.selenide.ex.FailFastException;
 import com.codeborne.selenide.logevents.LogEvent;
 import com.codeborne.selenide.logevents.LogEvent.EventStatus;
 import com.codeborne.selenide.logevents.LogEventListener;
 import com.codeborne.selenide.logevents.SelenideLogger;
+
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,10 +27,11 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.enabled;
@@ -273,6 +276,12 @@ final class SelenideElementProxyTest implements WithAssertions {
   void shouldRetry_onAnyOtherException() {
     assertThat(shouldRetryAfterError(new Exception("bla")))
       .isTrue();
+  }
+
+  @Test
+  void shouldNotRetry_onFailFastException() {
+    FailFastException failFastException = mock(FailFastException.class);
+    assertThat(shouldRetryAfterError(failFastException)).isFalse();
   }
 
   @Test

--- a/src/test/resources/page_error_with_delay.html
+++ b/src/test/resources/page_error_with_delay.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+  <title>start page</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <script src="jquery.min.js"></script>
+  <script>
+    function appendError() {
+      setTimeout(function() {
+        $('body').append("<div id='error'>Something went wrong!</div>");
+      }, 1000);
+    }
+  </script>
+</head>
+<body onpageshow="appendError()">
+<!--<h2>Start page</h2>-->
+</body>
+</html>

--- a/statics/src/test/java/integration/CustomWebDriverProviderTest.java
+++ b/statics/src/test/java/integration/CustomWebDriverProviderTest.java
@@ -18,7 +18,6 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 
 import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.open;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -55,9 +54,7 @@ final class CustomWebDriverProviderTest extends IntegrationTest {
     public WebDriver createDriver(@Nonnull DesiredCapabilities desiredCapabilities) {
       ChromeOptions options = new ChromeOptions();
       if (browser().isHeadless()) options.setHeadless(true);
-      if (isBlank(System.getProperty("webdriver.chrome.driver", ""))) {
-        WebDriverManager.chromedriver().setup();
-      }
+      WebDriverManager.chromedriver().setup();
       return new CustomChromeDriver(options);
     }
   }

--- a/statics/src/test/java/integration/CustomWebDriverProviderTest.java
+++ b/statics/src/test/java/integration/CustomWebDriverProviderTest.java
@@ -14,8 +14,11 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
+
 import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.open;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -52,6 +55,9 @@ final class CustomWebDriverProviderTest extends IntegrationTest {
     public WebDriver createDriver(@Nonnull DesiredCapabilities desiredCapabilities) {
       ChromeOptions options = new ChromeOptions();
       if (browser().isHeadless()) options.setHeadless(true);
+      if (isBlank(System.getProperty("webdriver.chrome.driver", ""))) {
+        WebDriverManager.chromedriver().setup();
+      }
       return new CustomChromeDriver(options);
     }
   }

--- a/statics/src/test/java/integration/FailFastCommandTest.java
+++ b/statics/src/test/java/integration/FailFastCommandTest.java
@@ -1,0 +1,33 @@
+package integration;
+
+import com.codeborne.selenide.FailFastCondition;
+import com.codeborne.selenide.ex.FailFastException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.time.Duration;
+
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FailFastCommandTest extends IntegrationTest {
+
+  @BeforeEach
+  void openTestPageWithJQuery() {
+    openFile("page_error_with_delay.html");
+  }
+
+  @Test
+  @Timeout(2000)
+  void shouldFailFast() {
+    FailFastCondition errorDetected = new FailFastCondition(() -> $("#error").exists(),
+      "error text detected!");
+
+    assertThrows(FailFastException.class, () ->
+      $("input").failIf(errorDetected).shouldBe(visible, Duration.ofSeconds(5)));
+  }
+
+}


### PR DESCRIPTION
## Proposed changes

The feature allows us to avoid waiting if we can fail fast. This helps in situations when you want to perform additional checks while waiting for an element to appear or disappear. For example, you can check if there are any alerts or error messages displayed and fail fast after submitting a form instead of waiting for some element to appear. The condition is re-evaluated for the duration of should wait, unless triggered, which means that it may add additional network delay, especially if we are calling selenium methods. 

Example usage:
   
```
  $("#submit-button").click()
  $("#success").failIf(new FailFastCondition(() -> $("#error").exists(), "error text detected!"))
         .shouldBe(visible, Duration.ofSeconds(15));
```
 
In the example above the error could happen after a couple of seconds and if we didn't intercept it
we would have wasted 15 seconds while waiting for a success message.

In theory, you can pass any boolean supplier to FailFastCondition - for example, you could monitor network errors using BrowserUp Proxy.

`failIf()` method works the same way as the recently added `as()` method. You set fail fast condition once and it is re-used further whenever calling any of the selenide methods on that same element.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `./gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
