### PR TITLE
Fix ignored prefs in FirefoxOptions

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -68,6 +68,7 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
     if (!ffProfile.isEmpty()) {
       transferFirefoxProfileFromSystemProperties(firefoxOptions, ffProfile);
     }
+    injectFirefoxPrefs(firefoxOptions);
     return firefoxOptions;
   }
 
@@ -149,6 +150,24 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
     }
     else {
       profile.setPreference(capability, value);
+    }
+  }
+
+  private void injectFirefoxPrefs(FirefoxOptions options) {
+    if (Optional.ofNullable(options.getCapability("moz:firefoxOptions")).isPresent()) {
+      Map<String, Map<String, Object>> mozOptions = (Map<String, Map<String, Object>>) options.getCapability("moz:firefoxOptions");
+
+      if (mozOptions.containsKey("prefs")) {
+        for (Map.Entry<String, Object> pref : mozOptions.get("prefs").entrySet()) {
+          if (pref.getValue() instanceof String) {
+            options.addPreference(pref.getKey(), (String) pref.getValue());
+          } else if (pref.getValue() instanceof Integer) {
+            options.addPreference(pref.getKey(), (Integer) pref.getValue());
+          } else if (pref.getValue() instanceof Boolean) {
+            options.addPreference(pref.getKey(), (Boolean) pref.getValue());
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
@@ -164,6 +164,23 @@ final class FirefoxDriverFactoryTest implements WithAssertions {
     assertThat(options.getProfile()).isNull();
   }
 
+  @Test
+  public void injectPrefs() {
+    FirefoxOptions firefoxOptions = new FirefoxOptions();
+    firefoxOptions.addPreference("general.useragent.override", "my agent");
+    firefoxOptions.addPreference("boolean pref", true);
+    firefoxOptions.addPreference("int pref", 10);
+    config.browserCapabilities(new DesiredCapabilities(firefoxOptions));
+
+    Map<String, Object> options = driverFactory.createCapabilities(config, browser, proxy, null).asMap();
+    assertThat(options.get("moz:firefoxOptions") != null);
+
+    Map<String, Object> prefs = (Map<String, Object>) ((Map<String, Object>) options.get("moz:firefoxOptions")).get("prefs");
+    assertThat(prefs.get("general.useragent.override")).isEqualTo("my agent");
+    assertThat(prefs.get("boolean pref")).isEqualTo(true);
+    assertThat(prefs.get("int pref")).isEqualTo(10);
+  }
+
   @SuppressWarnings("unchecked")
   private Map<String, Object> prefs(FirefoxOptions options) {
     Map<String, Object> firefoxOptions = (Map<String, Object>) options.asMap().get("moz:firefoxOptions");


### PR DESCRIPTION
## Proposed changes
Fix ignored Firefox prefs - issue [1436](https://github.com/selenide/selenide/issues/1436) 

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
