### PR TITLE
Add support to `Condition.textCaseSensitive` for selected options in `select` element

### DIFF
--- a/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
@@ -4,8 +4,10 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 
 @ParametersAreNonnullByDefault
 public class CaseSensitiveText extends Condition {
@@ -18,7 +20,19 @@ public class CaseSensitiveText extends Condition {
 
   @Override
   public boolean apply(Driver driver, WebElement element) {
-    return Html.text.containsCaseSensitive(element.getText(), expectedText);
+    String elementText = "select".equalsIgnoreCase(element.getTagName()) ?
+      getSelectedOptionsTexts(element) :
+      element.getText();
+    return Html.text.containsCaseSensitive(elementText, expectedText);
+  }
+
+  private String getSelectedOptionsTexts(WebElement element) {
+    List<WebElement> selectedOptions = new Select(element).getAllSelectedOptions();
+    StringBuilder sb = new StringBuilder();
+    for (WebElement selectedOption : selectedOptions) {
+      sb.append(selectedOption.getText());
+    }
+    return sb.toString();
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/conditions/TextCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/TextCaseSensitiveTest.java
@@ -1,0 +1,113 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class TextCaseSensitiveTest {
+
+  private final Driver driver = mock(Driver.class);
+  private WebElement elementShort;
+  private WebElement elementLong;
+  private WebElement singleSelectElement;
+  private WebElement multiSelectElement;
+
+  @BeforeEach
+  void setUp() {
+    elementShort = elementWithText("One");
+    elementLong = elementWithText("ZeroOneTwo");
+    singleSelectElement = selectSingle("One", "Two", "Three"); // only the first element is selected
+    multiSelectElement = selectMulti("One", "Two", "Three");  //  all elements are selected
+  }
+
+  @Test
+  void shouldMatchExpectedTextWithSameCase() {
+    assertThat(new CaseSensitiveText("One").apply(driver, elementShort)).isEqualTo(true);
+  }
+
+  @Test
+  void shouldNotMatchExpectedTextWithDifferentCase() {
+    assertThat(new CaseSensitiveText("one").apply(driver, elementShort)).isEqualTo(false);
+  }
+
+  @Test
+  void shouldNotMatchDifferentExpectedText() {
+    assertThat(new CaseSensitiveText("Two").apply(driver, elementShort)).isEqualTo(false);
+  }
+
+  @Test
+  void shouldMatchExpectedTextWithinOtherText() {
+    assertThat(new CaseSensitiveText("One").apply(driver, elementLong)).isEqualTo(true);
+  }
+
+  @Test
+  void shouldMatchExpectedTextInSelectedOptions() {
+    assertThat(new CaseSensitiveText("One").apply(driver, singleSelectElement)).isEqualTo(true);
+
+    assertThat(new CaseSensitiveText("Two").apply(driver, multiSelectElement)).isEqualTo(true);
+    assertThat(new CaseSensitiveText("OneTwo").apply(driver, multiSelectElement)).isEqualTo(true);
+  }
+
+  @Test
+  void shouldNotMatchExpectedTextWithDifferentCaseInSelectedOptions() {
+    assertThat(new CaseSensitiveText("one").apply(driver, singleSelectElement)).isEqualTo(false);
+
+    assertThat(new CaseSensitiveText("one").apply(driver, multiSelectElement)).isEqualTo(false);
+    assertThat(new CaseSensitiveText("oneTwo").apply(driver, multiSelectElement)).isEqualTo(false);
+  }
+
+  @Test
+  void shouldNotMatchExpectedTextInNonSelectedOptions() {
+    assertThat(new CaseSensitiveText("Two").apply(driver, singleSelectElement)).isEqualTo(false);
+    assertThat(new CaseSensitiveText("Three").apply(driver, singleSelectElement)).isEqualTo(false);
+  }
+
+  @Test
+  void shouldHaveCorrectToString() {
+    assertThat(new CaseSensitiveText("One")).hasToString("textCaseSensitive 'One'");
+  }
+
+  private WebElement elementWithText(String text) {
+    WebElement webElement = mock(WebElement.class);
+    when(webElement.getText()).thenReturn(text);
+    return webElement;
+  }
+
+  private WebElement selectSingle(String... optionTexts) {
+    WebElement select = mock(WebElement.class);
+    when(select.getTagName()).thenReturn("select");
+
+    List<WebElement> options = Stream.of(optionTexts)
+      .map(this::elementWithText)
+      .peek(option -> when(option.isSelected()).thenReturn(false))
+      .collect(toList());
+
+    when(options.get(0).isSelected()).thenReturn(true);
+
+    when(select.findElements(By.tagName("option"))).thenReturn(options);
+    return select;
+  }
+
+  private WebElement selectMulti(String... optionTexts) {
+    WebElement select = mock(WebElement.class);
+    when(select.getTagName()).thenReturn("select");
+
+    List<WebElement> options = Stream.of(optionTexts)
+      .map(this::elementWithText)
+      .peek(option -> when(option.isSelected()).thenReturn(true))
+      .collect(toList());
+
+    when(select.findElements(By.tagName("option"))).thenReturn(options);
+    return select;
+  }
+}

--- a/src/test/resources/page_with_selects_without_jquery.html
+++ b/src/test/resources/page_with_selects_without_jquery.html
@@ -203,5 +203,16 @@
   </select>
 </div>
 
+<div class="container">
+  <label for="cars">Choose your cars:</label>
+  <br/>
+  <select name="cars" id="cars" multiple>
+    <option value="volvo">Volvo</option>
+    <option value="saab">Saab</option>
+    <option value="opel">Opel</option>
+    <option value="audi">Audi</option>
+  </select>
+</div>
+
 </body>
 </html>

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.By;
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.selected;
 import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.textCaseSensitive;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Selectors.byName;
 import static com.codeborne.selenide.Selenide.$;
@@ -166,7 +167,33 @@ final class SelectsTest extends IntegrationTest {
     $("#hero").shouldNotHave(text("John Mc'Lain").because("Option is not selected yet"));
 
     $("#hero").selectOptionByValue("john mc'lain");
-    $("#hero").shouldHave(text("John Mc'Lain").because("Option `john mc'lain` is selected"));
+    $("#hero").shouldHave(text("john mc'lain").because("Option with text `John Mc'Lain` is selected"));
+    $("#hero").shouldHave(textCaseSensitive("John Mc'Lain").because("Option with text `John Mc'Lain` is selected"));
+  }
+
+  @Test
+  void shouldHaveTextChecksSelectedOptions() {
+    $("#cars").selectOptionByValue("saab", "audi");
+
+    $("#cars").shouldHave(text("audi").because("Option with text `Audi` is selected"));
+    $("#cars").shouldHave(text("saab").because("Option with text `Saab` is selected"));
+    $("#cars").shouldHave(textCaseSensitive("Audi").because("Option with text `Audi` is selected"));
+    $("#cars").shouldHave(textCaseSensitive("Saab").because("Option with text `Saab` is selected"));
+  }
+
+  @Test()
+  void throwsAssertionErrorForSelectedElementsWithDifferentTextOrCase() {
+    $("#hero").selectOptionByValue("john mc'lain");
+    assertThatThrownBy(() -> $("#hero").shouldHave(text("Denzel Washington")))
+      .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> $("#hero").shouldHave(textCaseSensitive("john mc'lain")))
+      .isInstanceOf(AssertionError.class);
+
+    $("#cars").selectOptionByValue("saab", "audi");
+    assertThatThrownBy(() -> $("#cars").shouldHave(text("volvo")))
+      .isInstanceOf(AssertionError.class);
+    assertThatThrownBy(() -> $("#cars").shouldHave(textCaseSensitive("audi")))
+      .isInstanceOf(AssertionError.class);
   }
 
   @Test

--- a/statics/src/test/java/integration/pageobjects/FieldOfGenericTypeTest.java
+++ b/statics/src/test/java/integration/pageobjects/FieldOfGenericTypeTest.java
@@ -28,30 +28,32 @@ public class FieldOfGenericTypeTest extends IntegrationTest {
     assertThat(page.body).isInstanceOf(DummyTypedElement.class);
     assertThat(page.body.names).isNull();
     assertThat(page.body.selects).isInstanceOf(List.class);
-    assertThat(page.body.selects).hasSize(3);
+    assertThat(page.body.selects).hasSize(4);
     assertThat(page.body.getSelf()).isEqualTo($("body"));
     assertThat(page.body.selects.get(0)).isEqualTo($("select[name=domain]"));
     assertThat(page.body.selects.get(1)).isEqualTo($("select#hero"));
     assertThat(page.body.selects.get(2)).isEqualTo($("select#gender"));
+    assertThat(page.body.selects.get(3)).isEqualTo($("select#cars"));
   }
 
   @Test
   void injectsFoundSelenideElementAsSelf2() {
     AnotherPage page = page(AnotherPage.class);
-    assertThat(page.body.selects).hasSize(3);
+    assertThat(page.body.selects).hasSize(4);
     assertThat(page.body).isInstanceOf(ElementsContainer.class);
     assertThat(page.body.getSelf()).isEqualTo($("body"));
     assertThat(page.body.selects.get(0)).isInstanceOf(WebElement.class);
     assertThat(page.body.selects.get(0)).isEqualTo($("select[name=domain]"));
     assertThat(page.body.selects.get(1)).isEqualTo($("select#hero"));
     assertThat(page.body.selects.get(2)).isEqualTo($("select#gender"));
+    assertThat(page.body.selects.get(3)).isEqualTo($("select#cars"));
   }
 
   @Test
   void injectsFoundSelenideElementAsSelf3() {
     YetAnotherPage page = page(YetAnotherPage.class);
     assertThat(page.body).isNotNull();
-    assertThat(page.body.selects).hasSize(3);
+    assertThat(page.body.selects).hasSize(4);
 
     assertThatThrownBy(() -> page.body.selects.get(0))
       .isInstanceOf(RuntimeException.class)


### PR DESCRIPTION
### Given

```html
<select name="numbers" id="numbers" multiple>
    <option value="one">One</option>
    <option value="two">Two</option>
    <option value="three">Three</option>
    <option value="four">Four</option>
</select>
```

### Before 
To directly assert the selected option(-s) in `select` element, the user would do something like this:

```java
$("select").selectOptionByValue("one");
$("select").shouldHave(text("one"));
$("select").shouldNotHave(text("two"));
```

### After
This minor change adds the same feature for `Condition.textCaseSensitive()`. 
It's possible to check the selected option with case-sensitive assertion.

```java
$("select").selectOptionByValue("one");
$("select").shouldHave(textCaseSensitive("One"));
$("select").shouldNotHave(textCaseSensitive("Two"));
```

The multi-select lists work the same way as with `Condition.text()`:

```java
$("select").selectOptionByValue("one", "two");
$("select").shouldHave(textCaseSensitive("One"), textCaseSensitive("Two"));
$("select").shouldNotHave(textCaseSensitive("Three"), textCaseSensitive("one"));
```

### Notes

Might break the existing user code where a test relies on checking *all the available* options, selected and not:

```java
//  do not select anything, just check the 'select' text right away
$("select").shouldHave(textCaseSensitive("One"), textCaseSensitive("Two")); // fail
```

Although I think it's inconsistent that `text()` currently checks the selected options and `textCaseSensitive()` checks all the available options. Hence, this change.