### PR TITLE
Fix Or and And conditions logic: empty list in ctor not allowed, PECS in ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * #1532 fix searching shadow roots inside of a web element  --  see PR #1536
 * #1527 `$.execute(Command)` and `$.execute(Command, Duration)` methods no longer pass arguments to custom command  --  thanks to Evgenii Plugatar for PR #1535
 * #1467 Avoid spam in logs when webdriver is already closed  --  see PR #1540
+* #1534 `Or` and `And` conditions work correctly with non-existent element  --  thanks to Evgenii Plugatar for PR #1539
+* `Or` and `And` conditions support PECS principle in ctor, no longer allow empty list in ctor  --  thanks to Evgenii Plugatar for PR #1542
 
 ## 5.23.3 (released 19.08.2021)
 * #1528 fix "exe" or "dmg" file download in Chrome  -  see PR #1529

--- a/src/main/java/com/codeborne/selenide/conditions/Or.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Or.java
@@ -13,11 +13,25 @@ import static java.util.stream.Collectors.joining;
 @ParametersAreNonnullByDefault
 public class Or extends Condition {
 
-  private final List<Condition> conditions;
+  private final List<? extends Condition> conditions;
 
-  public Or(String name, List<Condition> conditions) {
-    super(name, conditions.stream().anyMatch(Condition::applyNull));
+  /**
+   * Ctor.
+   *
+   * @param name       condition name
+   * @param conditions conditions list
+   * @throws IllegalArgumentException if {@code conditions} is empty
+   */
+  public Or(String name, List<? extends Condition> conditions) {
+    super(name, checkedConditionsListCtorArg(conditions).stream().anyMatch(Condition::applyNull));
     this.conditions = conditions;
+  }
+
+  private static List<? extends Condition> checkedConditionsListCtorArg(List<? extends Condition> conditions) {
+    if (conditions.isEmpty()) {
+      throw new IllegalArgumentException("conditions list is empty");
+    }
+    return conditions;
   }
 
   @Nonnull
@@ -43,7 +57,6 @@ public class Or extends Condition {
 
   @Override
   public String toString() {
-    String conditionsToString = conditions.stream().map(Condition::toString).collect(joining(" or "));
-    return String.format("%s: %s", getName(), conditionsToString);
+    return getName() + ": " + conditions.stream().map(Condition::toString).collect(joining(" or "));
   }
 }

--- a/src/test/java/com/codeborne/selenide/conditions/AndTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/AndTest.java
@@ -8,20 +8,39 @@ import org.openqa.selenium.WebElement;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import static com.codeborne.selenide.Condition.attribute;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 
 final class AndTest {
 
   @Test
-  void verifyToString() {
-    Condition and = new And("checked", asList(
-      attribute("checked", "true"),
-      attribute("checked", "on")
-    ));
-    assertThat(and).hasToString("checked: attribute checked=\"true\" and attribute checked=\"on\"");
+  void ctorOfEmptyConditionsListThrowsException() {
+    assertThatCode(() -> {
+      new And("", emptyList());
+    }).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void ofSingleConditionToString() {
+    assertThat(
+      new And("CONDITION_NAME", singletonList(
+        new SimpleCondition(true)
+      ))
+    ).hasToString("CONDITION_NAME: SimpleCondition(true, false)");
+  }
+
+  @Test
+  void ofConditionsListToString() {
+    assertThat(
+      new And("CONDITION_NAME", asList(
+        new SimpleCondition(true),
+        new SimpleCondition(false)
+      ))
+    ).hasToString("CONDITION_NAME: SimpleCondition(true, false) and SimpleCondition(false, false)");
   }
 
   @Test
@@ -170,6 +189,11 @@ final class AndTest {
     @Override
     public Condition negate() {
       return new Not(this, !this.applyNull());
+    }
+
+    @Override
+    public String toString() {
+      return "SimpleCondition(" + this.applyResult + ", " + this.applyNull() + ")";
     }
   }
 }

--- a/src/test/java/com/codeborne/selenide/conditions/OrTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/OrTest.java
@@ -8,20 +8,39 @@ import org.openqa.selenium.WebElement;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import static com.codeborne.selenide.Condition.attribute;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 
 final class OrTest {
 
   @Test
-  void verifyToString() {
-    Condition or = new Or("checked", asList(
-      attribute("checked", "true"),
-      attribute("checked", "on")
-    ));
-    assertThat(or).hasToString("checked: attribute checked=\"true\" or attribute checked=\"on\"");
+  void ctorOfEmptyConditionsListThrowsException() {
+    assertThatCode(() -> {
+      new Or("", emptyList());
+    }).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void ofSingleConditionToString() {
+    assertThat(
+      new Or("CONDITION_NAME", singletonList(
+        new SimpleCondition(true)
+      ))
+    ).hasToString("CONDITION_NAME: SimpleCondition(true, false)");
+  }
+
+  @Test
+  void ofConditionsListToString() {
+    assertThat(
+      new Or("CONDITION_NAME", asList(
+        new SimpleCondition(true),
+        new SimpleCondition(false)
+      ))
+    ).hasToString("CONDITION_NAME: SimpleCondition(true, false) or SimpleCondition(false, false)");
   }
 
   @Test
@@ -170,6 +189,11 @@ final class OrTest {
     @Override
     public Condition negate() {
       return new Not(this, !this.applyNull());
+    }
+
+    @Override
+    public String toString() {
+      return "SimpleCondition(" + this.applyResult + ", " + this.applyNull() + ")";
     }
   }
 }


### PR DESCRIPTION
## Proposed changes
- fixed logic for `com.codeborne.selenide.conditions.Or`, `com.codeborne.selenide.conditions.And`
- added tests to `com.codeborne.selenide.conditions.OrTest`,  `com.codeborne.selenide.conditions.AndTest`
- added info to `CHANGELOG.md`

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
