### PR TITLE
WIP: Added $$.should() method + JavaDoc fixes

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -180,11 +180,11 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    * Examples:
    * <pre code='java'>
    * // collection 1: [Tom, Dick, Harry]
-   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry"); // success
+   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry")); // success
    * // collection 2: [Tom, John, Dick, Harry]
-   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry"); // success
+   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry")); // success
    * // collection 3: [John, Harry, Tom]
-   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry"); // fail
+   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry")); // fail
    * </pre>
    *
    * @param expectedTexts the expected texts that the collection should contain
@@ -200,11 +200,11 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
    * Examples:
    * <pre code='java'>
    * // collection 1: [Tom, Dick, Harry]
-   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry"); // success
+   * $$("collection 1 locator").should(containTexts("Tom", "Dick", "Harry")); // success
    * // collection 2: [Tom, John, Dick, Harry]
-   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry"); // success
+   * $$("collection 2 locator").should(containTexts("Tom", "Dick", "Harry")); // success
    * // collection 3: [John, Harry, Tom]
-   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry"); // fail
+   * $$("collection 3 locator").should(containTexts("Tom", "Dick", "Harry")); // fail
    * </pre>
    * @param expectedTexts the expected texts that the collection should contain
    */

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -85,7 +85,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    * <p> For example: </p>
    * {@code $$(".text_list").should(containTexts("text1", "text2"));}
    * {@code $$(".cat_list").should(allMatch("value==cat",
-   * el -> el.getAttribute("value").equals("cat"))));}
+   * el -> el.getAttribute("value").equals("cat")));}
    */
   @Nonnull
   public ElementsCollection should(CollectionCondition... conditions) {

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -81,6 +81,28 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
   }
 
   /**
+   * Check if a collection matches given condition(s).
+   * <p> For example: </p>
+   * {@code $$(".text_list").should(containTexts("text1", "text2"));}
+   * {@code $$(".cat_list").should(allMatch("value==cat",
+   * el -> el.getAttribute("value").equals("cat"))));}
+   */
+  @Nonnull
+  public ElementsCollection should(CollectionCondition... conditions) {
+    return should("", Duration.ofMillis(driver().config().timeout()), conditions);
+  }
+
+  /**
+   * Check if a collection matches a given condition within the given time period.
+   *
+   * @param timeout maximum waiting time
+   */
+  @Nonnull
+  public ElementsCollection should(CollectionCondition condition, Duration timeout) {
+    return should("", timeout, toArray(condition));
+  }
+
+  /**
    * For example: {@code $$(".error").shouldBe(empty)}
    */
   @Nonnull

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -23,6 +23,7 @@ import java.util.ListIterator;
 import static com.codeborne.selenide.CollectionCondition.allMatch;
 import static com.codeborne.selenide.CollectionCondition.anyMatch;
 import static com.codeborne.selenide.CollectionCondition.empty;
+import static com.codeborne.selenide.CollectionCondition.containTexts;
 import static com.codeborne.selenide.CollectionCondition.exactTexts;
 import static com.codeborne.selenide.CollectionCondition.itemWithText;
 import static com.codeborne.selenide.CollectionCondition.noneMatch;
@@ -576,9 +577,17 @@ final class CollectionMethodsTest extends ITest {
   }
 
   @Test
+  void shouldContainTexts() {
+    $$("#hero option")
+      .should(containTexts("Denzel Washington", "John Mc'Lain", "Arnold \"Schwarzenegger\""));
+    $$("#user-table th")
+      .should(containTexts("First name", "Last name"));
+  }
+
+  @Test
   void errorWhenItemWithTextNotMatchedButShouldBe() {
     String expectedText = "Luis";
-    assertThatThrownBy(()  -> $$("#user-table tbody tr td.firstname").shouldHave(itemWithText(expectedText)))
+    assertThatThrownBy(() -> $$("#user-table tbody tr td.firstname").shouldHave(itemWithText(expectedText)))
       .isInstanceOf(ElementWithTextNotFound.class)
       .hasMessageContaining(String.format("Element with text not found" +
         "%nActual: %s" +


### PR DESCRIPTION
## Proposed changes
- Added `$$("collection").should()` method to increase code readability for certain `CollectionCondition` entities:
```java
// Collection of numbers should contain text elements "one", "two", "three"
$$("#numbers-collection")
  .should(containTexts("one", "two", "three"));

// Names should all match the conditon "All names == Chuck" (all names equal "Chuck")
$$("#names-collection")
  .should(allMatch("All names == Chuck", el -> el.getAttribute("name").equals("Chuck")));
```

- Fixed JavaDoc for `CollectionCondition.containTexts()` methods
- Added UI tests for `CollectionCondition.containTexts()` and `$$.should()` methods.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
