### PR TITLE
#1525 add SelenideElement execute(Command, Duration) method

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1218,6 +1218,17 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   <ReturnType> ReturnType execute(Command<ReturnType> command);
 
   /**
+   * Execute custom implemented command with given timeout
+   *
+   * @param command custom command
+   * @param timeout given timeout
+   * @return whatever the command returns (incl. null)
+   * @see com.codeborne.selenide.commands.Execute
+   * @see com.codeborne.selenide.Command
+   */
+  <ReturnType> ReturnType execute(Command<ReturnType> command, Duration timeout);
+
+  /**
    * Check if image is properly loaded.
    *
    * @throws IllegalArgumentException if argument is not an "img" element

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -624,6 +624,19 @@ final class SelenideMethodsTest extends IntegrationTest {
   }
 
   @Test
+  void canExecuteCustomCommandWithGivenTimeout() {
+    $("#username").setValue("value");
+    Replace replace = Replace.withValue("custom value");
+    Command<Void> doubleClick = new DoubleClick();
+    $("#username").scrollTo()
+      .execute(replace, Duration.ofSeconds(3))
+      .pressEnter()
+      .execute(doubleClick, Duration.ofSeconds(3));
+    String mirrorText = $("#username-mirror").text();
+    assertThat(mirrorText).startsWith("custom value");
+  }
+
+  @Test
   void canExecuteJavascript() {
     Long value = Selenide.executeJavaScript("return 10;");
     assertThat(value).isEqualTo(10);


### PR DESCRIPTION
## Proposed changes
Issue #1525 - Add execute(Command, Duration) method to SelenideElement

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
