### PR TITLE
Replace long timeout with Duration for ElementsCollection 

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -26,6 +26,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.time.Duration;
 import java.util.AbstractList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -83,12 +84,12 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    */
   @Nonnull
   public ElementsCollection shouldBe(CollectionCondition... conditions) {
-    return should("be", driver().config().timeout(), conditions);
+    return should("be", Duration.ofMillis(driver().config().timeout()), conditions);
   }
 
   @Nonnull
-  public ElementsCollection shouldBe(CollectionCondition condition, long timeoutMs) {
-    return should("be", timeoutMs, toArray(condition));
+  public ElementsCollection shouldBe(CollectionCondition condition, Duration timeout) {
+    return should("be", timeout, toArray(condition));
   }
 
   /**
@@ -98,36 +99,36 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    */
   @Nonnull
   public ElementsCollection shouldHave(CollectionCondition... conditions) {
-    return should("have", driver().config().timeout(), conditions);
+    return should("have", Duration.ofMillis(driver().config().timeout()), conditions);
   }
 
   /**
    * Check if a collection matches given condition within given period
    *
-   * @param timeoutMs maximum waiting time in milliseconds
+   * @param timeout maximum waiting time
    */
   @Nonnull
-  public ElementsCollection shouldHave(CollectionCondition condition, long timeoutMs) {
-    return should("have", timeoutMs, toArray(condition));
+  public ElementsCollection shouldHave(CollectionCondition condition, Duration timeout) {
+    return should("have", timeout, toArray(condition));
   }
 
   private CollectionCondition[] toArray(CollectionCondition condition) {
     return new CollectionCondition[]{condition};
   }
 
-  protected ElementsCollection should(String prefix, long timeoutMs, CollectionCondition... conditions) {
+  protected ElementsCollection should(String prefix, Duration timeout, CollectionCondition... conditions) {
     validateAssertionMode(driver().config());
 
     SelenideLog log = SelenideLogger.beginStep(collection.description(), "should " + prefix, (Object[]) conditions);
     try {
       for (CollectionCondition condition : conditions) {
-        waitUntil(condition, timeoutMs);
+        waitUntil(condition, timeout);
       }
       SelenideLogger.commitStep(log, PASS);
       return this;
     }
     catch (Error error) {
-      Error wrappedError = UIAssertionError.wrap(driver(), error, timeoutMs);
+      Error wrappedError = UIAssertionError.wrap(driver(), error, timeout.toMillis());
       SelenideLogger.commitStep(log, wrappedError);
       switch (driver().config().assertionMode()) {
         case SOFT:
@@ -142,10 +143,10 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
     }
   }
 
-  protected void waitUntil(CollectionCondition condition, long timeoutMs) {
+  protected void waitUntil(CollectionCondition condition, Duration timeout) {
     Throwable lastError = null;
     List<WebElement> actualElements = null;
-    Stopwatch stopwatch = new Stopwatch(timeoutMs);
+    Stopwatch stopwatch = new Stopwatch(timeout.toMillis());
     do {
       try {
         actualElements = collection.getElements();
@@ -176,7 +177,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
       throw (UIAssertionError) lastError;
     }
     else {
-      condition.fail(collection, actualElements, (Exception) lastError, timeoutMs);
+      condition.fail(collection, actualElements, (Exception) lastError, timeout.toMillis());
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -93,6 +93,15 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   }
 
   /**
+   * @deprecated use {@link #shouldBe(CollectionCondition, Duration)}
+   */
+  @Nonnull
+  @Deprecated
+  public ElementsCollection shouldBe(CollectionCondition condition, long timeoutMs) {
+    return should("be", Duration.ofMillis(timeoutMs), toArray(condition));
+  }
+
+  /**
    * For example:
    * {@code $$(".error").shouldHave(size(3))}
    * {@code $$(".error").shouldHave(texts("Error1", "Error2"))}
@@ -110,6 +119,18 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   @Nonnull
   public ElementsCollection shouldHave(CollectionCondition condition, Duration timeout) {
     return should("have", timeout, toArray(condition));
+  }
+
+  /**
+   * Check if a collection matches given condition within given period
+   *
+   * @param timeoutMs maximum waiting time in milliseconds
+   * @deprecated use {@link #shouldHave(CollectionCondition, Duration)}
+   */
+  @Nonnull
+  @Deprecated
+  public ElementsCollection shouldHave(CollectionCondition condition, long timeoutMs) {
+    return should("have", Duration.ofMillis(timeoutMs), toArray(condition));
   }
 
   private CollectionCondition[] toArray(CollectionCondition condition) {

--- a/src/test/java/com/codeborne/selenide/ElementsCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/ElementsCollectionTest.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -70,7 +71,7 @@ final class ElementsCollectionTest implements WithAssertions {
     ElementsCollection collection = new ElementsCollection(source);
     when(source.getElements()).thenReturn(emptyList());
 
-    assertThatThrownBy(() -> collection.should("Size", 1, CollectionCondition.size(1)))
+    assertThatThrownBy(() -> collection.should("Size", Duration.ofMillis(1), CollectionCondition.size(1)))
       .isInstanceOf(Error.class);
   }
 
@@ -79,7 +80,7 @@ final class ElementsCollectionTest implements WithAssertions {
     ElementsCollection collection = new ElementsCollection(source);
     doThrow(RuntimeException.class).when(source).getElements();
 
-    assertThatThrownBy(() -> collection.should("Be size 1", 1, CollectionCondition.size(1)))
+    assertThatThrownBy(() -> collection.should("Be size 1", Duration.ofMillis(1), CollectionCondition.size(1)))
       .isInstanceOf(RuntimeException.class);
   }
 

--- a/statics/debug.log
+++ b/statics/debug.log
@@ -1,0 +1,1 @@
+[0119/221532.796:ERROR:directory_reader_win.cc(43)] FindFirstFile: Системе не удается найти указанный путь. (0x3)

--- a/statics/debug.log
+++ b/statics/debug.log
@@ -1,1 +1,0 @@
-[0119/221532.796:ERROR:directory_reader_win.cc(43)] FindFirstFile: Системе не удается найти указанный путь. (0x3)

--- a/statics/src/test/java/integration/CollectionWaitTest.java
+++ b/statics/src/test/java/integration/CollectionWaitTest.java
@@ -7,6 +7,7 @@ import com.codeborne.selenide.ex.TextsSizeMismatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static com.codeborne.selenide.CollectionCondition.size;
@@ -95,14 +96,14 @@ final class CollectionWaitTest extends IntegrationTest {
   @Test
   void customTimeoutForCollections() {
     Configuration.timeout = 1;
-    $$("#collection li").last(2).shouldHave(texts("Element #18", "Element #19"), 5000);
+    $$("#collection li").last(2).shouldHave(texts("Element #18", "Element #19"), Duration.ofSeconds(5));
   }
 
   @Test
   void waitsForCustomTimeoutForCollections() {
     Configuration.timeout = 1;
     assertThatThrownBy(() ->
-      $$("#collection li").last(2).shouldHave(texts("Element #88888", "Element #99999"), 2000)
+      $$("#collection li").last(2).shouldHave(texts("Element #88888", "Element #99999"), Duration.ofMillis(2000))
     )
       .isInstanceOf(TextsMismatch.class)
       .hasMessageContaining("Actual: [Element #18, Element #19]")

--- a/statics/src/test/java/integration/CollectionWaitTest.java
+++ b/statics/src/test/java/integration/CollectionWaitTest.java
@@ -96,6 +96,7 @@ final class CollectionWaitTest extends IntegrationTest {
   @Test
   void customTimeoutForCollections() {
     Configuration.timeout = 1;
+    $$("#collection li").first(2).shouldHave(texts("Element #0", "Element #1"), 5000);
     $$("#collection li").last(2).shouldHave(texts("Element #18", "Element #19"), Duration.ofSeconds(5));
   }
 


### PR DESCRIPTION
## Proposed changes
Since recently all 'should' methods in SelenideElement have a Duration argument for condition waiting. To make things consistent these changes update all 'should' methods for ElementsCollection to also use Duration instead of long for timeouts.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
