### PR TITLE
Add new Condition attributeContainsText(k, v)

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -31,6 +31,7 @@ import com.codeborne.selenide.conditions.SelectedText;
 import com.codeborne.selenide.conditions.Text;
 import com.codeborne.selenide.conditions.Value;
 import com.codeborne.selenide.conditions.Visible;
+import com.codeborne.selenide.conditions.AttributeContainsText;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -147,6 +148,19 @@ public abstract class Condition {
   @Nonnull
   public static Condition attributeMatching(String attributeName, String attributeRegex) {
     return new MatchAttributeWithValue(attributeName, attributeRegex);
+  }
+
+  /**
+   * Asserts that the given attribute of an element contains text
+   *
+   * <p>Sample: <code>$("h1").should(attributeContainsVal("fieldId", "Hello Wor"))</code></p>
+   * @param attributeName name of attribute
+   * @param expectedAttributeValue text expected in the attribute
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition attributeContainsText(String attributeName, String expectedAttributeValue) {
+    return new AttributeContainsText(attributeName, expectedAttributeValue);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/conditions/AttributeContainsText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/AttributeContainsText.java
@@ -1,0 +1,40 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Driver;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class AttributeContainsText extends Condition {
+
+  private final String attributeName;
+  private final String expectedAttributeValue;
+
+  public AttributeContainsText(String attributeName, String expectedAttributeValue) {
+    super("attribute contains text");
+    this.attributeName = attributeName;
+    this.expectedAttributeValue = expectedAttributeValue;
+  }
+
+  @CheckReturnValue
+  @Override
+  public boolean apply(Driver driver, WebElement element) {
+    return getAttributeValue(element).contains(expectedAttributeValue);
+  }
+
+  protected String getAttributeValue(WebElement element) {
+    String attr = element.getAttribute(attributeName);
+    return attr == null ? "" : attr;
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String toString() {
+    return String.format("%s %s=\"%s\"", getName(), attributeName, expectedAttributeValue);
+  }
+}

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -30,6 +30,7 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.textCaseSensitive;
 import static com.codeborne.selenide.Condition.type;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Condition.attributeContainsText;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
@@ -205,6 +206,14 @@ final class ConditionTest {
     assertThat(attributeMatching("name", "selenide.*").apply(driver, elementWithAttribute("name", "selenide is great"))).isTrue();
     assertThat(attributeMatching("name", "selenide.*").apply(driver, elementWithAttribute("id", "selenide"))).isFalse();
     assertThat(attributeMatching("name", "value.*").apply(driver, elementWithAttribute("name", "another value"))).isFalse();
+  }
+
+  @Test
+  void elementValueContainsText() {
+    assertThat(attributeContainsText("name", "sel").apply(driver, elementWithAttribute("name", "selenide"))).isTrue();
+    assertThat(attributeContainsText("name", "seleni").apply(driver, elementWithAttribute("name", "selenide is great"))).isTrue();
+    assertThat(attributeContainsText("name", "sel").apply(driver, elementWithAttribute("id", "selenide"))).isFalse();
+    assertThat(attributeContainsText("name", "sel").apply(driver, elementWithAttribute("id", "another value"))).isFalse();
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/conditions/AttributeWithValueTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/AttributeWithValueTest.java
@@ -28,6 +28,13 @@ final class AttributeWithValueTest {
   }
 
   @Test
+  void containsText() {
+    assertThat(new AttributeContainsText("data-id", "actual").apply(driver, element)).isTrue();
+    assertThat(new AttributeContainsText("data-id", "act").apply(driver, element)).isTrue();
+    assertThat(new AttributeContainsText("data-id", "exp").apply(driver, element)).isFalse();
+  }
+
+  @Test
   void actualValue() {
     assertThat(new AttributeWithValue("data-id", "expected").actualValue(driver, element)).isEqualTo("data-id=\"actual\"");
 


### PR DESCRIPTION
While writing tests, I ran into the problem several times that there was not enough method to check the value of an attribute for a part of the test, I had to look for workarounds.

ru - При написании тестов я несколько раз сталкивался с проблемой, что не хватало метода для проверки значения атрибута на наличие части текста. Приходилось искать обходные пути решения.