### PR TITLE
Checks for disabled select/option when using selectOption* methods

### DIFF
--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
@@ -43,14 +43,14 @@ public class SelectOptionByTextOrIndex implements Command<Void> {
     Select select = new Select(selectWebElement);
     for (String text : texts) {
       try {
+        select.selectByVisibleText(text);
+
         WebElement option = selectWebElement.findElement(By.xpath(
           ".//option[normalize-space(.) = " + Quotes.escape(text) + "]"));
         if (!option.isEnabled()) {
           throw new InvalidStateException(selectField.driver(),
             "Cannot select a disabled option: " + selectField.description() + "/option[text:" + text + "]");
         }
-
-        select.selectByVisibleText(text);
       }
       catch (NoSuchElementException e) {
         throw new ElementNotFound(selectField.driver(),
@@ -64,14 +64,14 @@ public class SelectOptionByTextOrIndex implements Command<Void> {
     Select select = new Select(selectWebElement);
     for (int index : indexes) {
       try {
+        select.selectByIndex(index);
+
         WebElement option = selectWebElement.findElement(By.xpath(
           ".//option[" + (index + 1) + "]"));
         if (!option.isEnabled()) {
           throw new InvalidStateException(selectField.driver(),
             "Cannot select a disabled option: " + selectField.description() + "/option[index:" + index + "]");
         }
-
-        select.selectByIndex(index);
       }
       catch (NoSuchElementException e) {
         throw new ElementNotFound(selectField.driver(),

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
@@ -3,8 +3,12 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.InvalidStateException;
 import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Quotes;
 import org.openqa.selenium.support.ui.Select;
 
 import javax.annotation.Nullable;
@@ -17,29 +21,41 @@ public class SelectOptionByValue implements Command<Void> {
   @Override
   @Nullable
   public Void execute(SelenideElement proxy, WebElementSource selectField, @Nullable Object[] args) {
-    Select select = new Select(selectField.getWebElement());
+    if (!selectField.getWebElement().isEnabled()) {
+      throw new InvalidStateException(selectField.driver(),
+        "Cannot select anything in a disabled select element: " + selectField);
+    }
 
     if (args == null || args.length == 0) {
       throw new IllegalArgumentException("Missing arguments");
     }
     else if (args[0] instanceof String) {
-      selectOptionByValue(selectField, select, (String) args[0]);
+      selectOptionByValue(selectField, (String) args[0]);
     }
     else if (args[0] instanceof String[]) {
       String[] values = (String[]) args[0];
       for (String value : values) {
-        selectOptionByValue(selectField, select, value);
+        selectOptionByValue(selectField, value);
       }
     }
     return null;
   }
 
-  private void selectOptionByValue(WebElementSource selectField, Select select, String value) {
+  private void selectOptionByValue(WebElementSource selectField, String value) {
+    Select select = new Select(selectField.getWebElement());
     try {
+      WebElement option = selectField.getWebElement().findElement(By.xpath(
+        ".//option[@value = " + Quotes.escape(value) + "]"));
+      if (!option.isEnabled()) {
+        throw new InvalidStateException(selectField.driver(),
+          "Cannot select a disabled option: " + selectField.description() + "/option[value:" + value + "]");
+      }
+
       select.selectByValue(value);
     }
     catch (NoSuchElementException e) {
-      throw new ElementNotFound(selectField.driver(), selectField.description() + "/option[value:" + value + ']', exist, e);
+      throw new ElementNotFound(selectField.driver(),
+        selectField.description() + "/option[value:" + value + ']', exist, e);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
@@ -44,14 +44,14 @@ public class SelectOptionByValue implements Command<Void> {
   private void selectOptionByValue(WebElementSource selectField, String value) {
     Select select = new Select(selectField.getWebElement());
     try {
+      select.selectByValue(value);
+
       WebElement option = selectField.getWebElement().findElement(By.xpath(
         ".//option[@value = " + Quotes.escape(value) + "]"));
       if (!option.isEnabled()) {
         throw new InvalidStateException(selectField.driver(),
           "Cannot select a disabled option: " + selectField.description() + "/option[value:" + value + "]");
       }
-
-      select.selectByValue(value);
     }
     catch (NoSuchElementException e) {
       throw new ElementNotFound(selectField.driver(),

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionContainingText.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionContainingText.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.InvalidStateException;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -30,8 +31,17 @@ public class SelectOptionContainingText implements Command<Void> {
     if (options.isEmpty()) {
       throw new NoSuchElementException("Cannot locate option containing text: " + text);
     }
+    if (!element.isEnabled()) {
+      throw new InvalidStateException(selectField.driver(),
+        "Cannot select anything in a disabled select element: " + selectField);
+    }
 
     for (WebElement option : options) {
+      if (!option.isEnabled()) {
+        throw new InvalidStateException(selectField.driver(),
+          "Cannot select a disabled option containing text: " + text);
+      }
+
       setSelected(option);
       if (!select.isMultiple()) {
         break;

--- a/src/test/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndexCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndexCommandTest.java
@@ -32,14 +32,18 @@ final class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
     when(selectField.getWebElement()).thenReturn(mockedElement);
     when(mockedElement.getText()).thenReturn(defaultElementText);
     when(mockedElement.getTagName()).thenReturn("select");
+    when(mockedElement.isEnabled()).thenReturn(true);
 
     when(mockedFoundElement.isSelected()).thenReturn(true);
+    when(mockedFoundElement.isEnabled()).thenReturn(true);
   }
 
   @Test
   void testSelectOptionByText() {
     when(mockedElement.findElements(By.xpath(".//option[normalize-space(.) = " + Quotes.escape(defaultElementText) + "]")))
       .thenReturn(singletonList(mockedFoundElement));
+    when(mockedElement.findElement(By.xpath(".//option[normalize-space(.) = " + Quotes.escape(defaultElementText) + "]")))
+      .thenReturn(mockedFoundElement);
     selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new String[]{this.defaultElementText}});
   }
 
@@ -71,6 +75,7 @@ final class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
   @Test
   void selectOptionByIndex() {
     when(mockedElement.findElements(By.tagName("option"))).thenReturn(singletonList(mockedFoundElement));
+    when(mockedElement.findElement(By.xpath(".//option[" + (defaultIndex + 1) + "]"))).thenReturn(mockedFoundElement);
     when(mockedFoundElement.getAttribute("index")).thenReturn(String.valueOf(defaultIndex));
     selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new int[]{defaultIndex}});
   }

--- a/src/test/java/com/codeborne/selenide/commands/SelectOptionContainingTextTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectOptionContainingTextTest.java
@@ -28,6 +28,9 @@ final class SelectOptionContainingTextTest implements WithAssertions {
   void setUp() {
     doReturn(element).when(select).getWebElement();
     doReturn("select").when(element).getTagName();
+    doReturn(true).when(element).isEnabled();
+    doReturn(true).when(option1).isEnabled();
+    doReturn(true).when(option2).isEnabled();
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
@@ -30,13 +30,17 @@ final class SelectionOptionByValueCommandTest implements WithAssertions {
     when(selectField.description()).thenReturn("By.tagName{select}");
     when(element.getText()).thenReturn("walue");
     when(element.getTagName()).thenReturn("select");
+    when(element.isEnabled()).thenReturn(true);
     when(foundElement.isSelected()).thenReturn(true);
+    when(foundElement.isEnabled()).thenReturn(true);
   }
 
   @Test
   void selectByValueWithStringFromArgs() {
     when(element.findElements(By.xpath(".//option[@value = \"walue\"]")))
       .thenReturn(Collections.singletonList(foundElement));
+    when(element.findElement(By.xpath(".//option[@value = \"walue\"]")))
+      .thenReturn(foundElement);
     selectOptionByValueCommand.execute(proxy, selectField, new Object[]{"walue"});
   }
 
@@ -44,6 +48,8 @@ final class SelectionOptionByValueCommandTest implements WithAssertions {
   void selectByValueWithStringArrayFromArgs() {
     when(element.findElements(By.xpath(".//option[@value = \"walue\"]")))
       .thenReturn(Collections.singletonList(foundElement));
+    when(element.findElement(By.xpath(".//option[@value = \"walue\"]")))
+      .thenReturn(foundElement);
     selectOptionByValueCommand.execute(proxy, selectField, new Object[]{new String[]{"walue"}});
   }
 

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -7,6 +7,7 @@ import com.codeborne.selenide.ex.InvalidStateException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 
 import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.empty;
@@ -341,5 +342,15 @@ final class SelectsTest extends IntegrationTest {
     assertThatThrownBy(() -> selectMultiple.selectOptionByValue("volvo", "audi", "saab"))
       .isInstanceOf(InvalidStateException.class)
       .hasMessageContaining("Cannot select a disabled option: #cars/option[value:saab]");
+
+    assertThatThrownBy(() -> select.selectOptionByValue("somevalue"))
+      .isInstanceOf(ElementNotFound.class);
+    assertThatThrownBy(() -> select.selectOption(10))
+      .isInstanceOf(ElementNotFound.class);
+    assertThatThrownBy(() -> select.selectOption("TEXT"))
+      .isInstanceOf(ElementNotFound.class);
+    assertThatThrownBy(() -> select.selectOptionContainingText("TEXT"))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageContaining("Cannot locate option containing text: TEXT");
   }
 }

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -342,15 +342,5 @@ final class SelectsTest extends IntegrationTest {
     assertThatThrownBy(() -> selectMultiple.selectOptionByValue("volvo", "audi", "saab"))
       .isInstanceOf(InvalidStateException.class)
       .hasMessageContaining("Cannot select a disabled option: #cars/option[value:saab]");
-
-    assertThatThrownBy(() -> select.selectOptionByValue("somevalue"))
-      .isInstanceOf(ElementNotFound.class);
-    assertThatThrownBy(() -> select.selectOption(10))
-      .isInstanceOf(ElementNotFound.class);
-    assertThatThrownBy(() -> select.selectOption("TEXT"))
-      .isInstanceOf(ElementNotFound.class);
-    assertThatThrownBy(() -> select.selectOptionContainingText("TEXT"))
-      .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("Cannot locate option containing text: TEXT");
   }
 }


### PR DESCRIPTION
## Changes

### Before: 
`SelenideElement.selectOption*` methods used underlying Selenium's `Select.setSelected()` method that simply clicked on the option. If `<select>` element was _disabled_ or the selected `<option>` was _disabled_ , no exceptions were raised, and the test continued.

### Now:

All `SelenideElement.selectOption*` methods will throw `InvalidStateException` if the test selects an option either from disabled `<select>` element or the `<option>` itself is disabled.