### PR TITLE
Add `SelenideElement.ancestor()` method

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -640,13 +640,42 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement lastChild();
 
   /**
-   * Locates closes ancestor element matching given criteria
+   * Locates the closest ancestor element matching given criteria.
+   * <br/>
+   * For example, $("td").ancestor("table") returns the closest "table" element above "td".
+   * <br/>
+   * Same as {@code ancestor("tagOrClass", 0)} or {@code closest("tagOrClass")}.
    *
-   * For example, $("td").closest("table") could give some "table".
-   *
-   * @param tagOrClass Either HTML tag or CSS class. E.g. "form" or ".active".
+   * @param tagOrClass Either HTML tag or CSS class. E.g. "form" (tag) or ".active" (class).
    * @return Matching ancestor element
-   * @see com.codeborne.selenide.commands.GetClosest
+   * @see com.codeborne.selenide.commands.Ancestor
+   * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
+   */
+  @CheckReturnValue
+  @Nonnull
+  SelenideElement ancestor(String tagOrClass);
+
+  /**
+   * Locates the Nth ancestor element matching given criteria.
+   * <br/>
+   * For example, $("td").closest("table", 1) returns the 2nd "table" element above "td".
+   *
+   * @param tagOrClass Either HTML tag or CSS class. E.g. "form" (tag) or ".active" (class).
+   * @param index      0...N index of the ancestor. 0 is the closest, 1 is higher up the hierarchy, etc...
+   * @return Matching ancestor element
+   * @see com.codeborne.selenide.commands.Ancestor
+   * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
+   */
+  @CheckReturnValue
+  @Nonnull
+  SelenideElement ancestor(String tagOrClass, int index);
+
+  /**
+   * Same as {@link #ancestor(String)}.
+   *
+   * @param tagOrClass Either HTML tag or CSS class. E.g. "form" (tag) or ".active" (class).
+   * @return Matching ancestor element
+   * @see com.codeborne.selenide.commands.Ancestor
    * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
    */
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/commands/Ancestor.java
+++ b/src/main/java/com/codeborne/selenide/commands/Ancestor.java
@@ -14,15 +14,19 @@ import static com.codeborne.selenide.commands.Util.firstOf;
 import static java.lang.String.format;
 
 @ParametersAreNonnullByDefault
-public class GetClosest implements Command<SelenideElement> {
+public class Ancestor implements Command<SelenideElement> {
   @Override
   @CheckReturnValue
   @Nonnull
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     String tagOrClass = firstOf(args);
+    int indexPredicate = args.length > 1 ?
+      (args[1] instanceof Integer ? (int) args[1] + 1 : 1) :
+      1;
+
     String xpath = tagOrClass.startsWith(".") ?
-        format("ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')][1]", tagOrClass.substring(1)) :
-        format("ancestor::%s[1]", tagOrClass);
+      format("ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')][" + indexPredicate + "]", tagOrClass.substring(1)) :
+      format("ancestor::%s[" + indexPredicate + "]", tagOrClass);
     return locator.find(proxy, By.xpath(xpath), 0);
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/Ancestor.java
+++ b/src/main/java/com/codeborne/selenide/commands/Ancestor.java
@@ -25,8 +25,10 @@ public class Ancestor implements Command<SelenideElement> {
       1;
 
     String xpath = tagOrClass.startsWith(".") ?
-      format("ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')][" + indexPredicate + "]", tagOrClass.substring(1)) :
-      format("ancestor::%s[" + indexPredicate + "]", tagOrClass);
+      format("ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')][" + indexPredicate + "]",
+        tagOrClass.substring(1)) :
+      format("ancestor::%s[" + indexPredicate + "]",
+        tagOrClass);
     return locator.find(proxy, By.xpath(xpath), 0);
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -101,7 +101,8 @@ public class Commands {
     add("findAll", new FindAll());
     add("$$", new FindAll());
     add("$$x", new FindAllByXpath());
-    add("closest", new GetClosest());
+    add("ancestor", new Ancestor());
+    add("closest", new Ancestor());
     add("parent", new GetParent());
     add("sibling", new GetSibling());
     add("preceding", new GetPreceding());

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -47,7 +47,8 @@ class SelenideElementProxy implements InvocationHandler {
       "sibling",
       "preceding",
       "lastChild",
-      "closest"
+      "closest",
+      "ancestor"
   ));
 
   private static final Set<String> methodsForSoftAssertion = new HashSet<>(asList(

--- a/src/test/java/com/codeborne/selenide/commands/AncestorCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/AncestorCommandTest.java
@@ -9,11 +9,11 @@ import org.openqa.selenium.By;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class GetClosestCommandTest implements WithAssertions {
+final class AncestorCommandTest implements WithAssertions {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetClosest getClosestCommand = new GetClosest();
+  private final Ancestor ancestorCommand = new Ancestor();
 
   @Test
   void testExecuteMethodWithTagsStartsWithDot() {
@@ -26,7 +26,7 @@ final class GetClosestCommandTest implements WithAssertions {
           argument.substring(1))),
       0)).
       thenReturn(mockedElement);
-    assertThat(getClosestCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
+    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
       .isEqualTo(mockedElement);
   }
 
@@ -36,7 +36,29 @@ final class GetClosestCommandTest implements WithAssertions {
     String elementAttribute = "hello";
     when(mockedElement.getAttribute(argument)).thenReturn(elementAttribute);
     when(locator.find(proxy, By.xpath(String.format("ancestor::%s[1]", argument)), 0)).thenReturn(mockedElement);
-    assertThat(getClosestCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
+    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
+      .isEqualTo(mockedElement);
+  }
+
+  @Test
+  void testExecuteMethodWithZeroIndex() {
+    String argument = "class";
+    String elementAttribute = "hello";
+    when(mockedElement.getAttribute(argument)).thenReturn(elementAttribute);
+    when(locator.find(proxy, By.xpath(String.format("ancestor::%s[1]", argument)), 0))
+      .thenReturn(mockedElement);
+    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{argument, 0}))
+      .isEqualTo(mockedElement);
+  }
+
+  @Test
+  void testExecuteMethodWithNonZeroIndex() {
+    String argument = "class";
+    String elementAttribute = "hello";
+    when(mockedElement.getAttribute(argument)).thenReturn(elementAttribute);
+    when(locator.find(proxy, By.xpath(String.format("ancestor::%s[3]", argument)), 0))
+      .thenReturn(mockedElement);
+    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{argument, 2}))
       .isEqualTo(mockedElement);
   }
 }

--- a/src/test/java/integration/ParentTest.java
+++ b/src/test/java/integration/ParentTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.codeborne.selenide.SelenideElement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -48,5 +49,33 @@ final class ParentTest extends ITest {
       .isEqualTo($("#multirowTable"));
     assertThat($(".second_row").closest(".multirow_table"))
       .isEqualTo($("#multirowTable"));
+  }
+
+  @Test
+  void canGetAncestorByTagName() {
+    SelenideElement element = $(By.name("domain"));
+
+    assertThat(element.ancestor("div"))
+      .isEqualTo($("#dropdown-list-container"));
+    assertThat(element.ancestor("div", 0))
+      .isEqualTo($("#dropdown-list-container"));
+    assertThat(element.ancestor("div", 1))
+      .isEqualTo($("#domain-container"));
+    assertThat(element.ancestor("div", 10).exists())
+      .isFalse();
+  }
+
+  @Test
+  void canGetAncestorByClassName() {
+    SelenideElement element = $(By.name("domain"));
+
+    assertThat(element.ancestor(".container"))
+      .isEqualTo($("#dropdown-list-container"));
+    assertThat(element.ancestor(".container", 0))
+      .isEqualTo($("#dropdown-list-container"));
+    assertThat(element.ancestor(".container", 1))
+      .isEqualTo($("#domain-container"));
+    assertThat(element.ancestor(".container", 10).exists())
+      .isFalse();
   }
 }


### PR DESCRIPTION
## Proposed changes
Implementation for #1556 

## Note
I thought that simply having `ancestor()` method as a synonym for `closest()` is a bit misleading because `ancestor` in XPath is a more general function, so I decided to add overloaded version with **index** as a parameter as well:
```java
$("td").ancestor("div"); // same as $("td").closest("div")
$("td").ancestor("div", 0); // same as $("td").closest("div")
$("td").ancestor("div", 1); // gets the 2nd closest element to "td" (up the hierarchy)
```

Existing `SelenideElement` "find" functions like `preceding()` and `sibling()` also have indexes as parameters, so probably this is ok too. Let me know what you guys think of it.