### PR TITLE
#1365 disable webdriver logs by default

### DIFF
--- a/src/main/java/com/codeborne/selenide/Config.java
+++ b/src/main/java/com/codeborne/selenide/Config.java
@@ -11,6 +11,7 @@ public interface Config {
   String browserPosition();
   boolean startMaximized();
   boolean driverManagerEnabled();
+  boolean webdriverLogsEnabled();
   String browserBinary();
   String pageLoadStrategy();
   long pageLoadTimeout();

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -18,6 +18,7 @@ public class SelenideConfig implements Config {
   private String browserPosition = System.getProperty("selenide.browserPosition");
   private boolean startMaximized = Boolean.parseBoolean(System.getProperty("selenide.startMaximized", "false"));
   private boolean driverManagerEnabled = Boolean.parseBoolean(System.getProperty("selenide.driverManagerEnabled", "true"));
+  private boolean webdriverLogsEnabled = Boolean.parseBoolean(System.getProperty("selenide.webdriverLogsEnabled", "false"));
   private String browserBinary = System.getProperty("selenide.browserBinary", "");
   private String pageLoadStrategy = System.getProperty("selenide.pageLoadStrategy", "normal");
   private long pageLoadTimeout = Long.parseLong(System.getProperty("selenide.pageLoadTimeout", "30000"));
@@ -311,6 +312,15 @@ public class SelenideConfig implements Config {
 
   public SelenideConfig driverManagerEnabled(boolean driverManagerEnabled) {
     this.driverManagerEnabled = driverManagerEnabled;
+    return this;
+  }
+  @Override
+  public boolean webdriverLogsEnabled() {
+    return webdriverLogsEnabled;
+  }
+
+  public SelenideConfig webdriverLogsEnabled(boolean webdriverLogsEnabled) {
+    this.webdriverLogsEnabled = webdriverLogsEnabled;
     return this;
   }
 

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -6,6 +6,7 @@ import com.codeborne.selenide.impl.FileNamer;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.service.DriverService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +43,13 @@ public abstract class AbstractDriverFactory implements DriverFactory {
     File logFile = new File(logFolder, logFileName).getAbsoluteFile();
     log.info("Write webdriver logs to: {}", logFile);
     return logFile;
+  }
+
+  protected <DS extends DriverService, B extends DriverService.Builder<DS, ?>> DS withLog(Config config, B dsBuilder) {
+    if (config.webdriverLogsEnabled()) {
+      dsBuilder.withLogFile(webdriverLog(config));
+    }
+    return dsBuilder.build();
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -58,9 +58,7 @@ public class ChromeDriverFactory extends AbstractDriverFactory {
   @CheckReturnValue
   @Nonnull
   protected ChromeDriverService buildService(Config config) {
-    return new ChromeDriverService.Builder()
-      .withLogFile(webdriverLog(config))
-      .build();
+    return withLog(config, new ChromeDriverService.Builder());
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -50,9 +50,7 @@ public class EdgeDriverFactory extends AbstractDriverFactory {
   }
 
   private EdgeDriverService createDriverService(Config config) {
-    return new EdgeDriverService.Builder()
-      .withLogFile(webdriverLog(config))
-      .build();
+    return withLog(config, new EdgeDriverService.Builder());
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -48,10 +48,7 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
   @CheckReturnValue
   @Nonnull
   protected GeckoDriverService createDriverService(Config config) {
-    File logFile = webdriverLog(config);
-    return new GeckoDriverService.Builder()
-      .withLogFile(logFile)
-      .build();
+    return withLog(config, new GeckoDriverService.Builder());
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/OperaDriverFactory.java
@@ -44,9 +44,7 @@ public class OperaDriverFactory extends AbstractDriverFactory {
   }
 
   private OperaDriverService createDriverService(Config config) {
-    return new OperaDriverService.Builder()
-      .withLogFile(webdriverLog(config))
-      .build();
+    return withLog(config, new OperaDriverService.Builder());
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/webdriver/SafariDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/SafariDriverFactory.java
@@ -31,10 +31,7 @@ public class SafariDriverFactory extends AbstractDriverFactory {
   }
 
   private SafariDriverService createDriverService(Config config) {
-    return new SafariDriverService.Builder()
-      .usingTechnologyPreview(false)
-      .withLogFile(webdriverLog(config))
-      .build();
+    return withLog(config, new SafariDriverService.Builder().usingTechnologyPreview(false));
   }
 
   @Nonnull

--- a/src/test/java/integration/LogTestNameExtension.java
+++ b/src/test/java/integration/LogTestNameExtension.java
@@ -6,32 +6,29 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.opentest4j.TestAbortedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static integration.BaseIntegrationTest.browser;
+import static org.slf4j.LoggerFactory.getLogger;
 
 final class LogTestNameExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
-  private static final Logger log = LoggerFactory.getLogger(LogTestNameExtension.class);
-
   @Override
   public void beforeAll(ExtensionContext context) {
-    log.info("Starting {} @ {}", context.getDisplayName(), browser);
+    getLogger(context.getDisplayName()).info("Starting tests @ {}", browser);
   }
 
   @Override
   public void afterAll(ExtensionContext context) {
-    log.info("Finished {} @ {} - {}", context.getDisplayName(), browser, verdict(context));
+    getLogger(context.getDisplayName()).info("Finished tests @ {} - {}", browser, verdict(context));
   }
 
   @Override
   public void beforeEach(ExtensionContext context) {
-    log.info("  starting {} ...", context.getDisplayName());
+    getLogger(context.getRequiredTestClass().getName()).info("starting {} ...", context.getDisplayName());
   }
 
   @Override
   public void afterEach(ExtensionContext context) {
-    log.info("  finished {} - {}", context.getDisplayName(), verdict(context));
+    getLogger(context.getRequiredTestClass().getName()).info("finished {} - {}", context.getDisplayName(), verdict(context));
   }
 
   private String verdict(ExtensionContext context) {

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -327,6 +327,22 @@ public class Configuration {
   public static boolean driverManagerEnabled = defaults.driverManagerEnabled();
 
   /**
+   * <p>
+   *  Whether webdriver logs should be enabled.
+   * </p>
+   *
+   * <p>
+   *   These logs may be useful for debugging some webdriver issues.
+   *   But in most cases they are not needed (and can take quite a lot of disk space),
+   *   that's why don't enable them by default.
+   * </p>
+   *
+   * Default: false
+   * @since 5.18.0
+   */
+  public static boolean webdriverLogsEnabled = defaults.webdriverLogsEnabled();
+
+  /**
    * Enables the ability to run the browser in headless mode.
    * Works only for Chrome(59+) and Firefox(56+).
    * Can be configured either programmatically or by system property "-Dselenide.headless=true"

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
@@ -152,6 +152,11 @@ public class StaticConfig implements Config {
   }
 
   @Override
+  public boolean webdriverLogsEnabled() {
+    return Configuration.webdriverLogsEnabled;
+  }
+
+  @Override
   public String browserBinary() {
     return Configuration.browserBinary;
   }


### PR DESCRIPTION
they still can be enabled by Configuration.webdriverLogsEnabled = true

fixes issue https://github.com/selenide/selenide/issues/1365