### PR TITLE
#1527 execute method doesn't pass args to custom command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.24.0
 * #1525 add method `$.execute(Command, Duration)` for running custom commands with a custom timeout  --  thanks to Evgenii Plugatar for PR #1531
 * #1532 fix searching shadow roots inside of a web element  --  see PR #1536
+* #1527 `$.execute(Command)` and `$.execute(Command, Duration)` methods no longer pass arguments to custom command  --  thanks to Evgenii Plugatar for PR #1535
 
 ## 5.23.3 (released 19.08.2021)
 * #1528 fix "exe" or "dmg" file download in Chrome  -  see PR #1529

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.files.FileFilter;
+import com.codeborne.selenide.impl.WebElementSource;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -1205,7 +1206,9 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement dragAndDropTo(String targetCssSelector, DragAndDropOptions options);
 
   /**
-   * Execute custom implemented command
+   * Execute custom implemented command (this command will not receive
+   * any arguments through {@link Command#execute(SelenideElement, WebElementSource, Object[])}
+   * when executed).
    *
    * @param command custom command
    * @return whatever the command returns (incl. null)
@@ -1215,7 +1218,9 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   <ReturnType> ReturnType execute(Command<ReturnType> command);
 
   /**
-   * Execute custom implemented command with given timeout
+   * Execute custom implemented command with given timeout (this command will not receive
+   * any arguments through {@link Command#execute(SelenideElement, WebElementSource, Object[])}
+   * when executed).
    *
    * @param command custom command
    * @param timeout given timeout

--- a/src/main/java/com/codeborne/selenide/commands/Execute.java
+++ b/src/main/java/com/codeborne/selenide/commands/Execute.java
@@ -17,7 +17,7 @@ public class Execute<ReturnType> implements Command<ReturnType> {
   public ReturnType execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     Command<ReturnType> command = firstOf(args);
     try {
-      return command.execute(proxy, locator, args);
+      return command.execute(proxy, locator, NO_ARGS);
     } catch (IOException e) {
       throw new RuntimeException("Unable to execute custom command", e);
     }

--- a/src/test/java/integration/ExecuteMethodTest.java
+++ b/src/test/java/integration/ExecuteMethodTest.java
@@ -12,6 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -53,6 +54,43 @@ final class ExecuteMethodTest extends ITest {
       .hasMessageContaining("Timeout: 1.100 s.");
     long elapsedTimeMs = System.currentTimeMillis() - startMs;
     assertThat(elapsedTimeMs).isBetween(timeout, timeout * 2);
+  }
+
+  @Test
+  void executeMethodDoesNotPassArgsToCustomCommand() {
+    AtomicReference<Object[]> passedArgsRef = new AtomicReference<>();
+    $("#username").execute(
+      new Command<Void>() {
+        @Override
+        @Nullable
+        public Void execute(@Nonnull SelenideElement proxy,
+                            @Nonnull WebElementSource locator,
+                            @Nullable Object[] args) {
+          passedArgsRef.set(args);
+          return null;
+        }
+      }
+    );
+    assertThat(passedArgsRef.get()).isEmpty();
+  }
+
+  @Test
+  void executeMethodWithGivenTimeoutDoesNotPassArgsToCustomCommand() {
+    AtomicReference<Object[]> passedArgsRef = new AtomicReference<>();
+    $("#username").execute(
+      new Command<Void>() {
+        @Override
+        @Nullable
+        public Void execute(@Nonnull SelenideElement proxy,
+                            @Nonnull WebElementSource locator,
+                            @Nullable Object[] args) {
+          passedArgsRef.set(args);
+          return null;
+        }
+      },
+      Duration.ofMillis(1)
+    );
+    assertThat(passedArgsRef.get()).isEmpty();
   }
 
   @ParametersAreNonnullByDefault


### PR DESCRIPTION
## Proposed changes
From #1527 
- change `com.codeborne.selenide.commands.Execute`: command doesn't pass args to custom command
- add tests to `integration.ExecuteMethodTest`
- update `com.codeborne.selenide.SelenideElement` javadoc

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
