### PR TITLE
add selenide.properties support

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.impl.CiReportUrl;
+import com.codeborne.selenide.impl.PropertiesUtils;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -10,38 +11,39 @@ import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.SelectorMode.CSS;
 
 public class SelenideConfig implements Config {
-  private String browser = System.getProperty("selenide.browser", CHROME);
-  private boolean headless = Boolean.parseBoolean(System.getProperty("selenide.headless", "false"));
-  private String remote = System.getProperty("selenide.remote");
-  private String browserSize = System.getProperty("selenide.browserSize", "1366x768");
-  private String browserVersion = System.getProperty("selenide.browserVersion");
-  private String browserPosition = System.getProperty("selenide.browserPosition");
-  private boolean driverManagerEnabled = Boolean.parseBoolean(System.getProperty("selenide.driverManagerEnabled", "true"));
-  private boolean webdriverLogsEnabled = Boolean.parseBoolean(System.getProperty("selenide.webdriverLogsEnabled", "false"));
-  private String browserBinary = System.getProperty("selenide.browserBinary", "");
-  private String pageLoadStrategy = System.getProperty("selenide.pageLoadStrategy", "normal");
-  private long pageLoadTimeout = Long.parseLong(System.getProperty("selenide.pageLoadTimeout", "30000"));
+  
+  private String browser = getProperty("selenide.browser", CHROME);
+  private boolean headless = Boolean.parseBoolean(getProperty("selenide.headless", "false"));
+  private String remote = getProperty("selenide.remote", null);
+  private String browserSize = getProperty("selenide.browserSize", "1366x768");
+  private String browserVersion = getProperty("selenide.browserVersion", null);
+  private String browserPosition = getProperty("selenide.browserPosition", null);
+  private boolean driverManagerEnabled = Boolean.parseBoolean(getProperty("selenide.driverManagerEnabled", "true"));
+  private boolean webdriverLogsEnabled = Boolean.parseBoolean(getProperty("selenide.webdriverLogsEnabled", "false"));
+  private String browserBinary = getProperty("selenide.browserBinary", "");
+  private String pageLoadStrategy = getProperty("selenide.pageLoadStrategy", "normal");
+  private long pageLoadTimeout = Long.parseLong(getProperty("selenide.pageLoadTimeout", "30000"));
   private MutableCapabilities browserCapabilities = new DesiredCapabilities();
 
-  private String baseUrl = System.getProperty("selenide.baseUrl", "http://localhost:8080");
-  private long timeout = Long.parseLong(System.getProperty("selenide.timeout", "4000"));
-  private long pollingInterval = Long.parseLong(System.getProperty("selenide.pollingInterval", "200"));
-  private boolean holdBrowserOpen = Boolean.getBoolean("selenide.holdBrowserOpen");
-  private boolean reopenBrowserOnFail = Boolean.parseBoolean(System.getProperty("selenide.reopenBrowserOnFail", "true"));
-  private boolean clickViaJs = Boolean.parseBoolean(System.getProperty("selenide.clickViaJs", "false"));
-  private boolean screenshots = Boolean.parseBoolean(System.getProperty("selenide.screenshots", "true"));
+  private String baseUrl = getProperty("selenide.baseUrl", "http://localhost:8080");
+  private long timeout = Long.parseLong(getProperty("selenide.timeout", "4000"));
+  private long pollingInterval = Long.parseLong(getProperty("selenide.pollingInterval", "200"));
+  private boolean holdBrowserOpen = Boolean.getBoolean(getProperty("selenide.holdBrowserOpen", "false"));
+  private boolean reopenBrowserOnFail = Boolean.parseBoolean(getProperty("selenide.reopenBrowserOnFail", "true"));
+  private boolean clickViaJs = Boolean.parseBoolean(getProperty("selenide.clickViaJs", "false"));
+  private boolean screenshots = Boolean.parseBoolean(getProperty("selenide.screenshots", "true"));
 
-  private boolean savePageSource = Boolean.parseBoolean(System.getProperty("selenide.savePageSource", "true"));
-  private String reportsFolder = System.getProperty("selenide.reportsFolder", "build/reports/tests");
-  private String downloadsFolder = System.getProperty("selenide.downloadsFolder", "build/downloads");
-  private String reportsUrl = new CiReportUrl().getReportsUrl(System.getProperty("selenide.reportsUrl"));
-  private boolean fastSetValue = Boolean.parseBoolean(System.getProperty("selenide.fastSetValue", "false"));
-  private SelectorMode selectorMode = SelectorMode.valueOf(System.getProperty("selenide.selectorMode", CSS.name()));
-  private AssertionMode assertionMode = AssertionMode.valueOf(System.getProperty("selenide.assertionMode", STRICT.name()));
-  private FileDownloadMode fileDownload = FileDownloadMode.valueOf(System.getProperty("selenide.fileDownload", HTTPGET.name()));
-  private boolean proxyEnabled = Boolean.parseBoolean(System.getProperty("selenide.proxyEnabled", "false"));
-  private String proxyHost = System.getProperty("selenide.proxyHost", "");
-  private int proxyPort = Integer.parseInt(System.getProperty("selenide.proxyPort", "0"));
+  private boolean savePageSource = Boolean.parseBoolean(getProperty("selenide.savePageSource", "true"));
+  private String reportsFolder = getProperty("selenide.reportsFolder", "build/reports/tests");
+  private String downloadsFolder = getProperty("selenide.downloadsFolder", "build/downloads");
+  private String reportsUrl = new CiReportUrl().getReportsUrl(getProperty("selenide.reportsUrl", null));
+  private boolean fastSetValue = Boolean.parseBoolean(getProperty("selenide.fastSetValue", "false"));
+  private SelectorMode selectorMode = SelectorMode.valueOf(getProperty("selenide.selectorMode", CSS.name()));
+  private AssertionMode assertionMode = AssertionMode.valueOf(getProperty("selenide.assertionMode", STRICT.name()));
+  private FileDownloadMode fileDownload = FileDownloadMode.valueOf(getProperty("selenide.fileDownload", HTTPGET.name()));
+  private boolean proxyEnabled = Boolean.parseBoolean(getProperty("selenide.proxyEnabled", "false"));
+  private String proxyHost = getProperty("selenide.proxyHost", "");
+  private int proxyPort = Integer.parseInt(getProperty("selenide.proxyPort", "0"));
 
   @Override
   public String baseUrl() {
@@ -292,6 +294,7 @@ public class SelenideConfig implements Config {
     this.driverManagerEnabled = driverManagerEnabled;
     return this;
   }
+
   @Override
   public boolean webdriverLogsEnabled() {
     return webdriverLogsEnabled;
@@ -340,6 +343,10 @@ public class SelenideConfig implements Config {
   public SelenideConfig browserCapabilities(DesiredCapabilities browserCapabilities) {
     this.browserCapabilities = browserCapabilities;
     return this;
+  }
+
+  private String getProperty(String key, String defaultValue) {
+    return PropertiesUtils.loadSelenideProperties().getProperty(key, defaultValue);
   }
 
 }

--- a/src/main/java/com/codeborne/selenide/impl/PropertiesUtils.java
+++ b/src/main/java/com/codeborne/selenide/impl/PropertiesUtils.java
@@ -1,0 +1,36 @@
+package com.codeborne.selenide.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public final class PropertiesUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesUtils.class);
+
+  private static final String SELENIDE_PROPERTIES_FILE = "selenide.properties";
+
+  private PropertiesUtils() {
+  }
+
+  public static Properties loadSelenideProperties() {
+    final Properties properties = new Properties();
+    loadPropertiesFrom(ClassLoader.getSystemClassLoader(), properties);
+    loadPropertiesFrom(Thread.currentThread().getContextClassLoader(), properties);
+    properties.putAll(System.getProperties());
+    return properties;
+  }
+
+  private static void loadPropertiesFrom(final ClassLoader classLoader, final Properties properties) {
+    try (InputStream stream = classLoader.getResourceAsStream(SELENIDE_PROPERTIES_FILE)) {
+      if (stream != null) {
+        properties.load(stream);
+      }
+    } catch (IOException e) {
+      LOGGER.error("Error while reading selenide.properties file from classpath: {}", e.getMessage());
+    }
+  }
+}

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -35,7 +35,7 @@ public class Configuration {
 
   /**
    * Base url for open() function calls
-   * Can be configured either programmatically or by system property "-Dselenide.baseUrl=http://myhost".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.baseUrl=http://myhost".
    * <br>
    * Default value: http://localhost:8080
    */
@@ -43,7 +43,7 @@ public class Configuration {
 
   /**
    * Timeout in milliseconds to fail the test, if conditions still not met
-   * Can be configured either programmatically or by system property "-Dselenide.timeout=10000"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.timeout=10000"
    * <br>
    * Default value: 4000 (milliseconds)
    */
@@ -51,7 +51,7 @@ public class Configuration {
 
   /**
    * Interval in milliseconds, when checking if a single element or collection elements are appeared
-   * Can be configured either programmatically or by system property "-Dselenide.pollingInterval=50"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.pollingInterval=50"
    * <br>
    * Default value: 200 (milliseconds)
    */
@@ -59,7 +59,7 @@ public class Configuration {
 
   /**
    * If holdBrowserOpen is true, browser window stays open after running tests. It may be useful for debugging.
-   * Can be configured either programmatically or by system property "-Dselenide.holdBrowserOpen=true".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.holdBrowserOpen=true".
    * <br>
    * Default value: false.
    */
@@ -68,7 +68,7 @@ public class Configuration {
   /**
    * Should Selenide re-spawn browser if it's disappeared (hangs, broken, unexpectedly closed).
    * <br>
-   * Can be configured either programmatically or by system property "-Dselenide.reopenBrowserOnFail=false".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.reopenBrowserOnFail=false".
    * <br>
    * Set this property to false if you want to disable automatic re-spawning the browser.
    * <br>
@@ -78,7 +78,7 @@ public class Configuration {
 
   /**
    * Which browser to use.
-   * Can be configured either programmatically or by system property "-Dselenide.browser=ie".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.browser=ie".
    * Supported values: "chrome", "firefox", "ie", "opera", "edge"
    * <br>
    * Default value: "chrome"
@@ -87,7 +87,7 @@ public class Configuration {
 
   /**
    * Which browser version to use (for Internet Explorer).
-   * Can be configured either programmatically or by system property "-Dselenide.browserVersion=8".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.browserVersion=8".
    * <br>
    * Default value: none
    */
@@ -95,7 +95,7 @@ public class Configuration {
 
   /**
    * URL of remote web driver (in case of using Selenium Grid).
-   * Can be configured either programmatically or by system property "-Dselenide.remote=http://localhost:5678/wd/hub".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.remote=http://localhost:5678/wd/hub".
    * <br>
    * Default value: null (Grid is not used).
    */
@@ -103,7 +103,7 @@ public class Configuration {
 
   /**
    * The browser window size.
-   * Can be configured either programmatically or by system property "-Dselenide.browserSize=1024x768".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.browserSize=1024x768".
    * <br>
    * Default value: 1366x768
    */
@@ -111,7 +111,7 @@ public class Configuration {
 
   /**
    * The browser window position on screen.
-   * Can be configured either programmatically or by system property "-Dselenide.browserPosition=10x10".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.browserPosition=10x10".
    * <br>
    * Default value: none
    */
@@ -129,7 +129,7 @@ public class Configuration {
    * Should webdriver wait until page is completely loaded.
    * Possible values: "none", "normal" and "eager".
    * <br>
-   * Can be configured either programmatically or by system property "-Dselenide.pageLoadStrategy=eager".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.pageLoadStrategy=eager".
    * Default value: "normal".
    * <br>
    * - `normal`: return after the load event fires on the new page (it's default in Selenium webdriver);
@@ -158,7 +158,7 @@ public class Configuration {
    * ATTENTION! Automatic WebDriver waiting after click isn't working in case of using this feature.
    * Use clicking via JavaScript instead common element clicking.
    * This solution may be helpful for testing in Internet Explorer.
-   * Can be configured either programmatically or by system property "-Dselenide.clickViaJs=true".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.clickViaJs=true".
    * <br>
    * Default value: false
    */
@@ -166,7 +166,7 @@ public class Configuration {
 
   /**
    * Defines if Selenide takes screenshots on failing tests.
-   * Can be configured either programmatically or by system property "-Dselenide.screenshots=false".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.screenshots=false".
    * <br>
    * Default value: true
    */
@@ -174,7 +174,7 @@ public class Configuration {
 
   /**
    * Defines if Selenide saves page source on failing tests.
-   * Can be configured either programmatically or by system property "-Dselenide.savePageSource=false".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.savePageSource=false".
    * <br>
    * Default value: true
    */
@@ -182,7 +182,7 @@ public class Configuration {
 
   /**
    * Folder to store screenshots to.
-   * Can be configured either programmatically or by system property "-Dselenide.reportsFolder=test-result/reports".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.reportsFolder=test-result/reports".
    * <br>
    * Default value: "build/reports/tests" (this is default for Gradle projects)
    */
@@ -190,7 +190,7 @@ public class Configuration {
 
     /**
    * Folder to store downloaded files to.
-   * Can be configured either programmatically or by system property "-Dselenide.downloadsFolder=test-result/downloads".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.downloadsFolder=test-result/downloads".
    * <br>
    * Default value: "build/downloads" (this is default for Gradle projects)
    */
@@ -200,7 +200,7 @@ public class Configuration {
    * Optional: URL of CI server where reports are published to.
    * In case of Jenkins, it is "BUILD_URL/artifact" by default.
    * <br>
-   * Can be configured either programmatically or by system property "-Dselenide.reportsUrl=http://jenkins-host/reports".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.reportsUrl=http://jenkins-host/reports".
    * <br>
    * If it's given, names of screenshots are printed as
    * "http://ci.mycompany.com/job/my-job/446/artifact/build/reports/tests/my_test.png" - it's useful to analyze test
@@ -217,7 +217,7 @@ public class Configuration {
    * slow via network to Selenium Grid on cloud).
    * <br>
    * https://github.com/selenide/selenide/issues/135
-   * Can be configured either programmatically or by system property "-Dselenide.fastSetValue=true".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.fastSetValue=true".
    * <br>
    * Default value: false
    */
@@ -227,7 +227,7 @@ public class Configuration {
    * <p>Choose how Selenide should retrieve web elements: using default CSS or Sizzle (CSS3).</p>
    * <br>
    * <p>
-   * Can be configured either programmatically or by system property "-Dselenide.selectorMode=Sizzle".
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.selectorMode=Sizzle".
    * </p>
    * <br>
    *   Possible values: "CSS" or "Sizzle"
@@ -241,7 +241,7 @@ public class Configuration {
   /**
    * <p>Assertion mode</p>
    *
-   * <p>Can be configured either programmatically or by system property "-Dselenide.assertionMode=SOFT".</p>
+   * <p>Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.assertionMode=SOFT".</p>
    *
    * <br>
    *   Possible values: "STRICT" or "SOFT"
@@ -254,7 +254,7 @@ public class Configuration {
 
   /**
    * Defines if files are downloaded via direct HTTP or vie selenide embedded proxy server
-   * Can be configured either programmatically or by system property "-Dselenide.fileDownload=PROXY"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.fileDownload=PROXY"
    * <br>
    * Default: HTTPGET
    */
@@ -266,7 +266,7 @@ public class Configuration {
    * But it's not enabled by default because sometimes it would not work (more exactly, if tests and browser and
    * executed on different machines, and "test machine" is not accessible from "browser machine"). If it's not your
    * case, I recommend to enable proxy.
-   * Can be configured either programmatically or by system property "-Dselenide.proxyEnabled=true"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.proxyEnabled=true"
    * <br>
    * Default: false
    */
@@ -275,7 +275,7 @@ public class Configuration {
   /**
    * Host of Selenide proxy server.
    * Used only if proxyEnabled == true.
-   * Can be configured either programmatically or by system property "-Dselenide.proxyHost=127.0.0.1"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.proxyHost=127.0.0.1"
    * <br>
    * Default: empty (meaning that Selenide will detect current machine's ip/hostname automatically)
    *
@@ -286,7 +286,7 @@ public class Configuration {
   /**
    * Port of Selenide proxy server.
    * Used only if proxyEnabled == true.
-   * Can be configured either programmatically or by system property "-Dselenide.proxyPort=8888"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.proxyPort=8888"
    * <br>
    * Default: 0 (meaning that Selenide will choose a random free port on current machine)
    */
@@ -296,7 +296,7 @@ public class Configuration {
    * Controls Selenide and WebDriverManager integration.
    * When integration is enabled you don't need to download and setup any browser driver executables.
    * See https://github.com/bonigarcia/webdrivermanager for WebDriverManager configuration details.
-   * Can be configured either programmatically or by system property "-Dselenide.driverManagerEnabled=false"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.driverManagerEnabled=false"
    * <br>
    *
    * Default: true
@@ -322,7 +322,7 @@ public class Configuration {
   /**
    * Enables the ability to run the browser in headless mode.
    * Works only for Chrome(59+) and Firefox(56+).
-   * Can be configured either programmatically or by system property "-Dselenide.headless=true"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.headless=true"
    * <br>
    * Default: false
    */
@@ -331,7 +331,7 @@ public class Configuration {
   /**
    * Sets the path to browser executable.
    * Works only for Chrome, Firefox and Opera.
-   * Can be configured either programmatically or by system property "-Dselenide.browserBinary=/path/to/binary"
+   * Can be configured either programmatically, via selenide.properties file or by system property "-Dselenide.browserBinary=/path/to/binary"
    */
   public static String browserBinary = defaults.browserBinary();
 


### PR DESCRIPTION
## Proposed changes
This improvement will allow users to configure their frameworks in a more flexible way.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
