### PR TITLE
#980 add current page URL to the error message in case of test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * #1532 fix searching shadow roots inside of a web element  --  see PR #1536
 * #1527 `$.execute(Command)` and `$.execute(Command, Duration)` methods no longer pass arguments to custom command  --  thanks to Evgenii Plugatar for PR #1535
 * #1467 Avoid spam in logs when webdriver is already closed  --  see PR #1540
+* #980 add current page URL to the error message in case of test failure  --  see PR #1538
 
 ## 5.23.3 (released 19.08.2021)
 * #1528 fix "exe" or "dmg" file download in Chrome  -  see PR #1529

--- a/src/main/java/com/codeborne/selenide/ex/ErrorMessages.java
+++ b/src/main/java/com/codeborne/selenide/ex/ErrorMessages.java
@@ -20,8 +20,15 @@ public class ErrorMessages {
   private static final DurationFormat df = new DurationFormat();
 
   @CheckReturnValue
+  @Nonnull
   protected static String timeout(long timeoutMs) {
     return String.format("%nTimeout: %s", df.format(timeoutMs));
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  protected static String pageUrl(@Nullable String pageUrl) {
+    return pageUrl == null ? "" : String.format("%nPage url: %s", pageUrl);
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/ex/UIAssertionError.java
+++ b/src/main/java/com/codeborne/selenide/ex/UIAssertionError.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.ex.ErrorMessages.causedBy;
+import static com.codeborne.selenide.ex.ErrorMessages.pageUrl;
 import static com.codeborne.selenide.ex.ErrorMessages.timeout;
 
 
@@ -24,6 +25,7 @@ public class UIAssertionError extends AssertionError {
 
   private Screenshot screenshot = Screenshot.none();
   public long timeoutMs;
+  public String pageUrl;
 
   protected UIAssertionError(Driver driver, String message) {
     super(message);
@@ -49,7 +51,7 @@ public class UIAssertionError extends AssertionError {
 
   @CheckReturnValue
   protected String uiDetails() {
-    return screenshot.summary() + timeout(timeoutMs) + causedBy(getCause());
+    return screenshot.summary() + pageUrl(pageUrl) + timeout(timeoutMs) + causedBy(getCause());
   }
 
   /**
@@ -77,6 +79,7 @@ public class UIAssertionError extends AssertionError {
     UIAssertionError uiError = error instanceof UIAssertionError ?
       (UIAssertionError) error : wrapToUIAssertionError(driver, error);
     uiError.timeoutMs = timeoutMs;
+    uiError.pageUrl = getPageUrl(driver);
     if (uiError.screenshot.isPresent()) {
       log.warn("UIAssertionError already has screenshot: {} {} -> {}",
         uiError.getClass().getName(), uiError.getMessage(), uiError.screenshot);
@@ -87,6 +90,17 @@ public class UIAssertionError extends AssertionError {
         .takeScreenshot(driver, config.screenshots(), config.savePageSource());
     }
     return uiError;
+  }
+
+  @CheckReturnValue
+  @Nullable
+  private static String getPageUrl(Driver driver) {
+    try {
+      return driver.url();
+    }
+    catch (WebDriverException commandNotImplemented) {
+      return null;
+    }
   }
 
   @CheckReturnValue

--- a/src/test/java/com/codeborne/selenide/DriverStub.java
+++ b/src/test/java/com/codeborne/selenide/DriverStub.java
@@ -124,13 +124,21 @@ public class DriverStub implements Driver {
 
   @Override
   @CheckReturnValue
-  @Nonnull  public SelenideTargetLocator switchTo() {
+  @Nonnull
+  public SelenideTargetLocator switchTo() {
     return new SelenideTargetLocator(this);
   }
 
   @Override
   @CheckReturnValue
-  @Nonnull  public Actions actions() {
+  @Nonnull
+  public Actions actions() {
     return new Actions(getWebDriver());
+  }
+
+  @Nonnull
+  @Override
+  public String url() {
+    return "https://test.selenide.org/page.html";
   }
 }

--- a/src/test/java/com/codeborne/selenide/Mocks.java
+++ b/src/test/java/com/codeborne/selenide/Mocks.java
@@ -30,6 +30,7 @@ public class Mocks {
   public static CollectionSource mockCollection(String description, WebElement... elements) {
     Driver driver = mock(Driver.class);
     when(driver.config()).thenReturn(new SelenideConfig());
+    when(driver.url()).thenReturn("https://test.selenide.org/page.html");
 
     CollectionSource collection = mock(CollectionSource.class);
     when(collection.driver()).thenReturn(driver);

--- a/statics/src/test/java/integration/errormessages/MissingElementTest.java
+++ b/statics/src/test/java/integration/errormessages/MissingElementTest.java
@@ -20,6 +20,7 @@ import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Configuration.baseUrl;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.element;
@@ -66,6 +67,7 @@ final class MissingElementTest extends IntegrationTest {
           "Expected: text 'expected text'%n" +
           "Screenshot: " + path + png() + "%n" +
           "Page source: " + path + html() + "%n" +
+          "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
           "Timeout: 15 ms.%n" +
           "Caused by: NoSuchElementException:.*"));
       assertThat(expected.getScreenshot().getImage()).matches(path + pngOrHtml());
@@ -83,6 +85,7 @@ final class MissingElementTest extends IntegrationTest {
         "Element: '<h2>Dropdown list</h2>'%n" +
         "Screenshot: " + path + png() + "%n" +
         "Page source: " + path + html() + "%n" +
+        "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
         "Timeout: 15 ms."));
   }
 
@@ -98,6 +101,7 @@ final class MissingElementTest extends IntegrationTest {
         "Actual value: name=\"\"%n" +
         "Screenshot: " + path + png() + "%n" +
         "Page source: " + path + html() + "%n" +
+        "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
         "Timeout: 15 ms."));
   }
 
@@ -112,6 +116,7 @@ final class MissingElementTest extends IntegrationTest {
         "Element: '<h2>Dropdown list</h2>'%n" +
         "Screenshot: " + path + png() + "%n" +
         "Page source: " + path + html() + "%n" +
+        "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
         "Timeout: 15 ms."));
   }
 
@@ -128,6 +133,7 @@ final class MissingElementTest extends IntegrationTest {
           "Actual value: visible:false, 1%n" +
           "Screenshot: " + path + png() + "%n" +
           "Page source: " + path + html() + "%n" +
+          "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
           "Timeout: 15 ms."));
   }
 
@@ -142,6 +148,7 @@ final class MissingElementTest extends IntegrationTest {
         "Element: '<h2>Dropdown list</h2>'%n" +
         "Screenshot: " + path + png() + "%n" +
         "Page source: " + path + html() + "%n" +
+        "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
         "Timeout: 15 ms."));
   }
 
@@ -156,6 +163,7 @@ final class MissingElementTest extends IntegrationTest {
         "Element: '<h2>Dropdown list</h2>'%n" +
         "Screenshot: " + path + png() + "%n" +
         "Page source: " + path + html() + "%n" +
+        "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
         "Timeout: 15 ms."));
   }
 
@@ -178,6 +186,7 @@ final class MissingElementTest extends IntegrationTest {
         "Expected: visible or transparent: visible or have css value opacity=0%n" +
         "Screenshot: " + path + png() + "%n" +
         "Page source: " + path + html() + "%n" +
+        "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
         "Timeout: 15 ms.%n" +
         "Caused by: NoSuchElementException:.*"));
   }
@@ -193,6 +202,7 @@ final class MissingElementTest extends IntegrationTest {
         "Element: '<h2>Dropdown list</h2>'%n" +
         "Screenshot: " + path + png() + "%n" +
         "Page source: " + path + html() + "%n" +
+        "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
         "Timeout: 15 ms."));
   }
 
@@ -207,6 +217,7 @@ final class MissingElementTest extends IntegrationTest {
         "Expected: not hidden%n" +
         "Screenshot: " + path + png() + "%n" +
         "Page source: " + path + html() + "%n" +
+        "Page url: " + baseUrl + "/page_with_selects_without_jquery\\.html\\?browser=" + Configuration.browser+ "&timeout=15%n" +
         "Timeout: 15 ms.%n" +
         "Caused by: NoSuchElementException:.*"));
   }


### PR DESCRIPTION
implementation of https://github.com/selenide/selenide/issues/980

NB! We need to make it configurable (pluggable): in many projects this URL is not needed