### PR TITLE
#1508 `numberOfWindows` condition for `webdriver()`

### DIFF
--- a/src/main/java/com/codeborne/selenide/WebDriverConditions.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverConditions.java
@@ -1,11 +1,6 @@
 package com.codeborne.selenide;
 
-import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrl;
-import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrlContaining;
-import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrlStartingWith;
-import com.codeborne.selenide.conditions.webdriver.Url;
-import com.codeborne.selenide.conditions.webdriver.UrlContaining;
-import com.codeborne.selenide.conditions.webdriver.UrlStartingWith;
+import com.codeborne.selenide.conditions.webdriver.*;
 import org.openqa.selenium.WebDriver;
 
 /**
@@ -34,5 +29,14 @@ public class WebDriverConditions {
 
   public static ObjectCondition<WebDriver> currentFrameUrlContaining(String expectedUrl) {
     return new CurrentFrameUrlContaining(expectedUrl);
+  }
+
+  /**
+   * Check that the number of tabs in the browser is as expected.
+   * Example:
+   * {@code webdriver().shouldHave(numberOfTabs(2)) }
+   */
+  public static ObjectCondition<WebDriver> numberOfTabs(int numberOfTabs) {
+    return new NumberOfTabs(numberOfTabs);
   }
 }

--- a/src/main/java/com/codeborne/selenide/WebDriverConditions.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverConditions.java
@@ -1,6 +1,12 @@
 package com.codeborne.selenide;
 
-import com.codeborne.selenide.conditions.webdriver.*;
+import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrl;
+import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrlStartingWith;
+import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrlContaining;
+import com.codeborne.selenide.conditions.webdriver.NumberOfTabs;
+import com.codeborne.selenide.conditions.webdriver.Url;
+import com.codeborne.selenide.conditions.webdriver.UrlContaining;
+import com.codeborne.selenide.conditions.webdriver.UrlStartingWith;
 import org.openqa.selenium.WebDriver;
 
 /**

--- a/src/main/java/com/codeborne/selenide/WebDriverConditions.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverConditions.java
@@ -3,7 +3,7 @@ package com.codeborne.selenide;
 import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrl;
 import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrlStartingWith;
 import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrlContaining;
-import com.codeborne.selenide.conditions.webdriver.NumberOfTabs;
+import com.codeborne.selenide.conditions.webdriver.NumberOfWindows;
 import com.codeborne.selenide.conditions.webdriver.Url;
 import com.codeborne.selenide.conditions.webdriver.UrlContaining;
 import com.codeborne.selenide.conditions.webdriver.UrlStartingWith;
@@ -38,11 +38,11 @@ public class WebDriverConditions {
   }
 
   /**
-   * Check that the number of tabs in the browser is as expected.
+   * Check that the number of windows/tabs in the browser is as expected.
    * Example:
-   * {@code webdriver().shouldHave(numberOfTabs(2)) }
+   * {@code webdriver().shouldHave(numberOfWindows(2)) }
    */
-  public static ObjectCondition<WebDriver> numberOfTabs(int numberOfTabs) {
-    return new NumberOfTabs(numberOfTabs);
+  public static ObjectCondition<WebDriver> numberOfWindows(int numberOfWindows) {
+    return new NumberOfWindows(numberOfWindows);
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfTabs.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfTabs.java
@@ -1,0 +1,45 @@
+package com.codeborne.selenide.conditions.webdriver;
+
+import com.codeborne.selenide.ObjectCondition;
+import org.openqa.selenium.WebDriver;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class NumberOfWindows implements ObjectCondition<WebDriver> {
+  private final int expectedNumberOfWindows;
+
+  public NumberOfWindows(int expectedNumberOfWindows) {
+    this.expectedNumberOfWindows = expectedNumberOfWindows;
+  }
+
+  @Nonnull
+  @Override
+  public String description() {
+    return "should have number of windows = " + expectedNumberOfWindows;
+  }
+
+  @Nonnull
+  @Override
+  public String negativeDescription() {
+    return "should not have number of windows = " + expectedNumberOfWindows;
+  }
+
+  @Override
+  public boolean test(WebDriver webDriver) {
+    return webDriver.getWindowHandles().size() == expectedNumberOfWindows;
+  }
+
+  @Nullable
+  @Override
+  public String actualValue(WebDriver webDriver) {
+    return String.valueOf(webDriver.getWindowHandles().size());
+  }
+
+  @Nonnull
+  @Override
+  public String describe(WebDriver webDriver) {
+    return "webdriver";
+  }
+}
+

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfTabs.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfTabs.java
@@ -6,28 +6,28 @@ import org.openqa.selenium.WebDriver;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class NumberOfWindows implements ObjectCondition<WebDriver> {
-  private final int expectedNumberOfWindows;
+public class NumberOfTabs implements ObjectCondition<WebDriver> {
+  private final int expectedNumberOfTabs;
 
-  public NumberOfWindows(int expectedNumberOfWindows) {
-    this.expectedNumberOfWindows = expectedNumberOfWindows;
+  public NumberOfTabs(int expectedNumberOfTabs) {
+    this.expectedNumberOfTabs = expectedNumberOfTabs;
   }
 
   @Nonnull
   @Override
   public String description() {
-    return "should have number of windows = " + expectedNumberOfWindows;
+    return "should have " + expectedNumberOfTabs + " tab(s)";
   }
 
   @Nonnull
   @Override
   public String negativeDescription() {
-    return "should not have number of windows = " + expectedNumberOfWindows;
+    return "should not have " + expectedNumberOfTabs + " tab(s)";
   }
 
   @Override
   public boolean test(WebDriver webDriver) {
-    return webDriver.getWindowHandles().size() == expectedNumberOfWindows;
+    return webDriver.getWindowHandles().size() == expectedNumberOfTabs;
   }
 
   @Nullable
@@ -42,4 +42,3 @@ public class NumberOfWindows implements ObjectCondition<WebDriver> {
     return "webdriver";
   }
 }
-

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfWindows.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfWindows.java
@@ -6,28 +6,28 @@ import org.openqa.selenium.WebDriver;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class NumberOfTabs implements ObjectCondition<WebDriver> {
-  private final int expectedNumberOfTabs;
+public class NumberOfWindows implements ObjectCondition<WebDriver> {
+  private final int expectedNumberOfWindows;
 
-  public NumberOfTabs(int expectedNumberOfTabs) {
-    this.expectedNumberOfTabs = expectedNumberOfTabs;
+  public NumberOfWindows(int expectedNumberOfWindows) {
+    this.expectedNumberOfWindows = expectedNumberOfWindows;
   }
 
   @Nonnull
   @Override
   public String description() {
-    return "should have " + expectedNumberOfTabs + " tab(s)";
+    return "should have " + expectedNumberOfWindows + " window(s)";
   }
 
   @Nonnull
   @Override
   public String negativeDescription() {
-    return "should not have " + expectedNumberOfTabs + " tab(s)";
+    return "should not have " + expectedNumberOfWindows + " window(s)";
   }
 
   @Override
   public boolean test(WebDriver webDriver) {
-    return webDriver.getWindowHandles().size() == expectedNumberOfTabs;
+    return webDriver.getWindowHandles().size() == expectedNumberOfWindows;
   }
 
   @Nullable

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -11,8 +11,16 @@ import javax.annotation.Nonnull;
 
 import static com.codeborne.selenide.Configuration.baseUrl;
 import static com.codeborne.selenide.Selectors.byText;
-import static com.codeborne.selenide.Selenide.*;
-import static com.codeborne.selenide.WebDriverConditions.*;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.switchTo;
+import static com.codeborne.selenide.Selenide.webdriver;
+import static com.codeborne.selenide.WebDriverConditions.currentFrameUrl;
+import static com.codeborne.selenide.WebDriverConditions.currentFrameUrlContaining;
+import static com.codeborne.selenide.WebDriverConditions.currentFrameUrlStartingWith;
+import static com.codeborne.selenide.WebDriverConditions.numberOfWindows;
+import static com.codeborne.selenide.WebDriverConditions.url;
+import static com.codeborne.selenide.WebDriverConditions.urlContaining;
+import static com.codeborne.selenide.WebDriverConditions.urlStartingWith;
 import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -120,33 +128,33 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
-  void checkNumberOfOpenTabs() {
+  void checkNumberOfOpenWindows() {
     openFile("page_with_tabs.html");
 
-    webdriver().shouldHave(numberOfTabs(1));
+    webdriver().shouldHave(numberOfWindows(1));
     $(byText("Page4: same title")).click();
-    webdriver().shouldHave(numberOfTabs(2));
+    webdriver().shouldHave(numberOfWindows(2));
     $(byText("Page5: same title")).click();
-    webdriver().shouldHave(numberOfTabs(3));
+    webdriver().shouldHave(numberOfWindows(3));
 
     switchTo().window(2).close();
-    webdriver().shouldHave(numberOfTabs(2));
+    webdriver().shouldHave(numberOfWindows(2));
     switchTo().window(1).close();
-    webdriver().shouldHave(numberOfTabs(1));
+    webdriver().shouldHave(numberOfWindows(1));
   }
 
   @Test
-  void errorMessageForNumberOfTabs() {
+  void errorMessageForNumberOfWindows() {
     assertThatThrownBy(() ->
-      webdriver().shouldHave(numberOfTabs(2)))
+      webdriver().shouldHave(numberOfWindows(2)))
       .isInstanceOf(ConditionNotMetException.class)
-      .hasMessageContaining("webdriver should have 2 tab(s)")
+      .hasMessageContaining("webdriver should have 2 window(s)")
       .hasMessageContaining("Actual value: 1");
 
     assertThatThrownBy(() ->
-      webdriver().shouldNotHave(numberOfTabs(1)))
+      webdriver().shouldNotHave(numberOfWindows(1)))
       .isInstanceOf(ConditionMetException.class)
-      .hasMessageContaining("webdriver should not have 1 tab(s)")
+      .hasMessageContaining("webdriver should not have 1 window(s)")
       .hasMessageContaining("Actual value: 1");
   }
 


### PR DESCRIPTION
## Proposed changes
The feature similar to `FluentWait` condition `numberOfWindowsToBe()`.

```java
webdriver().shouldHave(numberOfTabs(2));
webdriver().shouldHave(numberOfTabs(2), ofSeconds(60));
```

### Note
@asolntsev I'm not so sure about the naming here. `numberOfWindows` is closer to the original condition in Selenium, but it's a bit misleading (we're dealing with tabs of the browser; "windows" can be attributed to the several browsers/browser's windows) and long. `tabs()` is a bit short and doesn't sound that grammatically correct ("web driver should have tabs...") or accurate. That's why I went with `numberOfTabs`, but I'm open to suggestions.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
