### PR TITLE
add getSessionId method to Driver

### DIFF
--- a/src/main/java/com/codeborne/selenide/Driver.java
+++ b/src/main/java/com/codeborne/selenide/Driver.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.proxy.SelenideProxyServer;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.SessionId;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -94,5 +97,18 @@ public interface Driver {
   @Nonnull
   default Actions actions() {
     return new Actions(getWebDriver());
+  }
+
+  @CheckReturnValue
+  @Nullable
+  default SessionId getSessionId() {
+    WebDriver driver = getWebDriver();
+    if (getWebDriver() instanceof EventFiringWebDriver) {
+      driver = ((EventFiringWebDriver) getWebDriver()).getWrappedDriver();
+    }
+    if (driver instanceof RemoteWebDriver) {
+      return ((RemoteWebDriver) driver).getSessionId();
+    }
+    return null;
   }
 }

--- a/src/main/java/com/codeborne/selenide/Driver.java
+++ b/src/main/java/com/codeborne/selenide/Driver.java
@@ -100,15 +100,12 @@ public interface Driver {
   }
 
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   default SessionId getSessionId() {
     WebDriver driver = getWebDriver();
-    if (getWebDriver() instanceof EventFiringWebDriver) {
-      driver = ((EventFiringWebDriver) getWebDriver()).getWrappedDriver();
+    if (driver instanceof EventFiringWebDriver) {
+      driver = ((EventFiringWebDriver) driver).getWrappedDriver();
     }
-    if (driver instanceof RemoteWebDriver) {
-      return ((RemoteWebDriver) driver).getSessionId();
-    }
-    return null;
+    return ((RemoteWebDriver) driver).getSessionId();
   }
 }

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -13,6 +13,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.support.events.WebDriverEventListener;
 
 import javax.annotation.CheckReturnValue;
@@ -382,6 +383,12 @@ public class SelenideDriver {
   @Nonnull
   public String getUserAgent() {
     return driver().getUserAgent();
+  }
+
+  @CheckReturnValue
+  @Nullable
+  public SessionId getSessionId() {
+    return driver().getSessionId();
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -386,7 +386,7 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   public SessionId getSessionId() {
     return driver().getSessionId();
   }

--- a/src/test/java/com/codeborne/selenide/DriverStub.java
+++ b/src/test/java/com/codeborne/selenide/DriverStub.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.proxy.SelenideProxyServer;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.SessionId;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -112,6 +113,13 @@ public class DriverStub implements Driver {
   @Nonnull
   public String getUserAgent() {
     return "zhopera";
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public SessionId getSessionId() {
+    return new SessionId("testSession");
   }
 
   @Override

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.remote.SessionId;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -1054,5 +1055,16 @@ public class Selenide {
   @CheckReturnValue
   public static Clipboard clipboard() {
     return getSelenideDriver().getClipboard();
+  }
+
+  /**
+   * Get current browser session Id
+   *
+   * @return SessionId
+   */
+  @Nullable
+  @CheckReturnValue
+  public static SessionId sessionId(){
+    return getSelenideDriver().getSessionId();
   }
 }

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -1062,7 +1062,7 @@ public class Selenide {
    *
    * @return SessionId
    */
-  @Nullable
+  @Nonnull
   @CheckReturnValue
   public static SessionId sessionId(){
     return getSelenideDriver().getSessionId();


### PR DESCRIPTION
## Proposed changes
I faced a bug with selenide-selenoid. In case when added listener to driver(class which implements WebDriverEventListener).  
Method getWebDriver() returns instance of EventFiringWebDriver which cannot be casted to RemoteWebDriver. It produce ClassCastException [here](https://github.com/selenide/selenide-selenoid/blob/2758043b06b90407ab5f65103a1caeee1173a0da/src/main/java/org/selenide/selenoid/DownloadFileInSelenoid.java#L55) and in the other places of selenide-selenoid project

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
