### PR TITLE
avoid using Selenium 3* transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.0.3 (released 27.10.2021)
+* Add workaround for Maven users to avoid occasional using Selenium 3 transitive dependencies 
+
 ## 6.0.2 (released 26.10.2021)
 * #1623 remove occasional JUnit dependency from published selenide artifact
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 allprojects {
   group = 'com.codeborne'
-  version = '6.0.2'
+  version = '6.0.3-SNAPSHOT'
 }
 
 subprojects {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,6 +16,7 @@ subprojects {
   }
 
   dependencies {
+    api("org.seleniumhq.selenium:selenium-java:$seleniumVersion") {exclude group: 'net.bytebuddy'}
     implementation("com.google.guava:guava:31.0.1-jre")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("commons-io:commons-io:2.11.0")

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -16,9 +16,6 @@ sourceSets {
 dependencies {
   api('org.opentest4j:opentest4j:1.2.0')
 
-  api("org.seleniumhq.selenium:selenium-java:$seleniumVersion") {
-    exclude group: 'net.bytebuddy'
-  }
   api('io.github.bonigarcia:webdrivermanager:5.0.3') {
     exclude group: 'org.apache.httpcomponents.core5', module: 'httpcore5-h2'
     exclude group: 'com.github.docker-java'

--- a/modules/proxy/build.gradle
+++ b/modules/proxy/build.gradle
@@ -4,7 +4,10 @@ ext {
 
 dependencies {
   api project(":statics")
-  api("com.browserup:browserup-proxy-core:${browserupProxyVersion}") {exclude group: 'io.netty'}
+  api("com.browserup:browserup-proxy-core:${browserupProxyVersion}") {
+    exclude group: 'io.netty'
+    exclude group: 'org.seleniumhq.selenium'
+  }
   implementation("xyz.rogfam:littleproxy:${littleProxyVersion}")
   implementation("io.netty:netty-all:$nettyVersion") {because 'used by browserup-proxy'}
 }


### PR DESCRIPTION
Maven prefers an older "selenium-api-3*.jar" instead of a newer "selenium-api-4*.jar" because it's located "higher" in a dependency tree (because it's a transitive dependency of browserup proxy, allure etc.).

This commit is a workaround against this wrong Maven behaviour.
