### PR TITLE
Session Storage Utils

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -430,6 +430,12 @@ public class SelenideDriver {
     return new LocalStorage(driver());
   }
 
+  @CheckReturnValue
+  @Nonnull
+  public SessionStorage getSessionStorage() {
+    return new SessionStorage(driver());
+  }
+
   private static final PageObjectFactory pageFactory = inject(PageObjectFactory.class);
   private static DownloadFileWithHttpRequest downloadFileWithHttpRequest;
 

--- a/src/main/java/com/codeborne/selenide/SessionStorage.java
+++ b/src/main/java/com/codeborne/selenide/SessionStorage.java
@@ -1,0 +1,46 @@
+package com.codeborne.selenide;
+
+import static java.lang.Integer.parseInt;
+import static java.util.Optional.ofNullable;
+
+/**
+ * Created by dbudim on 10.02.2021
+ */
+
+public class SessionStorage {
+
+  private final Driver driver;
+
+  SessionStorage(Driver driver) {
+    this.driver = driver;
+  }
+
+  public boolean containsItem(String key) {
+    return ofNullable(getItem(key)).isPresent();
+  }
+
+  public String getItem(String key) {
+    return driver.executeJavaScript("return sessionStorage.getItem(arguments[0])", key);
+  }
+
+  public void setItem(String key, String value) {
+    driver.executeJavaScript("sessionStorage.setItem(arguments[0], arguments[1])", key, value);
+  }
+
+  public void removeItem(String key) {
+    driver.executeJavaScript("sessionStorage.removeItem(arguments[0])", key);
+  }
+
+  public void clear() {
+    driver.executeJavaScript("sessionStorage.clear()");
+  }
+
+  public int size() {
+    return parseInt(driver.executeJavaScript("return sessionStorage.length").toString());
+  }
+
+  public boolean isEmpty() {
+    return size() == 0;
+  }
+
+}

--- a/src/main/java/com/codeborne/selenide/SessionStorage.java
+++ b/src/main/java/com/codeborne/selenide/SessionStorage.java
@@ -1,11 +1,10 @@
 package com.codeborne.selenide;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 import static java.lang.Integer.parseInt;
 import static java.util.Optional.ofNullable;
-
-/**
- * Created by dbudim on 10.02.2021
- */
 
 public class SessionStorage {
 
@@ -15,6 +14,8 @@ public class SessionStorage {
     this.driver = driver;
   }
 
+  @Nonnull
+  @CheckReturnValue
   public boolean containsItem(String key) {
     return ofNullable(getItem(key)).isPresent();
   }
@@ -35,10 +36,12 @@ public class SessionStorage {
     driver.executeJavaScript("sessionStorage.clear()");
   }
 
+  @CheckReturnValue
   public int size() {
     return parseInt(driver.executeJavaScript("return sessionStorage.length").toString());
   }
 
+  @CheckReturnValue
   public boolean isEmpty() {
     return size() == 0;
   }

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -988,4 +988,9 @@ public class Selenide {
   public static LocalStorage localStorage() {
     return getSelenideDriver().getLocalStorage();
   }
+
+  @Nonnull
+  public static SessionStorage sessionStorage(){
+    return getSelenideDriver().getSessionStorage();
+  }
 }

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -989,6 +989,13 @@ public class Selenide {
     return getSelenideDriver().getLocalStorage();
   }
 
+  /**
+   * Access browser's session storage.
+   * Allows setting, getting, removing items as well as getting the size, check for contains item and clear the storage.
+   *
+   * @return sessionStorage
+   */
+
   @Nonnull
   public static SessionStorage sessionStorage(){
     return getSelenideDriver().getSessionStorage();

--- a/statics/src/test/java/integration/SessionStorageTest.java
+++ b/statics/src/test/java/integration/SessionStorageTest.java
@@ -1,0 +1,56 @@
+package integration;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Selenide.closeWebDriver;
+import static com.codeborne.selenide.Selenide.sessionStorage;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Created by dbudim on 10.02.2021
+ */
+
+public class SessionStorageTest extends IntegrationTest {
+
+  @BeforeEach
+  public void openTestPage() {
+    openFile("empty.html");
+  }
+
+  @Test
+  public void setGetItem() {
+    sessionStorage().setItem("pied", "piper");
+    assertEquals("piper", sessionStorage().getItem("pied"), "there is no item in session storage");
+  }
+
+  @Test
+  public void getSize() {
+    sessionStorage().setItem("pied", "piper");
+    sessionStorage().setItem("John", "Wick");
+    assertEquals(2, sessionStorage().size(), "session storage size doesn't match");
+  }
+
+  @Test
+  public void removeItem() {
+    sessionStorage().setItem("pied", "piper");
+    sessionStorage().setItem("John", "Wick");
+
+    sessionStorage().removeItem("pied");
+    assertFalse(sessionStorage().containsItem("pied"), "item wasn't removed fromm session storage");
+  }
+
+  @Test
+  public void clearTest() {
+    sessionStorage().setItem("pied", "piper");
+    sessionStorage().setItem("John", "Wick");
+    sessionStorage().clear();
+    assertTrue(sessionStorage().isEmpty(), "session storage wasn't cleared");
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    closeWebDriver();
+  }
+}


### PR DESCRIPTION
## Proposed changes
Add utils for working with Session storage (e.g. adding and removing special keys). 
Often used while testing some backdoors with timeouts on Front etc.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
