### PR TITLE
speed up $(shadowCss())

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/FileContent.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileContent.java
@@ -1,0 +1,37 @@
+package com.codeborne.selenide.impl;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static java.lang.Thread.currentThread;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Read file content from classpath
+ *
+ * The point is in lazy loading: the content is loaded only on the first usage, and only once.
+ */
+public class FileContent {
+  private final String filePath;
+  private String content;
+
+  public FileContent(String filePath) {
+    this.filePath = filePath;
+  }
+
+  public synchronized String content() {
+    if (content == null) {
+      try {
+        URL sizzleJs = requireNonNull(currentThread().getContextClassLoader().getResource(filePath));
+        content = IOUtils.toString(sizzleJs, UTF_8);
+      }
+      catch (IOException e) {
+        throw new IllegalArgumentException("Cannot load " + filePath + " from classpath", e);
+      }
+    }
+    return content;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSelector.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSelector.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
-import org.apache.commons.io.IOUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.By.ByCssSelector;
 import org.openqa.selenium.NoSuchElementException;
@@ -13,14 +12,9 @@ import org.openqa.selenium.WebElement;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.codeborne.selenide.SelectorMode.CSS;
-import static java.lang.Thread.currentThread;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Thanks to http://selenium.polteq.com/en/injecting-the-sizzle-css-selector-library/
@@ -29,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 public class WebElementSelector {
   public static WebElementSelector instance = new WebElementSelector();
 
-  protected String sizzleSource;
+  protected final FileContent sizzleSource = new FileContent("sizzle.js");
 
   @CheckReturnValue
   @Nonnull
@@ -111,14 +105,6 @@ public class WebElementSelector {
   }
 
   protected synchronized void injectSizzle(Driver driver) {
-    if (sizzleSource == null) {
-      try {
-        URL sizzleJs = requireNonNull(currentThread().getContextClassLoader().getResource("sizzle.js"));
-        sizzleSource = IOUtils.toString(sizzleJs, StandardCharsets.UTF_8);
-      } catch (IOException e) {
-        throw new RuntimeException("Cannot load sizzle.js from classpath", e);
-      }
-    }
-    driver.executeJavaScript(sizzleSource);
+    driver.executeJavaScript(sizzleSource.content());
   }
 }

--- a/src/main/resources/find-in-shadow-roots.js
+++ b/src/main/resources/find-in-shadow-roots.js
@@ -1,0 +1,25 @@
+(function () {
+  function findInShadows(target, shadowRoots, searchContext) {
+    if (shadowRoots.length === 0) {
+      return Array.from(searchContext.querySelectorAll(target));
+    }
+
+    const nextSelector = shadowRoots[0];
+    const otherSelectors = shadowRoots.slice(1);
+    const nextInnerShadowRoots = Array.from(searchContext.querySelectorAll(nextSelector));
+    return nextInnerShadowRoots.map(function (childShadowRoot) {
+      return findInShadows(target, otherSelectors, getShadowRoot(childShadowRoot));
+    }).flat();
+  }
+
+  function getShadowRoot(element) {
+    if (!element.shadowRoot) {
+      throw Error('The element is not a shadow host or has \'closed\' shadow-dom mode: ' + element);
+    }
+    return element.shadowRoot;
+  }
+
+  return arguments.length === 2 ?
+    findInShadows(arguments[0], arguments[1], document) :
+    findInShadows(arguments[0], arguments[1], getShadowRoot(arguments[2]));
+})

--- a/src/test/java/com/codeborne/selenide/SelectorsTest.java
+++ b/src/test/java/com/codeborne/selenide/SelectorsTest.java
@@ -157,33 +157,24 @@ final class SelectorsTest implements WithAssertions {
 
   @Test
   void byClassName() {
-    String className = "selenide";
-    By classNameSelector = Selectors.byClassName(className);
-    assertThat(classNameSelector)
-      .isInstanceOf(By.ByClassName.class);
-    assertThat(classNameSelector)
-      .hasToString("By.className: " + className);
+    By classNameSelector = Selectors.byClassName("btn-active");
+    assertThat(classNameSelector).isInstanceOf(By.ByClassName.class);
+    assertThat(classNameSelector).hasToString("By.className: btn-active");
   }
 
   @Test
   void byShadowCss() {
-    String target = "#target";
-    String shadow = "#shadow";
-    String innerShadow = "#inner-shadow";
-    By cssSelector = Selectors.shadowCss(target, shadow, innerShadow);
+    By cssSelector = Selectors.shadowCss("#target", "#shadow", "#inner-shadow");
     assertThat(cssSelector)
       .isInstanceOf(ByShadow.ByShadowCss.class);
     assertThat(cssSelector)
-      .hasToString("By.cssSelector: " + shadow + " [" + innerShadow + "] " + target);
+      .hasToString("By.cssSelector: #shadow -> #inner-shadow -> #target");
   }
 
   @Test
   void byTagName() {
-    String tagName = "selenide";
-    By tagNameSelector = Selectors.byTagName(tagName);
-    assertThat(tagNameSelector)
-      .isInstanceOf(By.ByTagName.class);
-    assertThat(tagNameSelector)
-      .hasToString("By.tagName: " + tagName);
+    By tagNameSelector = Selectors.byTagName("div");
+    assertThat(tagNameSelector).isInstanceOf(By.ByTagName.class);
+    assertThat(tagNameSelector).hasToString("By.tagName: div");
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/FileContentTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/FileContentTest.java
@@ -1,0 +1,12 @@
+package com.codeborne.selenide.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileContentTest {
+  @Test
+  void canReadFileContent() {
+    assertThat(new FileContent("find-in-shadow-roots.js").content()).contains("function findInShadows");
+  }
+}

--- a/src/test/java/integration/ShadowElementTest.java
+++ b/src/test/java/integration/ShadowElementTest.java
@@ -26,6 +26,13 @@ final class ShadowElementTest extends ITest {
   }
 
   @Test
+  void clickInsideShadowHostInsideOfElement() {
+    $("#shadow-host")
+      .find(shadowCss("p", "#inner-shadow-host"))
+      .shouldHave(text("The Shadow-DOM inside another shadow tree"));
+  }
+
+  @Test
   void getTargetElementViaShadowHost() {
     $(shadowCss("p", "#shadow-host"))
       .shouldHave(text("Inside Shadow-DOM"));
@@ -61,9 +68,9 @@ final class ShadowElementTest extends ITest {
   void throwErrorWhenInnerShadowHostAbsent() {
     assertThatThrownBy(() -> $(shadowCss("p", "#shadow-host", "#nonexistent")).text())
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("Element not found {#shadow-host [#nonexistent] p}")
+      .hasMessageContaining("Element not found {#shadow-host -> #nonexistent -> p}")
       .hasCauseInstanceOf(NoSuchElementException.class)
-      .hasMessageContaining("The element was not found: #nonexistent");
+      .hasMessageContaining("Cannot locate an element p in shadow roots #shadow-host -> #nonexistent");
   }
 
   @Test
@@ -86,7 +93,7 @@ final class ShadowElementTest extends ITest {
 
   @Test
   void getAllElementsInAllNestedShadowHosts() {
-    final ElementsCollection elements = $$(shadowCss(".shadow-container-child-child-item",
+    ElementsCollection elements = $$(shadowCss(".shadow-container-child-child-item",
       "#shadow-container", ".shadow-container-child", ".shadow-container-child-child"));
     elements.shouldHaveSize(3);
     assertThat(elements.get(0).getText()).isEqualTo("shadowContainerChildChild1Host1").as("Mismatch in name of first child container");

--- a/src/test/resources/page_with_shadow_dom.html
+++ b/src/test/resources/page_with_shadow_dom.html
@@ -7,59 +7,68 @@
   <script type="text/javascript" src="jquery.min.js"></script>
   <script type="text/javascript">
 
-    function appendChildItem(shadowContainer, clazz, text) {
-      var shadowContainerChildHost = document.createElement("div");
-      shadowContainerChildHost.setAttribute('class', clazz);
-      var shadowContainerChild = shadowContainerChildHost.attachShadow( { mode: "open" } );
+/*
+    function findInShadows(root, shadowRoots, leaf) {
+      if (shadowRoots.length === 0) {
+        return Array.from(root.querySelectorAll(leaf));
+      }
 
-      var shadowContainerChildItem = document.createElement("div");
-      shadowContainerChildItem.setAttribute('class', clazz + '-item');
-      let p = document.createElement("p");
-      p.appendChild(document.createTextNode(text));
-      shadowContainerChildItem.appendChild(p);
+      const nextSelector = shadowRoots[0];
+      const otherSelectors = shadowRoots.slice(1);
+
+      return Array.from(root.querySelectorAll(nextSelector)).map(function(childShadowRoot) {
+        return findInShadows(childShadowRoot.shadowRoot, otherSelectors, leaf);
+      }).flat();
+    }
+*/
+
+    function newElement(tag, attributes, text) {
+      const element = document.createElement(tag);
+      Object.keys(attributes).forEach(function (attributeName) {
+        element.setAttribute(attributeName, attributes[attributeName]);
+      });
+      if (text) {
+        element.appendChild(document.createTextNode(text));
+      }
+      return element;
+    }
+
+    function appendChildItem(shadowContainer, clazz, text) {
+      const shadowContainerChildHost = newElement('div', {'class': clazz});
+      const shadowContainerChild = shadowContainerChildHost.attachShadow({mode: "open"});
+
+      const shadowContainerChildItem = newElement('div', {'class': clazz + '-item'});
+      shadowContainerChildItem.appendChild(newElement('p', {}, text));
       shadowContainerChild.appendChild(shadowContainerChildItem);
 
       shadowContainer.appendChild(shadowContainerChildHost);
-
       return shadowContainerChild;
     }
 
     $(function () {
-      var shadow = document.getElementById('shadow-host').attachShadow( { mode: "open" } )
+      const shadow = document.getElementById('shadow-host').attachShadow({mode: "open"});
 
-      var p = document.createElement("p");
-      var div = document.createElement("div");
-      var div2 = document.createElement("div");
-      var div3 = document.createElement("div");
       var input = document.createElement("input");
       var button = document.createElement("button");
       button.setAttribute("id", "anyButton");
       button.textContent = `Button`;
       button.onclick = function() {this.textContent = "Changed text";};
       input.setAttribute("type", "text");
-      div.setAttribute('id', 'inner-shadow-host');
-      div2.setAttribute('class', 'test-class');
-      div3.setAttribute('class', 'test-class');
-      var text = document.createTextNode("Inside Shadow-DOM");
-      p.appendChild(text);
-      shadow.appendChild(p);
-      shadow.appendChild(div);
-      shadow.appendChild(div2);
-      shadow.appendChild(div3);
+
+      shadow.appendChild(newElement('p', {}, 'Inside Shadow-DOM'));
+      shadow.appendChild(newElement('div', {'id': 'inner-shadow-host'}));
+      shadow.appendChild(newElement('div', {class: 'test-class'}, 'text-test-class-1'));
+      shadow.appendChild(newElement('div', {class: 'test-class'}, 'text-test-class-2'));
       shadow.appendChild(input);
       shadow.appendChild(button);
 
       var shadow2 = shadow.getElementById("inner-shadow-host").attachShadow( { mode: "open" } )
+      shadow2.appendChild(newElement('p', {}, 'The Shadow-DOM inside another shadow tree'));
 
-      var p2 = document.createElement("p");
-      var text2 = document.createTextNode("The Shadow-DOM inside another shadow tree");
-      p2.appendChild(text2);
-      shadow2.appendChild(p2);
-
-      var shadowContainer = document.getElementById('shadow-container').attachShadow( { mode: "open" } )
-      shadowContainerChild1 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost1');
-      shadowContainerChild2 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost2');
-      shadowContainerChild3 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost3');
+      const shadowContainer = document.getElementById('shadow-container').attachShadow({mode: "open"});
+      const shadowContainerChild1 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost1');
+      const shadowContainerChild2 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost2');
+      const shadowContainerChild3 = appendChildItem(shadowContainer, 'shadow-container-child', 'shadowContainerChildHost3');
 
       appendChildItem(shadowContainerChild1, 'shadow-container-child-child', 'shadowContainerChildChild1Host1')
       appendChildItem(shadowContainerChild1, 'shadow-container-child-child', 'shadowContainerChildChild2Host1')

--- a/statics/src/test/java/com/codeborne/selenide/WebDriverRunnerTest.java
+++ b/statics/src/test/java/com/codeborne/selenide/WebDriverRunnerTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.verify;
 final class WebDriverRunnerTest implements WithAssertions {
   private static WebDriver driver;
 
-  private URL url = currentThread().getContextClassLoader().getResource("start_page.html");
+  private final URL url = currentThread().getContextClassLoader().getResource("start_page.html");
 
   @BeforeEach
   void resetWebDriverContainer() {


### PR DESCRIPTION
find all shadow roots by a single JS call instead of calling WebDriver.executeJavascript() multiple times

occasionally, it also fixes (currently failing) tests in latests Firefox

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
