### PR TITLE
add file Properties support

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -1,8 +1,11 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.impl.CiReportUrl;
+import com.codeborne.selenide.impl.PropertiesUtils;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.util.Properties;
 
 import static com.codeborne.selenide.AssertionMode.STRICT;
 import static com.codeborne.selenide.Browsers.CHROME;
@@ -10,40 +13,50 @@ import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.SelectorMode.CSS;
 
 public class SelenideConfig implements Config {
-  private String browser = System.getProperty("selenide.browser", CHROME);
-  private boolean headless = Boolean.parseBoolean(System.getProperty("selenide.headless", "false"));
-  private String remote = System.getProperty("selenide.remote");
-  private String browserSize = System.getProperty("selenide.browserSize", "1366x768");
-  private String browserVersion = System.getProperty("selenide.browserVersion");
-  private String browserPosition = System.getProperty("selenide.browserPosition");
-  private boolean startMaximized = Boolean.parseBoolean(System.getProperty("selenide.startMaximized", "false"));
-  private boolean driverManagerEnabled = Boolean.parseBoolean(System.getProperty("selenide.driverManagerEnabled", "true"));
-  private boolean webdriverLogsEnabled = Boolean.parseBoolean(System.getProperty("selenide.webdriverLogsEnabled", "false"));
-  private String browserBinary = System.getProperty("selenide.browserBinary", "");
-  private String pageLoadStrategy = System.getProperty("selenide.pageLoadStrategy", "normal");
-  private long pageLoadTimeout = Long.parseLong(System.getProperty("selenide.pageLoadTimeout", "30000"));
+  private String browser = getProperty("selenide.browser", CHROME);
+  private boolean headless = Boolean.parseBoolean(getProperty("selenide.headless", "false"));
+  private String remote = getProperty("selenide.remote");
+  private String browserSize = getProperty("selenide.browserSize", "1366x768");
+  private String browserVersion = getProperty("selenide.browserVersion");
+  private String browserPosition = getProperty("selenide.browserPosition");
+  private boolean startMaximized = Boolean.parseBoolean(getProperty("selenide.startMaximized", "false"));
+  private boolean driverManagerEnabled = Boolean.parseBoolean(getProperty("selenide.driverManagerEnabled", "true"));
+  private boolean webdriverLogsEnabled = Boolean.parseBoolean(getProperty("selenide.webdriverLogsEnabled", "false"));
+  private String browserBinary = getProperty("selenide.browserBinary", "");
+  private String pageLoadStrategy = getProperty("selenide.pageLoadStrategy", "normal");
+  private long pageLoadTimeout = Long.parseLong(getProperty("selenide.pageLoadTimeout", "30000"));
   private MutableCapabilities browserCapabilities = new DesiredCapabilities();
 
-  private String baseUrl = System.getProperty("selenide.baseUrl", "http://localhost:8080");
-  private long timeout = Long.parseLong(System.getProperty("selenide.timeout", "4000"));
-  private long pollingInterval = Long.parseLong(System.getProperty("selenide.pollingInterval", "200"));
+  private String baseUrl = getProperty("selenide.baseUrl", "http://localhost:8080");
+  private long timeout = Long.parseLong(getProperty("selenide.timeout", "4000"));
+  private long pollingInterval = Long.parseLong(getProperty("selenide.pollingInterval", "200"));
   private boolean holdBrowserOpen = Boolean.getBoolean("selenide.holdBrowserOpen");
-  private boolean reopenBrowserOnFail = Boolean.parseBoolean(System.getProperty("selenide.reopenBrowserOnFail", "true"));
-  private boolean clickViaJs = Boolean.parseBoolean(System.getProperty("selenide.clickViaJs", "false"));
-  private boolean screenshots = Boolean.parseBoolean(System.getProperty("selenide.screenshots", "true"));
+  private boolean reopenBrowserOnFail = Boolean.parseBoolean(getProperty("selenide.reopenBrowserOnFail", "true"));
+  private boolean clickViaJs = Boolean.parseBoolean(getProperty("selenide.clickViaJs", "false"));
+  private boolean screenshots = Boolean.parseBoolean(getProperty("selenide.screenshots", "true"));
 
-  private boolean savePageSource = Boolean.parseBoolean(System.getProperty("selenide.savePageSource", "true"));
-  private String reportsFolder = System.getProperty("selenide.reportsFolder", "build/reports/tests");
-  private String downloadsFolder = System.getProperty("selenide.downloadsFolder", "build/downloads");
-  private String reportsUrl = new CiReportUrl().getReportsUrl(System.getProperty("selenide.reportsUrl"));
-  private boolean fastSetValue = Boolean.parseBoolean(System.getProperty("selenide.fastSetValue", "false"));
-  private boolean versatileSetValue = Boolean.parseBoolean(System.getProperty("selenide.versatileSetValue", "false"));
-  private SelectorMode selectorMode = SelectorMode.valueOf(System.getProperty("selenide.selectorMode", CSS.name()));
-  private AssertionMode assertionMode = AssertionMode.valueOf(System.getProperty("selenide.assertionMode", STRICT.name()));
-  private FileDownloadMode fileDownload = FileDownloadMode.valueOf(System.getProperty("selenide.fileDownload", HTTPGET.name()));
-  private boolean proxyEnabled = Boolean.parseBoolean(System.getProperty("selenide.proxyEnabled", "false"));
-  private String proxyHost = System.getProperty("selenide.proxyHost", "");
-  private int proxyPort = Integer.parseInt(System.getProperty("selenide.proxyPort", "0"));
+  private boolean savePageSource = Boolean.parseBoolean(getProperty("selenide.savePageSource", "true"));
+  private String reportsFolder = getProperty("selenide.reportsFolder", "build/reports/tests");
+  private String downloadsFolder = getProperty("selenide.downloadsFolder", "build/downloads");
+  private String reportsUrl = new CiReportUrl().getReportsUrl(getProperty("selenide.reportsUrl"));
+  private boolean fastSetValue = Boolean.parseBoolean(getProperty("selenide.fastSetValue", "false"));
+  private boolean versatileSetValue = Boolean.parseBoolean(getProperty("selenide.versatileSetValue", "false"));
+  private SelectorMode selectorMode = SelectorMode.valueOf(getProperty("selenide.selectorMode", CSS.name()));
+  private AssertionMode assertionMode = AssertionMode.valueOf(getProperty("selenide.assertionMode", STRICT.name()));
+  private FileDownloadMode fileDownload = FileDownloadMode.valueOf(getProperty("selenide.fileDownload", HTTPGET.name()));
+  private boolean proxyEnabled = Boolean.parseBoolean(getProperty("selenide.proxyEnabled", "false"));
+  private String proxyHost = getProperty("selenide.proxyHost", "");
+  private int proxyPort = Integer.parseInt(getProperty("selenide.proxyPort", "0"));
+
+  private final Properties props;
+
+  public SelenideConfig() {
+    props = PropertiesUtils.getSelenideProperties();
+  }
+
+  public SelenideConfig(Properties props) {
+    this.props = props;
+  }
 
   @Override
   public String baseUrl() {
@@ -362,6 +375,14 @@ public class SelenideConfig implements Config {
   public SelenideConfig browserCapabilities(DesiredCapabilities browserCapabilities) {
     this.browserCapabilities = browserCapabilities;
     return this;
+  }
+
+  private String getProperty(String propKey, String defaultValue){
+    return props.getOrDefault(propKey, defaultValue).toString();
+  }
+
+  private String getProperty(String propKey){
+    return props.getProperty(propKey);
   }
 
 }

--- a/src/main/java/com/codeborne/selenide/impl/PropertiesUtils.java
+++ b/src/main/java/com/codeborne/selenide/impl/PropertiesUtils.java
@@ -1,0 +1,35 @@
+package com.codeborne.selenide.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertiesUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(DownloadFileToFolder.class);
+  private static final String SELENIDE_PROPERTIES = "selenide.properties";
+
+  private PropertiesUtils() {
+  }
+
+  public static Properties getSelenideProperties() {
+    final Properties properties = new Properties();
+    loadPropertiesFrom(ClassLoader.getSystemClassLoader(), properties);
+    loadPropertiesFrom(Thread.currentThread().getContextClassLoader(), properties);
+    properties.putAll(System.getProperties());
+    return properties;
+  }
+
+  private static void loadPropertiesFrom(final ClassLoader classLoader, final Properties properties) {
+    try (InputStream stream = classLoader.getResourceAsStream(SELENIDE_PROPERTIES)) {
+      if (stream != null) {
+        properties.load(stream);
+      }
+    } catch (IOException e) {
+      log.error("Error while reading selenide.properties file from classpath: {}", e.getMessage());
+    }
+  }
+}

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -5,13 +5,14 @@ import org.openqa.selenium.MutableCapabilities;
 /**
  * Configuration settings for Selenide default browser
  * <br>
- * This class is designed so that every setting can be set either via system property or programmatically.
+ * This class is designed so that every setting can be set either via system property or programmatically or
+ * via resource properties file - selenide.properties.
  * <br>
  * Please note that all fields are static, meaning that
  * every change will immediately reflect in all threads (if you run tests in parallel).
  *
  * <p>
- *   These system properties can be additonally used having effect on every new created browser in test.
+ *   These system properties can be additionally used having effect on every new created browser in test.
  *   For example as -D&lt;property&gt;=&lt;value&gt; in command-line
  * </p>
  * <p>


### PR DESCRIPTION
## Proposed changes
Added support for loading properties from resource selenide.properties how it works in Allure with allure.properties. 
Added constructor to SelenideConfig with Properties parameter in a case when you want to create a browser with custom config
I know that this pull can be debatable and Andrei already gave two questions.
1. Resource format( properties, JSON, XML) - XML old and not popular, JSON good for js frameworks but in java, for me, better looks properties, as the standard format and current realization is based on it to
2. Users already have their realization -  this pull shouldn't break their solutions, but give an option to make it from the box

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
