### PR TITLE
Proposed collection condition: check if collection elements contain / do not contain given attribute with value

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide;
 
 import com.codeborne.selenide.collections.AllMatch;
 import com.codeborne.selenide.collections.AnyMatch;
+import com.codeborne.selenide.collections.Attribute;
 import com.codeborne.selenide.collections.ContainExactTextsCaseSensitive;
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.collections.ExactTextsCaseSensitiveInAnyOrder;
@@ -148,6 +149,11 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
   @CheckReturnValue
   public static CollectionCondition allMatch(String description, java.util.function.Predicate<WebElement> predicate) {
     return new AllMatch(description, predicate);
+  }
+
+  @CheckReturnValue
+  public static CollectionCondition allElementsWithAttribute(String attribute, String attributeValue) {
+    return new Attribute(attribute, attributeValue);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/collections/Attribute.java
+++ b/src/main/java/com/codeborne/selenide/collections/Attribute.java
@@ -1,0 +1,54 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.CollectionCondition;
+import com.codeborne.selenide.ex.CollectionNotAllElementsHaveAttributeWithValue;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.impl.CollectionSource;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+
+@ParametersAreNonnullByDefault
+public class Attribute extends CollectionCondition {
+
+  private final String attributeName;
+  private final String attributeValue;
+
+  public Attribute(String attributeName, String attributeValue) {
+    this.attributeName = attributeName;
+    this.attributeValue = attributeValue;
+  }
+
+  @Override
+  public void fail(
+    CollectionSource collection,
+    @Nullable List<WebElement> elements,
+    @Nullable Exception lastError,
+    long timeoutMs
+  ) {
+    if (elements == null || elements.isEmpty()) {
+      ElementNotFound elementNotFound = new ElementNotFound(collection, toString(), lastError);
+      elementNotFound.timeoutMs = timeoutMs;
+      throw elementNotFound;
+    } else {
+      throw new CollectionNotAllElementsHaveAttributeWithValue(
+        collection.driver(),
+        "Not all elements have attribute " + attributeName + " with value " + attributeValue,
+        lastError
+      );
+    }
+
+  }
+
+  @Override
+  public boolean missingElementSatisfiesCondition() {
+    return false;
+  }
+
+  @Override
+  public boolean test(List<WebElement> webElements) {
+    return webElements.stream().allMatch(el -> el.getAttribute(attributeName).equals(attributeValue));
+  }
+}

--- a/src/main/java/com/codeborne/selenide/ex/CollectionNotAllElementsHaveAttributeWithValue.java
+++ b/src/main/java/com/codeborne/selenide/ex/CollectionNotAllElementsHaveAttributeWithValue.java
@@ -1,0 +1,12 @@
+package com.codeborne.selenide.ex;
+
+import com.codeborne.selenide.Driver;
+
+import javax.annotation.Nullable;
+
+public class CollectionNotAllElementsHaveAttributeWithValue extends UIAssertionError {
+
+  public CollectionNotAllElementsHaveAttributeWithValue(Driver driver, String message, @Nullable Throwable cause) {
+    super(driver, message, cause);
+  }
+}


### PR DESCRIPTION
Proposing a new collection condition that asserts that all collection elements contain or do not contain a given attribute with value.
There's already a condition `CollectionCondition.allMatch()` and `noneMatch()`, but I see two downsides with it. First, it accepts the `Predicate<WebElement>` and it might not be easy and clear for many users how to use it. Second, when the above conditions fail, the error message is generic, it says `Collection matcher error` and doesn't give information on the predicate that was applied. That is understandable, why it doesn't provide more info - because you can't extract more information from the predicate.

With the proposed new condition - the usage would be much simpler, the user would need just to pass in an attribute name and value that all collection elements are expected to have. And it would be possible to specify a more descriptive and informative error message under the hood with both the attribute and name that are expected but not met.

@asolntsev what do you think about this? Is it needed or is unnecessary?
I have quickly created a rough prototype in this PR just to initiate a discussion. Not ready for review yet. Just a draft, so that we all won't waste time if the decision would be not doing it.