### PR TITLE
Validate element when assert if `disabled` or `enabled`

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -457,14 +457,21 @@ public abstract class Condition {
   public static final Condition focused = new Focused();
 
   /**
-   * Checks that element is not disabled
+   * Checks that element is not disabled.
+   * <br>
+   * Will throw {@code IllegalArgumentException} if called on an element which is not {@code input}
    *
    * @see WebElement#isEnabled()
    */
   public static final Condition enabled = new Enabled();
 
   /**
-   * Checks that element is disabled
+   * Checks that element is disabled.
+   * <br>
+   * Will throw {@code IllegalArgumentException} if called on an element which is not {@code input}
+   * <br>
+   * Use {@code $("div").shouldHave(Condition.attribute("disabled");} to assert the {@code disabled} attribute
+   * on a non {@code input} element.
    *
    * @see WebElement#isEnabled()
    */

--- a/src/main/java/com/codeborne/selenide/conditions/Disabled.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Disabled.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.conditions.enabled.ElementValidation;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -9,12 +10,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class Disabled extends Condition {
 
+  private final ElementValidation elementValidation = new ElementValidation();
+
   public Disabled() {
     super("disabled");
   }
 
   @Override
   public boolean apply(Driver driver, WebElement element) {
+    elementValidation.validaElementIsApplicableForEnabledCondition(element);
     return !element.isEnabled();
   }
 

--- a/src/main/java/com/codeborne/selenide/conditions/Enabled.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Enabled.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.conditions.enabled.ElementValidation;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -9,12 +10,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class Enabled extends Condition {
 
+  private final ElementValidation elementValidation = new ElementValidation();
+
   public Enabled() {
     super("enabled");
   }
 
   @Override
   public boolean apply(Driver driver, WebElement element) {
+    elementValidation.validaElementIsApplicableForEnabledCondition(element);
     return element.isEnabled();
   }
 

--- a/src/main/java/com/codeborne/selenide/conditions/enabled/ElementValidation.java
+++ b/src/main/java/com/codeborne/selenide/conditions/enabled/ElementValidation.java
@@ -1,0 +1,17 @@
+package com.codeborne.selenide.conditions.enabled;
+
+import org.openqa.selenium.WebElement;
+
+import java.util.Objects;
+
+public class ElementValidation {
+
+  public void validaElementIsApplicableForEnabledCondition(WebElement element) {
+    String elementTag = element.getTagName();
+    if (!Objects.equals(elementTag, "input")) {
+      throw new IllegalArgumentException(
+        "This condition can be applied to the input element element only. Given element is: " + elementTag
+      );
+    }
+  }
+}

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -182,6 +182,7 @@ final class ConditionTest {
 
   private WebElement elementWithEnabled(boolean isEnabled) {
     WebElement element = mock(WebElement.class);
+    when(element.getTagName()).thenReturn("input");
     when(element.isEnabled()).thenReturn(isEnabled);
     return element;
   }

--- a/src/test/java/com/codeborne/selenide/commands/MatchesCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/MatchesCommandTest.java
@@ -31,6 +31,7 @@ final class MatchesCommandTest {
   @Test
   void elementDoesNotMeetCondition() {
     when(locator.getWebElement()).thenReturn(mockedElement);
+    when(mockedElement.getTagName()).thenReturn("input");
     when(mockedElement.isEnabled()).thenReturn(true);
     assertThat(command.execute(proxy, locator, new Object[]{disabled}))
       .isFalse();
@@ -40,6 +41,7 @@ final class MatchesCommandTest {
   void elementMeetsCondition() {
     when(locator.getWebElement()).thenReturn(mockedElement);
     when(mockedElement.isEnabled()).thenReturn(true);
+    when(mockedElement.getTagName()).thenReturn("input");
     assertThat(command.execute(proxy, locator, new Object[]{enabled}))
       .isTrue();
   }

--- a/src/test/java/integration/ConditionsTest.java
+++ b/src/test/java/integration/ConditionsTest.java
@@ -9,7 +9,6 @@ import static com.codeborne.selenide.Condition.and;
 import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.be;
 import static com.codeborne.selenide.Condition.cssClass;
-import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.have;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.match;
@@ -43,10 +42,10 @@ final class ConditionsTest extends ITest {
   @Test
   void orShouldReportAllConditions() {
     assertThatThrownBy(() ->
-      $("#multirowTable").shouldBe(or("non-active", be(disabled), have(cssClass("inactive"))))
+      $("#multirowTable").shouldBe(or("non-active", be(hidden), have(cssClass("inactive"))))
     )
       .isInstanceOf(ElementShould.class)
-      .hasMessageStartingWith("Element should be non-active: be disabled or have css class 'inactive' {#multirowTable}");
+      .hasMessageStartingWith("Element should be non-active: be hidden or have css class 'inactive' {#multirowTable}");
   }
 
   @Test

--- a/src/test/java/integration/ElementEnabledTest.java
+++ b/src/test/java/integration/ElementEnabledTest.java
@@ -35,4 +35,16 @@ final class ElementEnabledTest extends ITest {
     $("#captcha").shouldBe(enabled);
     $("#captcha").shouldNotBe(disabled);
   }
+
+  @Test
+  void shouldThrowForNonInputElementWhenCheckIfDisabled() {
+    assertThatThrownBy(() -> $("#disabled-label").shouldBe(disabled))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowForNonInputElementWhenCheckIfEnabled() {
+    assertThatThrownBy(() -> $("#enabled-label").shouldBe(enabled))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/src/test/resources/page_with_disabled_elements.html
+++ b/src/test/resources/page_with_disabled_elements.html
@@ -26,6 +26,8 @@
       </label>
     </fieldset>
     <input type="button" id="login-button" value="don't click me, I'm disabled" disabled/>
+    <label id="disabled-label" disabled>Label with disabled attribute</label>
+    <label id="enabled-label">Label without disabled attribute</label>
   </form>
 </div>
 </body>

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -333,9 +333,9 @@ final class SelenideMethodsTest extends IntegrationTest {
 
   @Test
   void canUseBeWrapper_errorMessage() {
-    assertThatThrownBy(() -> $("#username-blur-counter").should(be(disabled)))
+    assertThatThrownBy(() -> $("#username-blur-counter").should(be(hidden)))
       .isInstanceOf(ElementShould.class)
-      .hasMessageContaining("Element should be disabled {#username-blur-counter}");
+      .hasMessageContaining("Element should be hidden {#username-blur-counter}");
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes
Add validation to check if the element is applicable for the disabled/enabled condition. The `Condition.enabled/disabled` is calling the Selenium's `WebElement.isEnabled()` that should be called on the `input` element. Without knowing that enabled/disabled should be called on the `input`, the Selenide's user can call this assertion on an any other element that has `disabled` attribute, and it will either fail with an ambiguous error message or even worse - will pass, which will be a false positive.
With this validation, the test will fail if called on a non-input element. Thus, the user will know exactly what went wrong.

For example, given an element:
```html
<label disabled id="disabled-label">Label with disabled attribute</label>
```
When asserting it with `$("#disabled-label").shouldBe(disabled)`, then it will fail with an ambiguous error message:
```
Element should be disabled {#disabled-label}
Element: '<label disabled id="disabled-label">Label with disabled attribute</label>'
Actual value: enabled
```
When asserting it with `$("#disabled-label").shouldBe(enabled)`, then the test will pass. Which is technically correct from Selenium's perspective. But likely is not correct from the user's experience who doesn't know that this assertion should be used only on `input`. 

In modern web frameworks, front end developers can set a `disabled` attribute on any element. So, the proposed change will help testers to use a disabled/enabled condition properly.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
