### PR TITLE
added get element alias method

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -131,11 +131,10 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   /**
    * Element alias, which can be set with {@link #as(String text)}
    *
-   * @return Alias of this element or empty string, if element alias is not set
+   * @return Alias of this element or null, if element alias is not set
    * @see com.codeborne.selenide.commands.GetAlias
    */
   @CheckReturnValue
-  @Nonnull
   String getAlias();
 
   /**

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -129,6 +129,16 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   String getText();
 
   /**
+   * Element alias, which can be set with {@link #as(String text)}
+   *
+   * @return Alias of this element or empty string, if element alias is not set
+   * @see com.codeborne.selenide.commands.GetAlias
+   */
+  @CheckReturnValue
+  @Nonnull
+  String getAlias();
+
+  /**
    * Short form of {@link #getText()}
    *
    * @see WebElement#getText()

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -43,6 +43,7 @@ public class Commands {
 
   private void addTechnicalCommands() {
     add("as", new As());
+    add("getAlias", new GetAlias());
     add("toString", new ToString());
     add("toWebElement", new ToWebElement());
     add("getWrappedElement", new GetWrappedElement());

--- a/src/main/java/com/codeborne/selenide/commands/GetAlias.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetAlias.java
@@ -1,0 +1,20 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class GetAlias implements Command<String> {
+
+  @Override
+  @CheckReturnValue
+  @Nullable
+  public String execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+    return locator.getAlias() == null ? "" : locator.getAlias();
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/GetAlias.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetAlias.java
@@ -15,6 +15,6 @@ public class GetAlias implements Command<String> {
   @CheckReturnValue
   @Nullable
   public String execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
-    return locator.getAlias() == null ? "" : locator.getAlias();
+    return locator.getAlias();
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -46,6 +46,10 @@ public abstract class WebElementSource {
     this.alias = alias;
   }
 
+  public String getAlias() {
+    return alias;
+  }
+
   @CheckReturnValue
   @Nonnull
   public String description() {

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -53,7 +53,7 @@ public abstract class WebElementSource {
   @CheckReturnValue
   @Nonnull
   public String description() {
-    return alias != null ? alias : getSearchCriteria();
+    return getAlias() != null ? getAlias() : getSearchCriteria();
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/WebElementWrapper.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementWrapper.java
@@ -48,7 +48,7 @@ public class WebElementWrapper extends WebElementSource {
   @CheckReturnValue
   @Nonnull
   public String toString() {
-    return alias != null ? alias : describe.fully(driver(), delegate);
+    return getAlias() != null ? getAlias() : describe.fully(driver(), delegate);
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/commands/GetAliasCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetAliasCommandTest.java
@@ -1,0 +1,34 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GetAliasCommandTest implements WithAssertions {
+
+  private final SelenideElement proxy = mock(SelenideElement.class);
+  private final WebElementSource locator = mock(WebElementSource.class);
+  private final GetAlias getAlias = new GetAlias();
+
+  @Test
+  void testExecuteMethod() {
+    String alias = "my element";
+    when(locator.getAlias()).thenReturn(alias);
+    assertThat(getAlias.execute(proxy, locator, new Object[]{}))
+      .as("should return element alias")
+      .isEqualTo(alias);
+  }
+
+  @Test
+  void testReturnEmptyWhenAliasNotSet() {
+    assertThat(getAlias.execute(proxy, locator, new Object[]{}))
+      .as("should return empty string when alias is not set")
+      .isEmpty();
+  }
+
+}

--- a/src/test/java/com/codeborne/selenide/commands/GetAliasCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetAliasCommandTest.java
@@ -25,10 +25,10 @@ public class GetAliasCommandTest implements WithAssertions {
   }
 
   @Test
-  void testReturnEmptyWhenAliasNotSet() {
+  void testReturnNullWhenAliasNotSet() {
     assertThat(getAlias.execute(proxy, locator, new Object[]{}))
-      .as("should return empty string when alias is not set")
-      .isEmpty();
+      .as("should return null when alias is not set")
+      .isNull();
   }
 
 }


### PR DESCRIPTION
## Proposed changes
Added a method to get element alias. Until today it was only possible to set an alias using `as()` method. Now you can also use `getAlias()` to log elements with ugly xpath'es or css selectors in a human-readable form.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
