### PR TITLE
#1376 display duration argument in report as "1s" or "300 ms"

### DIFF
--- a/src/main/java/com/codeborne/selenide/ex/ErrorMessages.java
+++ b/src/main/java/com/codeborne/selenide/ex/ErrorMessages.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.ex;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Cleanup;
+import com.codeborne.selenide.impl.DurationFormat;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
@@ -14,16 +15,11 @@ import static org.apache.commons.lang3.StringUtils.substring;
 
 @ParametersAreNonnullByDefault
 public class ErrorMessages {
+  private static final DurationFormat df = new DurationFormat();
+
   @CheckReturnValue
   protected static String timeout(long timeoutMs) {
-    if (timeoutMs < 1000) {
-      return String.format("%nTimeout: %d ms.", timeoutMs);
-    }
-    if (timeoutMs % 1000 == 0) {
-      return String.format("%nTimeout: %d s.", timeoutMs / 1000);
-    }
-
-    return String.format("%nTimeout: %.3f s.", timeoutMs / 1000.0);
+    return String.format("%nTimeout: %s", df.format(timeoutMs));
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/impl/DurationFormat.java
+++ b/src/main/java/com/codeborne/selenide/impl/DurationFormat.java
@@ -1,0 +1,25 @@
+package com.codeborne.selenide.impl;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.time.Duration;
+
+@ParametersAreNonnullByDefault
+public class DurationFormat {
+  @CheckReturnValue
+  public String format(Duration duration) {
+    return format(duration.toMillis());
+  }
+
+  @CheckReturnValue
+  public String format(long milliseconds) {
+    if (milliseconds < 1000) {
+      return String.format("%d ms.", milliseconds);
+    }
+    if (milliseconds % 1000 == 0) {
+      return String.format("%d s.", milliseconds / 1000);
+    }
+
+    return String.format("%.3f s.", milliseconds / 1000.0);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/logevents/SelenideLogger.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SelenideLogger.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide.logevents;
 
+import com.codeborne.selenide.impl.DurationFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,12 +8,15 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.FAIL;
+import static java.util.stream.Collectors.joining;
 
 /**
  * Logs Selenide test steps and notifies all registered LogEventListener about it
@@ -22,6 +26,8 @@ public class SelenideLogger {
   private static final Logger LOG = LoggerFactory.getLogger(SelenideLogger.class);
 
   protected static final ThreadLocal<Map<String, LogEventListener>> listeners = new ThreadLocal<>();
+
+  private static final DurationFormat df = new DurationFormat();
 
   /**
    * Add a listener (to the current thread).
@@ -54,7 +60,7 @@ public class SelenideLogger {
   @CheckReturnValue
   @Nonnull
   static String readableArguments(@Nullable Object... args) {
-    if (args == null) {
+    if (args == null || args.length == 0) {
       return "";
     }
 
@@ -72,7 +78,16 @@ public class SelenideLogger {
   @CheckReturnValue
   @Nonnull
   private static String arrayToString(Object[] args) {
-    return args.length == 1 ? String.valueOf(args[0]) : Arrays.toString(args);
+    return args.length == 1 ?
+      argToString(args[0]) :
+      '[' + Stream.of(args).map(SelenideLogger::argToString).collect(joining(", ")) + ']';
+  }
+
+  private static String argToString(Object arg) {
+    if (arg instanceof Duration) {
+      return df.format((Duration) arg);
+    }
+    return String.valueOf(arg);
   }
 
   @CheckReturnValue

--- a/src/test/java/com/codeborne/selenide/impl/DurationFormatTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DurationFormatTest.java
@@ -1,0 +1,42 @@
+package com.codeborne.selenide.impl;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class DurationFormatTest {
+  private final DurationFormat df = new DurationFormat();
+
+  @Test
+  void zero() {
+    assertThat(df.format(0)).isEqualTo("0 ms.");
+  }
+
+  @Test
+  void lessThanSecond() {
+    assertThat(df.format(1)).isEqualTo("1 ms.");
+    assertThat(df.format(999)).isEqualTo("999 ms.");
+  }
+
+  @Test
+  void integerSeconds() {
+    assertThat(df.format(1000)).isEqualTo("1 s.");
+    assertThat(df.format(2000)).isEqualTo("2 s.");
+  }
+
+  @Test
+  void greaterThanSecond() {
+    assertThat(df.format(1500)).isEqualTo("1.500 s.");
+    assertThat(df.format(1567)).isEqualTo("1.567 s.");
+    assertThat(df.format(2001)).isEqualTo("2.001 s.");
+  }
+
+  @Test
+  void greaterThanMinute() {
+    assertThat(df.format(Duration.ofMinutes(1))).isEqualTo("60 s.");
+    assertThat(df.format(Duration.ofMinutes(2).plusSeconds(2))).isEqualTo("122 s.");
+    assertThat(df.format(Duration.ofMinutes(3).plusMillis(300))).isEqualTo("180.300 s.");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/logevents/SelenideLoggerTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/SelenideLoggerTest.java
@@ -9,8 +9,12 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
+
+import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.FAIL;
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
+import static com.codeborne.selenide.logevents.SelenideLogger.readableArguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -42,24 +46,24 @@ final class SelenideLoggerTest implements WithAssertions {
 
   @Test
   void printsReadableArgumentsValues() {
-    assertThat(SelenideLogger.readableArguments((Object[]) null))
-      .isEqualTo("");
-    assertThat(SelenideLogger.readableArguments(111))
-      .isEqualTo("111");
-    assertThat(SelenideLogger.readableArguments(1, 2, 3))
-      .isEqualTo("[1, 2, 3]");
-    assertThat(SelenideLogger.readableArguments((Object[]) new String[]{"a"}))
-      .isEqualTo("a");
-    assertThat(SelenideLogger.readableArguments((Object[]) new String[]{"a", "bb"}))
-      .isEqualTo("[a, bb]");
-    assertThat(SelenideLogger.readableArguments((Object[]) new String[]{null}))
-      .isEqualTo("null");
-    assertThat(SelenideLogger.readableArguments((Object[]) new String[]{null, "a", null}))
-      .isEqualTo("[null, a, null]");
-    assertThat(SelenideLogger.readableArguments((Object) new int[]{1}))
-      .isEqualTo("1");
-    assertThat(SelenideLogger.readableArguments((Object) new int[]{1, 2}))
-      .isEqualTo("[1, 2]");
+    assertThat(readableArguments((Object[]) null)).isEqualTo("");
+    assertThat(readableArguments(111)).isEqualTo("111");
+    assertThat(readableArguments(1, 2, 3)).isEqualTo("[1, 2, 3]");
+    assertThat(readableArguments((Object[]) new String[]{"a"})).isEqualTo("a");
+    assertThat(readableArguments((Object[]) new String[]{"a", "bb"})).isEqualTo("[a, bb]");
+    assertThat(readableArguments((Object[]) new String[]{null})).isEqualTo("null");
+    assertThat(readableArguments((Object[]) new String[]{null, "a", null})).isEqualTo("[null, a, null]");
+    assertThat(readableArguments((Object) new int[]{1})).isEqualTo("1");
+    assertThat(readableArguments((Object) new int[]{1, 2})).isEqualTo("[1, 2]");
+  }
+
+  @Test
+  void printsDurationAmongArguments() {
+    assertThat(readableArguments(Duration.ofMillis(900))).isEqualTo("900 ms.");
+    assertThat(readableArguments(visible, Duration.ofSeconds(42))).isEqualTo("[visible, 42 s.]");
+    assertThat(readableArguments(visible, Duration.ofMillis(8500))).isEqualTo("[visible, 8.500 s.]");
+    assertThat(readableArguments(visible, Duration.ofMillis(900))).isEqualTo("[visible, 900 ms.]");
+    assertThat(readableArguments(visible, Duration.ofNanos(0))).isEqualTo("[visible, 0 ms.]");
   }
 
   @Test

--- a/statics/src/test/java/integration/proxy/MultipleDownloadsTest.java
+++ b/statics/src/test/java/integration/proxy/MultipleDownloadsTest.java
@@ -1,5 +1,6 @@
 package integration.proxy;
 
+import com.codeborne.selenide.impl.FileContent;
 import integration.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,6 @@ public class MultipleDownloadsTest extends IntegrationTest {
     );
 
     assertEquals("empty.html", text.getName());
-    assertEquals(224, text.length());
+    assertEquals(new FileContent("empty.html").content().length(), text.length());
   }
 }


### PR DESCRIPTION
Fix issue https://github.com/selenide/selenide/issues/1376

Display human-readable timeouts like "1 s." or "300 ms." in Selenide/Allure report (instead of "PT2S"). 