### PR TITLE
#1541 removed deprecated Condition method applyNull()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * #1467 Avoid spam in logs when webdriver is already closed  --  see PR #1540
 * #1534 `Or` and `And` conditions work correctly with non-existent element  --  thanks to Evgenii Plugatar for PR #1539
 * `Or` and `And` conditions support PECS principle in ctor, no longer allow empty list in ctor  --  thanks to Evgenii Plugatar for PR #1542
-* #1541 removed deprecated `Condition` method `applyNull()`  --  thanks to Evgenii Plugatar for PR #1544
+* #1541 removed deprecated `Condition` method `applyNull()` and renamed `CollectionCondition` `applyNull()` method  --  thanks to Evgenii Plugatar for PR #1544
 
 ## 5.23.3 (released 19.08.2021)
 * #1528 fix "exe" or "dmg" file download in Chrome  -  see PR #1529

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * #1467 Avoid spam in logs when webdriver is already closed  --  see PR #1540
 * #1534 `Or` and `And` conditions work correctly with non-existent element  --  thanks to Evgenii Plugatar for PR #1539
 * `Or` and `And` conditions support PECS principle in ctor, no longer allow empty list in ctor  --  thanks to Evgenii Plugatar for PR #1542
+* #1541 removed deprecated `Condition` method `applyNull()`  --  thanks to Evgenii Plugatar for PR #1544
 
 ## 5.23.3 (released 19.08.2021)
 * #1528 fix "exe" or "dmg" file download in Chrome  -  see PR #1529

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -269,8 +269,8 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
     }
 
     @Override
-    public boolean applyNull() {
-      return delegate.applyNull();
+    public boolean missingElementSatisfiesCondition() {
+      return delegate.missingElementSatisfiesCondition();
     }
 
     @Override
@@ -287,5 +287,5 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
     return new ExplainedCollectionCondition(this, explanation);
   }
 
-  public abstract boolean applyNull();
+  public abstract boolean missingElementSatisfiesCondition();
 }

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -560,15 +560,15 @@ public abstract class Condition {
   }
 
   private final String name;
-  private final boolean absentElementMatchesCondition;
+  private final boolean missingElementSatisfiesCondition;
 
   public Condition(String name) {
     this(name, false);
   }
 
-  public Condition(String name, boolean absentElementMatchesCondition) {
+  public Condition(String name, boolean missingElementSatisfiesCondition) {
     this.name = name;
-    this.absentElementMatchesCondition = absentElementMatchesCondition;
+    this.missingElementSatisfiesCondition = missingElementSatisfiesCondition;
   }
 
   /**
@@ -578,10 +578,6 @@ public abstract class Condition {
    * @return true if element matches condition
    */
   public abstract boolean apply(Driver driver, WebElement element);
-
-  public boolean applyNull() {
-    return absentElementMatchesCondition;
-  }
 
   /**
    * If element didn't match the condition, returns the actual value of element.
@@ -599,7 +595,7 @@ public abstract class Condition {
 
   @Nonnull
   public Condition negate() {
-    return new Not(this, absentElementMatchesCondition);
+    return new Not(this, missingElementSatisfiesCondition);
   }
 
   /**
@@ -621,6 +617,6 @@ public abstract class Condition {
   }
 
   public boolean missingElementSatisfiesCondition() {
-    return absentElementMatchesCondition;
+    return missingElementSatisfiesCondition;
   }
 }

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -199,7 +199,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
         if (Cleanup.of.isInvalidSelectorError(elementNotFound)) {
           throw Cleanup.of.wrap(elementNotFound);
         }
-        if (condition.applyNull()) {
+        if (condition.missingElementSatisfiesCondition()) {
           return;
         }
         lastError = elementNotFound;

--- a/src/main/java/com/codeborne/selenide/collections/ContainExactTextsCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/collections/ContainExactTextsCaseSensitive.java
@@ -59,7 +59,7 @@ public class ContainExactTextsCaseSensitive extends CollectionCondition {
   }
 
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return false;
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
@@ -68,7 +68,7 @@ public class ExactTexts extends CollectionCondition {
   }
 
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return false;
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
+++ b/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
@@ -41,7 +41,7 @@ public class ItemWithText extends CollectionCondition {
 
   @CheckReturnValue
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return false;
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/ListSize.java
+++ b/src/main/java/com/codeborne/selenide/collections/ListSize.java
@@ -34,7 +34,7 @@ public class ListSize extends CollectionCondition {
 
   @CheckReturnValue
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return apply(0);
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/PredicateCollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/collections/PredicateCollectionCondition.java
@@ -38,7 +38,7 @@ public abstract class PredicateCollectionCondition extends CollectionCondition {
   }
 
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return false;
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/SizeGreaterThan.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeGreaterThan.java
@@ -31,7 +31,7 @@ public class SizeGreaterThan extends CollectionCondition {
   }
 
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return apply(0);
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/SizeGreaterThanOrEqual.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeGreaterThanOrEqual.java
@@ -31,7 +31,7 @@ public class SizeGreaterThanOrEqual extends CollectionCondition {
   }
 
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return apply(0);
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/SizeLessThan.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeLessThan.java
@@ -31,7 +31,7 @@ public class SizeLessThan extends CollectionCondition {
   }
 
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return apply(0);
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/SizeLessThanOrEqual.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeLessThanOrEqual.java
@@ -31,7 +31,7 @@ public class SizeLessThanOrEqual extends CollectionCondition {
   }
 
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return apply(0);
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/SizeNotEqual.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeNotEqual.java
@@ -31,7 +31,7 @@ public class SizeNotEqual extends CollectionCondition {
   }
 
   @Override
-  public boolean applyNull() {
+  public boolean missingElementSatisfiesCondition() {
     return apply(0);
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/Matches.java
+++ b/src/main/java/com/codeborne/selenide/commands/Matches.java
@@ -26,7 +26,7 @@ public class Matches implements Command<Boolean> {
       return condition.apply(locator.driver(), element);
     }
 
-    return condition.applyNull();
+    return condition.missingElementSatisfiesCondition();
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/conditions/And.java
+++ b/src/main/java/com/codeborne/selenide/conditions/And.java
@@ -25,7 +25,7 @@ public class And extends Condition {
    * @throws IllegalArgumentException if {@code conditions} is empty
    */
   public And(String name, List<? extends Condition> conditions) {
-    super(name, checkedConditionsListCtorArg(conditions).stream().allMatch(Condition::applyNull));
+    super(name, checkedConditionsListCtorArg(conditions).stream().allMatch(Condition::missingElementSatisfiesCondition));
     this.conditions = conditions;
   }
 
@@ -39,7 +39,7 @@ public class And extends Condition {
   @Nonnull
   @Override
   public Condition negate() {
-    return new Not(this, conditions.stream().map(Condition::negate).allMatch(Condition::applyNull));
+    return new Not(this, conditions.stream().map(Condition::negate).allMatch(Condition::missingElementSatisfiesCondition));
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/conditions/Or.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Or.java
@@ -23,7 +23,7 @@ public class Or extends Condition {
    * @throws IllegalArgumentException if {@code conditions} is empty
    */
   public Or(String name, List<? extends Condition> conditions) {
-    super(name, checkedConditionsListCtorArg(conditions).stream().anyMatch(Condition::applyNull));
+    super(name, checkedConditionsListCtorArg(conditions).stream().anyMatch(Condition::missingElementSatisfiesCondition));
     this.conditions = conditions;
   }
 
@@ -37,7 +37,7 @@ public class Or extends Condition {
   @Nonnull
   @Override
   public Condition negate() {
-    return new Not(this, conditions.stream().map(Condition::negate).anyMatch(Condition::applyNull));
+    return new Not(this, conditions.stream().map(Condition::negate).anyMatch(Condition::missingElementSatisfiesCondition));
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -110,7 +110,7 @@ public abstract class WebElementSource {
     }
 
     if (element == null) {
-      if (!check.applyNull()) {
+      if (!check.missingElementSatisfiesCondition()) {
         throw createElementNotFoundError(check, lastError);
       }
     }

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -410,9 +410,9 @@ final class ConditionTest {
   }
 
   @Test
-  void conditionApplyNull() {
+  void conditionMissingElementSatisfiesCondition() {
     Condition condition = attribute("name");
-    assertThat(condition.applyNull()).isFalse();
+    assertThat(condition.missingElementSatisfiesCondition()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/collections/ContainExactTextsCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ContainExactTextsCaseSensitiveTest.java
@@ -194,11 +194,11 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testApplyNull() {
+  void testMissingElementSatisfiesCondition() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-One", "Test-Two", "Test-Three");
 
-    assertThat(expectedTexts.applyNull())
+    assertThat(expectedTexts.missingElementSatisfiesCondition())
       .isFalse();
   }
 }

--- a/src/test/java/com/codeborne/selenide/conditions/AndTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/AndTest.java
@@ -106,24 +106,24 @@ final class AndTest {
   }
 
   @Test
-  void applyNullMethodReturnsTrueOnlyIfAllConditionsReturnTrue() {
+  void missingElementSatisfiesConditionMethodReturnsTrueOnlyIfAllConditionsReturnTrue() {
     assertThat(
       new And("", asList(
         new SimpleCondition(false, true),
         new SimpleCondition(false, true),
         new SimpleCondition(false, true)
-      )).applyNull()
+      )).missingElementSatisfiesCondition()
     ).isTrue();
   }
 
   @Test
-  void applyNullMethodReturnsFalseIfAtLeastOneOfConditionsReturnFalse() {
+  void missingElementSatisfiesConditionMethodReturnsFalseIfAtLeastOneOfConditionsReturnFalse() {
     assertThat(
       new And("", asList(
         new SimpleCondition(true, false),
         new SimpleCondition(true, true),
         new SimpleCondition(true, true)
-      )).applyNull()
+      )).missingElementSatisfiesCondition()
     ).isFalse();
 
     assertThat(
@@ -131,7 +131,7 @@ final class AndTest {
         new SimpleCondition(true, true),
         new SimpleCondition(true, true),
         new SimpleCondition(true, false)
-      )).applyNull()
+      )).missingElementSatisfiesCondition()
     ).isFalse();
 
     assertThat(
@@ -139,31 +139,31 @@ final class AndTest {
         new SimpleCondition(false, false),
         new SimpleCondition(false, false),
         new SimpleCondition(false, false)
-      )).applyNull()
+      )).missingElementSatisfiesCondition()
     ).isFalse();
   }
 
   @Test
-  void negativeConditionApplyNullMethodRecalculatedResultForNegativeInnerConditions() {
+  void negativeConditionMissingElementSatisfiesConditionMethodRecalculatedResultForNegativeInnerConditions() {
     assertThat(
       new And("", asList(
         new SimpleCondition(false, true),
         new SimpleCondition(false, true)
-      )).negate().applyNull()
+      )).negate().missingElementSatisfiesCondition()
     ).isFalse();
 
     assertThat(
       new And("", asList(
         new SimpleCondition(false, false),
         new SimpleCondition(false, false)
-      )).negate().applyNull()
+      )).negate().missingElementSatisfiesCondition()
     ).isTrue();
 
     assertThat(
       new And("", asList(
         new SimpleCondition(false, true),
         new SimpleCondition(false, false)
-      )).negate().applyNull()
+      )).negate().missingElementSatisfiesCondition()
     ).isFalse();
   }
 
@@ -175,8 +175,8 @@ final class AndTest {
       this(applyResult, false);
     }
 
-    SimpleCondition(boolean applyResult, boolean applyNull) {
-      super("", applyNull);
+    SimpleCondition(boolean applyResult, boolean missingElementSatisfiesConditionResult) {
+      super("", missingElementSatisfiesConditionResult);
       this.applyResult = applyResult;
     }
 
@@ -188,12 +188,12 @@ final class AndTest {
     @Nonnull
     @Override
     public Condition negate() {
-      return new Not(this, !this.applyNull());
+      return new Not(this, !this.missingElementSatisfiesCondition());
     }
 
     @Override
     public String toString() {
-      return "SimpleCondition(" + this.applyResult + ", " + this.applyNull() + ")";
+      return "SimpleCondition(" + this.applyResult + ", " + this.missingElementSatisfiesCondition() + ")";
     }
   }
 }

--- a/src/test/java/com/codeborne/selenide/conditions/OrTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/OrTest.java
@@ -106,24 +106,24 @@ final class OrTest {
   }
 
   @Test
-  void applyNullMethodReturnsFalseOnlyIfAllConditionsReturnFalse() {
+  void missingElementSatisfiesConditionMethodReturnsFalseOnlyIfAllConditionsReturnFalse() {
     assertThat(
       new Or("", asList(
         new SimpleCondition(true, false),
         new SimpleCondition(true, false),
         new SimpleCondition(true, false)
-      )).applyNull()
+      )).missingElementSatisfiesCondition()
     ).isFalse();
   }
 
   @Test
-  void applyNullMethodReturnsTrueIfAtLeastOneOfConditionsReturnTrue() {
+  void missingElementSatisfiesConditionMethodReturnsTrueIfAtLeastOneOfConditionsReturnTrue() {
     assertThat(
       new Or("", asList(
         new SimpleCondition(true, true),
         new SimpleCondition(true, false),
         new SimpleCondition(true, false)
-      )).applyNull()
+      )).missingElementSatisfiesCondition()
     ).isTrue();
 
     assertThat(
@@ -131,7 +131,7 @@ final class OrTest {
         new SimpleCondition(true, false),
         new SimpleCondition(true, false),
         new SimpleCondition(true, true)
-      )).applyNull()
+      )).missingElementSatisfiesCondition()
     ).isTrue();
 
     assertThat(
@@ -139,31 +139,31 @@ final class OrTest {
         new SimpleCondition(false, true),
         new SimpleCondition(false, true),
         new SimpleCondition(false, true)
-      )).applyNull()
+      )).missingElementSatisfiesCondition()
     ).isTrue();
   }
 
   @Test
-  void negativeConditionApplyNullMethodRecalculatedResultForNegativeInnerConditions() {
+  void negativeConditionMissingElementSatisfiesConditionMethodRecalculatedResultForNegativeInnerConditions() {
     assertThat(
       new Or("", asList(
         new SimpleCondition(false, false),
         new SimpleCondition(false, false)
-      )).negate().applyNull()
+      )).negate().missingElementSatisfiesCondition()
     ).isTrue();
 
     assertThat(
       new Or("", asList(
         new SimpleCondition(false, true),
         new SimpleCondition(false, true)
-      )).negate().applyNull()
+      )).negate().missingElementSatisfiesCondition()
     ).isFalse();
 
     assertThat(
       new Or("", asList(
         new SimpleCondition(false, true),
         new SimpleCondition(false, false)
-      )).negate().applyNull()
+      )).negate().missingElementSatisfiesCondition()
     ).isTrue();
   }
 
@@ -175,8 +175,8 @@ final class OrTest {
       this(applyResult, false);
     }
 
-    SimpleCondition(boolean applyResult, boolean applyNull) {
-      super("", applyNull);
+    SimpleCondition(boolean applyResult, boolean missingElementSatisfiesConditionResult) {
+      super("", missingElementSatisfiesConditionResult);
       this.applyResult = applyResult;
     }
 
@@ -188,12 +188,12 @@ final class OrTest {
     @Nonnull
     @Override
     public Condition negate() {
-      return new Not(this, !this.applyNull());
+      return new Not(this, !this.missingElementSatisfiesCondition());
     }
 
     @Override
     public String toString() {
-      return "SimpleCondition(" + this.applyResult + ", " + this.applyNull() + ")";
+      return "SimpleCondition(" + this.applyResult + ", " + this.missingElementSatisfiesCondition() + ")";
     }
   }
 }


### PR DESCRIPTION
From #1541

## Proposed changes
- removed method `applyNull`
- replaced `applyNull` `Condition` method usages with `missingElementSatisfiesCondition`
- renamed `applyNull` `CollectionCondition` method to `missingElementSatisfiesCondition`


## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
