### PR TITLE
#1429 add overload methods to sibling()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.20.2 (released 29.03.2021)
+* #1429 add overload methods to sibling() (by tag name, by tag and index, by tag attribute name and attribute value) 
+
 ## 5.20.1 (released 23.03.2021)
 * #1438 Added $$.should() method + JavaDoc fixes  --  thanks to Oleg Berezhnoy @bereg2k
 * #1439 rename containTexts() to containExactTextsCaseSensitive()  --  thanks to Oleg Berezhnoy @bereg2k and Pavel Fokin @fokinp

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -593,6 +593,49 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement sibling(int index);
 
   /**
+   * Get the following sibling element by tag of this element
+   * ATTENTION! This method doesn't start any search yet!
+   * For example, $("td").sibling("div") will give the first following "div" sibling element of "td"
+   *
+   * @param tag the tag of sibling element
+   * @return Sibling element by tag name
+   * @see com.codeborne.selenide.commands.GetSibling
+   */
+  @CheckReturnValue
+  @Nonnull
+  SelenideElement sibling(String tag);
+
+  /**
+   * Get the following sibling element by tag of this element
+   * ATTENTION! This method doesn't start any search yet!
+   * For example, $("td").sibling("div", 1) will give the second following "div" sibling element of "td"
+   *
+   * @param tag the tag of sibling element
+   * @param index the index of sibling element
+   * @return Sibling element by tag name
+   * @see com.codeborne.selenide.commands.GetSibling
+   */
+  @CheckReturnValue
+  @Nonnull
+  SelenideElement sibling(String tag, int index);
+
+  /**
+   * Get the following sibling element by tag of this element
+   * ATTENTION! This method doesn't start any search yet!
+   * For example, $("td").sibling("div", "name", "selenide") will give the first following "div" sibling element of "td"
+   * with attribute name "name" and attribute value "selenide"
+   *
+   * @param tag the tag of sibling element
+   * @param attributeName the attribute name of sibling element
+   * @param attributeValue the attribute value of sibling element
+   * @return Sibling element by tag name, attribute name and attribute value
+   * @see com.codeborne.selenide.commands.GetSibling
+   */
+  @CheckReturnValue
+  @Nonnull
+  SelenideElement sibling(String tag, String attributeName, String attributeValue);
+
+  /**
    * Get the preceding sibling element of this element
    * ATTENTION! This method doesn't start any search yet!
    * For example, $("td").preceding(0) will give the first preceding sibling element of "td"

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -2,6 +2,11 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.commands.sibling.Sibling;
+import com.codeborne.selenide.commands.sibling.GetSiblingByTab;
+import com.codeborne.selenide.commands.sibling.GetSiblingByTagAndAttribute;
+import com.codeborne.selenide.commands.sibling.GetSiblingByIndex;
+import com.codeborne.selenide.commands.sibling.GetSiblingByTagAndIndex;
 import com.codeborne.selenide.impl.WebElementSource;
 
 import javax.annotation.CheckReturnValue;
@@ -9,10 +14,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.codeborne.selenide.impl.Plugins.inject;
+import static java.util.Arrays.asList;
 
 @ParametersAreNonnullByDefault
 public class Commands {
@@ -103,9 +110,14 @@ public class Commands {
     add("$$x", new FindAllByXpath());
     add("closest", new GetClosest());
     add("parent", new GetParent());
-    add("sibling", new GetSibling());
+    add("sibling", new GetSibling(getSiblingOverloads()));
     add("preceding", new GetPreceding());
     add("lastChild", new GetLastChild());
+  }
+
+  private List<Sibling> getSiblingOverloads() {
+    return asList(new GetSiblingByIndex(), new GetSiblingByTab(), new GetSiblingByTagAndAttribute(),
+      new GetSiblingByTagAndIndex());
   }
 
   private void addKeyboardCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/GetSibling.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSibling.java
@@ -2,24 +2,36 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.commands.sibling.Sibling;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.openqa.selenium.By;
+import org.apache.commons.lang3.NotImplementedException;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-
-import static com.codeborne.selenide.commands.Util.firstOf;
+import java.util.List;
 
 @ParametersAreNonnullByDefault
 public class GetSibling implements Command<SelenideElement> {
+
+  private final List<Sibling> siblings;
+
+  public GetSibling(List<Sibling> siblings) {
+    this.siblings = siblings;
+  }
 
   @Override
   @CheckReturnValue
   @Nonnull
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
-    int siblingIndex = (int) firstOf(args) + 1;
-    return locator.find(proxy, By.xpath(String.format("following-sibling::*[%d]", siblingIndex)), 0);
+    if (args == null) {
+      throw new IllegalArgumentException("Missing arguments");
+    }
+    return siblings.stream()
+      .filter(sibling -> sibling.canExecute(args))
+      .findFirst()
+      .map(sibling -> sibling.execute(proxy, locator, args))
+      .orElseThrow(() -> new NotImplementedException("Not implemented"));
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/sibling/GetSiblingByIndex.java
+++ b/src/main/java/com/codeborne/selenide/commands/sibling/GetSiblingByIndex.java
@@ -1,0 +1,25 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+public class GetSiblingByIndex implements Sibling {
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    int index = (int) args[0] + 1;
+    return locator.find(proxy, By.xpath(String.format("following-sibling::*[%d]", index)), 0);
+  }
+
+  @Override
+  public boolean canExecute(@Nonnull Object[] args) {
+    return args.length == 1
+      && args[0] instanceof Integer;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/sibling/GetSiblingByTab.java
+++ b/src/main/java/com/codeborne/selenide/commands/sibling/GetSiblingByTab.java
@@ -1,0 +1,25 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+public class GetSiblingByTab implements Sibling {
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    String tag = (String) args[0];
+    return locator.find(proxy, By.xpath(String.format("following-sibling::%s", tag)), 0);
+  }
+
+  @Override
+  public boolean canExecute(@Nonnull Object[] args) {
+    return args.length == 1
+      && args[0] instanceof String;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/sibling/GetSiblingByTagAndAttribute.java
+++ b/src/main/java/com/codeborne/selenide/commands/sibling/GetSiblingByTagAndAttribute.java
@@ -1,0 +1,30 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+public class GetSiblingByTagAndAttribute implements Sibling {
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    String tag = (String) args[0];
+    String attributeName = (String) args[1];
+    String attributeValue = (String) args[2];
+    return locator.find(proxy, By.xpath(String.format("following-sibling::%s[@%s='%s']",
+      tag, attributeName, attributeValue)), 0);
+  }
+
+  @Override
+  public boolean canExecute(@Nonnull Object[] args) {
+    return args.length == 3
+      && args[0] instanceof String
+      && args[1] instanceof String
+      && args[2] instanceof String;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/sibling/GetSiblingByTagAndIndex.java
+++ b/src/main/java/com/codeborne/selenide/commands/sibling/GetSiblingByTagAndIndex.java
@@ -1,0 +1,27 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+public class GetSiblingByTagAndIndex implements Sibling {
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    String tag = (String) args[0];
+    int index = (int) args[1] + 1;
+    return locator.find(proxy, By.xpath(String.format("following-sibling::%s[%d]", tag, index)), 0);
+  }
+
+  @Override
+  public boolean canExecute(@Nonnull Object[] args) {
+    return args.length == 2
+      && args[0] instanceof String
+      && args[1] instanceof Integer;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/sibling/Sibling.java
+++ b/src/main/java/com/codeborne/selenide/commands/sibling/Sibling.java
@@ -1,0 +1,15 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+public interface Sibling {
+  @CheckReturnValue
+  @Nonnull
+  SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args);
+
+  boolean canExecute(@Nonnull Object[] args);
+}

--- a/src/test/java/com/codeborne/selenide/commands/GetSiblingCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSiblingCommandTest.java
@@ -1,29 +1,46 @@
 package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.commands.sibling.Sibling;
 import com.codeborne.selenide.impl.WebElementSource;
+import org.apache.commons.lang3.NotImplementedException;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.*;
 
 final class GetSiblingCommandTest implements WithAssertions {
+
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetSibling getSiblingCommand = new GetSibling();
+  private final Sibling sibling = mock(Sibling.class);
+  private final GetSibling getSiblingCommand = new GetSibling(singletonList(sibling));
 
   @Test
   void executeMethod() {
-    when(locator.find(any(), any(), anyInt())).thenReturn(mockedElement);
+    Object[] args = {0};
+    when(sibling.canExecute(args)).thenReturn(true);
+    when(sibling.execute(proxy, locator, args)).thenReturn(mockedElement);
 
-    assertThat(getSiblingCommand.execute(proxy, locator, new Object[]{0})).isEqualTo(mockedElement);
+    assertThat(getSiblingCommand.execute(proxy, locator, args)).isEqualTo(mockedElement);
 
-    verify(locator).find(proxy, By.xpath("following-sibling::*[1]"), 0);
+    verify(sibling).canExecute(args);
+    verify(sibling).execute(proxy, locator, args);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenArgsNull() {
+    assertThatThrownBy(() -> getSiblingCommand.execute(proxy, locator, null))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Missing arguments");
+  }
+
+  @Test
+  void shouldThrowExceptionWhenMethodNotImplemented() {
+    assertThatThrownBy(() -> getSiblingCommand.execute(proxy, locator, new Object[]{1, 2, 3, 4, 5}))
+      .isInstanceOf(NotImplementedException.class)
+      .hasMessage("Not implemented");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/sibling/GetSiblingByIndexTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/sibling/GetSiblingByIndexTest.java
@@ -1,0 +1,43 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetSiblingByIndexTest {
+
+  private final SelenideElement proxy = mock(SelenideElement.class);
+  private final WebElementSource locator = mock(WebElementSource.class);
+  private final SelenideElement mockedElement = mock(SelenideElement.class);
+
+  private final Sibling sibling = new GetSiblingByIndex();
+
+  @Test
+  void shouldCanExecuteWhenParametersCountIsOneAndInteger() {
+    assertThat(sibling.canExecute(new Object[]{0})).isTrue();
+  }
+
+  @Test
+  void shouldNotCanExecuteWhenParametersCountIsOneAndString() {
+    assertThat(sibling.canExecute(new Object[]{"a"})).isFalse();
+  }
+
+  @Test
+  void shouldNotCanExecuteWhenParametersCountIsTwo() {
+    assertThat(sibling.canExecute(new Object[]{0, 1})).isFalse();
+  }
+
+  @Test
+  void shouldReturnSibling() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(mockedElement);
+    SelenideElement actual = sibling.execute(proxy, locator, new Object[]{0});
+
+    assertThat(actual).isEqualTo(mockedElement);
+  }
+}

--- a/src/test/java/com/codeborne/selenide/commands/sibling/GetSiblingByTabTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/sibling/GetSiblingByTabTest.java
@@ -1,0 +1,43 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetSiblingByTabTest {
+
+  private final SelenideElement proxy = mock(SelenideElement.class);
+  private final WebElementSource locator = mock(WebElementSource.class);
+  private final SelenideElement mockedElement = mock(SelenideElement.class);
+
+  private final Sibling sibling = new GetSiblingByTab();
+
+  @Test
+  void shouldCanExecuteWhenParametersCountIsOneAndString() {
+    assertThat(sibling.canExecute(new Object[]{"a"})).isTrue();
+  }
+
+  @Test
+  void shouldNotCanExecuteWhenParametersCountIsOneAndInteger() {
+    assertThat(sibling.canExecute(new Object[]{0})).isFalse();
+  }
+
+  @Test
+  void shouldNotCanExecuteWhenParametersCountIsTwo() {
+    assertThat(sibling.canExecute(new Object[]{"a", "b"})).isFalse();
+  }
+
+  @Test
+  void shouldReturnSibling() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(mockedElement);
+    SelenideElement actual = sibling.execute(proxy, locator, new Object[]{"a"});
+
+    assertThat(actual).isEqualTo(mockedElement);
+  }
+}

--- a/src/test/java/com/codeborne/selenide/commands/sibling/GetSiblingByTagAndAttributeTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/sibling/GetSiblingByTagAndAttributeTest.java
@@ -1,0 +1,43 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetSiblingByTagAndAttributeTest {
+
+  private final SelenideElement proxy = mock(SelenideElement.class);
+  private final WebElementSource locator = mock(WebElementSource.class);
+  private final SelenideElement mockedElement = mock(SelenideElement.class);
+
+  private final Sibling sibling = new GetSiblingByTagAndAttribute();
+
+  @Test
+  void shouldCanExecuteWhenParametersCountIsThreeAndAllStrings() {
+    assertThat(sibling.canExecute(new Object[]{"a", "b", "c"})).isTrue();
+  }
+
+  @Test
+  void shouldNotCanExecuteWhenParametersCountIsThreeAndInteger() {
+    assertThat(sibling.canExecute(new Object[]{0, 1, 2})).isFalse();
+  }
+
+  @Test
+  void shouldNotCanExecuteWhenParametersCountIsTwo() {
+    assertThat(sibling.canExecute(new Object[]{"a", "b"})).isFalse();
+  }
+
+  @Test
+  void shouldReturnSibling() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(mockedElement);
+    SelenideElement actual = sibling.execute(proxy, locator, new Object[]{"a", "b", "c"});
+
+    assertThat(actual).isEqualTo(mockedElement);
+  }
+}

--- a/src/test/java/com/codeborne/selenide/commands/sibling/GetSiblingByTagAndIndexTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/sibling/GetSiblingByTagAndIndexTest.java
@@ -1,0 +1,43 @@
+package com.codeborne.selenide.commands.sibling;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetSiblingByTagAndIndexTest {
+
+  private final SelenideElement proxy = mock(SelenideElement.class);
+  private final WebElementSource locator = mock(WebElementSource.class);
+  private final SelenideElement mockedElement = mock(SelenideElement.class);
+
+  private final Sibling sibling = new GetSiblingByTagAndIndex();
+
+  @Test
+  void shouldCanExecuteWhenParametersCountIsTwoStringAndInteger() {
+    assertThat(sibling.canExecute(new Object[]{"a", 0})).isTrue();
+  }
+
+  @Test
+  void shouldNotCanExecuteWhenParametersCountIsTwoIntegerAndInteger() {
+    assertThat(sibling.canExecute(new Object[]{0, 1})).isFalse();
+  }
+
+  @Test
+  void shouldNotCanExecuteWhenParametersCountIsOne() {
+    assertThat(sibling.canExecute(new Object[]{0})).isFalse();
+  }
+
+  @Test
+  void shouldReturnSibling() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(mockedElement);
+    SelenideElement actual = sibling.execute(proxy, locator, new Object[]{"a", 0});
+
+    assertThat(actual).isEqualTo(mockedElement);
+  }
+}

--- a/src/test/java/integration/SiblingTest.java
+++ b/src/test/java/integration/SiblingTest.java
@@ -1,12 +1,11 @@
 package integration;
 
+import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Condition.cssClass;
-import static com.codeborne.selenide.Condition.id;
-import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class SiblingTest extends ITest {
@@ -27,8 +26,48 @@ final class SiblingTest extends ITest {
   }
 
   @Test
+  void canGetSiblingByTag() {
+    $("#text-area").sibling("input").shouldHave(value("18"));
+  }
+
+  @Test
+  void errorWhenSiblingByTagAbsent() {
+    SelenideElement element = $("#text-area").sibling("div");
+    assertThatThrownBy(element::click)
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {#text-area/By.xpath: following-sibling::div}");
+  }
+
+  @Test
+  void canGetSiblingByTagAndIndex() {
+    $("#text-area").sibling("input", 1).shouldHave(value("Log in"));
+  }
+
+  @Test
+  void errorWhenSiblingByTagAndIndexAbsent() {
+    SelenideElement element = $("#text-area").sibling("div", 0);
+    assertThatThrownBy(element::click)
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {#text-area/By.xpath: following-sibling::div[1]}");
+  }
+
+  @Test
+  void canGetSiblingByTagAndAttribute() {
+    $("#text-area").sibling("input", "type", "submit").shouldHave(value("Log in"));
+  }
+
+  @Test
+  void errorWhenSiblingByTagAndAttributeAbsent() {
+    SelenideElement element = $("#text-area").sibling("input", "name", "qwe");
+    assertThatThrownBy(element::click)
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {#text-area/By.xpath: following-sibling::input[@name='qwe']}");
+  }
+
+  @Test
   void errorWhenSiblingAbsent() {
-    assertThatThrownBy(() -> $("#multirowTableFirstRow").sibling(3).click())
+    SelenideElement element = $("#multirowTableFirstRow").sibling(3);
+    assertThatThrownBy(element::click)
       .isInstanceOf(ElementNotFound.class)
       .hasMessageStartingWith("Element not found {#multirowTableFirstRow/By.xpath: following-sibling::*[4]}");
   }
@@ -46,7 +85,8 @@ final class SiblingTest extends ITest {
 
   @Test
   void errorWhenPrecedingElementAbsent() {
-    assertThatThrownBy(() -> $("#multirowTableSecondRow").preceding(3).click())
+    SelenideElement element = $("#multirowTableSecondRow").preceding(3);
+    assertThatThrownBy(element::click)
       .isInstanceOf(ElementNotFound.class)
       .hasMessageStartingWith("Element not found {#multirowTableSecondRow/By.xpath: preceding-sibling::*[4]}");
   }


### PR DESCRIPTION
## Proposed changes
Added overload methods to sibling()

SelenideElement sibling(String tag);
SelenideElement sibling(String tag, int index);
SelenideElement sibling(String tag, String attributeName, String attributeValue);

https://github.com/selenide/selenide/issues/1429

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
