### PR TITLE
Pass noproxy options to outside proxy

### DIFF
--- a/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
@@ -12,7 +12,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.lang.Integer.parseInt;
@@ -62,8 +64,12 @@ public class SelenideProxyServer {
     proxy.setTrustAllServers(true);
     if (outsideProxy != null) {
       proxy.setChainedProxy(getProxyAddress(outsideProxy));
+      String noProxy = outsideProxy.getNoProxy();
+      if (noProxy != null) {
+        List<String> noProxyHosts = Arrays.asList(noProxy.split(","));
+        proxy.setChainedProxyNonProxyHosts(noProxyHosts);
+      }
     }
-
     addRequestFilter("authentication", new AuthenticationFilter());
     addRequestFilter("requestSizeWatchdog", new RequestSizeWatchdog());
     addResponseFilter("responseSizeWatchdog", new ResponseSizeWatchdog());

--- a/src/test/java/com/codeborne/selenide/proxy/SelenideProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/SelenideProxyServerTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Proxy;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -29,6 +31,34 @@ final class SelenideProxyServerTest implements WithAssertions {
 
     FileDownloadFilter filter = proxyServer.responseFilter("download");
     assertThat(filter.downloads().files()).hasSize(0);
+  }
+
+  @Test
+  void canChainProxyServersWithNoProxySettings() {
+    Proxy proxy = new Proxy();
+    proxy.setHttpProxy("127.0.0.1:3128");
+    proxy.setNoProxy("localhost,https://example.com/");
+
+    SelenideProxyServer proxyServer = new SelenideProxyServer(config, proxy, new InetAddressResolverStub(), bmp);
+    proxyServer.start();
+
+    verify(bmp).setChainedProxy(any(InetSocketAddress.class));
+    verify(bmp).setChainedProxyNonProxyHosts(Arrays.asList("localhost", "https://example.com/"));
+    verify(bmp).start(0);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void canChainProxyServersWithEmptyNoProxySettings() {
+    Proxy proxy = new Proxy();
+    proxy.setHttpProxy("127.0.0.1:3128");
+
+    SelenideProxyServer proxyServer = new SelenideProxyServer(config, proxy, new InetAddressResolverStub(), bmp);
+    proxyServer.start();
+
+    verify(bmp).setChainedProxy(any(InetSocketAddress.class));
+    verify(bmp, never()).setChainedProxyNonProxyHosts(any(List.class));
+    verify(bmp).start(0);
   }
 
   @Test


### PR DESCRIPTION
## The problem
```
Proxy proxy = new Proxy();
proxy.setHttpProxy("127.0.0.1:3128"); 
proxy.setNoProxy("localhost");
WebDriverRunner.setProxy(proxy);      
Configuration.proxyEnabled = true;
open("http://localhost")
```
it can not open localhost because noproxy settings gets lost. 

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
