### PR TITLE
Add original collection description to snapshot version of it

### DIFF
--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -12,6 +12,7 @@ import com.codeborne.selenide.impl.HeadOfCollection;
 import com.codeborne.selenide.impl.LastCollectionElement;
 import com.codeborne.selenide.impl.SelenideElementIterator;
 import com.codeborne.selenide.impl.SelenideElementListIterator;
+import com.codeborne.selenide.impl.SnapshotCollection;
 import com.codeborne.selenide.impl.TailOfCollection;
 import com.codeborne.selenide.impl.CollectionSource;
 import com.codeborne.selenide.impl.WebElementsCollectionWrapper;
@@ -465,7 +466,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   @CheckReturnValue
   @Nonnull
   public ElementsCollection snapshot() {
-    return new ElementsCollection(fetch());
+    return new ElementsCollection(new SnapshotCollection(collection));
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/SnapshotCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/SnapshotCollection.java
@@ -1,0 +1,50 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.Driver;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.List;
+
+@ParametersAreNonnullByDefault
+public class SnapshotCollection implements CollectionSource {
+
+  private final CollectionSource originalCollection;
+  private final List<WebElement> elementsSnapshot;
+
+  public SnapshotCollection(CollectionSource collection) {
+    this.originalCollection = collection;
+    this.elementsSnapshot = new ArrayList<>(collection.getElements());
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public List<WebElement> getElements() {
+    return elementsSnapshot;
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public WebElement getElement(int index) {
+    return elementsSnapshot.get(index);
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public String description() {
+    return String.format("%s.snapshot(%d elements)", originalCollection.description(), elementsSnapshot.size());
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public Driver driver() {
+    return originalCollection.driver();
+  }
+}

--- a/src/test/java/com/codeborne/selenide/impl/SnapshotCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SnapshotCollectionTest.java
@@ -1,0 +1,86 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.Driver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openqa.selenium.WebElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SnapshotCollectionTest {
+
+  private CollectionSource mockedCollection = mock(CollectionSource.class);
+
+  @AfterEach
+  void verifyNoMoreInteractions() {
+    verify(mockedCollection).getElements();
+    Mockito.verifyNoMoreInteractions(mockedCollection);
+  }
+
+  @Test
+  void getOriginalCollectionSnapshotElements() {
+    WebElement mockedWebElement1 = mock(WebElement.class);
+    WebElement mockedWebElement2 = mock(WebElement.class);
+
+    List<WebElement> originalCollectionElements = Arrays.asList(mockedWebElement1, mockedWebElement2);
+    when(mockedCollection.getElements()).thenReturn(originalCollectionElements);
+
+    SnapshotCollection snapshotCollection = new SnapshotCollection(mockedCollection);
+    List<WebElement> snapshotCollectionElements = snapshotCollection.getElements();
+
+    assertThat(snapshotCollectionElements).isNotSameAs(originalCollectionElements);
+    assertThat(snapshotCollectionElements).isEqualTo(originalCollectionElements);
+
+    // Returns snapshot version nevertheless how many times we call getElements()
+    List<WebElement> snapshotCollectionElements2 = snapshotCollection.getElements();
+    assertThat(snapshotCollectionElements2).isSameAs(snapshotCollectionElements);
+    assertThat(snapshotCollectionElements2).isEqualTo(snapshotCollectionElements);
+  }
+
+  @Test
+  void getOriginalCollectionSnapshotElement() {
+    WebElement mockedWebElement = mock(WebElement.class);
+
+    when(mockedCollection.getElements()).thenReturn(Arrays.asList(mockedWebElement));
+
+    WebElement collectionElement = new SnapshotCollection(mockedCollection).getElement(0);
+    assertThat(collectionElement).isEqualTo(mockedWebElement);
+  }
+
+  @Test
+  void description() {
+    WebElement mockedWebElement1 = mock(WebElement.class);
+    WebElement mockedWebElement2 = mock(WebElement.class);
+
+    when(mockedCollection.description()).thenReturn("Collection description");
+    when(mockedCollection.getElements()).thenReturn(Arrays.asList(mockedWebElement1, mockedWebElement2));
+
+    SnapshotCollection snapshotCollection = new SnapshotCollection(mockedCollection);
+    assertThat(snapshotCollection.description()).isEqualTo("Collection description.snapshot(2 elements)");
+    // Call one more time to check that getElements() is executed only once
+    assertThat(snapshotCollection.description()).isEqualTo("Collection description.snapshot(2 elements)");
+
+    verify(mockedCollection, times(2)).description();
+  }
+
+
+  @Test
+  void driver() {
+    Driver driver = mock(Driver.class);
+
+    when(mockedCollection.driver()).thenReturn(driver);
+
+    SnapshotCollection snapshotCollection = new SnapshotCollection(mockedCollection);
+    assertThat(snapshotCollection.driver()).isEqualTo(driver);
+
+    verify(mockedCollection).driver();
+  }
+}


### PR DESCRIPTION
was: $$(<size> elements)
now: <original collection description>.snapshot(<size> elements)

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
