### PR TITLE
big cleanup of unit-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It defines concise fluent API, natural language assertions and does some magic f
 Selenide is based on and is compatible to Selenium WebDriver 2.0+ and 3.0+
 
     @Test
-    public void testLogin() {
+    public void login() {
       open("/login");
       $(By.name("user.name")).setValue("johny");
       $("#submit").click();

--- a/modules/testng/src/test/java/com/codeborne/selenide/testng/SoftAssertsTest.java
+++ b/modules/testng/src/test/java/com/codeborne/selenide/testng/SoftAssertsTest.java
@@ -2,17 +2,16 @@ package com.codeborne.selenide.testng;
 
 import com.codeborne.selenide.logevents.ErrorsCollector;
 import com.codeborne.selenide.logevents.SelenideLogger;
-import org.assertj.core.api.WithAssertions;
 import org.testng.IClass;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.testng.internal.ConstructorOrMethod;
 
 import static com.codeborne.selenide.logevents.ErrorsCollector.LISTENER_SOFT_ASSERT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
@@ -24,7 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.ITestResult.FAILURE;
 
-final class SoftAssertsTest implements WithAssertions {
+final class SoftAssertsTest {
   private final SoftAsserts listener = new SoftAsserts();
 
   @AfterMethod

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -200,7 +200,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
       }
       catch (WebDriverException | IndexOutOfBoundsException | UIAssertionError elementNotFound) {
         if (Cleanup.of.isInvalidSelectorError(elementNotFound)) {
-          throw Cleanup.of.wrap(elementNotFound);
+          throw Cleanup.of.wrapInvalidSelectorException(elementNotFound);
         }
         if (condition.missingElementSatisfiesCondition()) {
           return;

--- a/src/main/java/com/codeborne/selenide/commands/Exists.java
+++ b/src/main/java/com/codeborne/selenide/commands/Exists.java
@@ -22,12 +22,14 @@ public class Exists implements Command<Boolean> {
       //noinspection ResultOfMethodCallIgnored
       locator.getWebElement();
       return true;
-    } catch (WebDriverException | ElementNotFound elementNotFound) {
+    }
+    catch (WebDriverException | ElementNotFound elementNotFound) {
       if (Cleanup.of.isInvalidSelectorError(elementNotFound)) {
-        throw Cleanup.of.wrap(elementNotFound);
+        throw Cleanup.of.wrapInvalidSelectorException(elementNotFound);
       }
       return false;
-    } catch (IndexOutOfBoundsException invalidElementIndex) {
+    }
+    catch (IndexOutOfBoundsException invalidElementIndex) {
       return false;
     }
   }

--- a/src/main/java/com/codeborne/selenide/commands/GetLastChild.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetLastChild.java
@@ -16,10 +16,10 @@ public class GetLastChild implements Command<SelenideElement> {
   private final Find find;
 
   public GetLastChild() {
-    find = new Find();
+    this(new Find());
   }
 
-  public GetLastChild(Find find) {
+  GetLastChild(Find find) {
     this.find = find;
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/GetParent.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetParent.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-
 import org.openqa.selenium.By;
 
 import javax.annotation.CheckReturnValue;
@@ -16,7 +15,7 @@ public class GetParent implements Command<SelenideElement> {
   private final Find find;
 
   GetParent() {
-    this.find = new Find();
+    this(new Find());
   }
 
   GetParent(Find find) {

--- a/src/main/java/com/codeborne/selenide/commands/GetPreceding.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetPreceding.java
@@ -19,8 +19,6 @@ public class GetPreceding implements Command<SelenideElement> {
   @CheckReturnValue
   @Nonnull
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
-    assert args != null;
-
     int siblingIndex = (int) firstOf(args) + 1;
     return locator.find(proxy, By.xpath(String.format("preceding-sibling::*[%d]", siblingIndex)), 0);
   }

--- a/src/main/java/com/codeborne/selenide/commands/GetSelectedValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSelectedValue.java
@@ -8,24 +8,23 @@ import org.openqa.selenium.WebElement;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.io.IOException;
 
 @ParametersAreNonnullByDefault
 public class GetSelectedValue implements Command<String> {
-  private final Command<SelenideElement> getSelectedOption;
+  private final GetSelectedOption getSelectedOption;
 
   public GetSelectedValue() {
-    this.getSelectedOption = new GetSelectedOption();
+    this(new GetSelectedOption());
   }
 
-  public GetSelectedValue(Command<SelenideElement> getSelectedOption) {
+  GetSelectedValue(GetSelectedOption getSelectedOption) {
     this.getSelectedOption = getSelectedOption;
   }
 
   @Override
   @CheckReturnValue
   @Nullable
-  public String execute(SelenideElement proxy, WebElementSource selectElement, @Nullable Object[] args) throws IOException {
+  public String execute(SelenideElement proxy, WebElementSource selectElement, @Nullable Object[] args) {
     WebElement option = getSelectedOption.execute(proxy, selectElement, args);
     return option == null ? null : option.getAttribute("value");
   }

--- a/src/main/java/com/codeborne/selenide/commands/GetText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetText.java
@@ -15,10 +15,10 @@ public class GetText implements Command<String> {
   private final GetSelectedText getSelectedText;
 
   public GetText() {
-    this.getSelectedText = new GetSelectedText();
+    this(new GetSelectedText());
   }
 
-  public GetText(GetSelectedText getSelectedtext) {
+  GetText(GetSelectedText getSelectedtext) {
     this.getSelectedText = getSelectedtext;
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/IsDisplayed.java
+++ b/src/main/java/com/codeborne/selenide/commands/IsDisplayed.java
@@ -28,7 +28,7 @@ public class IsDisplayed implements Command<Boolean> {
     }
     catch (WebDriverException | ElementNotFound elementNotFound) {
       if (Cleanup.of.isInvalidSelectorError(elementNotFound)) {
-        throw Cleanup.of.wrap(elementNotFound);
+        throw Cleanup.of.wrapInvalidSelectorException(elementNotFound);
       }
       return false;
     }

--- a/src/main/java/com/codeborne/selenide/commands/Matches.java
+++ b/src/main/java/com/codeborne/selenide/commands/Matches.java
@@ -34,14 +34,14 @@ public class Matches implements Command<Boolean> {
   protected WebElement getElementOrNull(WebElementSource locator) {
     try {
       return locator.getWebElement();
-    } catch (WebDriverException | ElementNotFound elementNotFound) {
+    }
+    catch (WebDriverException | ElementNotFound elementNotFound) {
       if (Cleanup.of.isInvalidSelectorError(elementNotFound))
-        throw Cleanup.of.wrap(elementNotFound);
+        throw Cleanup.of.wrapInvalidSelectorException(elementNotFound);
       return null;
-    } catch (IndexOutOfBoundsException ignore) {
+    }
+    catch (IndexOutOfBoundsException ignore) {
       return null;
-    } catch (RuntimeException e) {
-      throw Cleanup.of.wrap(e);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.support.ui.Select;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Arrays;
 
 import static com.codeborne.selenide.Condition.exist;
 
@@ -22,11 +23,15 @@ public class SelectOptionByTextOrIndex implements Command<Void> {
     }
     else if (args[0] instanceof String[]) {
       selectOptionsByTexts(selectField, (String[]) args[0]);
+      return null;
     }
     else if (args[0] instanceof int[]) {
       selectOptionsByIndexes(selectField, (int[]) args[0]);
+      return null;
     }
-    return null;
+    else {
+      throw new IllegalArgumentException("Unsupported argument (expected String or Integer): " + Arrays.toString(args));
+    }
   }
 
   private void selectOptionsByTexts(WebElementSource selectField, String[] texts) {

--- a/src/main/java/com/codeborne/selenide/commands/SelectRadio.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectRadio.java
@@ -21,10 +21,10 @@ public class SelectRadio implements Command<SelenideElement> {
   private final Click click;
 
   public SelectRadio() {
-    this.click = new Click();
+    this(new Click());
   }
 
-  public SelectRadio(Click click) {
+  SelectRadio(Click click) {
     this.click = click;
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/SetValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SetValue.java
@@ -20,11 +20,10 @@ public class SetValue implements Command<SelenideElement> {
   private final SelectRadio selectRadio;
 
   public SetValue() {
-    this.selectOptionByValue = new SelectOptionByValue();
-    this.selectRadio = new SelectRadio();
+    this(new SelectOptionByValue(), new SelectRadio());
   }
 
-  public SetValue(SelectOptionByValue selectOptionByValue, SelectRadio selectRadio) {
+  SetValue(SelectOptionByValue selectOptionByValue, SelectRadio selectRadio) {
     this.selectOptionByValue = selectOptionByValue;
     this.selectRadio = selectRadio;
   }
@@ -34,19 +33,23 @@ public class SetValue implements Command<SelenideElement> {
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     String text = firstOf(args);
     WebElement element = locator.findAndAssertElementIsInteractable();
+    Driver driver = locator.driver();
 
-    if (locator.driver().config().versatileSetValue()
-      && "select".equalsIgnoreCase(element.getTagName())) {
+    if (!driver.config().versatileSetValue()) {
+      setValueForTextInput(driver, element, text);
+      return proxy;
+    }
+
+    String tagName = element.getTagName();
+    if ("select".equalsIgnoreCase(tagName)) {
       selectOptionByValue.execute(proxy, locator, args);
-      return proxy;
     }
-    if (locator.driver().config().versatileSetValue()
-      && "input".equalsIgnoreCase(element.getTagName()) && "radio".equals(element.getAttribute("type"))) {
+    else if ("input".equalsIgnoreCase(tagName) && "radio".equals(element.getAttribute("type"))) {
       selectRadio.execute(proxy, locator, args);
-      return proxy;
     }
-
-    setValueForTextInput(locator.driver(), element, text);
+    else {
+      setValueForTextInput(driver, element, text);
+    }
     return proxy;
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/Val.java
+++ b/src/main/java/com/codeborne/selenide/commands/Val.java
@@ -17,7 +17,7 @@ public class Val implements Command<Object> {
     this.setValue = new SetValue();
   }
 
-  public Val(GetValue getValue, SetValue setValue) {
+  Val(GetValue getValue, SetValue setValue) {
     this.getValue = getValue;
     this.setValue = setValue;
   }

--- a/src/main/java/com/codeborne/selenide/impl/Cleanup.java
+++ b/src/main/java/com/codeborne/selenide/impl/Cleanup.java
@@ -65,7 +65,7 @@ public class Cleanup {
       message.contains("INVALID_EXPRESSION_ERR");
   }
 
-  public InvalidSelectorException wrap(Throwable error) {
+  public InvalidSelectorException wrapInvalidSelectorException(Throwable error) {
     return (error instanceof InvalidSelectorException) ?
       (InvalidSelectorException) error :
       new InvalidSelectorException("Invalid selector", error);

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -144,7 +144,7 @@ class SelenideElementProxy implements InvocationHandler {
       }
 
       if (Cleanup.of.isInvalidSelectorError(lastError)) {
-        throw Cleanup.of.wrap(lastError);
+        throw Cleanup.of.wrapInvalidSelectorException(lastError);
       }
       else if (!shouldRetryAfterError(lastError)) {
         throw lastError;

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSelector.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSelector.java
@@ -92,8 +92,8 @@ public class WebElementSelector {
     injectSizzleIfNeeded(driver);
 
     String sizzleSelector = sizzleCssSelector.toString()
-        .replace("By.selector: ", "")
-        .replace("By.cssSelector: ", "");
+      .replace("By.selector: ", "")
+      .replace("By.cssSelector: ", "");
 
     if (context instanceof WebElement)
       return driver.executeJavaScript("return Sizzle(arguments[0], arguments[1])", sizzleSelector, context);
@@ -110,7 +110,8 @@ public class WebElementSelector {
   protected Boolean sizzleLoaded(Driver driver) {
     try {
       return driver.executeJavaScript("return typeof Sizzle != 'undefined'");
-    } catch (WebDriverException e) {
+    }
+    catch (WebDriverException e) {
       return false;
     }
   }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -106,7 +106,7 @@ public abstract class WebElementSource {
     }
 
     if (lastError != null && Cleanup.of.isInvalidSelectorError(lastError)) {
-      throw Cleanup.of.wrap(lastError);
+      throw Cleanup.of.wrapInvalidSelectorException(lastError);
     }
 
     if (element == null) {

--- a/src/main/java/com/codeborne/selenide/logevents/SelenideLog.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SelenideLog.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.IN_PROGRESS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 @ParametersAreNonnullByDefault
 public class SelenideLog implements LogEvent {
@@ -47,7 +48,7 @@ public class SelenideLog implements LogEvent {
 
   @Override
   public long getDuration() {
-    return (endNs - startNs) / 1_000_000;
+    return NANOSECONDS.toMillis(endNs - startNs);
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/ClickOptionsTest.java
+++ b/src/test/java/com/codeborne/selenide/ClickOptionsTest.java
@@ -1,14 +1,14 @@
 package com.codeborne.selenide;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.ClickMethod.DEFAULT;
 import static com.codeborne.selenide.ClickMethod.JS;
 import static com.codeborne.selenide.ClickOptions.usingDefaultMethod;
 import static com.codeborne.selenide.ClickOptions.usingJavaScript;
+import static org.assertj.core.api.Assertions.assertThat;
 
-final class ClickOptionsTest implements WithAssertions {
+final class ClickOptionsTest {
   @Test
   void javaScriptMethod() {
     assertThat(usingJavaScript().clickOption()).isEqualTo(JS);

--- a/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
@@ -11,57 +11,48 @@ import com.codeborne.selenide.collections.SizeLessThanOrEqual;
 import com.codeborne.selenide.collections.SizeNotEqual;
 import com.codeborne.selenide.collections.Texts;
 import com.codeborne.selenide.collections.TextsInAnyOrder;
-
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 
-final class CollectionConditionTest implements WithAssertions {
+final class CollectionConditionTest {
   @Test
-  void testSizeIsEmptyListSize() {
-    CollectionCondition collectionCondition = CollectionCondition.size(10);
-    assertThat(collectionCondition)
-      .isInstanceOf(ListSize.class);
+  void exactSize() {
+    assertThat(CollectionCondition.size(10)).isInstanceOf(ListSize.class);
   }
 
   @Test
-  void testSizeGreaterThan() {
-    CollectionCondition collectionCondition = CollectionCondition.sizeGreaterThan(10);
-    assertThat(collectionCondition)
-      .isInstanceOf(SizeGreaterThan.class);
+  void sizeGreaterThan() {
+    assertThat(CollectionCondition.sizeGreaterThan(10)).isInstanceOf(SizeGreaterThan.class);
   }
 
   @Test
-  void testSizeGraterThenOrEqual() {
-    CollectionCondition collectionCondition = CollectionCondition.sizeGreaterThanOrEqual(10);
-    assertThat(collectionCondition)
+  void sizeGraterThenOrEqual() {
+    assertThat(CollectionCondition.sizeGreaterThanOrEqual(10))
       .isInstanceOf(SizeGreaterThanOrEqual.class);
   }
 
   @Test
-  void testSizeLessThan() {
-    CollectionCondition collectionCondition = CollectionCondition.sizeLessThan(10);
-    assertThat(collectionCondition)
+  void sizeLessThan() {
+    assertThat(CollectionCondition.sizeLessThan(10))
       .isInstanceOf(SizeLessThan.class);
   }
 
   @Test
-  void testSizeLessThanOrEqual() {
-    CollectionCondition collectionCondition = CollectionCondition.sizeLessThanOrEqual(10);
-    assertThat(collectionCondition)
+  void sizeLessThanOrEqual() {
+    assertThat(CollectionCondition.sizeLessThanOrEqual(10))
       .isInstanceOf(SizeLessThanOrEqual.class);
   }
 
   @Test
-  void testSizeNotEqual() {
-    CollectionCondition collectionCondition = CollectionCondition.sizeNotEqual(10);
-    assertThat(collectionCondition)
+  void sizeNotEqual() {
+    assertThat(CollectionCondition.sizeNotEqual(10))
       .isInstanceOf(SizeNotEqual.class);
   }
 
   @Test
-  void testTextsWithObjectsList() {
+  void textsWithObjectsList() {
     CollectionCondition collectionCondition = CollectionCondition.texts("One", "Two", "Three");
     assertThat(collectionCondition)
       .isInstanceOf(Texts.class);
@@ -71,7 +62,7 @@ final class CollectionConditionTest implements WithAssertions {
   }
 
   @Test
-  void testTextsWithListOfStrings() {
+  void textsWithListOfStrings() {
     CollectionCondition collectionCondition = CollectionCondition.texts(asList("One", "Two", "Three"));
     assertThat(collectionCondition)
       .isInstanceOf(Texts.class);
@@ -81,7 +72,7 @@ final class CollectionConditionTest implements WithAssertions {
   }
 
   @Test
-  void testExactTextsWithObjectsList() {
+  void exactTextsWithObjectsList() {
     CollectionCondition collectionCondition = CollectionCondition.exactTexts("One", "Two", "Three");
     assertThat(collectionCondition)
       .isInstanceOf(ExactTexts.class);
@@ -91,7 +82,7 @@ final class CollectionConditionTest implements WithAssertions {
   }
 
   @Test
-  void testExactTextsWithListOfStrings() {
+  void exactTextsWithListOfStrings() {
     CollectionCondition collectionCondition = CollectionCondition.exactTexts(asList("One", "Two", "Three"));
     assertThat(collectionCondition)
       .isInstanceOf(ExactTexts.class);
@@ -101,7 +92,7 @@ final class CollectionConditionTest implements WithAssertions {
   }
 
   @Test
-  void testTextsInAnyOrderWithObjectsList() {
+  void textsInAnyOrderWithObjectsList() {
     CollectionCondition collectionCondition = CollectionCondition.textsInAnyOrder("One", "Two", "Three");
     assertThat(collectionCondition)
       .isInstanceOf(TextsInAnyOrder.class);
@@ -111,7 +102,7 @@ final class CollectionConditionTest implements WithAssertions {
   }
 
   @Test
-  void testTextsInAnyOrderWithStringsList() {
+  void textsInAnyOrderWithStringsList() {
     CollectionCondition collectionCondition = CollectionCondition.textsInAnyOrder(asList("One", "Two", "Three"));
     assertThat(collectionCondition)
       .isInstanceOf(TextsInAnyOrder.class);
@@ -121,7 +112,7 @@ final class CollectionConditionTest implements WithAssertions {
   }
 
   @Test
-  void testExplanationIsIncludedToString() {
+  void explanationIsIncludedToString() {
     CollectionCondition collectionCondition = CollectionCondition.texts("One").because("should be");
     assertThat(collectionCondition)
       .as("Should contain explanation")
@@ -129,25 +120,25 @@ final class CollectionConditionTest implements WithAssertions {
   }
 
   @Test
-  void testExactTextsCaseSensitiveInAnyOrderWithList() {
+  void exactTextsCaseSensitiveInAnyOrderWithList() {
     CollectionCondition condition = CollectionCondition.exactTextsCaseSensitiveInAnyOrder(asList("One", "Two"));
     assertThat(condition).isInstanceOf(ExactTextsCaseSensitiveInAnyOrder.class);
   }
 
   @Test
-  void testExactTextsCaseSensitiveInAnyOrderWithVarargs() {
+  void exactTextsCaseSensitiveInAnyOrderWithVarargs() {
     CollectionCondition condition = CollectionCondition.exactTextsCaseSensitiveInAnyOrder("One", "Two");
     assertThat(condition).isInstanceOf(ExactTextsCaseSensitiveInAnyOrder.class);
   }
 
   @Test
-  void testContainTextsWithStringList() {
+  void containTextsWithStringList() {
     CollectionCondition condition = CollectionCondition.containExactTextsCaseSensitive(asList("One", "Two", "Three"));
     assertThat(condition).isInstanceOf(ContainExactTextsCaseSensitive.class);
   }
 
   @Test
-  void testContainTextsWithVarargs() {
+  void containTextsWithVarargs() {
     CollectionCondition condition = CollectionCondition.containExactTextsCaseSensitive("One", "Two", "Three");
     assertThat(condition).isInstanceOf(ContainExactTextsCaseSensitive.class);
   }

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -26,6 +26,7 @@ import static com.codeborne.selenide.Condition.selected;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.type;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Mocks.elementWithAttribute;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
@@ -54,12 +55,6 @@ final class ConditionTest {
     assertThat(Condition.value("John").apply(driver, element)).isTrue();
     assertThat(Condition.value("John Malkovich").apply(driver, element)).isTrue();
     assertThat(Condition.value("malko").apply(driver, element)).isTrue();
-  }
-
-  private WebElement elementWithAttribute(String name, String value) {
-    WebElement element = mock(WebElement.class);
-    when(element.getAttribute(name)).thenReturn(value);
-    return element;
   }
 
   @Test
@@ -142,19 +137,19 @@ final class ConditionTest {
   }
 
   @Test
-  void elementHasType() {
-    assertThat(type("selenide").apply(driver, elementWithAttribute("type", "selenide"))).isTrue();
-    assertThat(type("selenide").apply(driver, elementWithAttribute("type", "selenide is great"))).isFalse();
+  void checksValueOfTypeAttribute() {
+    assertThat(type("radio").apply(driver, elementWithAttribute("type", "radio"))).isTrue();
+    assertThat(type("radio").apply(driver, elementWithAttribute("type", "radio-button"))).isFalse();
   }
 
   @Test
-  void elementHasId() {
+  void checksValueOfIdAttribute() {
     assertThat(id("selenide").apply(driver, elementWithAttribute("id", "selenide"))).isTrue();
     assertThat(id("selenide").apply(driver, elementWithAttribute("id", "selenide is great"))).isFalse();
   }
 
   @Test
-  void elementHasClass() {
+  void checksValueOfClassAttribute() {
     assertThat(cssClass("btn").apply(driver, elementWithAttribute("class", "btn btn-warning"))).isTrue();
     assertThat(cssClass("btn-warning").apply(driver, elementWithAttribute("class", "btn btn-warning"))).isTrue();
     assertThat(cssClass("active").apply(driver, elementWithAttribute("class", "btn btn-warning"))).isFalse();

--- a/src/test/java/com/codeborne/selenide/ElementsCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/ElementsCollectionTest.java
@@ -1,9 +1,8 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.impl.CollectionSource;
 import com.codeborne.selenide.impl.SelenideElementIterator;
 import com.codeborne.selenide.impl.SelenideElementListIterator;
-import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.JavascriptException;
@@ -21,6 +20,8 @@ import static com.codeborne.selenide.Condition.text;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -30,7 +31,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class ElementsCollectionTest implements WithAssertions {
+final class ElementsCollectionTest {
   private final DriverStub driver = new DriverStub();
   private final CollectionSource source = mock(CollectionSource.class);
   private final WebElement element1 = element("h1");

--- a/src/test/java/com/codeborne/selenide/InternetExplorerNamesTest.java
+++ b/src/test/java/com/codeborne/selenide/InternetExplorerNamesTest.java
@@ -1,9 +1,10 @@
 package com.codeborne.selenide;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-final class InternetExplorerNamesTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class InternetExplorerNamesTest {
   @Test
   void internetExplorerShortNameTest() {
     assertThat(new Browser(Browsers.IE, false).isIE()).isTrue();

--- a/src/test/java/com/codeborne/selenide/Mocks.java
+++ b/src/test/java/com/codeborne/selenide/Mocks.java
@@ -1,17 +1,27 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.impl.CollectionSource;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import static java.util.Arrays.asList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ParametersAreNonnullByDefault
 public class Mocks {
+  @Nonnull
+  @CheckReturnValue
   public static SelenideElement mockElement(String text) {
     return mockElement("div", text);
   }
 
+  @Nonnull
+  @CheckReturnValue
   public static SelenideElement mockElement(String tag, String text) {
     SelenideElement element = mock(SelenideElement.class);
     when(element.getTagName()).thenReturn(tag);
@@ -19,6 +29,39 @@ public class Mocks {
     return element;
   }
 
+  @Nonnull
+  @CheckReturnValue
+  public static WebElement elementWithAttribute(String name, String value) {
+    WebElement element = mock(WebElement.class);
+    when(element.getAttribute(name)).thenReturn(value);
+    return element;
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  public static SelenideElement mockSelect(WebElement... options) {
+    SelenideElement select = mockElement("select", "");
+    when(select.isSelected()).thenReturn(true);
+    when(select.findElements(By.tagName("option"))).thenReturn(asList(options));
+    return select;
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  public static WebElement option(String text) {
+    return option(text, false);
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  public static WebElement option(String text, boolean selected) {
+    WebElement option = mockElement("option", text);
+    when(option.isSelected()).thenReturn(selected);
+    return option;
+  }
+
+  @Nonnull
+  @CheckReturnValue
   public static WebElement mockWebElement(String tag, String text) {
     WebElement element = mock(WebElement.class);
     when(element.getTagName()).thenReturn(tag);
@@ -27,6 +70,8 @@ public class Mocks {
     return element;
   }
 
+  @Nonnull
+  @CheckReturnValue
   public static CollectionSource mockCollection(String description, WebElement... elements) {
     Driver driver = mock(Driver.class);
     when(driver.config()).thenReturn(new SelenideConfig());

--- a/src/test/java/com/codeborne/selenide/SelectorsTest.java
+++ b/src/test/java/com/codeborne/selenide/SelectorsTest.java
@@ -1,11 +1,12 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.selector.ByShadow;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
-final class SelectorsTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class SelectorsTest {
 
   @Test
   void byAttributeUsesXPath() {

--- a/src/test/java/com/codeborne/selenide/SelenideConfigTest.java
+++ b/src/test/java/com/codeborne/selenide/SelenideConfigTest.java
@@ -1,11 +1,12 @@
 package com.codeborne.selenide;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-final class SelenideConfigTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class SelenideConfigTest {
   @Test
   void getsReportsUrlFromSystemProperty() {
     System.setProperty("selenide.reportsUrl", "http://ci.org/job/123/artifact/");

--- a/src/test/java/com/codeborne/selenide/collections/AllMatchTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/AllMatchTest.java
@@ -4,14 +4,15 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.MatcherError;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-final class AllMatchTest implements WithAssertions {
+final class AllMatchTest {
   private final SelenideElement element1 = mockElement("Test-One");
   private final SelenideElement element2 = mockElement("Test-Two");
   private final SelenideElement element3 = mockElement("Test-Three");

--- a/src/test/java/com/codeborne/selenide/collections/AnyMatchTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/AnyMatchTest.java
@@ -4,15 +4,16 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.MatcherError;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-final class AnyMatchTest implements WithAssertions {
+final class AnyMatchTest {
   private final SelenideElement element1 = mockElement("Hello");
   private final SelenideElement element2 = mockElement("World");
 

--- a/src/test/java/com/codeborne/selenide/collections/ContainExactTextsCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ContainExactTextsCaseSensitiveTest.java
@@ -5,7 +5,6 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.DoesNotContainTextsError;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -13,8 +12,10 @@ import java.util.Collections;
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
+public class ContainExactTextsCaseSensitiveTest {
   private final SelenideElement element1 = mockElement("Test-One");
   private final SelenideElement element2 = mockElement("Test-Two");
   private final SelenideElement element3 = mockElement("Test-Three");
@@ -48,7 +49,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   private final CollectionSource emptyCollection = mockCollection("Empty collection");
 
   @Test
-  void testExactCollection() {
+  void exactCollection() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-One", "Test-Two", "Test-Three");
 
@@ -57,7 +58,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testCollectionUnordered() {
+  void collectionUnordered() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-Three", "Test-One", "Test-Two");
 
@@ -66,7 +67,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testCollectionUnorderedMoreElements() {
+  void collectionUnorderedMoreElements() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-Three", "Test-One", "Test-Two");
 
@@ -75,7 +76,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testCollectionUnorderedMoreElementsWithDuplicates() {
+  void collectionUnorderedMoreElementsWithDuplicates() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-Three", "Test-One", "Test-Two");
 
@@ -84,7 +85,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testCollectionWithoutElement() {
+  void collectionWithoutElement() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-One", "Test-Two", "Test-Three");
 
@@ -107,7 +108,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testCollectionMoreElementsWithoutSomeElements() {
+  void collectionMoreElementsWithoutSomeElements() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-One", "Test-Two", "Test-Three");
 
@@ -130,7 +131,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testCollectionLessElementsWithoutElement() {
+  void collectionLessElementsWithoutElement() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-One", "Test-Two", "Test-Three");
 
@@ -153,7 +154,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testCollectionNullElements() {
+  void collectionNullElements() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-One", "Test-Two", "Test-Three");
 
@@ -169,7 +170,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testCollectionEmpty() {
+  void collectionEmpty() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-One", "Test-Two", "Test-Three");
 
@@ -194,7 +195,7 @@ public class ContainExactTextsCaseSensitiveTest implements WithAssertions {
   }
 
   @Test
-  void testMissingElementSatisfiesCondition() {
+  void missingElementSatisfiesCondition() {
     ContainExactTextsCaseSensitive expectedTexts =
       new ContainExactTextsCaseSensitive("Test-One", "Test-Two", "Test-Three");
 

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrderTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrderTest.java
@@ -1,61 +1,53 @@
 package com.codeborne.selenide.collections;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.WebElement;
 
+import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Arrays.asList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
-class ExactTextsCaseSensitiveInAnyOrderTest implements WithAssertions {
+final class ExactTextsCaseSensitiveInAnyOrderTest {
 
   @Test
   void shouldMatchWithSameOrder() {
     ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder(asList("One", "Two", "Three"));
-    testApplyMethod(true, texts);
-  }
-
-  private void testApplyMethod(boolean shouldMatch, ExactTextsCaseSensitiveInAnyOrder texts) {
-    WebElement mockElement1 = mock(WebElement.class);
-    WebElement mockElement2 = mock(WebElement.class);
-    WebElement mockElement3 = mock(WebElement.class);
-
-    when(mockElement1.getText()).thenReturn("One");
-    when(mockElement2.getText()).thenReturn("Two");
-    when(mockElement3.getText()).thenReturn("Three");
-    assertThat(texts.test(asList(mockElement1, mockElement2, mockElement3)))
-      .isEqualTo(shouldMatch);
+    assertThat(texts.test(asList(mockElement("One"), mockElement("Two"), mockElement("Three"))))
+      .isTrue();
   }
 
   @Test
   void shouldMatchWithDifferentOrder() {
     ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder(asList("One", "Three", "Two"));
-    testApplyMethod(true, texts);
+    assertThat(texts.test(asList(mockElement("One"), mockElement("Two"), mockElement("Three"))))
+      .isTrue();
   }
 
   @Test
   void shouldNotMatchWithSameOrderAndDifferentCase() {
     ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder("one", "two", "three");
-    testApplyMethod(false, texts);
+    assertThat(texts.test(asList(mockElement("One"), mockElement("Two"), mockElement("Three"))))
+      .isFalse();
   }
 
   @Test
   void shouldNotMatchWithDifferentOrderAndDifferentCase() {
     ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder("one", "three", "two");
-    testApplyMethod(false, texts);
+    assertThat(texts.test(asList(mockElement("One"), mockElement("Two"), mockElement("Three"))))
+      .isFalse();
   }
 
   @Test
   void shouldNotMatchWithSmallerListSize() {
     ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder("One", "Two");
-    testApplyMethod(false, texts);
+    assertThat(texts.test(asList(mockElement("One"), mockElement("Two"), mockElement("Three"))))
+      .isFalse();
   }
 
   @Test
   void shouldNotMatchWithBiggerListSize() {
     ExactTextsCaseSensitiveInAnyOrder texts = new ExactTextsCaseSensitiveInAnyOrder("One", "Two", "Three", "four");
-    testApplyMethod(false, texts);
+    assertThat(texts.test(asList(mockElement("One"), mockElement("Two"), mockElement("Three"))))
+      .isFalse();
   }
 
   @Test
@@ -63,5 +55,4 @@ class ExactTextsCaseSensitiveInAnyOrderTest implements WithAssertions {
     assertThat(new ExactTextsCaseSensitiveInAnyOrder("One", "Two"))
       .hasToString("Exact texts case sensitive in any order [One, Two]");
   }
-
 }

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.collections;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.TextsMismatch;
 import com.codeborne.selenide.ex.TextsSizeMismatch;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
@@ -14,10 +13,12 @@ import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class ExactTextsTest implements WithAssertions {
+final class ExactTextsTest {
   @Test
   void varArgsConstructor() {
     ExactTexts exactTexts = new ExactTexts("One", "Two", "Three");

--- a/src/test/java/com/codeborne/selenide/collections/ItemWithTextTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ItemWithTextTest.java
@@ -1,32 +1,34 @@
 package com.codeborne.selenide.collections;
 
-import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementWithTextNotFound;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.ArrayList;
 
+import static com.codeborne.selenide.ElementsCollection.texts;
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockElement;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-final class ItemWithTextTest implements WithAssertions {
+final class ItemWithTextTest {
   private final SelenideElement element1 = mockElement("Test-One");
   private final SelenideElement element2 = mockElement("Test-Two");
   private final SelenideElement element3 = mockElement("Test-Three");
   private final CollectionSource collection = mockCollection("Collection description", element1, element2, element3);
 
   @Test
-  void applyOnCorrectElementText() {
+  void correctElementText() {
     assertThat(new ItemWithText("Test-One")
       .test(collection.getElements()))
       .isTrue();
   }
 
   @Test
-  void applyOnWrongElementText() {
+  void wrongElementText() {
     assertThat(new ItemWithText("Test-X")
       .test(collection.getElements()))
       .isFalse();
@@ -39,10 +41,9 @@ final class ItemWithTextTest implements WithAssertions {
   }
 
   @Test
-  void testApplyWithEmptyList() {
-    CollectionSource emptyCollection = mockCollection("empty collection");
+  void emptyList() {
     assertThat(new ItemWithText("Test-X")
-      .test(emptyCollection.getElements()))
+      .test(new ArrayList<>()))
       .isFalse();
   }
 
@@ -53,9 +54,8 @@ final class ItemWithTextTest implements WithAssertions {
       .fail(collection,
         collection.getElements(),
         new Exception("Exception message"), 10000)).isInstanceOf(ElementWithTextNotFound.class)
-      .hasMessageContaining(
-        String.format(String.format("Element with text not found" +
-          "%nActual: %s" +
-          "%nExpected: %s", ElementsCollection.texts(collection.getElements()), Collections.singletonList(expectedText))));
+      .hasMessageContaining(String.format("Element with text not found" +
+        "%nActual: %s" +
+        "%nExpected: %s", texts(collection.getElements()), singletonList(expectedText)));
   }
 }

--- a/src/test/java/com/codeborne/selenide/collections/ListSizeTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ListSizeTest.java
@@ -2,16 +2,17 @@ package com.codeborne.selenide.collections;
 
 import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-final class ListSizeTest implements WithAssertions {
+final class ListSizeTest {
   @Test
   void applyWithEmptyList() {
     assertThat(new ListSize(10).test(emptyList()))

--- a/src/test/java/com/codeborne/selenide/collections/NoneMatchTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/NoneMatchTest.java
@@ -4,14 +4,15 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.MatcherError;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-final class NoneMatchTest implements WithAssertions {
+final class NoneMatchTest {
   private final SelenideElement element1 = mockElement("Test-One");
   private final SelenideElement element2 = mockElement("Test-Two");
   private final SelenideElement element3 = mockElement("Test-Three");

--- a/src/test/java/com/codeborne/selenide/collections/SizeGreaterThanOrEqualTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/SizeGreaterThanOrEqualTest.java
@@ -3,16 +3,17 @@ package com.codeborne.selenide.collections;
 import com.codeborne.selenide.Mocks;
 import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-final class SizeGreaterThanOrEqualTest implements WithAssertions {
+final class SizeGreaterThanOrEqualTest {
   @Test
   void applyWithEmptyList() {
     assertThat(new SizeGreaterThanOrEqual(10).test(emptyList()))

--- a/src/test/java/com/codeborne/selenide/collections/SizeGreaterThanTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/SizeGreaterThanTest.java
@@ -3,16 +3,17 @@ package com.codeborne.selenide.collections;
 import com.codeborne.selenide.Mocks;
 import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-final class SizeGreaterThanTest implements WithAssertions {
+final class SizeGreaterThanTest {
   @Test
   void applyWithEmptyList() {
     assertThat(new SizeGreaterThan(10).test(emptyList()))

--- a/src/test/java/com/codeborne/selenide/collections/SizeLessThanOrEqualTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/SizeLessThanOrEqualTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.collections;
 
 import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
@@ -10,9 +9,11 @@ import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-final class SizeLessThanOrEqualTest implements WithAssertions {
+final class SizeLessThanOrEqualTest {
   @Test
   void applyWithWrongSizeList() {
     assertThat(new SizeLessThanOrEqual(1).test(asList(mock(WebElement.class), mock(WebElement.class))))

--- a/src/test/java/com/codeborne/selenide/collections/SizeLessThanTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/SizeLessThanTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.collections;
 
 import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
@@ -10,9 +9,11 @@ import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-final class SizeLessThanTest implements WithAssertions {
+final class SizeLessThanTest {
   @Test
   void applyWithWrongSizeList() {
     assertThat(new SizeLessThan(1).test(asList(mock(WebElement.class), mock(WebElement.class))))

--- a/src/test/java/com/codeborne/selenide/collections/SizeNotEqualTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/SizeNotEqualTest.java
@@ -2,16 +2,17 @@ package com.codeborne.selenide.collections;
 
 import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-final class SizeNotEqualTest implements WithAssertions {
+final class SizeNotEqualTest {
   @Test
   void applyWithEmptyList() {
     assertThat(new SizeNotEqual(10).test(emptyList()))

--- a/src/test/java/com/codeborne/selenide/collections/TextsInAnyOrderTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/TextsInAnyOrderTest.java
@@ -1,48 +1,41 @@
 package com.codeborne.selenide.collections;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import java.util.List;
+
+import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Arrays.asList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
-final class TextsInAnyOrderTest implements WithAssertions {
+final class TextsInAnyOrderTest {
   @Test
-  void testApplyWithSameOrder() {
+  void elementsInSameOrder() {
     TextsInAnyOrder texts = new TextsInAnyOrder(asList("One", "Two", "Three"));
-    testApplyMethod(true, texts);
-  }
-
-  private void testApplyMethod(boolean shouldMatch, TextsInAnyOrder texts) {
-    WebElement mockElement1 = mock(WebElement.class);
-    WebElement mockElement2 = mock(WebElement.class);
-    WebElement mockElement3 = mock(WebElement.class);
-
-    when(mockElement1.getText()).thenReturn("One");
-    when(mockElement2.getText()).thenReturn("Two");
-    when(mockElement3.getText()).thenReturn("Three");
-    assertThat(texts.test(asList(mockElement1, mockElement2, mockElement3)))
-      .isEqualTo(shouldMatch);
+    List<WebElement> collection = asList(mockElement("One"), mockElement("Two"), mockElement("Three"));
+    assertThat(texts.test(collection)).isTrue();
   }
 
   @Test
-  void testApplyWithDifferentOrder() {
+  void elementsInDifferentOrder() {
     TextsInAnyOrder texts = new TextsInAnyOrder(asList("Two", "One", "Three"));
-    testApplyMethod(true, texts);
+    List<WebElement> collection = asList(mockElement("One"), mockElement("Two"), mockElement("Three"));
+    assertThat(texts.test(collection)).isTrue();
   }
 
   @Test
-  void testApplyWithWrongListSize() {
+  void tooLongListSize() {
     TextsInAnyOrder texts = new TextsInAnyOrder(asList("Two", "One"));
-    testApplyMethod(false, texts);
+    List<WebElement> collection = asList(mockElement("One"), mockElement("Two"), mockElement("Three"));
+    assertThat(texts.test(collection)).isFalse();
   }
 
   @Test
-  void testApplyWithBiggerSize() {
+  void tooShortList() {
     TextsInAnyOrder texts = new TextsInAnyOrder(asList("Two", "One", "four", "three"));
-    testApplyMethod(false, texts);
+    List<WebElement> collection = asList(mockElement("One"), mockElement("Two"), mockElement("Three"));
+    assertThat(texts.test(collection)).isFalse();
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/collections/TextsTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/TextsTest.java
@@ -1,16 +1,16 @@
 package com.codeborne.selenide.collections;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class TextsTest implements WithAssertions {
+final class TextsTest {
   @Test
   void applyWithEmptyList() {
     assertThat(new Texts("One", "Two", "Three").test(emptyList()))

--- a/src/test/java/com/codeborne/selenide/commands/AncestorCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/AncestorCommandTest.java
@@ -2,86 +2,85 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-final class AncestorCommandTest implements WithAssertions {
+final class AncestorCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
   private final Ancestor ancestorCommand = new Ancestor();
 
-  @Test
-  void testExecuteMethodWithTagsStartsWithDot() {
-    String argument = ".class";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute(argument)).thenReturn(elementAttribute);
-    when(locator.find(proxy,
-      By.xpath(
-        String.format("ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' %s ')][1]",
-          argument.substring(1))),
-      0)).
-      thenReturn(mockedElement);
-    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
-      .isEqualTo(mockedElement);
+  @BeforeEach
+  void setUp() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(mockedElement);
+  }
+
+  @AfterEach
+  void tearDown() {
+    verifyNoMoreInteractions(mockedElement, locator, proxy);
   }
 
   @Test
-  void testExecuteMethodWithTagsThatDoesNotStartWithDot() {
-    String argument = "class";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute(argument)).thenReturn(elementAttribute);
-    when(locator.find(proxy, By.xpath(String.format("ancestor::%s[1]", argument)), 0)).thenReturn(mockedElement);
-    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
+  void executeWithTagsStartsWithDot() {
+    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{".active-btn", ""}))
       .isEqualTo(mockedElement);
+
+    verify(locator).find(proxy,
+      By.xpath("ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' active-btn ')][1]"),
+      0);
   }
 
   @Test
-  void testExecuteMethodWithZeroIndex() {
-    String argument = "class";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute(argument)).thenReturn(elementAttribute);
-    when(locator.find(proxy, By.xpath(String.format("ancestor::%s[1]", argument)), 0))
-      .thenReturn(mockedElement);
-    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{argument, 0}))
+  void executeWithTagsThatDoesNotStartWithDot() {
+    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{"table", ""}))
       .isEqualTo(mockedElement);
+
+    verify(locator).find(proxy, By.xpath("ancestor::table[1]"), 0);
   }
 
   @Test
-  void testExecuteMethodWithNonZeroIndex() {
-    String argument = "class";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute(argument)).thenReturn(elementAttribute);
-    when(locator.find(proxy, By.xpath(String.format("ancestor::%s[3]", argument)), 0))
-      .thenReturn(mockedElement);
-    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{argument, 2}))
+  void executeWithZeroIndex() {
+    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{"tr", 0}))
       .isEqualTo(mockedElement);
+    verify(locator).find(proxy, By.xpath("ancestor::tr[1]"), 0);
   }
 
   @Test
-  void testExecuteMethodWithAttributeNameAndValue() {
+  void executeWithNonZeroIndex() {
+    assertThat(ancestorCommand.execute(proxy, locator, new Object[]{"td", 2}))
+      .isEqualTo(mockedElement);
+
+    verify(locator).find(proxy, By.xpath("ancestor::td[3]"), 0);
+  }
+
+  @Test
+  void executeWithAttributeNameAndValue() {
     String selector = "[test-argument=test-value]";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute(selector)).thenReturn(elementAttribute);
-    when(locator.find(proxy, By.xpath("ancestor::*[@test-argument='test-value'][1]"), 0))
-      .thenReturn(mockedElement);
+
     assertThat(
-      ancestorCommand.execute(proxy, locator, new Object[]{selector, "something more"})
+      ancestorCommand.execute(proxy, locator, new Object[]{selector, ""})
     ).isEqualTo(mockedElement);
+
+    verify(locator).find(proxy, By.xpath("ancestor::*[@test-argument='test-value'][1]"), 0);
   }
 
   @Test
-  void testExecuteMethodWithAttribute() {
-    String selector = "[test-argument]";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute(selector)).thenReturn(elementAttribute);
-    when(locator.find(proxy, By.xpath("ancestor::*[@test-argument][1]"), 0)).thenReturn(mockedElement);
+  void executeWithAttribute() {
     assertThat(
-      ancestorCommand.execute(proxy, locator, new Object[]{selector, "something more"})
+      ancestorCommand.execute(proxy, locator, new Object[]{"[test-argument]", ""})
     ).isEqualTo(mockedElement);
+
+    verify(locator).find(proxy, By.xpath("ancestor::*[@test-argument][1]"), 0);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/DownloadFileTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/DownloadFileTest.java
@@ -11,7 +11,6 @@ import com.codeborne.selenide.impl.DownloadFileWithHttpRequest;
 import com.codeborne.selenide.impl.DownloadFileWithProxyServer;
 import com.codeborne.selenide.impl.WebElementSource;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
@@ -23,6 +22,7 @@ import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
 import static com.codeborne.selenide.files.DownloadActions.click;
 import static com.codeborne.selenide.files.FileFilters.none;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-final class DownloadFileTest implements WithAssertions {
+final class DownloadFileTest {
   private final SelenideConfig config = new SelenideConfig();
   private final Driver driver = mock(Driver.class);
   private final DownloadFileWithHttpRequest httpget = mock(DownloadFileWithHttpRequest.class);

--- a/src/test/java/com/codeborne/selenide/commands/FindByXpathCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/FindByXpathCommandTest.java
@@ -2,37 +2,41 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class FindByXpathCommandTest implements WithAssertions {
+final class FindByXpathCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelenideElement element1 = mock(SelenideElement.class);
-  private final FindByXpath findByXpathCommand = new FindByXpath();
+  private final SelenideElement element = mock(SelenideElement.class);
+  private final FindByXpath command = new FindByXpath();
 
   @Test
-  void testExecuteMethodWithNoArgsPassed() {
-    assertThatThrownBy(() -> findByXpathCommand.execute(proxy, locator))
+  void noArgs() {
+    assertThatThrownBy(() -> command.execute(proxy, locator))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Missing arguments");
   }
 
   @Test
-  void testExecuteMethodWithZeroLengthArgs() {
-    when(locator.find(proxy, By.xpath("."), 0)).thenReturn(element1);
-    assertThat(findByXpathCommand.execute(proxy, locator, "."))
-      .isEqualTo(element1);
+  void zeroLengthArgs() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(element);
+    assertThat(command.execute(proxy, locator, ".")).isEqualTo(element);
+    verify(locator).find(proxy, By.xpath("."), 0);
   }
 
   @Test
-  void testExecuteMethodWithMoreThenOneArgsList() {
-    when(locator.find(proxy, By.xpath("."), 1)).thenReturn(element1);
-    assertThat(findByXpathCommand.execute(proxy, locator, ".", 1))
-      .isEqualTo(element1);
+  void moreThanOneArg() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(element);
+    assertThat(command.execute(proxy, locator, ".", 1)).isEqualTo(element);
+    verify(locator).find(proxy, By.xpath("."), 1);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/FindCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/FindCommandTest.java
@@ -2,36 +2,40 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class FindCommandTest implements WithAssertions {
+final class FindCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelenideElement element1 = mock(SelenideElement.class);
-  private final Find findCommand = new Find();
+  private final SelenideElement element = mock(SelenideElement.class);
+  private final Find command = new Find();
 
   @Test
-  void testExecuteMethodWithNoArgsPassed() {
-    assertThatThrownBy(() -> findCommand.execute(proxy, locator))
+  void noArgs() {
+    assertThatThrownBy(() -> command.execute(proxy, locator))
       .isInstanceOf(ArrayIndexOutOfBoundsException.class);
   }
 
   @Test
-  void testExecuteMethodWithZeroLengthArgs() {
-    when(locator.find(proxy, By.xpath(".."), 0)).thenReturn(element1);
-    assertThat(findCommand.execute(proxy, locator, By.xpath("..")))
-      .isEqualTo(element1);
+  void zeroLengthArgs() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(element);
+    assertThat(command.execute(proxy, locator, By.xpath(".."))).isEqualTo(element);
+    verify(locator).find(proxy, By.xpath(".."), 0);
   }
 
   @Test
-  void testExecuteMethodWithMoreThenOneArgsList() {
-    when(locator.find(proxy, By.xpath(".."), 1)).thenReturn(element1);
-    assertThat(findCommand.execute(proxy, locator, By.xpath(".."), 1))
-      .isEqualTo(element1);
+  void moreThenOneArg() {
+    when(locator.find(any(), any(), anyInt())).thenReturn(element);
+    assertThat(command.execute(proxy, locator, By.xpath(".."), 1)).isEqualTo(element);
+    verify(locator).find(proxy, By.xpath(".."), 1);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetAliasCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetAliasCommandTest.java
@@ -3,14 +3,14 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.impl.Alias.NONE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class GetAliasCommandTest implements WithAssertions {
+public class GetAliasCommandTest {
 
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);

--- a/src/test/java/com/codeborne/selenide/commands/GetAttributeCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetAttributeCommandTest.java
@@ -2,18 +2,21 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetAttributeCommandTest implements WithAssertions {
+final class GetAttributeCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final WebElement mockedElement = mock(WebElement.class);
+  private final GetAttribute command = new GetAttribute();
 
   @BeforeEach
   void setup() {
@@ -21,12 +24,9 @@ final class GetAttributeCommandTest implements WithAssertions {
   }
 
   @Test
-  void testExecuteMethod() {
-    GetAttribute getAttributeCommand = new GetAttribute();
-    String argument = "class";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute(argument)).thenReturn(elementAttribute);
-    assertThat(getAttributeCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
-      .isEqualTo(elementAttribute);
+  void returnsValueOfAttributeWithGivenName() {
+    when(mockedElement.getAttribute(any())).thenReturn("hello");
+    assertThat(command.execute(proxy, locator, new Object[]{"class", ""})).isEqualTo("hello");
+    verify(mockedElement).getAttribute("class");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetCssValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetCssValueCommandTest.java
@@ -2,15 +2,17 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetCssValueCommandTest implements WithAssertions {
+final class GetCssValueCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final WebElement mockedElement = mock(WebElement.class);
@@ -21,12 +23,10 @@ final class GetCssValueCommandTest implements WithAssertions {
   }
 
   @Test
-  void testExecuteMethod() {
-    GetCssValue getCssValue = new GetCssValue();
-    String argument = "display";
-    String elementAttribute = "none";
-    when(mockedElement.getCssValue(argument)).thenReturn(elementAttribute);
-    assertThat(getCssValue.execute(proxy, locator, new Object[]{argument, "something more"}))
-      .isEqualTo(elementAttribute);
+  void execute() {
+    when(mockedElement.getCssValue(any())).thenReturn("none");
+    assertThat(new GetCssValue().execute(proxy, locator, new Object[]{"display", ""}))
+      .isEqualTo("none");
+    verify(mockedElement).getCssValue("display");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetDataAttributeCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetDataAttributeCommandTest.java
@@ -2,38 +2,39 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetDataAttributeCommandTest implements WithAssertions {
+final class GetDataAttributeCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetDataAttribute getDataAttributeCommand = new GetDataAttribute();
+  private final SelenideElement webElement = mock(SelenideElement.class);
+  private final GetDataAttribute command = new GetDataAttribute();
 
   @BeforeEach
   void setup() {
-    when(locator.getWebElement()).thenReturn(mockedElement);
+    when(locator.getWebElement()).thenReturn(webElement);
   }
 
   @Test
-  void testExecuteMethodWithDataAttribute() {
-    String argument = "class";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute("data-" + argument)).thenReturn(elementAttribute);
-    assertThat(getDataAttributeCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
-      .isEqualTo(elementAttribute);
+  void returnsValueOfDataAttribute() {
+    when(webElement.getAttribute(any())).thenReturn("hello");
+    assertThat(command.execute(proxy, locator, new Object[]{"test-id"}))
+      .isEqualTo("hello");
+    verify(webElement).getAttribute("data-test-id");
   }
 
   @Test
-  void testExecuteMethodWithNoDataAttribute() {
-    String argument = "class";
-    when(mockedElement.getAttribute("data-" + argument)).thenReturn(null);
-    assertThat(getDataAttributeCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
+  void returnsNullIfDataAttributeIsMissing() {
+    when(webElement.getAttribute(any())).thenReturn(null);
+    assertThat(command.execute(proxy, locator, new Object[]{"test-id"}))
       .isNull();
+    verify(webElement).getAttribute("data-test-id");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetInnerHtmlCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetInnerHtmlCommandTest.java
@@ -3,29 +3,33 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetInnerHtmlCommandTest implements WithAssertions {
+final class GetInnerHtmlCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetInnerHtml getInnerHtmlCommand = new GetInnerHtml();
+  private final SelenideElement webElement = mock(SelenideElement.class);
+  private final GetInnerHtml command = new GetInnerHtml();
 
   @BeforeEach
   void setup() {
-    when(locator.getWebElement()).thenReturn(mockedElement);
+    when(locator.getWebElement()).thenReturn(webElement);
   }
 
   @Test
   void uses_innerHTML_attribute() {
     when(locator.driver()).thenReturn(new DriverStub("firefox"));
+    when(webElement.getAttribute(any())).thenReturn("hello");
 
-    when(mockedElement.getAttribute("innerHTML")).thenReturn("hello");
-    assertThat(getInnerHtmlCommand.execute(proxy, locator, null)).isEqualTo("hello");
+    assertThat(command.execute(proxy, locator, null)).isEqualTo("hello");
+
+    verify(webElement).getAttribute("innerHTML");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetInnerTextCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetInnerTextCommandTest.java
@@ -3,37 +3,43 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetInnerTextCommandTest implements WithAssertions {
+final class GetInnerTextCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetInnerText getInnerTextCommand = new GetInnerText();
+  private final SelenideElement webElement = mock(SelenideElement.class);
+  private final GetInnerText command = new GetInnerText();
 
   @BeforeEach
   void setup() {
-    when(locator.getWebElement()).thenReturn(mockedElement);
+    when(locator.getWebElement()).thenReturn(webElement);
   }
 
   @Test
   void uses_innerText_attribute_if_IE() {
     when(locator.driver()).thenReturn(new DriverStub("ie"));
+    when(webElement.getAttribute(any())).thenReturn("hello");
 
-    when(mockedElement.getAttribute("innerText")).thenReturn("hello");
-    assertThat(getInnerTextCommand.execute(proxy, locator, null)).isEqualTo("hello");
+    assertThat(command.execute(proxy, locator, null)).isEqualTo("hello");
+
+    verify(webElement).getAttribute("innerText");
   }
 
   @Test
   void uses_textContent_attribute_if_not_IE() {
     when(locator.driver()).thenReturn(new DriverStub("firefox"));
+    when(webElement.getAttribute(any())).thenReturn("hello");
 
-    when(mockedElement.getAttribute("textContent")).thenReturn("hello");
-    assertThat(getInnerTextCommand.execute(proxy, locator, null)).isEqualTo("hello");
+    assertThat(command.execute(proxy, locator, null)).isEqualTo("hello");
+
+    verify(webElement).getAttribute("textContent");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetLastChildTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetLastChildTest.java
@@ -3,42 +3,27 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
-import java.lang.reflect.Field;
-
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetLastChildTest implements WithAssertions {
+final class GetLastChildTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final Find findMock = mock(Find.class);
-  private final GetLastChild getLastChildCommand = new GetLastChild(findMock);
-
-  @BeforeEach
-  void setup() {
-    when(locator.getWebElement()).thenReturn(mockedElement);
-    when(findMock.execute(proxy, locator, By.xpath("*[last()]"), 0)).thenReturn(mockedElement);
-  }
+  private final SelenideElement webElement = mock(SelenideElement.class);
+  private final Find find = mock(Find.class);
+  private final GetLastChild command = new GetLastChild(find);
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    GetLastChild getLastChild = new GetLastChild();
-    Field findField = getLastChild.getClass().getDeclaredField("find");
-    findField.setAccessible(true);
-    Find find = (Find) findField.get(getLastChild);
-    assertThat(find)
-      .isNotNull();
-  }
-
-  @Test
-  void testExecuteMethod() {
-    assertThat(getLastChildCommand.execute(proxy, locator, new Object[]{"*[last()]", "something more"}))
-      .isEqualTo(mockedElement);
+  void findsLastChildUsingXpath() {
+    when(find.execute(any(), any(), any(), anyInt())).thenReturn(webElement);
+    assertThat(command.execute(proxy, locator, null)).isEqualTo(webElement);
+    verify(find).execute(proxy, locator, By.xpath("*[last()]"), 0);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetNameCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetNameCommandTest.java
@@ -2,30 +2,30 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetNameCommandTest implements WithAssertions {
+final class GetNameCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetName getNameCommand = new GetName();
+  private final SelenideElement webElement = mock(SelenideElement.class);
+  private final GetName command = new GetName();
 
   @BeforeEach
   void setup() {
-    when(locator.getWebElement()).thenReturn(mockedElement);
+    when(locator.getWebElement()).thenReturn(webElement);
   }
 
   @Test
-  void testExecuteMethod() {
-    String argument = "class";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute("name")).thenReturn(elementAttribute);
-    assertThat(getNameCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
-      .isEqualTo(elementAttribute);
+  void execute() {
+    when(webElement.getAttribute(any())).thenReturn("hello");
+    assertThat(command.execute(proxy, locator, null)).isEqualTo("hello");
+    verify(webElement).getAttribute("name");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetParentCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetParentCommandTest.java
@@ -2,42 +2,27 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
-import java.lang.reflect.Field;
-
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetParentCommandTest implements WithAssertions {
+final class GetParentCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final Find findMock = mock(Find.class);
-  private final GetParent getParentCommand = new GetParent(findMock);
-
-  @BeforeEach
-  void setup() {
-    when(locator.getWebElement()).thenReturn(mockedElement);
-    when(findMock.execute(proxy, locator, By.xpath(".."), 0)).thenReturn(mockedElement);
-  }
+  private final SelenideElement webElement = mock(SelenideElement.class);
+  private final Find find = mock(Find.class);
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    GetParent getParentCommand = new GetParent();
-    Field findField = getParentCommand.getClass().getDeclaredField("find");
-    findField.setAccessible(true);
-    Find find = (Find) findField.get(getParentCommand);
-    assertThat(find)
-      .isNotNull();
-  }
-
-  @Test
-  void testExecuteMethod() {
-    assertThat(getParentCommand.execute(proxy, locator, new Object[]{"..", "something more"}))
-      .isEqualTo(mockedElement);
+  void findsParentElementUsingXpath() {
+    when(find.execute(any(), any(), any(), anyInt())).thenReturn(webElement);
+    assertThat(new GetParent(find).execute(proxy, locator, null))
+      .isEqualTo(webElement);
+    verify(find).execute(proxy, locator, By.xpath(".."), 0);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetPrecedingCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetPrecedingCommandTest.java
@@ -2,28 +2,27 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetPrecedingCommandTest implements WithAssertions {
+final class GetPrecedingCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetPreceding getPrecedingCommand = new GetPreceding();
 
   @Test
-  void testExecuteMethod() {
+  void findsPrecedingElementUsingXpath() {
     when(locator.find(any(), any(), anyInt())).thenReturn(mockedElement);
 
-    assertThat(getPrecedingCommand.execute(proxy, locator, new Object[]{0})).isEqualTo(mockedElement);
+    assertThat(new GetPreceding().execute(proxy, locator, new Object[]{42})).isEqualTo(mockedElement);
 
-    verify(locator).find(proxy, By.xpath("preceding-sibling::*[1]"), 0);
+    verify(locator).find(proxy, By.xpath("preceding-sibling::*[43]"), 0);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetPseudoValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetPseudoValueCommandTest.java
@@ -3,17 +3,17 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetPseudoValueCommandTest implements WithAssertions {
+final class GetPseudoValueCommandTest {
 
   private final Driver driver = mock(Driver.class);
   private final SelenideElement proxy = mock(SelenideElement.class);

--- a/src/test/java/com/codeborne/selenide/commands/GetSearchCriteriaCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSearchCriteriaCommandTest.java
@@ -2,27 +2,21 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class GetSearchCriteriaCommandTest implements WithAssertions {
+final class GetSearchCriteriaCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final GetSearchCriteria getSearchCriteriaCommand = new GetSearchCriteria();
-  private final String defaultSearchCriteria = "by.xpath";
-
-  @BeforeEach
-  void setup() {
-    when(locator.getSearchCriteria()).thenReturn(defaultSearchCriteria);
-  }
 
   @Test
-  void testExecuteMethod() {
-    assertThat(getSearchCriteriaCommand.execute(proxy, locator, new Object[]{"something more"}))
-      .isEqualTo(defaultSearchCriteria);
+  void returnsSearchCriteria() {
+    when(locator.getSearchCriteria()).thenReturn("by.xpath");
+    assertThat(getSearchCriteriaCommand.execute(proxy, locator, null))
+      .isEqualTo("by.xpath");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetSelectedOptionCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSelectedOptionCommandTest.java
@@ -1,43 +1,29 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import static java.util.Arrays.asList;
+import static com.codeborne.selenide.Mocks.mockSelect;
+import static com.codeborne.selenide.Mocks.option;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class GetSelectedOptionCommandTest implements WithAssertions {
+final class GetSelectedOptionCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final String mockedElement1Text = "Element text2";
-  private final GetSelectedOption getSelectedOptionCommand = new GetSelectedOption();
-
-  @BeforeEach
-  void setup() {
-    when(locator.driver()).thenReturn(new DriverStub());
-    SelenideElement mockedElement = mock(SelenideElement.class);
-    WebElement mockedElement1 = mock(WebElement.class);
-    WebElement mockedElement2 = mock(WebElement.class);
-    when(locator.getWebElement()).thenReturn(mockedElement);
-    when(mockedElement.isSelected()).thenReturn(true);
-    when(mockedElement.getTagName()).thenReturn("select");
-    when(mockedElement.findElements(By.tagName("option"))).thenReturn(asList(mockedElement1, mockedElement2));
-    when(mockedElement1.isSelected()).thenReturn(true);
-    when(mockedElement1.getText()).thenReturn(mockedElement1Text);
-    when(mockedElement2.isSelected()).thenReturn(false);
-  }
+  private final GetSelectedOption command = new GetSelectedOption();
 
   @Test
-  void testExecuteMethod() {
-    SelenideElement selectedElement = getSelectedOptionCommand.execute(proxy, locator, new Object[]{"something more"});
-    assertThat(selectedElement.getText())
-      .isEqualTo(mockedElement1Text);
+  void returnsFirstSelectedOption() {
+    WebElement option1 = option("Tom", false);
+    WebElement option2 = option("Jerry", true);
+    SelenideElement select = mockSelect(option1, option2);
+    when(locator.getWebElement()).thenReturn(select);
+
+    SelenideElement selectedElement = command.execute(proxy, locator, null);
+    assertThat(selectedElement.getText()).isEqualTo("Jerry");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetSelectedOptionsCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSelectedOptionsCommandTest.java
@@ -4,49 +4,38 @@ import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import static com.codeborne.selenide.Mocks.mockSelect;
+import static com.codeborne.selenide.Mocks.option;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class GetSelectedOptionsCommandTest implements WithAssertions {
+final class GetSelectedOptionsCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final GetSelectedOptions getSelectedOptionsCommand = new GetSelectedOptions();
-  private List<WebElement> mMockedElementsList;
+  private final GetSelectedOptions command = new GetSelectedOptions();
 
   @BeforeEach
   void setup() {
     when(locator.driver()).thenReturn(new DriverStub());
-    SelenideElement mockedElement = mock(SelenideElement.class);
-    WebElement mockedElement1 = mock(WebElement.class);
-    WebElement mockedElement2 = mock(WebElement.class);
-    when(locator.getWebElement()).thenReturn(mockedElement);
-    when(mockedElement.isSelected()).thenReturn(true);
-    when(mockedElement.getTagName()).thenReturn("select");
-    mMockedElementsList = asList(mockedElement1, mockedElement2);
-    when(mockedElement.findElements(By.tagName("option"))).thenReturn(mMockedElementsList);
-    when(mockedElement1.isSelected()).thenReturn(true);
-    when(mockedElement1.getText()).thenReturn("Element text1");
-    when(mockedElement2.isSelected()).thenReturn(true);
-    when(mockedElement2.getText()).thenReturn("Element text2");
   }
 
   @Test
-  void testExecuteMethod() {
-    ElementsCollection elementsCollection = getSelectedOptionsCommand.execute(proxy, locator, new Object[]{"something more"});
-    final List<String> foundTexts = elementsCollection.stream().map(SelenideElement::getText).collect(Collectors.toList());
+  void returnsOnlySelectedOptionsOfGivenSelect() {
+    WebElement option1 = option("Leonardo", true);
+    WebElement option2 = option("Raphael", false);
+    WebElement option3 = option("Donatello", false);
+    WebElement option4 = option("Michelangelo", true);
+    SelenideElement select = mockSelect(option1, option2, option3, option4);
+    when(locator.getWebElement()).thenReturn(select);
 
-    assertThat(mMockedElementsList)
-      .extracting(WebElement::getText)
-      .isEqualTo(foundTexts);
+    ElementsCollection selectedOptions = command.execute(proxy, locator, null);
+
+    assertThat(selectedOptions).isEqualTo(asList(option1, option4));
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetSelectedTextCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSelectedTextCommandTest.java
@@ -3,13 +3,16 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Mocks.mockElement;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-final class GetSelectedTextCommandTest implements WithAssertions {
+final class GetSelectedTextCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource selectElement = mock(WebElementSource.class);
   private final GetSelectedOption getSelectedOptionCommand = mock(GetSelectedOption.class);

--- a/src/test/java/com/codeborne/selenide/commands/GetSelectedValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSelectedValueCommandTest.java
@@ -2,53 +2,39 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-
+import static com.codeborne.selenide.Mocks.mockElement;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetSelectedValueCommandTest implements WithAssertions {
+final class GetSelectedValueCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource selectElement = mock(WebElementSource.class);
-  private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private GetSelectedValue getSelectedValueCommand;
   private final GetSelectedOption getSelectedOptionCommand = mock(GetSelectedOption.class);
+  private final GetSelectedValue command = new GetSelectedValue(getSelectedOptionCommand);
 
-  @BeforeEach
-  void setup() {
-    getSelectedValueCommand = new GetSelectedValue(getSelectedOptionCommand);
+  @Test
+  void selectedOptionReturnsNothing() {
+    // TODO fix me: https://github.com/selenide/selenide/issues/1581
+    //when(getSelectedOptionCommand.execute(any(), any(), any())).thenThrow(new NoSuchElementException("No options are selected"));
+    when(getSelectedOptionCommand.execute(any(), any(), any())).thenReturn(null);
+    assertThat(command.execute(proxy, selectElement, null)).isNull();
+    verify(getSelectedOptionCommand).execute(proxy, selectElement, null);
   }
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    GetSelectedValue getSelectedText = new GetSelectedValue();
-    Field getSelectedOptionField = getSelectedText.getClass().getDeclaredField("getSelectedOption");
-    getSelectedOptionField.setAccessible(true);
-    GetSelectedOption getSelectedOption = (GetSelectedOption) getSelectedOptionField.get(getSelectedText);
-    assertThat(getSelectedOption)
-      .isNotNull();
-  }
+  void selectedOptionReturnsElement() {
+    SelenideElement option = mockElement("option", "Element text");
+    when(option.getAttribute("value")).thenReturn("Element value");
+    when(getSelectedOptionCommand.execute(any(), any(), any())).thenReturn(option);
 
-  @Test
-  void testExecuteMethodWhenSelectedOptionReturnsNothing() throws IOException {
-    Object[] args = {"something more"};
-    when(getSelectedOptionCommand.execute(proxy, selectElement, args)).thenReturn(null);
-    assertThat(getSelectedValueCommand.execute(proxy, selectElement, args))
-      .isNullOrEmpty();
-  }
+    String selectedValue = command.execute(proxy, selectElement, null);
 
-  @Test
-  void testExecuteMethodWhenSelectedOptionReturnsElement() throws IOException {
-    Object[] args = {"something more"};
-    when(getSelectedOptionCommand.execute(proxy, selectElement, args)).thenReturn(mockedElement);
-    String elementText = "Element text";
-    when(mockedElement.getAttribute("value")).thenReturn(elementText);
-    assertThat(getSelectedValueCommand.execute(proxy, selectElement, args))
-      .isEqualTo(elementText);
+    assertThat(selectedValue).isEqualTo("Element value");
+    verify(getSelectedOptionCommand).execute(proxy, selectElement, null);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetSiblingCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSiblingCommandTest.java
@@ -2,17 +2,17 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetSiblingCommandTest implements WithAssertions {
+final class GetSiblingCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);

--- a/src/test/java/com/codeborne/selenide/commands/GetTextCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetTextCommandTest.java
@@ -2,21 +2,21 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetTextCommandTest implements WithAssertions {
+final class GetTextCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
   private final GetSelectedText getSelectedTextCommand = mock(GetSelectedText.class);
-  private final GetText getTextCommand = new GetText(getSelectedTextCommand);
+  private final GetText command = new GetText(getSelectedTextCommand);
 
   @BeforeEach
   void setup() {
@@ -24,31 +24,19 @@ final class GetTextCommandTest implements WithAssertions {
   }
 
   @Test
-  void testDefaultConstructor() throws IllegalAccessException, NoSuchFieldException {
-    GetText getText = new GetText();
-    Field getSelectedTextField = getText.getClass().getDeclaredField("getSelectedText");
-    getSelectedTextField.setAccessible(true);
-    GetSelectedText getSelectedText = (GetSelectedText) getSelectedTextField.get(getText);
-    assertThat(getSelectedText)
-      .isNotNull();
-  }
-
-  @Test
-  void testExecuteMethodWithSelectElement() {
+  void selectElement() {
     when(mockedElement.getTagName()).thenReturn("select");
-    Object[] args = {"something more"};
-    String selectedElementText = "Selected Text";
-    when(getSelectedTextCommand.execute(proxy, locator, args)).thenReturn(selectedElementText);
-    assertThat(getTextCommand.execute(proxy, locator, args))
-      .isEqualTo(selectedElementText);
+    when(getSelectedTextCommand.execute(any(), any(), any())).thenReturn("Selected Text");
+
+    assertThat(command.execute(proxy, locator, null)).isEqualTo("Selected Text");
+
+    verify(getSelectedTextCommand).execute(proxy, locator, null);
   }
 
   @Test
-  void testExecuteMethodWithNotSelectElement() {
-    when(mockedElement.getTagName()).thenReturn("href");
-    String text = "This is text";
-    when(mockedElement.getText()).thenReturn(text);
-    assertThat(getTextCommand.execute(proxy, locator, new Object[]{"something more"}))
-      .isEqualTo(text);
+  void nonSelectElement() {
+    when(mockedElement.getTagName()).thenReturn("a");
+    when(mockedElement.getText()).thenReturn("This is text");
+    assertThat(command.execute(proxy, locator, null)).isEqualTo("This is text");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetValueCommandTest.java
@@ -2,18 +2,20 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class GetValueCommandTest implements WithAssertions {
+final class GetValueCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetValue getValueCommand = new GetValue();
+  private final GetValue command = new GetValue();
 
   @BeforeEach
   void setup() {
@@ -21,11 +23,9 @@ final class GetValueCommandTest implements WithAssertions {
   }
 
   @Test
-  void testExecuteMethod() {
-    String argument = "class";
-    String elementAttribute = "hello";
-    when(mockedElement.getAttribute("value")).thenReturn(elementAttribute);
-    assertThat(getValueCommand.execute(proxy, locator, new Object[]{argument, "something more"}))
-      .isEqualTo(elementAttribute);
+  void getsValueAttribute() {
+    when(mockedElement.getAttribute(any())).thenReturn("hello");
+    assertThat(command.execute(proxy, locator, null)).isEqualTo("hello");
+    verify(mockedElement).getAttribute("value");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/GetWrappedElementCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetWrappedElementCommandTest.java
@@ -2,27 +2,23 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class GetWrappedElementCommandTest implements WithAssertions {
+final class GetWrappedElementCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetWrappedElement getWrappedElementCommand = new GetWrappedElement();
-
-  @BeforeEach
-  void setup() {
-    when(locator.getWebElement()).thenReturn(mockedElement);
-  }
+  private final GetWrappedElement command = new GetWrappedElement();
 
   @Test
-  void testExecuteMethod() {
-    assertThat(getWrappedElementCommand.execute(proxy, locator, new Object[]{"something more"}))
+  void getsUnderlyingWebElement() {
+    when(locator.getWebElement()).thenReturn(mockedElement);
+
+    assertThat(command.execute(proxy, locator, null))
       .isEqualTo(mockedElement);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/IsImageCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/IsImageCommandTest.java
@@ -2,32 +2,24 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class IsImageCommandTest implements WithAssertions {
+final class IsImageCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final IsImage isImageCommand = new IsImage();
-
-  @BeforeEach
-  void setup() {
-    when(locator.getWebElement()).thenReturn(mockedElement);
-  }
+  private final IsImage command = new IsImage();
 
   @Test
-  void testExecuteMethodWhenElementIsNotImage() {
+  void isNotApplicableForNonImages() {
+    when(locator.getWebElement()).thenReturn(mockedElement);
     when(mockedElement.getTagName()).thenReturn("href");
-    try {
-      isImageCommand.execute(proxy, locator, new Object[]{"something more"});
-    } catch (IllegalArgumentException exception) {
-      assertThat(exception)
-        .hasMessage("Method isImage() is only applicable for img elements");
-    }
+    assertThatThrownBy(() -> command.execute(proxy, locator, null))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Method isImage() is only applicable for img elements");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndexCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndexCommandTest.java
@@ -4,90 +4,84 @@ import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.Quotes;
 
+import static com.codeborne.selenide.Mocks.mockWebElement;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class SelectOptionByTextOrIndexCommandTest implements WithAssertions {
+final class SelectOptionByTextOrIndexCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource selectField = mock(WebElementSource.class);
-  private final SelectOptionByTextOrIndex selectOptionByTextOrIndexCommand = new SelectOptionByTextOrIndex();
-  private final WebElement mockedElement = mock(WebElement.class);
-  private final String defaultElementText = "This is element text";
-  private final WebElement mockedFoundElement = mock(WebElement.class);
-  private final int defaultIndex = 1;
+  private final SelectOptionByTextOrIndex command = new SelectOptionByTextOrIndex();
+  private final WebElement select = mockWebElement("select", "This is element text");
+  private final WebElement option = mock(WebElement.class);
 
   @BeforeEach
   void setup() {
     when(selectField.driver()).thenReturn(new DriverStub());
-    when(selectField.getWebElement()).thenReturn(mockedElement);
-    when(mockedElement.getText()).thenReturn(defaultElementText);
-    when(mockedElement.getTagName()).thenReturn("select");
-
-    when(mockedFoundElement.isSelected()).thenReturn(true);
+    when(selectField.getWebElement()).thenReturn(select);
+    when(option.isSelected()).thenReturn(false);
   }
 
   @Test
-  void testSelectOptionByText() {
-    when(mockedElement.findElements(By.xpath(".//option[normalize-space(.) = " + Quotes.escape(defaultElementText) + "]")))
-      .thenReturn(singletonList(mockedFoundElement));
-    selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new String[]{this.defaultElementText}});
+  void selectOptionByText() {
+    when(select.findElements(any())).thenReturn(singletonList(option));
+    command.execute(proxy, selectField, new Object[]{new String[]{"This is element text"}});
+    verify(select).findElements(By.xpath(".//option[normalize-space(.) = \"This is element text\"]"));
   }
 
   @Test
   void selectOptionByTextWhenElementIsNotFound() {
-    try {
-      selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new String[]{this.defaultElementText}});
-    } catch (ElementNotFound exception) {
-      assertThat(exception)
-        .hasMessageStartingWith(String.format("Element not found {null/option[text:%s]}%nExpected: exist", this.defaultElementText));
-    }
+    assertThatThrownBy(() -> command.execute(proxy, selectField, new Object[]{new String[]{"This is element text"}}))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {null/option[text:This is element text]}")
+      .hasMessageContaining("Expected: exist");
   }
 
   @Test
   void selectedOptionByTextWhenNoSuchElementIsThrown() {
-    doThrow(new NoSuchElementException("no element found"))
-      .when(mockedElement)
-      .findElements(By.xpath(".//option[normalize-space(.) = " + Quotes.escape(defaultElementText) + "]"));
-    try {
-      selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new String[]{""}});
-    } catch (ElementNotFound exception) {
-      assertThat(exception)
-        .hasMessage(String.format("Element not found {null/option[text:]}%nExpected: exist%n" +
-          "Timeout: 0 ms.%n" +
-          "Caused by: NoSuchElementException: Cannot locate element with text:"));
-    }
+    doThrow(new NoSuchElementException("no element found")).when(select).findElements(any());
+    assertThatThrownBy(() -> command.execute(proxy, selectField, new Object[]{new String[]{"Mega text"}}))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {null/option[text:Mega text]}")
+      .hasMessageContaining("Expected: exist")
+      .hasMessageContaining("Caused by: NoSuchElementException: no element found");
+    verify(select).findElements(By.xpath(".//option[normalize-space(.) = \"Mega text\"]"));
   }
 
   @Test
   void selectOptionByIndex() {
-    when(mockedElement.findElements(By.tagName("option"))).thenReturn(singletonList(mockedFoundElement));
-    when(mockedFoundElement.getAttribute("index")).thenReturn(String.valueOf(defaultIndex));
-    selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new int[]{defaultIndex}});
+    when(select.findElements(any())).thenReturn(singletonList(option));
+    when(option.getAttribute(any())).thenReturn("33");
+
+    command.execute(proxy, selectField, new Object[]{new int[]{33}});
+
+    verify(option).click();
+    verify(select).findElements(By.tagName("option"));
+    verify(option).getAttribute("index");
   }
 
   @Test
   void selectOptionByIndexWhenNoElementFound() {
-    try {
-      selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new int[]{defaultIndex}});
-    } catch (ElementNotFound exception) {
-      assertThat(exception)
-        .hasMessageStartingWith(String.format("Element not found {null/option[index:%d]}%nExpected: exist", defaultIndex));
-    }
+    assertThatThrownBy(() -> command.execute(proxy, selectField, new Object[]{new int[]{42}}))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {null/option[index:42]}")
+      .hasMessageContaining("Expected: exist");
   }
 
   @Test
-  void executeMethodWhenArgIsNotStringOrInt() {
-    assertThat(selectOptionByTextOrIndexCommand.execute(proxy, selectField, new Object[]{new Double[]{1.0}}))
-      .isNull();
+  void throwsIllegalArgumentException_whenArgIsNotStringOrInt() {
+    assertThatThrownBy(() -> command.execute(proxy, selectField, new Object[]{new Double[]{1.0}}))
+      .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/SelectOptionContainingTextTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectOptionContainingTextTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -10,12 +9,15 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-final class SelectOptionContainingTextTest implements WithAssertions {
+final class SelectOptionContainingTextTest {
   private final SelectOptionContainingText command = new SelectOptionContainingText();
 
   private final WebElement element = mock(WebElement.class);
@@ -32,38 +34,34 @@ final class SelectOptionContainingTextTest implements WithAssertions {
 
   @Test
   void selectsFirstMatchingOptionForSingleSelect() {
-    doReturn("false").when(element).getAttribute("multiple");
-    doReturn(asList(option1, option2)).when(element)
-      .findElements(
-        By.xpath(".//option[contains(normalize-space(.), \"option-subtext\")]"));
+    when(element.getAttribute(any())).thenReturn("false");
+    when(element.findElements(any())).thenReturn(asList(option1, option2));
 
     command.execute(proxy, select, new Object[]{"option-subtext"});
 
     verify(option1).click();
     verify(option2, never()).click();
+    verify(element).getAttribute("multiple");
+    verify(element).findElements(By.xpath(".//option[contains(normalize-space(.), \"option-subtext\")]"));
   }
 
   @Test
   void selectsAllMatchingOptionsForMultipleSelect() {
-    doReturn("true").when(element).getAttribute("multiple");
-    doReturn(asList(option1, option2)).when(element)
-      .findElements(
-        By.xpath(".//option[contains(normalize-space(.), \"option-subtext\")]"));
+    when(element.getAttribute(any())).thenReturn("true");
+    when(element.findElements(any())).thenReturn(asList(option1, option2));
 
     command.execute(proxy, select, new Object[]{"option-subtext"});
 
     verify(option1).click();
     verify(option2).click();
+    verify(element).getAttribute("multiple");
+    verify(element).findElements(By.xpath(".//option[contains(normalize-space(.), \"option-subtext\")]"));
   }
 
   @Test
   void throwsNoSuchElementExceptionWhenNoElementsFound() {
-    String elementText = "option-subtext";
-    try {
-      command.execute(proxy, select, new Object[]{elementText});
-    } catch (NoSuchElementException exception) {
-      assertThat(exception)
-        .hasMessageContaining(String.format("Cannot locate option containing text: %s", elementText));
-    }
+    assertThatThrownBy(() -> command.execute(proxy, select, new Object[]{"option-subtext"}))
+      .isInstanceOf(NoSuchElementException.class)
+      .hasMessageContaining("Cannot locate option containing text: option-subtext");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/SelectRadioCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectRadioCommandTest.java
@@ -5,68 +5,67 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.InvalidStateException;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import java.lang.reflect.Field;
-import java.util.Collections;
-
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-final class SelectRadioCommandTest implements WithAssertions {
+final class SelectRadioCommandTest {
+  private final DriverStub driver = new DriverStub();
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelectRadio selectRadioCommand = new SelectRadio(mock(Click.class));
-  private final WebElement mockedFoundElement = mock(WebElement.class);
-  private final String defaultElementValue = "ElementValue";
+  private final Click click = mock(Click.class);
+  private final SelectRadio command = new SelectRadio(click);
 
   @BeforeEach
   void setup() {
-    when(locator.driver()).thenReturn(new DriverStub());
-    when(mockedFoundElement.getAttribute("value")).thenReturn(defaultElementValue);
+    when(locator.driver()).thenReturn(driver);
   }
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    SelectRadio selectRadio = new SelectRadio();
-    Field clickField = selectRadio.getClass().getDeclaredField("click");
-    clickField.setAccessible(true);
-    Click click = (Click) clickField.get(selectRadio);
-    assertThat(click)
-      .isNotNull();
+  void noElementsIsFound() {
+    when(locator.findAll()).thenReturn(emptyList());
+    assertThatThrownBy(() -> command.execute(proxy, locator, new Object[]{"ElementValue"}))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessageStartingWith("Element not found {null}")
+      .hasMessageContaining("Expected: value 'ElementValue'");
   }
 
   @Test
-  void testExecuteMethodWhenNoElementsIsFound() {
-    when(locator.findAll()).thenReturn(Collections.emptyList());
-    try {
-      selectRadioCommand.execute(proxy, locator, new Object[]{defaultElementValue});
-    } catch (ElementNotFound exception) {
-      assertThat(exception)
-        .hasMessageStartingWith(String.format("Element not found {null}%nExpected: value '%s'", defaultElementValue));
+  void radioButtonIsReadOnly() {
+    givenRadioInput("ElementValue", true);
+
+    assertThatThrownBy(() -> command.execute(proxy, locator, new Object[]{"ElementValue"}))
+      .isInstanceOf(InvalidStateException.class)
+      .hasMessageStartingWith("Invalid element state: Cannot select readonly radio button");
+
+    verifyNoInteractions(click);
+  }
+
+  @Test
+  void radioButton() {
+    WebElement input = givenRadioInput("ElementValue", false);
+
+    SelenideElement clickedElement = command.execute(proxy, locator, new Object[]{"ElementValue"});
+    assertThat(clickedElement.getWrappedElement()).isEqualTo(input);
+    verify(click).click(driver, input);
+  }
+
+  private WebElement givenRadioInput(String value, boolean readonly) {
+    WebElement input = mock(WebElement.class);
+    when(input.getAttribute("value")).thenReturn(value);
+    if (readonly) {
+      when(input.getAttribute("readonly")).thenReturn("true");
     }
-  }
-
-  @Test
-  void testExecuteMethodWhenRadioButtonIsReadOnly() {
-    when(locator.findAll()).thenReturn(Collections.singletonList(mockedFoundElement));
-    when(mockedFoundElement.getAttribute("readonly")).thenReturn("true");
-    try {
-      selectRadioCommand.execute(proxy, locator, new Object[]{defaultElementValue});
-    } catch (InvalidStateException exception) {
-      assertThat(exception)
-        .hasMessageStartingWith("Invalid element state: Cannot select readonly radio button");
-    }
-  }
-
-  @Test
-  void testExecuteMethodOnFoundRadioButton() {
-    when(locator.findAll()).thenReturn(Collections.singletonList(mockedFoundElement));
-    SelenideElement clickedElement = selectRadioCommand.execute(proxy, locator, new Object[]{defaultElementValue});
-    assertThat(clickedElement.getWrappedElement())
-      .isEqualTo(mockedFoundElement);
+    when(locator.findAll()).thenReturn(singletonList(input));
+    return input;
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SelectionOptionByValueCommandTest.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -13,10 +12,12 @@ import org.openqa.selenium.WebElement;
 import java.util.Collections;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class SelectionOptionByValueCommandTest implements WithAssertions {
+final class SelectionOptionByValueCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource selectField = mock(WebElementSource.class);
   private final SelectOptionByValue selectOptionByValueCommand = new SelectOptionByValue();

--- a/src/test/java/com/codeborne/selenide/commands/SetSelectedCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SetSelectedCommandTest.java
@@ -4,17 +4,18 @@ import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.InvalidStateException;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import java.lang.reflect.Field;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class SetSelectedCommandTest implements WithAssertions {
+final class SetSelectedCommandTest {
   private final Click mockedClick = mock(Click.class);
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
@@ -42,7 +43,8 @@ final class SetSelectedCommandTest implements WithAssertions {
     when(mockedFoundElement.isDisplayed()).thenReturn(false);
     try {
       setSelectedCommand.execute(proxy, locator, new Object[]{true});
-    } catch (InvalidStateException exception) {
+    }
+    catch (InvalidStateException exception) {
       assertThat(exception)
         .hasMessageStartingWith("Invalid element state: Cannot change invisible element");
     }
@@ -59,7 +61,8 @@ final class SetSelectedCommandTest implements WithAssertions {
     when(mockedFoundElement.getAttribute("type")).thenReturn("href");
     try {
       setSelectedCommand.execute(proxy, locator, new Object[]{true});
-    } catch (InvalidStateException exception) {
+    }
+    catch (InvalidStateException exception) {
       assertThat(exception)
         .hasMessageStartingWith("Invalid element state: Only use setSelected on checkbox/option/radio");
     }

--- a/src/test/java/com/codeborne/selenide/commands/SetValueCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/SetValueCommandTest.java
@@ -3,23 +3,23 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import java.lang.reflect.Field;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-final class SetValueCommandTest implements WithAssertions {
+final class SetValueCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final SelectOptionByValue mockedSelectByOption = mock(SelectOptionByValue.class);
-  private final SelectRadio mockedSelectRadio = mock(SelectRadio.class);
-  private final SetValue setValueCommand = new SetValue(mockedSelectByOption, mockedSelectRadio);
+  private final SelectOptionByValue selectOptionByValue = mock(SelectOptionByValue.class);
+  private final SelectRadio selectRadio = mock(SelectRadio.class);
+  private final SetValue command = new SetValue(selectOptionByValue, selectRadio);
   private final WebElement mockedFoundElement = mock(WebElement.class);
 
   @BeforeEach
@@ -29,62 +29,57 @@ final class SetValueCommandTest implements WithAssertions {
     when(locator.driver()).thenReturn(new DriverStub());
   }
 
-  @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    SetValue setValue = new SetValue();
-    Field selectOptionByValueField = setValue.getClass().getDeclaredField("selectOptionByValue");
-    Field selectRadioField = setValue.getClass().getDeclaredField("selectRadio");
-    selectOptionByValueField.setAccessible(true);
-    selectRadioField.setAccessible(true);
-    SelectOptionByValue selectOptionByValue = (SelectOptionByValue) selectOptionByValueField.get(setValue);
-    SelectRadio selectRadio = (SelectRadio) selectRadioField.get(setValue);
-    assertThat(selectOptionByValue)
-      .isNotNull();
-    assertThat(selectRadio)
-      .isNotNull();
+  @AfterEach
+  void noMoreInteractions() {
+    verify(locator).driver();
+    verify(locator).findAndAssertElementIsInteractable();
+    verify(mockedFoundElement).getTagName();
+    verifyNoMoreInteractions(proxy, locator, selectOptionByValue, selectRadio, mockedFoundElement);
   }
 
   @Test
-  void testExecuteWithSelectTagElement() {
+  void selectOptionByValue_inCaseOfSelectElement() {
     System.setProperty("selenide.versatileSetValue", "true");
     when(mockedFoundElement.getTagName()).thenReturn("select");
-    WebElement returnedElement = setValueCommand.execute(proxy, locator, new Object[]{"value"});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+    WebElement returnedElement = command.execute(proxy, locator, new Object[]{"new value"});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(selectOptionByValue).execute(proxy, locator, new Object[]{"new value"});
   }
 
   @Test
-  void testExecuteWithInputTagElement() {
+  void selectInputByValue_inCaseOfRadioElement() {
     when(mockedFoundElement.getTagName()).thenReturn("input");
     when(mockedFoundElement.getAttribute("type")).thenReturn("radio");
-    WebElement returnedElement = setValueCommand.execute(proxy, locator, new Object[]{"value"});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+    WebElement returnedElement = command.execute(proxy, locator, new Object[]{"new radio value"});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(selectRadio).execute(proxy, locator, new Object[]{"new radio value"});
+    verify(mockedFoundElement).getAttribute("type");
   }
 
   @Test
-  void testElementGetClearedWhenArgsTextIsNull() {
-    WebElement returnedElement = setValueCommand.execute(proxy, locator, new Object[]{null});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+  void clearsTheInputIfArgsTextIsNull() {
+    WebElement returnedElement = command.execute(proxy, locator, new Object[]{null});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(mockedFoundElement).clear();
   }
 
   @Test
-  void testElementGetClearedWhenArgsTextIsEmpty() {
-    WebElement returnedElement = setValueCommand.execute(proxy, locator, new Object[]{""});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+  void clearsTheInputIfArgsTextIsEmpty() {
+    WebElement returnedElement = command.execute(proxy, locator, new Object[]{""});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(mockedFoundElement).clear();
   }
 
   @Test
-  void testElementGetClearedWhenArgsTextIsNotEmpty() {
-    WebElement returnedElement = setValueCommand.execute(proxy, locator, new Object[]{"text"});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+  void typesGivenTextIntoInputField() {
+    WebElement returnedElement = command.execute(proxy, locator, new Object[]{"Stalker"});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(mockedFoundElement).clear();
+    verify(mockedFoundElement).sendKeys("Stalker");
   }
 
   @AfterEach
   void tearDown() {
-    System.setProperty("selenide.versatileSetValue", "false");
+    System.clearProperty("selenide.versatileSetValue");
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/ShouldBeCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ShouldBeCommandTest.java
@@ -1,50 +1,41 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import java.lang.reflect.Field;
-
+import static com.codeborne.selenide.Condition.disabled;
+import static com.codeborne.selenide.Condition.readonly;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-final class ShouldBeCommandTest implements WithAssertions {
+final class ShouldBeCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final ShouldBe shouldBeCommand = new ShouldBe();
-  private final WebElement mockedFoundElement = mock(WebElement.class);
+  private final ShouldBe command = new ShouldBe();
+  private final WebElement webElement = mock(WebElement.class);
 
   @BeforeEach
   void setup() {
-    when(locator.getWebElement()).thenReturn(mockedFoundElement);
+    when(locator.getWebElement()).thenReturn(webElement);
   }
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    ShouldBe shouldBe = new ShouldBe();
-    Field prefixField = shouldBe.getClass().getSuperclass().getDeclaredField("prefix");
-    prefixField.setAccessible(true);
-    String prefix = (String) prefixField.get(shouldBe);
-    assertThat(prefix)
-      .isEqualToIgnoringWhitespace("be");
+  void checksEveryConditionFromGivenParameters() {
+    SelenideElement returnedElement = command.execute(proxy, locator, new Object[]{disabled, readonly});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(locator).checkCondition("be ", disabled, false);
+    verify(locator).checkCondition("be ", readonly, false);
   }
 
   @Test
-  void testExecuteMethodWithNonStringArgs() {
-    SelenideElement returnedElement = shouldBeCommand.execute(proxy, locator, new Object[]{Condition.disabled});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
-  }
-
-  @Test
-  void testExecuteMethodWithStringArgs() {
-    SelenideElement returnedElement = shouldBeCommand.execute(proxy, locator, new Object[]{"hello"});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+  void noArgs() {
+    command.execute(proxy, locator, new Object[0]);
+    verifyNoMoreInteractions(locator);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/ShouldCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ShouldCommandTest.java
@@ -1,50 +1,34 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import java.lang.reflect.Field;
-
+import static com.codeborne.selenide.Condition.enabled;
+import static com.codeborne.selenide.Condition.visible;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class ShouldCommandTest implements WithAssertions {
+final class ShouldCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final Should shouldCommand = new Should();
-  private final WebElement mockedFoundElement = mock(WebElement.class);
+  private final Should command = new Should();
+  private final WebElement webElement = mock(WebElement.class);
 
   @BeforeEach
   void setup() {
-    when(locator.getWebElement()).thenReturn(mockedFoundElement);
+    when(locator.getWebElement()).thenReturn(webElement);
   }
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    Should should = new Should();
-    Field prefixField = should.getClass().getDeclaredField("prefix");
-    prefixField.setAccessible(true);
-    String prefix = (String) prefixField.get(should);
-    assertThat(prefix.isEmpty())
-      .isTrue();
-  }
-
-  @Test
-  void testExecuteMethodWithNonStringArgs() {
-    SelenideElement returnedElement = shouldCommand.execute(proxy, locator, new Object[]{Condition.disabled});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
-  }
-
-  @Test
-  void testExecuteMethodWithStringArgs() {
-    SelenideElement returnedElement = shouldCommand.execute(proxy, locator, new Object[]{"hello"});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+  void checksEveryConditionFromGivenParameters() {
+    SelenideElement returnedElement = command.execute(proxy, locator, new Object[]{visible, enabled});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(locator).checkCondition("", visible, false);
+    verify(locator).checkCondition("", enabled, false);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/ShouldHaveCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ShouldHaveCommandTest.java
@@ -3,17 +3,18 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import java.lang.reflect.Field;
-
+import static com.codeborne.selenide.Condition.attribute;
+import static com.codeborne.selenide.Condition.text;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class ShouldHaveCommandTest implements WithAssertions {
+final class ShouldHaveCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final ShouldHave shouldHaveCommand = new ShouldHave();
@@ -25,26 +26,12 @@ final class ShouldHaveCommandTest implements WithAssertions {
   }
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    ShouldHave shouldHave = new ShouldHave();
-    Field prefixField = shouldHave.getClass().getSuperclass().getDeclaredField("prefix");
-    prefixField.setAccessible(true);
-    String prefix = (String) prefixField.get(shouldHave);
-    assertThat(prefix)
-      .isEqualToIgnoringWhitespace("have");
-  }
-
-  @Test
-  void testExecuteMethodWithNonStringArgs() {
-    SelenideElement returnedElement = shouldHaveCommand.execute(proxy, locator, new Object[]{Condition.disabled});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
-  }
-
-  @Test
-  void testExecuteMethodWithStringArgs() {
-    SelenideElement returnedElement = shouldHaveCommand.execute(proxy, locator, new Object[]{"hello"});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+  void checksEveryConditionFromGivenParameters() {
+    Condition condition1 = text("aaa");
+    Condition condition2 = attribute("readonly");
+    SelenideElement returnedElement = shouldHaveCommand.execute(proxy, locator, new Object[]{condition1, condition2});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(locator).checkCondition("have ", condition1, false);
+    verify(locator).checkCondition("have ", condition2, false);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/ShouldNotBeCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ShouldNotBeCommandTest.java
@@ -1,50 +1,32 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import java.lang.reflect.Field;
-
+import static com.codeborne.selenide.Condition.disabled;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class ShouldNotBeCommandTest implements WithAssertions {
+final class ShouldNotBeCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final ShouldNotBe shouldNotBeCommand = new ShouldNotBe();
-  private final WebElement mockedFoundElement = mock(WebElement.class);
+  private final ShouldNotBe command = new ShouldNotBe();
+  private final WebElement webElement = mock(WebElement.class);
 
   @BeforeEach
   void setup() {
-    when(locator.getWebElement()).thenReturn(mockedFoundElement);
+    when(locator.getWebElement()).thenReturn(webElement);
   }
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    ShouldNotBe shouldNotBe = new ShouldNotBe();
-    Field prefixField = shouldNotBe.getClass().getSuperclass().getDeclaredField("prefix");
-    prefixField.setAccessible(true);
-    String prefix = (String) prefixField.get(shouldNotBe);
-    assertThat(prefix)
-      .isEqualToIgnoringWhitespace("be");
-  }
-
-  @Test
-  void testExecuteMethodWithNonStringArgs() {
-    SelenideElement returnedElement = shouldNotBeCommand.execute(proxy, locator, new Object[]{Condition.disabled});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
-  }
-
-  @Test
-  void testExecuteMethodWithStringArgs() {
-    SelenideElement returnedElement = shouldNotBeCommand.execute(proxy, locator, new Object[]{"hello"});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+  void checksEveryConditionFromGivenParameters() {
+    SelenideElement returnedElement = command.execute(proxy, locator, new Object[]{disabled});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(locator).checkCondition("be ", disabled, true);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/ShouldNotCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ShouldNotCommandTest.java
@@ -1,50 +1,34 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
-import java.lang.reflect.Field;
-
+import static com.codeborne.selenide.Condition.disabled;
+import static com.codeborne.selenide.Condition.readonly;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class ShouldNotCommandTest implements WithAssertions {
+final class ShouldNotCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final ShouldNot shouldNotCommand = new ShouldNot();
-  private final WebElement mockedFoundElement = mock(WebElement.class);
+  private final ShouldNot command = new ShouldNot();
+  private final WebElement webElement = mock(WebElement.class);
 
   @BeforeEach
   void setup() {
-    when(locator.getWebElement()).thenReturn(mockedFoundElement);
+    when(locator.getWebElement()).thenReturn(webElement);
   }
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    ShouldNot shouldNot = new ShouldNot();
-    Field prefixField = shouldNot.getClass().getDeclaredField("prefix");
-    prefixField.setAccessible(true);
-    String prefix = (String) prefixField.get(shouldNot);
-    assertThat(prefix)
-      .isNullOrEmpty();
-  }
-
-  @Test
-  void testExecuteMethodWithNonStringArgs() {
-    SelenideElement returnedElement = shouldNotCommand.execute(proxy, locator, new Object[]{Condition.disabled});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
-  }
-
-  @Test
-  void testExecuteMethodWithStringArgs() {
-    SelenideElement returnedElement = shouldNotCommand.execute(proxy, locator, new Object[]{"hello"});
-    assertThat(returnedElement)
-      .isEqualTo(proxy);
+  void checksEveryConditionFromGivenParameters() {
+    SelenideElement returnedElement = command.execute(proxy, locator, new Object[]{disabled, readonly});
+    assertThat(returnedElement).isEqualTo(proxy);
+    verify(locator).checkCondition("", disabled, true);
+    verify(locator).checkCondition("", readonly, true);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/ToStringCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ToStringCommandTest.java
@@ -6,18 +6,18 @@ import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class ToStringCommandTest implements WithAssertions {
+final class ToStringCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final Driver driver = new DriverStub();
   private final WebElementSource locator = mock(WebElementSource.class);

--- a/src/test/java/com/codeborne/selenide/commands/ToWebElementCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ToWebElementCommandTest.java
@@ -2,28 +2,24 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class ToWebElementCommandTest implements WithAssertions {
+final class ToWebElementCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final ToWebElement toWebElementCommand = new ToWebElement();
-  private final WebElement mockedFoundElement = mock(WebElement.class);
-
-  @BeforeEach
-  void setup() {
-    when(locator.getWebElement()).thenReturn(mockedFoundElement);
-  }
+  private final ToWebElement command = new ToWebElement();
+  private final WebElement webElement = mock(WebElement.class);
 
   @Test
-  void testExecuteMethod() {
-    assertThat(toWebElementCommand.execute(proxy, locator, new Object[]{}))
-      .isEqualTo(mockedFoundElement);
+  void returnsUnderlyingWebElement() {
+    when(locator.getWebElement()).thenReturn(webElement);
+    assertThat(command.execute(proxy, locator, new Object[]{})).isEqualTo(webElement);
+    verify(locator).getWebElement();
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/UtilCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/UtilCommandTest.java
@@ -1,37 +1,50 @@
 package com.codeborne.selenide.commands;
 
-import java.util.List;
-
 import com.codeborne.selenide.Condition;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-import static java.util.Arrays.asList;
+import java.time.Duration;
+import java.util.List;
 
-final class UtilCommandTest implements WithAssertions {
+import static com.codeborne.selenide.Condition.appear;
+import static com.codeborne.selenide.Condition.disabled;
+import static com.codeborne.selenide.Condition.enabled;
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.readonly;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.commands.Util.argsToConditions;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class UtilCommandTest {
   @Test
-  void testArgsToCondition() {
-    List<Condition> conditions = Util.argsToConditions(new Object[]{
-      Condition.enabled,
-      new Condition[]{Condition.appear, Condition.exist},
-      "hello",
-      2L
-    });
-    assertThat(conditions)
-      .isEqualTo(asList(Condition.enabled, Condition.visible, Condition.exist));
+  void extractsConditionsFromGivenArguments() {
+    List<Condition> conditions = argsToConditions(new Object[]{enabled, visible});
+    assertThat(conditions).isEqualTo(asList(enabled, visible));
   }
 
   @Test
-  void testArgsToConditionWithIllegalArguments() {
-    assertThatThrownBy(() -> {
-      List<Condition> conditions = Util.argsToConditions(new Object[]{
-        Condition.enabled,
-        new Condition[]{Condition.appear, Condition.exist},
-        1,
-        2.0
-      });
-      assertThat(conditions)
-        .isEqualTo(asList(Condition.enabled, Condition.visible, Condition.exist));
-    }).isInstanceOf(IllegalArgumentException.class);
+  void supportsArraysOfConditions() {
+    List<Condition> conditions = argsToConditions(new Object[]{
+      enabled,
+      new Condition[]{appear, exist},
+      new Condition[]{disabled, enabled, readonly}
+    });
+    assertThat(conditions).isEqualTo(asList(enabled, appear, exist, disabled, enabled, readonly));
+  }
+
+  @Test
+  void ignores_String_Long_Duration_arguments() {
+    List<Condition> conditions = argsToConditions(new Object[]{42L, "Some text", exist, Duration.ofSeconds(3), visible});
+    assertThat(conditions).isEqualTo(asList(exist, visible));
+  }
+
+  @Test
+  void doesNotAllowOtherTypesOfArguments() {
+    assertThatThrownBy(() -> argsToConditions(new Object[]{enabled, 2}))
+      .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> argsToConditions(new Object[]{enabled, 2.0}))
+      .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/ValCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ValCommandTest.java
@@ -1,52 +1,40 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-
+import static com.codeborne.selenide.Command.NO_ARGS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class ValCommandTest implements WithAssertions {
+final class ValCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
-  private final GetValue mockedGetValue = mock(GetValue.class);
-  private final SetValue mockedSetValue = mock(SetValue.class);
-  private final Val valCommand = new Val(mockedGetValue, mockedSetValue);
+  private final GetValue getValue = mock(GetValue.class);
+  private final SetValue setValue = mock(SetValue.class);
+  private final Val command = new Val(getValue, setValue);
 
   @Test
-  void testDefaultConstructor() throws NoSuchFieldException, IllegalAccessException {
-    Val val = new Val();
-    Field getValueField = val.getClass().getDeclaredField("getValue");
-    Field setValueField = val.getClass().getDeclaredField("setValue");
-    getValueField.setAccessible(true);
-    setValueField.setAccessible(true);
-    GetValue getValue = (GetValue) getValueField.get(val);
-    SetValue setValue = (SetValue) setValueField.get(val);
-
-    assertThat(getValue)
-      .isNotNull();
-    assertThat(setValue)
-      .isNotNull();
+  void returnsValue_whenCalledWithoutArguments() {
+    when(getValue.execute(any(), any(), any())).thenReturn("some value");
+    assertThat(command.execute(proxy, locator, null)).isEqualTo("some value");
+    verify(getValue).execute(proxy, locator, NO_ARGS);
   }
 
   @Test
-  void testExecuteValueWithNoArgs() {
-    String getValueResult = "getValueResult";
-    when(mockedGetValue.execute(proxy, locator, Command.NO_ARGS)).thenReturn(getValueResult);
-    assertThat(valCommand.execute(proxy, locator, null))
-      .isEqualTo(getValueResult);
-    assertThat(valCommand.execute(proxy, locator, new Object[]{}))
-      .isEqualTo(getValueResult);
+  void returnsValue_whenCalledWithEmptyArguments() {
+    when(getValue.execute(any(), any(), any())).thenReturn("some value");
+    assertThat(command.execute(proxy, locator, new Object[]{})).isEqualTo("some value");
+    verify(getValue).execute(proxy, locator, NO_ARGS);
   }
 
   @Test
-  void testExecuteValueWithArgs() {
-    assertThat(valCommand.execute(proxy, locator, new Object[]{"value"}))
-      .isEqualTo(proxy);
+  void setsValue_whenCalledWithStringArgument() {
+    assertThat(command.execute(proxy, locator, new Object[]{"new value"})).isEqualTo(proxy);
+    verify(setValue).execute(proxy, locator, new Object[]{"new value"});
   }
 }

--- a/src/test/java/com/codeborne/selenide/conditions/MatchTextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/MatchTextTest.java
@@ -1,16 +1,16 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-final class MatchTextTest implements WithAssertions {
+final class MatchTextTest {
   private final Driver driver = mock(Driver.class);
 
   @Test

--- a/src/test/java/com/codeborne/selenide/conditions/TextCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/TextCaseSensitiveTest.java
@@ -2,24 +2,21 @@ package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static com.codeborne.selenide.Mocks.mockSelect;
+import static com.codeborne.selenide.Mocks.option;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 final class TextCaseSensitiveTest {
 
   private final Driver driver = mock(Driver.class);
-  private final WebElement elementShort = elementWithText("One");
-  private final WebElement elementLong = elementWithText("ZeroOneTwo");
-  private final WebElement singleSelectElement = selectSingle("One", "Two", "Three"); // only the first element is selected
-  private final WebElement multiSelectElement = selectMulti("One", "Two", "Three");  //  all elements are selected
+  private final WebElement elementShort = mockElement("One");
+  private final WebElement elementLong = mockElement("ZeroOneTwo");
+  private final WebElement singleSelectElement = mockSelect(option("One", true), option("Two"), option("Three"));
+  private final WebElement multiSelectElement = mockSelect(option("One", true), option("Two", true), option("Three", true));
 
   @Test
   void shouldMatchExpectedTextWithSameCase() {
@@ -66,39 +63,5 @@ final class TextCaseSensitiveTest {
   @Test
   void shouldHaveCorrectToString() {
     assertThat(new CaseSensitiveText("One")).hasToString("text case sensitive 'One'");
-  }
-
-  private WebElement elementWithText(String text) {
-    WebElement webElement = mock(WebElement.class);
-    when(webElement.getText()).thenReturn(text);
-    return webElement;
-  }
-
-  private WebElement selectSingle(String... optionTexts) {
-    WebElement select = mock(WebElement.class);
-    when(select.getTagName()).thenReturn("select");
-
-    List<WebElement> options = Stream.of(optionTexts)
-      .map(this::elementWithText)
-      .peek(option -> when(option.isSelected()).thenReturn(false))
-      .collect(toList());
-
-    when(options.get(0).isSelected()).thenReturn(true);
-
-    when(select.findElements(By.tagName("option"))).thenReturn(options);
-    return select;
-  }
-
-  private WebElement selectMulti(String... optionTexts) {
-    WebElement select = mock(WebElement.class);
-    when(select.getTagName()).thenReturn("select");
-
-    List<WebElement> options = Stream.of(optionTexts)
-      .map(this::elementWithText)
-      .peek(option -> when(option.isSelected()).thenReturn(true))
-      .collect(toList());
-
-    when(select.findElements(By.tagName("option"))).thenReturn(options);
-    return select;
   }
 }

--- a/src/test/java/com/codeborne/selenide/conditions/TextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/TextTest.java
@@ -1,40 +1,37 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static com.codeborne.selenide.Mocks.mockSelect;
+import static com.codeborne.selenide.Mocks.option;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
-final class TextTest implements WithAssertions {
-  private Driver driver = mock(Driver.class);
+final class TextTest {
+  private final Driver driver = mock(Driver.class);
 
   @Test
   void apply_for_textInput() {
-    assertThat(new Text("Hello World").apply(driver, elementWithText("Hello World"))).isTrue();
-    assertThat(new Text("Hello World").apply(driver, elementWithText("Hello"))).isFalse();
+    assertThat(new Text("Hello World").apply(driver, mockElement("Hello World"))).isTrue();
+    assertThat(new Text("Hello World").apply(driver, mockElement("Hello"))).isFalse();
   }
 
   @Test
   void apply_matchTextPartially() {
-    assertThat(new Text("Hello").apply(driver, elementWithText("Hello World"))).isTrue();
-    assertThat(new Text("World").apply(driver, elementWithText("Hello World"))).isTrue();
+    assertThat(new Text("Hello").apply(driver, mockElement("Hello World"))).isTrue();
+    assertThat(new Text("World").apply(driver, mockElement("Hello World"))).isTrue();
   }
 
   @Test
   void apply_for_select() {
-    assertThat(new Text("Hello World").apply(driver, select("Hello", "World"))).isFalse();
-    assertThat(new Text("Hello World").apply(driver, select("Hello", " World"))).isTrue();
+    assertThat(new Text("Hello World").apply(driver, mockSelect(option("Hello", true), option("World", true)))).isFalse();
+    assertThat(new Text("Hello World").apply(driver, mockSelect(option("Hello", true), option(" World", true)))).isTrue();
   }
 
   @Test
@@ -49,27 +46,31 @@ final class TextTest implements WithAssertions {
 
   @Test
   void apply_for_textInput_caseInsensitive() {
-    WebElement element = elementWithText("John Malkovich The First");
+    WebElement element = mockElement("John Malkovich The First");
     assertThat(new Text("john malkovich").apply(driver, element)).isTrue();
   }
 
   @Test
   void apply_for_select_caseInsensitive() {
-    WebElement element = select("John", " Malkovich", " The First");
+    WebElement element = mockSelect(
+      option("John", true),
+      option(" Malkovich", true),
+      option(" The First", true)
+    );
     assertThat(new Text("john malkovich").apply(driver, element)).isTrue();
   }
 
   @Test
   void apply_for_textInput_ignoresWhitespaces() {
-    assertThat(new Text("john the malkovich").apply(driver, elementWithText("John  the\n Malkovich")))
+    assertThat(new Text("john the malkovich").apply(driver, mockElement("John  the\n Malkovich")))
       .isTrue();
-    assertThat(new Text("This is nonbreakable space").apply(driver, elementWithText("This is nonbreakable\u00a0space")))
+    assertThat(new Text("This is nonbreakable space").apply(driver, mockElement("This is nonbreakable\u00a0space")))
       .isTrue();
   }
 
   @Test
   void shouldNotHaveActualValueBeforeAnyMatching() {
-    WebElement element = elementWithText("Hello");
+    WebElement element = mockElement("Hello");
 
     assertThat(new Text("Hello World").actualValue(driver, element)).isNull();
     verifyNoMoreInteractions(driver, element);
@@ -78,7 +79,7 @@ final class TextTest implements WithAssertions {
   @Test
   void shouldHaveCorrectActualValueAfterMatching() {
     Text condition = new Text("Hello");
-    WebElement element = elementWithText("Hello World");
+    WebElement element = mockElement("Hello World");
     condition.apply(driver, element);
 
     assertThat(condition.actualValue(driver, element)).isEqualTo("Hello World");
@@ -90,30 +91,11 @@ final class TextTest implements WithAssertions {
   @Test
   void shouldHaveCorrectActualValueAfterSelectMatching() {
     Text condition = new Text("Hello");
-    WebElement element = select("Hello", " World");
+    WebElement element = mockSelect(option("Hello", true), option(" World", true));
     condition.apply(driver, element);
 
     assertThat(condition.actualValue(driver, element)).isEqualTo("Hello World");
     // One time in Text condition, second in selenium Select
     verify(element, times(2)).getTagName();
-  }
-
-  private WebElement elementWithText(String text) {
-    WebElement webElement = mock(WebElement.class);
-    when(webElement.getText()).thenReturn(text);
-    return webElement;
-  }
-
-  private WebElement select(String... optionTexts) {
-    WebElement select = elementWithText("Hello World");
-    when(select.getTagName()).thenReturn("select");
-
-    List<WebElement> options = Stream.of(optionTexts)
-      .map(this::elementWithText)
-      .peek(option -> when(option.isSelected()).thenReturn(true))
-      .collect(toList());
-
-    when(select.findElements(By.tagName("option"))).thenReturn(options);
-    return select;
   }
 }

--- a/src/test/java/com/codeborne/selenide/drivercommands/BasicAuthUrlTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/BasicAuthUrlTest.java
@@ -1,10 +1,11 @@
 package com.codeborne.selenide.drivercommands;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-final class BasicAuthUrlTest implements WithAssertions {
-  private BasicAuthUrl basicAuthUrl = new BasicAuthUrl();
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class BasicAuthUrlTest {
+  private final BasicAuthUrl basicAuthUrl = new BasicAuthUrl();
 
   @Test
   void appendBasicAuthToURL_absoluteUrl() {

--- a/src/test/java/com/codeborne/selenide/drivercommands/LazyDriverTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/LazyDriverTest.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.Config;
 import com.codeborne.selenide.DummyWebDriver;
 import com.codeborne.selenide.impl.DummyFileNamer;
 import com.codeborne.selenide.webdriver.WebDriverFactory;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Proxy;
@@ -13,6 +12,8 @@ import org.openqa.selenium.WebDriver;
 import java.io.File;
 
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class LazyDriverTest implements WithAssertions {
+final class LazyDriverTest {
   private final Config config = mock(Config.class);
   private final WebDriver webdriver = new DummyWebDriver();
   private final WebDriverFactory factory = mock(WebDriverFactory.class);

--- a/src/test/java/com/codeborne/selenide/drivercommands/NavigatorTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/NavigatorTest.java
@@ -8,7 +8,6 @@ import com.codeborne.selenide.logevents.LogEventListener;
 import com.codeborne.selenide.logevents.SelenideLogger;
 import com.codeborne.selenide.proxy.AuthenticationFilter;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -17,12 +16,14 @@ import org.openqa.selenium.WebDriver;
 
 import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
-final class NavigatorTest implements WithAssertions {
+final class NavigatorTest {
   private final Navigator navigator = new Navigator();
   private final SelenideDriver selenideDriver = mock(SelenideDriver.class);
   private final WebDriver driver = mock(WebDriver.class);

--- a/src/test/java/com/codeborne/selenide/ex/DialogTextMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/DialogTextMismatchTest.java
@@ -2,10 +2,11 @@ package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-final class DialogTextMismatchTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class DialogTextMismatchTest {
   @Test
   void dialogMismatchTextStringTest() {
     Driver driver = new DriverStub();

--- a/src/test/java/com/codeborne/selenide/ex/ElementIsNotClickableExceptionTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementIsNotClickableExceptionTest.java
@@ -2,11 +2,12 @@ package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriverException;
 
-final class ElementIsNotClickableExceptionTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class ElementIsNotClickableExceptionTest {
   @Test
   void errorMessage() {
     Driver driver = new DriverStub();

--- a/src/test/java/com/codeborne/selenide/ex/ElementNotFoundTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementNotFoundTest.java
@@ -5,18 +5,18 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class ElementNotFoundTest implements WithAssertions {
-  private Driver driver = new DriverStub();
+final class ElementNotFoundTest {
+  private final Driver driver = new DriverStub();
 
   @Test
   void elementNotFoundWithByCriteria() {

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
@@ -2,15 +2,15 @@ package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Condition.appear;
 import static java.lang.System.lineSeparator;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-final class ElementShouldNotTest implements WithAssertions {
+final class ElementShouldNotTest {
   private final Driver driver = new DriverStub();
 
   @Test

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
@@ -3,14 +3,14 @@ package com.codeborne.selenide.ex;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static java.lang.System.lineSeparator;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-final class ElementShouldTest implements WithAssertions {
+final class ElementShouldTest {
   @Test
   void testToString() {
     String searchCriteria = "by.name: selenide";

--- a/src/test/java/com/codeborne/selenide/ex/ElementWithTextNotFoundTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementWithTextNotFoundTest.java
@@ -1,14 +1,14 @@
 package com.codeborne.selenide.ex;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 
-final class ElementWithTextNotFoundTest implements WithAssertions {
+final class ElementWithTextNotFoundTest {
   private final List<String> actualTexts = asList("Niff", "Naff", "Nuff");
   private final List<String> expectedTexts = asList("Piff", "Paff", "Puff");
   private final Throwable cause = new org.openqa.selenium.NoSuchElementException("ups");

--- a/src/test/java/com/codeborne/selenide/ex/ErrorMessagesTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ErrorMessagesTest.java
@@ -1,17 +1,17 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.SelenideConfig;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.chrome.ChromeDriver;
 
 import java.util.Locale;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class ErrorMessagesTest implements WithAssertions {
+final class ErrorMessagesTest {
   private final ChromeDriver webDriver = mock(ChromeDriver.class);
   private final SelenideConfig config = new SelenideConfig().reportsFolder("build/reports/tests");
 

--- a/src/test/java/com/codeborne/selenide/ex/InvalidStateExceptionTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/InvalidStateExceptionTest.java
@@ -2,11 +2,12 @@ package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.StaleElementReferenceException;
 
-final class InvalidStateExceptionTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class InvalidStateExceptionTest {
   private final Driver driver = new DriverStub();
 
   @Test

--- a/src/test/java/com/codeborne/selenide/ex/ListSizeMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ListSizeMismatchTest.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.ex;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
@@ -13,9 +12,10 @@ import java.util.List;
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-final class ListSizeMismatchTest implements WithAssertions {
+final class ListSizeMismatchTest {
   private final int expectedSize = 10;
   private final Driver driver = new DriverStub();
   private final CollectionSource collection = mockCollection("Collection description");

--- a/src/test/java/com/codeborne/selenide/ex/TextMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextMismatchTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.impl.CollectionSource;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,9 +9,10 @@ import java.util.List;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-final class TextMismatchTest implements WithAssertions {
+final class TextMismatchTest {
   private final CollectionSource collection = mockCollection("Collection description");
   private final List<String> actualTexts = asList("One", "Two", "Three");
   private final List<String> expectedTexts = asList("Four", "Five", "Six");

--- a/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
@@ -1,14 +1,14 @@
 package com.codeborne.selenide.ex;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 
-final class TextsMismatchTest implements WithAssertions {
+final class TextsMismatchTest {
   private final List<String> actualTexts = asList("Niff", "Naff", "Nuff");
   private final List<String> expectedTexts = asList("Piff", "Paff", "Puff");
 

--- a/src/test/java/com/codeborne/selenide/ex/TextsSizeMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsSizeMismatchTest.java
@@ -1,14 +1,14 @@
 package com.codeborne.selenide.ex;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 
-final class TextsSizeMismatchTest implements WithAssertions {
+final class TextsSizeMismatchTest {
   private final List<String> actualTexts = asList("Niff", "Naff", "Nuff%");
   private final List<String> expectedTexts = asList("Piff", "Paff", "Puff'\"bro");
 

--- a/src/test/java/com/codeborne/selenide/ex/UIAssertionErrorTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/UIAssertionErrorTest.java
@@ -2,10 +2,11 @@ package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-final class UIAssertionErrorTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class UIAssertionErrorTest {
   @Test
   void errorMessage() {
     Driver driver = new DriverStub();

--- a/src/test/java/com/codeborne/selenide/impl/BrowserHealthCheckerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/BrowserHealthCheckerTest.java
@@ -1,18 +1,18 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.drivercommands.BrowserHealthChecker;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
-final class BrowserHealthCheckerTest implements WithAssertions {
+final class BrowserHealthCheckerTest {
   private final WebDriver webdriver = mock(WebDriver.class);
   private final BrowserHealthChecker checker = new BrowserHealthChecker();
 

--- a/src/test/java/com/codeborne/selenide/impl/BySelectorCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/BySelectorCollectionTest.java
@@ -1,29 +1,25 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-final class BySelectorCollectionTest implements WithAssertions {
+final class BySelectorCollectionTest {
   private final Driver driver = mock(Driver.class);
-  private final WebElementSource mockedWebElement = new ElementFinder(driver, null, By.tagName("table"), 3);
+  private final WebElementSource webElement = new ElementFinder(driver, null, By.tagName("table"), 3);
 
   @Test
-  void testNoParentConstructor() {
-    BySelectorCollection bySelectorCollection = new BySelectorCollection(driver, By.id("selenide"));
-    String description = bySelectorCollection.description();
-    assertThat(description)
-      .isEqualTo("By.id: selenide");
+  void constructorWithoutParent() {
+    BySelectorCollection bySelectorCollection = new BySelectorCollection(driver, By.name("query"));
+    assertThat(bySelectorCollection.description()).isEqualTo("By.name: query");
   }
 
   @Test
-  void testWithWebElementParentConstructor() {
-    BySelectorCollection bySelectorCollection = new BySelectorCollection(driver, mockedWebElement, By.name("query"));
-    String description = bySelectorCollection.description();
-    assertThat(description)
-      .isEqualTo("By.tagName: table[3]/By.name: query");
+  void constructorWithParent() {
+    BySelectorCollection bySelectorCollection = new BySelectorCollection(driver, webElement, By.name("query"));
+    assertThat(bySelectorCollection.description()).isEqualTo("By.tagName: table[3]/By.name: query");
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/CleanupTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CleanupTest.java
@@ -1,16 +1,16 @@
 package com.codeborne.selenide.impl;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.InvalidSelectorException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriverException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-final class CleanupTest implements WithAssertions {
+final class CleanupTest {
   @Test
   void cleansWebDriverExceptionMessage() {
     String webDriverException = "org.openqa.selenium.NoSuchElementException: " +

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
@@ -5,7 +5,6 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -15,10 +14,11 @@ import java.util.List;
 import static com.codeborne.selenide.Condition.visible;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class CollectionElementByConditionTest implements WithAssertions {
+final class CollectionElementByConditionTest {
   private final Driver driver = new DriverStub();
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
@@ -5,16 +5,16 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class CollectionElementTest implements WithAssertions {
+final class CollectionElementTest {
   private final Driver driver = new DriverStub();
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
@@ -7,7 +7,6 @@ import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.files.DownloadedFile;
 import com.codeborne.selenide.proxy.FileDownloadFilter;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
@@ -23,6 +22,8 @@ import static com.codeborne.selenide.files.DownloadActions.click;
 import static com.codeborne.selenide.files.FileFilters.none;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
@@ -31,7 +32,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class DownloadFileWithProxyServerTest implements WithAssertions {
+final class DownloadFileWithProxyServerTest {
   private final Waiter waiter = new DummyWaiter();
   private final WindowsCloser windowsCloser = spy(new DummyWindowsCloser());
   private final DownloadFileWithProxyServer command = new DownloadFileWithProxyServer(waiter, windowsCloser);

--- a/src/test/java/com/codeborne/selenide/impl/ElementFinderTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ElementFinderTest.java
@@ -1,13 +1,13 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-final class ElementFinderTest implements WithAssertions {
+final class ElementFinderTest {
   private final Driver driver = mock(Driver.class);
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/EscapeQuotesTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/EscapeQuotesTest.java
@@ -1,10 +1,11 @@
 package com.codeborne.selenide.impl;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.support.ui.Quotes;
 
-final class EscapeQuotesTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class EscapeQuotesTest {
   @Test
   void textWithoutQuotes() {
     assertThat(Quotes.escape("john"))

--- a/src/test/java/com/codeborne/selenide/impl/FilteringCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/FilteringCollectionTest.java
@@ -1,17 +1,17 @@
 package com.codeborne.selenide.impl;
 
-import java.util.List;
-
 import com.codeborne.selenide.Condition;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
+import java.util.List;
+
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class FilteringCollectionTest implements WithAssertions {
+final class FilteringCollectionTest {
   @Test
   void getActualElement() {
     WebElement mockedWebElement1 = mock(WebElement.class);

--- a/src/test/java/com/codeborne/selenide/impl/HeadOfCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/HeadOfCollectionTest.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.impl;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class HeadOfCollectionTest implements WithAssertions {
+final class HeadOfCollectionTest {
   private final WebElement element1 = mock(WebElement.class);
   private final WebElement element2 = mock(WebElement.class);
   private final WebElement element3 = mock(WebElement.class);

--- a/src/test/java/com/codeborne/selenide/impl/HttpHelperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/HttpHelperTest.java
@@ -1,12 +1,13 @@
 package com.codeborne.selenide.impl;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-final class HttpHelperTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class HttpHelperTest {
   private final HttpHelper helper = new HttpHelper();
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/LastCollectionElementTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/LastCollectionElementTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.StaleElementReferenceException;
 
@@ -13,10 +12,11 @@ import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockElement;
 import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
-final class LastCollectionElementTest implements WithAssertions {
+final class LastCollectionElementTest {
   private final SelenideElement element1 = mockElement("Hello");
   private final SelenideElement element2 = mockElement("World");
   private final CollectionSource collection = mockCollection("ul#employees li.employee", element1, element2);

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideConfig;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -19,6 +18,7 @@ import static java.io.File.separatorChar;
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.IOUtils.resourceToByteArray;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openqa.selenium.OutputType.BYTES;
 
-final class ScreenShotLaboratoryTest implements WithAssertions {
+final class ScreenShotLaboratoryTest {
   private final String dir = System.getProperty("user.dir");
   private final String workingDirectory = new File(dir).toURI().toString().replaceAll("/$", "");
   private final ChromeDriver webDriver = mock(ChromeDriver.class);
@@ -41,7 +41,7 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
 
   @BeforeEach
   void setUp() {
-    when(photographer.takeScreenshot(any(), eq(BYTES))).thenReturn(Optional.of("siski".getBytes(UTF_8)));
+    when(photographer.takeScreenshot(any(), eq(BYTES))).thenReturn(Optional.of("some png source".getBytes(UTF_8)));
   }
 
   @Test
@@ -92,14 +92,14 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
   @Test
   void collectsAllScreenshots() {
     screenshots.startContext("ui/MyTest/test_some_method/");
-    screenshots.takeScreenShot(driver);
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
+    screenshots.takeScreenshot(driver, true, true);
     screenshots.finishContext();
     screenshots.startContext("ui/YourTest/test_another_method/");
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     screenshots.finishContext();
-    screenshots.takeScreenShot(driver);
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
+    screenshots.takeScreenshot(driver, true, true);
 
     List<File> allScreenshots = screenshots.getScreenshots();
     assertThat(allScreenshots).hasSize(5);
@@ -118,14 +118,14 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
   @Test
   void collectsAllThreadScreenshots() {
     screenshots.startContext("ui/MyTest/test_some_method/");
-    screenshots.takeScreenShot(driver);
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
+    screenshots.takeScreenshot(driver, true, true);
     screenshots.finishContext();
     screenshots.startContext("ui/YourTest/test_another_method/");
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     screenshots.finishContext();
-    screenshots.takeScreenShot(driver);
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
+    screenshots.takeScreenshot(driver, true, true);
 
     List<File> allThreadScreenshots = screenshots.getThreadScreenshots();
     assertThat(allThreadScreenshots).hasSize(5);
@@ -144,9 +144,9 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
   @Test
   void collectsContextScreenshots() {
     screenshots.startContext("build/reports/tests/ui/MyTest/test_some_method/");
-    screenshots.takeScreenShot(driver);
-    screenshots.takeScreenShot(driver);
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
+    screenshots.takeScreenshot(driver, true, true);
+    screenshots.takeScreenshot(driver, true, true);
 
     List<File> contextScreenshots = screenshots.getContextScreenshots();
     assertThat(contextScreenshots)
@@ -161,15 +161,15 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
   void canGetLastScreenshot() {
     assertThat(screenshots.getLastScreenshot()).isNull();
 
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastScreenshot())
       .hasToString(dir + normalize("/build/reports/tests/12356789.0.png"));
 
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastScreenshot())
       .hasToString(dir + normalize("/build/reports/tests/12356789.1.png"));
 
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastScreenshot())
       .hasToString(dir + normalize("/build/reports/tests/12356789.2.png"));
   }
@@ -179,15 +179,15 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
     assertThat(screenshots.getLastThreadScreenshot())
       .isEmpty();
 
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastThreadScreenshot())
       .hasValue(new File("build/reports/tests/12356789.0.png").getAbsoluteFile());
 
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastThreadScreenshot())
       .hasValue(new File("build/reports/tests/12356789.1.png").getAbsoluteFile());
 
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastThreadScreenshot())
       .hasValue(new File("build/reports/tests/12356789.2.png").getAbsoluteFile());
   }
@@ -200,15 +200,15 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
     screenshots.startContext("ui/MyTest/test_some_method/");
     assertThat(screenshots.getLastContextScreenshot())
       .isEmpty();
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastContextScreenshot())
       .hasValue(new File("build/reports/tests/ui/MyTest/test_some_method/12356789.0.png").getAbsoluteFile());
 
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastContextScreenshot())
       .hasValue(new File("build/reports/tests/ui/MyTest/test_some_method/12356789.1.png").getAbsoluteFile());
 
-    screenshots.takeScreenShot(driver);
+    screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshots.getLastContextScreenshot())
       .hasValue(new File("build/reports/tests/ui/MyTest/test_some_method/12356789.2.png").getAbsoluteFile());
   }
@@ -221,7 +221,7 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
     config.reportsUrl("http://ci.org/job/123/artifact");
     config.reportsFolder("build/reports/path with spaces/");
 
-    String screenShot = screenshots.formatScreenShotPath(driver);
+    String screenShot = screenshots.takeScreenshot(driver, true, false).getImage();
 
     assertThat(screenShot)
       .contains("http://ci.org/job/123/artifact/build/reports/path%20with%20spaces/");
@@ -234,7 +234,7 @@ final class ScreenShotLaboratoryTest implements WithAssertions {
 
     config.reportsUrl("http://ci.org/path%20with%spaces/");
 
-    String screenShotPath = screenshots.formatScreenShotPath(driver);
+    String screenShotPath = screenshots.takeScreenshot(driver, true, false).getImage();
 
     assertThat(screenShotPath)
       .contains("http://ci.org/path%20with%spaces/");

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementDescriberTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementDescriberTest.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.impl;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementShould;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -13,11 +12,12 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Condition.visible;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class SelenideElementDescriberTest implements WithAssertions {
+final class SelenideElementDescriberTest {
   private final SelenideElementDescriber describe = new SelenideElementDescriber();
 
   @Test
@@ -44,7 +44,7 @@ final class SelenideElementDescriberTest implements WithAssertions {
 
     SelenideElement selenideElement = mock(SelenideElement.class);
     when(selenideElement.toWebElement()).thenReturn(webElement);
-    doThrow(new ElementShould(driver, null, null, visible, webElement, null)).when(selenideElement).getTagName();
+    doThrow(new ElementShould(driver, "div", "", visible, webElement, null)).when(selenideElement).getTagName();
 
     assertThat(describe.briefly(driver, selenideElement))
       .isEqualTo("Ups, failed to described the element [caused by: StaleElementReferenceException: disappeared]");

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementIteratorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementIteratorTest.java
@@ -1,14 +1,15 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.SelenideElement;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockWebElement;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-final class SelenideElementIteratorTest implements WithAssertions {
+final class SelenideElementIteratorTest {
   private final WebElement webElement = mockWebElement("a", "click me if you can");
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementListIteratorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementListIteratorTest.java
@@ -1,17 +1,18 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.SelenideElement;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.Mocks.mockCollection;
 import static com.codeborne.selenide.Mocks.mockWebElement;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class SelenideElementListIteratorTest implements WithAssertions {
+final class SelenideElementListIteratorTest {
   private final WebElement webElement = mockWebElement("a", "click me if you can");
   private final CollectionSource collection = mockCollection("Collection description", webElement);
 

--- a/src/test/java/com/codeborne/selenide/impl/SelenidePageFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenidePageFactoryTest.java
@@ -109,7 +109,7 @@ final class SelenidePageFactoryTest {
     WebElement statusElement = mockWebElement("div", "the status");
     WebElement lastLogin = mockWebElement("div", "03.03.2003");
     WebElement name = mockWebElement("div", "lena");
-    when(webDriver.findElement(By.id("status"))).thenReturn(statusElement);
+    when(webDriver.findElement(any())).thenReturn(statusElement);
     when(statusElement.findElement(By.className("last-login"))).thenReturn(lastLogin);
     when(statusElement.findElement(By.className("name"))).thenReturn(name);
 

--- a/src/test/java/com/codeborne/selenide/impl/TailOfCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/TailOfCollectionTest.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.impl;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class TailOfCollectionTest implements WithAssertions {
+final class TailOfCollectionTest {
   private final WebElement element1 = mock(WebElement.class);
   private final WebElement element2 = mock(WebElement.class);
   private final WebElement element3 = mock(WebElement.class);

--- a/src/test/java/com/codeborne/selenide/impl/TextsTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/TextsTest.java
@@ -1,9 +1,10 @@
 package com.codeborne.selenide.impl;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-final class TextsTest implements WithAssertions {
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TextsTest {
   @Test
   void reduceSpacesRemovesReplacesMultipleSpacesBySingleSpace() {
     assertThat(Html.text.reduceSpaces("Bruce   \n\t   Willis"))

--- a/src/test/java/com/codeborne/selenide/impl/WebElementSelectorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebElementSelectorTest.java
@@ -38,9 +38,11 @@ final class WebElementSelectorTest {
     Config config = new SelenideConfig().selectorMode(CSS);
     Driver driver = new DriverStub(config, browser, webDriver, null);
     WebElement div = mock(WebElement.class);
-    when(webDriver.findElement(By.cssSelector("a.active"))).thenReturn(div);
+    when(webDriver.findElement(any())).thenReturn(div);
 
     assertThat(selector.findElement(driver, null, By.cssSelector("a.active"))).isSameAs(div);
+
+    verify(webDriver).findElement(By.cssSelector("a.active"));
   }
 
   @Test
@@ -48,9 +50,11 @@ final class WebElementSelectorTest {
     Config config = new SelenideConfig().selectorMode(Sizzle);
     Driver driver = new DriverStub(config, browser, webDriver, null);
     WebElement div = mock(WebElement.class);
-    when(webDriver.findElement(By.xpath("/div/h1"))).thenReturn(div);
+    when(webDriver.findElement(any())).thenReturn(div);
 
     assertThat(selector.findElement(driver, null, By.xpath("/div/h1"))).isSameAs(div);
+
+    verify(webDriver).findElement(By.xpath("/div/h1"));
   }
 
   @Test
@@ -88,9 +92,11 @@ final class WebElementSelectorTest {
     Config config = new SelenideConfig().selectorMode(CSS);
     Driver driver = new DriverStub(config, browser, webDriver, null);
     List<WebElement> divs = asList(mock(WebElement.class), mock(WebElement.class));
-    when(webDriver.findElements(By.cssSelector("a.active"))).thenReturn(divs);
+    when(webDriver.findElements(any())).thenReturn(divs);
 
     assertThat(selector.findElements(driver, null, By.cssSelector("a.active"))).isSameAs(divs);
+
+    verify(webDriver).findElements(By.cssSelector("a.active"));
   }
 
   @Test
@@ -98,9 +104,11 @@ final class WebElementSelectorTest {
     Config config = new SelenideConfig().selectorMode(Sizzle);
     Driver driver = new DriverStub(config, browser, webDriver, null);
     List<WebElement> divs = asList(mock(WebElement.class), mock(WebElement.class));
-    when(webDriver.findElements(By.xpath("/div/h1"))).thenReturn(divs);
+    when(webDriver.findElements(any())).thenReturn(divs);
 
     assertThat(selector.findElements(driver, null, By.xpath("/div/h1"))).isSameAs(divs);
+
+    verify(webDriver).findElements(By.xpath("/div/h1"));
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/WebElementWrapperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebElementWrapperTest.java
@@ -4,21 +4,22 @@ import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideConfig;
-import java.util.HashMap;
-import java.util.Map;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class WebElementWrapperTest implements WithAssertions {
+final class WebElementWrapperTest {
   private final SelenideConfig config = new SelenideConfig();
   private final WebDriver webDriver = mock(FirefoxDriver.class);
   private final Driver driver = new DriverStub(config, new Browser("firefox", false), webDriver, null);

--- a/src/test/java/com/codeborne/selenide/logevents/ErrorsCollectorTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/ErrorsCollectorTest.java
@@ -1,17 +1,18 @@
 package com.codeborne.selenide.logevents;
 
 import com.codeborne.selenide.ex.SoftAssertionError;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.StaleElementReferenceException;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class ErrorsCollectorTest implements WithAssertions {
+final class ErrorsCollectorTest {
   private final ErrorsCollector errorsCollector = new ErrorsCollector();
   private final LogEvent mockedInProgressEvent = mock(LogEvent.class);
   private final LogEvent mockedPassedEvent = mock(LogEvent.class);
@@ -71,7 +72,8 @@ final class ErrorsCollectorTest implements WithAssertions {
     try {
       errorsCollector.failIfErrors(defaultTestName);
       fail("Expected SoftAssertionError");
-    } catch (SoftAssertionError error) {
+    }
+    catch (SoftAssertionError error) {
       assertThat(error)
         .withFailMessage("I couldn't find default error message in error message")
         .hasMessageContaining(defaultErrorMessage);
@@ -90,7 +92,8 @@ final class ErrorsCollectorTest implements WithAssertions {
     try {
       errorsCollector.failIfErrors(defaultTestName);
       fail("Expected SoftAssertionError");
-    } catch (SoftAssertionError error) {
+    }
+    catch (SoftAssertionError error) {
       assertThat(error)
         .as("Error title")
         .hasMessageContaining(String.format("Test %s failed.", defaultTestName));

--- a/src/test/java/com/codeborne/selenide/logevents/EventsCollectorTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/EventsCollectorTest.java
@@ -1,16 +1,19 @@
 package com.codeborne.selenide.logevents;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
-final class EventsCollectorTest implements WithAssertions {
-  @Test
-  void testOnEvent() {
-    EventsCollector eventsCollector = new EventsCollector();
-    SelenideLog selenideLog = new SelenideLog("Link", "Not Found");
-    eventsCollector.afterEvent(selenideLog);
+import static org.assertj.core.api.Assertions.assertThat;
 
-    assertThat(eventsCollector.events())
-      .contains(selenideLog);
+final class EventsCollectorTest {
+  @Test
+  void collectsEvents() {
+    EventsCollector eventsCollector = new EventsCollector();
+    SelenideLog log1 = new SelenideLog("Link", "Not Found");
+    SelenideLog log2 = new SelenideLog("Link", "Not Found");
+
+    eventsCollector.afterEvent(log1);
+    eventsCollector.afterEvent(log2);
+
+    assertThat(eventsCollector.events()).containsExactly(log1, log2);
   }
 }

--- a/src/test/java/com/codeborne/selenide/logevents/SelenideLogTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/SelenideLogTest.java
@@ -1,45 +1,32 @@
 package com.codeborne.selenide.logevents;
 
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.IN_PROGRESS;
+import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
+import static org.assertj.core.api.Assertions.assertThat;
 
-final class SelenideLogTest implements WithAssertions {
+final class SelenideLogTest {
   @Test
-  void testGetSubject() {
-    SelenideLog log = new SelenideLog("Element", "Subject");
-    assertThat(log.getSubject())
-      .isEqualTo("Subject");
-  }
-
-  @Test
-  void testGetStatus() {
-    SelenideLog log = new SelenideLog("Element", "Subject");
-    assertThat(log.getStatus())
+  void initialStatusIsInProgress() {
+    assertThat(new SelenideLog("By.name: domain", "exists()").getStatus())
       .isEqualTo(IN_PROGRESS);
   }
 
   @Test
-  void testGetElement() {
-    SelenideLog log = new SelenideLog("Element", "Subject");
-    assertThat(log.getElement())
-      .isEqualTo("Element");
+  void measuresDurationOfEveryStep() throws InterruptedException {
+    SelenideLog step = new SelenideLog("By.name: domain", "exists()");
+
+    Thread.sleep(15);
+    step.setStatus(PASS);
+
+    assertThat(step.getStatus()).isEqualTo(PASS);
+    assertThat(step.getDuration()).isBetween(15L, 100L);
   }
 
   @Test
-  void testError() {
-    SelenideLog log = new SelenideLog("Element", "Subject");
-    Throwable error = new Throwable("Error message");
-    log.setError(error);
-    assertThat(log.getError())
-      .isEqualTo(error);
-  }
-
-  @Test
-  void testToString() {
-    SelenideLog log = new SelenideLog("Element", "Subject");
-    assertThat(log)
-      .hasToString(String.format("$(\"%s\") %s", log.getElement(), log.getSubject()));
+  void stringRepresentationUsedInReports() {
+    SelenideLog log = new SelenideLog("By.name: domain", "exists()");
+    assertThat(log).hasToString("$(\"By.name: domain\") exists()");
   }
 }

--- a/src/test/java/com/codeborne/selenide/logevents/SelenideLoggerTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/SelenideLoggerTest.java
@@ -1,15 +1,12 @@
 package com.codeborne.selenide.logevents;
 
 import integration.UseLocaleExtension;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 
 import java.time.Duration;
 
@@ -17,15 +14,15 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.FAIL;
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
 import static com.codeborne.selenide.logevents.SelenideLogger.readableArguments;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
-final class SelenideLoggerTest implements WithAssertions {
+final class SelenideLoggerTest {
   private final WebDriver webdriver = mock(WebDriver.class);
 
   @RegisterExtension
@@ -82,10 +79,6 @@ final class SelenideLoggerTest implements WithAssertions {
     SelenideLogger.addListener("simpleReport", listener1);
     SelenideLogger.addListener("softAsserts", listener2);
     SelenideLogger.addListener("userProvided", listener3);
-
-    WebElement webElement = mock(WebElement.class);
-    when(webdriver.findElement(By.cssSelector("div"))).thenReturn(webElement);
-    when(webElement.isDisplayed()).thenReturn(true);
 
     SelenideLogger.commitStep(SelenideLogger.beginStep("div", "click", NO_ARGS), PASS);
 

--- a/src/test/java/com/codeborne/selenide/proxy/AuthenticationFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/AuthenticationFilterTest.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.proxy;
 import com.codeborne.selenide.AuthenticationType;
 import com.codeborne.selenide.Credentials;
 import io.netty.handler.codec.http.DefaultHttpRequest;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
@@ -11,8 +10,9 @@ import java.util.Base64;
 import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
-final class AuthenticationFilterTest implements WithAssertions {
+final class AuthenticationFilterTest {
   private final AuthenticationFilter filter = new AuthenticationFilter();
   private final DefaultHttpRequest request = new DefaultHttpRequest(HTTP_1_1, GET, "/secured/page");
 

--- a/src/test/java/com/codeborne/selenide/proxy/FileDownloadFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/FileDownloadFilterTest.java
@@ -9,7 +9,6 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,11 +19,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 import static org.apache.commons.io.FileUtils.readFileToByteArray;
 import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-final class FileDownloadFilterTest implements WithAssertions {
+final class FileDownloadFilterTest {
   private final FileDownloadFilter filter = new FileDownloadFilter(
     new SelenideConfig().downloadsFolder("build/downloads"), new Downloader(new DummyRandomizer("random-text"))
   );

--- a/src/test/java/com/codeborne/selenide/proxy/SelenideProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/SelenideProxyServerTest.java
@@ -1,8 +1,7 @@
 package com.codeborne.selenide.proxy;
 
-import com.codeborne.selenide.Config;
 import com.browserup.bup.BrowserUpProxyServer;
-import org.assertj.core.api.WithAssertions;
+import com.codeborne.selenide.Config;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Proxy;
 
@@ -10,13 +9,14 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-final class SelenideProxyServerTest implements WithAssertions {
+final class SelenideProxyServerTest {
   private final BrowserUpProxyServer bmp = mock(BrowserUpProxyServer.class);
   private final Config config = mock(Config.class);
   private final SelenideProxyServer proxyServer = new SelenideProxyServer(config, null, new InetAddressResolverStub(), bmp);

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.SelenideConfig;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,9 +20,10 @@ import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBro
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchPrefs;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-final class ChromeDriverFactoryTest implements WithAssertions {
+final class ChromeDriverFactoryTest {
   private static final String CHROME_OPTIONS_PREFS = "chromeoptions.prefs";
   private static final String CHROME_OPTIONS_ARGS = "chromeoptions.args";
   private static final String DOWNLOADS_FOLDER = Paths.get("blah", "downloads").toString();

--- a/src/test/java/com/codeborne/selenide/webdriver/CommonCapabilitiesTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/CommonCapabilitiesTest.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Config;
 import com.codeborne.selenide.DummyWebDriver;
 import com.codeborne.selenide.SelenideConfig;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
@@ -21,12 +20,13 @@ import java.io.File;
 import static com.codeborne.selenide.Browsers.EDGE;
 import static com.codeborne.selenide.Browsers.IE;
 import static com.codeborne.selenide.Browsers.INTERNET_EXPLORER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_SSL_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
 
-final class CommonCapabilitiesTest implements WithAssertions {
+final class CommonCapabilitiesTest {
   private final AbstractDriverFactory driverFactory = new DummyDriverFactory();
   private final Proxy proxy = mock(Proxy.class);
 

--- a/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.SelenideConfig;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
@@ -19,9 +18,10 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchArgs;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-final class FirefoxDriverFactoryTest implements WithAssertions {
+final class FirefoxDriverFactoryTest {
   private static final String DOWNLOADS_FOLDER = Paths.get("blah", "downloads").toString();
 
   private final Proxy proxy = mock(Proxy.class);

--- a/src/test/java/com/codeborne/selenide/webdriver/OperaDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/OperaDriverFactoryTest.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.SelenideConfig;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.InvalidArgumentException;
@@ -12,9 +11,11 @@ import org.openqa.selenium.opera.OperaOptions;
 import java.io.File;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
-final class OperaDriverFactoryTest implements WithAssertions {
+final class OperaDriverFactoryTest {
   private final Proxy proxy = mock(Proxy.class);
   private final File browserDownloadsFolder = new File("build/downlao");
   private final SelenideConfig config = new SelenideConfig().headless(false);

--- a/src/test/java/com/codeborne/selenide/webdriver/TransferBrowserCapabilitiesFromConfigurationTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/TransferBrowserCapabilitiesFromConfigurationTest.java
@@ -3,16 +3,16 @@ package com.codeborne.selenide.webdriver;
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Config;
 import com.codeborne.selenide.SelenideConfig;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-final class TransferBrowserCapabilitiesFromConfigurationTest implements WithAssertions {
+final class TransferBrowserCapabilitiesFromConfigurationTest {
   private static final String SOME_CAP = "some.cap";
   private final AbstractDriverFactory driverFactory = new ChromeDriverFactory();
   private final Proxy proxy = mock(Proxy.class);

--- a/statics/src/test/java/com/codeborne/selenide/WebDriverRunnerTest.java
+++ b/statics/src/test/java/com/codeborne/selenide/WebDriverRunnerTest.java
@@ -1,7 +1,6 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.impl.WebDriverThreadLocalContainer;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +20,7 @@ import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.WebDriverRunner.webdriverContainer;
 import static java.lang.Thread.currentThread;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-final class WebDriverRunnerTest implements WithAssertions {
+final class WebDriverRunnerTest {
   private static WebDriver driver;
 
   private final URL url = currentThread().getContextClassLoader().getResource("start_page.html");

--- a/statics/src/test/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainerTest.java
+++ b/statics/src/test/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainerTest.java
@@ -3,7 +3,6 @@ package com.codeborne.selenide.impl;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.WebDriverProvider;
 import com.codeborne.selenide.WebDriverRunner;
-import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,10 +13,12 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 
 import static com.codeborne.selenide.Selenide.closeWebDriver;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-final class WebDriverThreadLocalContainerTest implements WithAssertions {
+final class WebDriverThreadLocalContainerTest {
   private final WebDriverThreadLocalContainer container = new WebDriverThreadLocalContainer();
 
   @BeforeEach


### PR DESCRIPTION
* create names for test-methods describing the case or behaviour they
are testing
* avoid names of test methods starting with "test". It's enough to have
annotation @Test.
* mock with "any()" and verify with concrete parameters
* rename "Cleanup.of.wrap" to "wrapInvalidSelectorException"
* remove useless unit-tests for constructors and getters
* avoid using helper methods with boolean parameters and asserts inside
* use static import instead of extending WithAssertions
