### PR TITLE
Add CollectionCondition.containTexts() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.20.0 (planned to xx.03.2021)
 * #1422 add headless mode to Microsoft Edge browser (chromium-based)
+* Add CollectionCondition.containTexts method 
 
 ## 5.19.0 (released 24.02.2021)
 * #1110 Implement drag and drop method with JavaScript (used by default, works in all browsers)  --  thanks to Dmitriy Budim for PR #1412

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -180,11 +180,11 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    * Examples:
    * <pre code='java'>
    * // collection 1: [Tom, Dick, Harry]
-   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry); // success
+   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry"); // success
    * // collection 2: [Tom, John, Dick, Harry]
-   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry); // success
+   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry"); // success
    * // collection 3: [John, Harry, Tom]
-   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry); // fail
+   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry"); // fail
    * </pre>
    *
    * @param expectedTexts the expected texts that the collection should contain
@@ -200,11 +200,11 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    * Examples:
    * <pre code='java'>
    * // collection 1: [Tom, Dick, Harry]
-   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry); // success
+   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry"); // success
    * // collection 2: [Tom, John, Dick, Harry]
-   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry); // success
+   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry"); // success
    * // collection 3: [John, Harry, Tom]
-   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry); // fail
+   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry"); // fail
    * </pre>
    * @param expectedTexts the expected texts that the collection should contain
    */

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide;
 
 import com.codeborne.selenide.collections.AllMatch;
 import com.codeborne.selenide.collections.AnyMatch;
+import com.codeborne.selenide.collections.ContainTexts;
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.collections.ExactTextsCaseSensitiveInAnyOrder;
 import com.codeborne.selenide.collections.ItemWithText;
@@ -171,6 +172,45 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
   @CheckReturnValue
   public static CollectionCondition itemWithText(String expectedText) {
     return new ItemWithText(expectedText);
+  }
+
+  /**
+   * Check that the given collection contains elements with given texts.
+   * <p></p>
+   * Examples:
+   * <pre code='java'>
+   * // collection 1: [Tom, Dick, Harry]
+   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry); // success
+   * // collection 2: [Tom, John, Dick, Harry]
+   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry); // success
+   * // collection 3: [John, Harry, Tom]
+   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry); // fail
+   * </pre>
+   *
+   * @param expectedTexts the expected texts that the collection should contain
+   */
+  @CheckReturnValue
+  public static CollectionCondition containTexts(String... expectedTexts) {
+    return new ContainTexts(expectedTexts);
+  }
+
+  /**
+   * Check that the given collection contains elements with given texts.
+   * <p></p>
+   * Examples:
+   * <pre code='java'>
+   * // collection 1: [Tom, Dick, Harry]
+   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry); // success
+   * // collection 2: [Tom, John, Dick, Harry]
+   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry); // success
+   * // collection 3: [John, Harry, Tom]
+   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry); // fail
+   * </pre>
+   * @param expectedTexts the expected texts that the collection should contain
+   */
+  @CheckReturnValue
+  public static CollectionCondition containTexts(List<String> expectedTexts) {
+    return new ContainTexts(expectedTexts);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/collections/ContainTexts.java
+++ b/src/main/java/com/codeborne/selenide/collections/ContainTexts.java
@@ -1,0 +1,68 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.ex.TextsSizeMismatch;
+import com.codeborne.selenide.impl.CollectionSource;
+
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+public class ContainTexts extends CollectionCondition {
+  private final List<String> expectedTexts;
+
+  public ContainTexts(String... expectedTexts) {
+    this(asList(expectedTexts));
+  }
+
+  public ContainTexts(List<String> expectedTexts) {
+    if (expectedTexts.isEmpty()) {
+      throw new IllegalArgumentException("No expected texts given");
+    }
+    this.expectedTexts = unmodifiableList(expectedTexts);
+  }
+
+  @Override
+  public boolean test(List<WebElement> elements) {
+    if (elements.size() < expectedTexts.size()) {
+      return false;
+    }
+
+    return ElementsCollection
+      .texts(elements)
+      .containsAll(expectedTexts);
+  }
+
+  @Override
+  public void fail(CollectionSource collection,
+                   @Nullable List<WebElement> elements,
+                   @Nullable Exception lastError,
+                   long timeoutMs) {
+    if (elements == null || elements.isEmpty()) {
+      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
+      elementNotFound.timeoutMs = timeoutMs;
+      throw elementNotFound;
+    } else if (elements.size() < expectedTexts.size()) {
+      throw new TextsSizeMismatch(collection, ElementsCollection.texts(elements), expectedTexts, explanation, timeoutMs);
+    } else {
+      throw new TextsMismatch(collection, ElementsCollection.texts(elements), expectedTexts, explanation, timeoutMs);
+    }
+  }
+
+  @Override
+  public boolean applyNull() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "Contains texts " + expectedTexts;
+  }
+}

--- a/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.collections.ContainTexts;
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.collections.ExactTextsCaseSensitiveInAnyOrder;
 import com.codeborne.selenide.collections.ListSize;
@@ -137,5 +138,17 @@ final class CollectionConditionTest implements WithAssertions {
   void testExactTextsCaseSensitiveInAnyOrderWithVarargs() {
     CollectionCondition condition = CollectionCondition.exactTextsCaseSensitiveInAnyOrder("One", "Two");
     assertThat(condition).isInstanceOf(ExactTextsCaseSensitiveInAnyOrder.class);
+  }
+
+  @Test
+  void testContainTextsWithStringList() {
+    CollectionCondition condition = CollectionCondition.containTexts(asList("One", "Two", "Three"));
+    assertThat(condition).isInstanceOf(ContainTexts.class);
+  }
+
+  @Test
+  void testContainTextsWithVarargs() {
+    CollectionCondition condition = CollectionCondition.containTexts("One", "Two", "Three");
+    assertThat(condition).isInstanceOf(ContainTexts.class);
   }
 }

--- a/src/test/java/com/codeborne/selenide/collections/ContainTextsTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ContainTextsTest.java
@@ -1,0 +1,190 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.ex.TextsSizeMismatch;
+import com.codeborne.selenide.impl.CollectionSource;
+
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static java.util.Arrays.asList;
+
+public class ContainTextsTest implements WithAssertions {
+  private final SelenideElement element1 = mockElement("Test-One");
+  private final SelenideElement element2 = mockElement("Test-Two");
+  private final SelenideElement element3 = mockElement("Test-Three");
+  private final SelenideElement element4 = mockElement("Test-Four");
+  private final SelenideElement element5 = mockElement("Test-Five");
+
+  private final CollectionSource collection = mockCollection(
+    "Collection with all 3 expected elements",
+    element1, element2, element3);
+  private final CollectionSource collectionMoreElements = mockCollection(
+    "Collection with more elements that includes all the expected elements",
+    element1, element2, element3, element4
+  );
+  private final CollectionSource collectionMoreElementsAndDuplicates = mockCollection(
+    "Collection with more elements than expected " +
+      "that contains duplicates of expected elements and includes all the expected elements",
+    element1, element2, element3, element4, element2, element3
+  );
+  private final CollectionSource collectionWithoutElement = mockCollection(
+    "Collection without one of the expected texts",
+    element1, element2, element4
+  );
+  private final CollectionSource collectionMoreElementsWithoutElement = mockCollection(
+    "Collection with more elements than expected and without one of the expected texts",
+    element1, element2, element4, element5
+  );
+  private final CollectionSource collectionLessElementsWithoutElement = mockCollection(
+    "Collection with less elements than expected and without one of the expected texts",
+    element1, element2
+  );
+  private final CollectionSource emptyCollection = mockCollection("Empty collection");
+
+  @Test
+  void testExactCollection() {
+    ContainTexts expectedTexts = new ContainTexts("Test-One", "Test-Two", "Test-Three");
+
+    assertThat(expectedTexts.test(collection.getElements()))
+      .isTrue();
+  }
+
+  @Test
+  void testCollectionUnordered() {
+    ContainTexts expectedTexts = new ContainTexts("Test-Three", "Test-One", "Test-Two");
+
+    assertThat(expectedTexts.test(collection.getElements()))
+      .isTrue();
+  }
+
+  @Test
+  void testCollectionUnorderedMoreElements() {
+    ContainTexts expectedTexts = new ContainTexts("Test-Three", "Test-One", "Test-Two");
+
+    assertThat(expectedTexts.test(collectionMoreElements.getElements()))
+      .isTrue();
+  }
+
+  @Test
+  void testCollectionUnorderedMoreElementsWithDuplicates() {
+    ContainTexts expectedTexts = new ContainTexts("Test-Three", "Test-One", "Test-Two");
+
+    assertThat(expectedTexts.test(collectionMoreElementsAndDuplicates.getElements()))
+      .isTrue();
+  }
+
+  @Test
+  void testCollectionWithoutElement() {
+    ContainTexts expectedTexts = new ContainTexts("Test-One", "Test-Two", "Test-Three");
+
+    assertThat(expectedTexts.test(collectionWithoutElement.getElements()))
+      .isFalse();
+
+    assertThatThrownBy(() -> new ContainTexts("Test-One", "Test-Two", "Test-Three")
+      .fail(collectionWithoutElement,
+        collectionWithoutElement.getElements(),
+        new Exception("Exception message"), 10_000))
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageContaining(
+        String.format("Texts mismatch" +
+            "%nActual: %s" +
+            "%nExpected: %s",
+          ElementsCollection.texts(collectionWithoutElement.getElements()),
+          asList("Test-One", "Test-Two", "Test-Three"))
+      );
+  }
+
+  @Test
+  void testCollectionMoreElementsWithoutElement() {
+    ContainTexts expectedTexts = new ContainTexts("Test-One", "Test-Two", "Test-Three");
+
+    assertThat(expectedTexts.test(collectionMoreElementsWithoutElement.getElements()))
+      .isFalse();
+
+    assertThatThrownBy(() -> new ContainTexts("Test-One", "Test-Two", "Test-Three")
+      .fail(collectionMoreElementsWithoutElement,
+        collectionMoreElementsWithoutElement.getElements(),
+        new Exception("Exception message"), 10_000))
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageContaining(
+        String.format("Texts mismatch" +
+            "%nActual: %s" +
+            "%nExpected: %s",
+          ElementsCollection.texts(collectionMoreElementsWithoutElement.getElements()),
+          asList("Test-One", "Test-Two", "Test-Three"))
+      );
+  }
+
+  @Test
+  void testCollectionLessElementsWithoutElement() {
+    ContainTexts expectedTexts = new ContainTexts("Test-One", "Test-Two", "Test-Three");
+
+    assertThat(expectedTexts.test(collectionLessElementsWithoutElement.getElements()))
+      .isFalse();
+
+    assertThatThrownBy(() -> new ContainTexts("Test-One", "Test-Two", "Test-Three")
+      .fail(collectionLessElementsWithoutElement,
+        collectionLessElementsWithoutElement.getElements(),
+        new Exception("Exception message"), 10_000))
+      .isInstanceOf(TextsSizeMismatch.class)
+      .hasMessageContaining(
+        String.format("Texts size mismatch" +
+            "%nActual: %s, List size: %s" +
+            "%nExpected: %s, List size: %s",
+          ElementsCollection.texts(collectionLessElementsWithoutElement.getElements()), "2",
+          asList("Test-One", "Test-Two", "Test-Three"), "3")
+      );
+  }
+
+  @Test
+  void testCollectionNullElements() {
+    ContainTexts expectedTexts = new ContainTexts("Test-One", "Test-Two", "Test-Three");
+
+    assertThatThrownBy(() -> expectedTexts
+      .fail(emptyCollection,
+        null,
+        new Exception("Exception message"), 10_000))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageContaining(
+        String.format("Element not found {Empty collection}" +
+          "%nExpected: Contains texts [Test-One, Test-Two, Test-Three]")
+      );
+  }
+
+  @Test
+  void testCollectionEmpty() {
+    ContainTexts expectedTexts = new ContainTexts("Test-One", "Test-Two", "Test-Three");
+
+    assertThatThrownBy(() -> expectedTexts
+      .fail(emptyCollection,
+        emptyCollection.getElements(),
+        new Exception("Exception message"), 10_000))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageContaining(
+        String.format("Element not found {Empty collection}" +
+          "%nExpected: Contains texts [Test-One, Test-Two, Test-Three]")
+      );
+  }
+
+  @Test
+  void testToString() {
+    ContainTexts expectedTexts = new ContainTexts("Test-One", "Test-Two", "Test-Three");
+
+    assertThat(expectedTexts)
+      .hasToString("Contains texts [Test-One, Test-Two, Test-Three]");
+  }
+
+  @Test
+  void testApplyNull() {
+    ContainTexts expectedTexts = new ContainTexts("Test-One", "Test-Two", "Test-Three");
+
+    assertThat(expectedTexts.applyNull())
+      .isFalse();
+  }
+}


### PR DESCRIPTION
## Proposed changes
This is a method for asserting that `ElementsCollection` **contains** a given list of strings/texts. 
All the existing methods for checking collection's elements against list of strings assume that `expectedCollection.size() == expectedTexts.size()` (in order to succeed). 
Although, sometimes it's useful to assert that a collection contains a *baseline* of elements with a given strings/texts.  

### Example E2E scenario:
The application provides a list of available currencies for the client. The list comes from the external system.
Verify that the external system always provides "USD", "EUR" and "GBP" currencies for this client.
The list from the external system may vary (some currencies may be added, some may be dropped), but it should always contain 3 specific currencies - "USD", "EUR" and "GBP".

Possible output in DOM:
```html
<div test-id='availableCurrencies'>
    <div test-id='currency'>USD</div>
    <div test-id='currency'>GBP</div>
    <div test-id='currency'>EUR</div>
    <div test-id='currency'>RUB</div>
    <div test-id='currency'>CAD</div>
</div>
```

Currency collection may be validated like this:
`$$("[test-id='currency']").should(containTexts("USD", "EUR", "GBP"));`

Without this method, Selenide's current functionality allows doing such assertions like this:
```
$$("[test-id='currency']").shouldHave(itemWithText("USD"));
$$("[test-id='currency']").shouldHave(itemWithText("EUR"));
$$("[test-id='currency']").shouldHave(itemWithText("GBP"));
```
As far as I understand, this approach requires more code and slows down the test a bit. 
That's why I think the addition of `CollectionCondition.containTexts` might be useful.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added **unit** tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
