### PR TITLE
WebDriverRunner no longer implements Browsers

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -20,7 +20,7 @@ import static com.codeborne.selenide.Configuration.headless;
  * A static facade for accessing WebDriver instance for current threads
  */
 @ParametersAreNonnullByDefault
-public class WebDriverRunner implements Browsers {
+public class WebDriverRunner {
   public static WebDriverContainer webdriverContainer = new WebDriverThreadLocalContainer();
   private static final SelenideDriver staticSelenideDriver = new ThreadLocalSelenideDriver();
 


### PR DESCRIPTION
## Proposed changes
Just the smallest refactoring :)
`WebDriverRunner implements Browsers` means "WebDriverRunner implements interface that contains only static constants". `WebDriverRunner` no longer implements `Browser`.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
