### PR TITLE
Do not log extended "find" methods (e.g. parent, sibling and so)

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -42,7 +42,12 @@ class SelenideElementProxy implements InvocationHandler {
       "find",
       "$$",
       "$$x",
-      "findAll"
+      "findAll",
+      "parent",
+      "sibling",
+      "preceding",
+      "lastChild",
+      "closest"
   ));
 
   private static final Set<String> methodsForSoftAssertion = new HashSet<>(asList(


### PR DESCRIPTION
"Find" methods might be used for Page Objects (PO) fields declaration
so in such cases they will be logged during PO initialization phase
no matter of they are used in real test or not

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
