### PR TITLE
use MutableCapabilities instead of DesiredCapabilities

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -337,7 +337,7 @@ public class SelenideConfig implements Config {
     return browserCapabilities;
   }
 
-  public SelenideConfig browserCapabilities(DesiredCapabilities browserCapabilities) {
+  public SelenideConfig browserCapabilities(MutableCapabilities browserCapabilities) {
     this.browserCapabilities = browserCapabilities;
     return this;
   }


### PR DESCRIPTION
starting from Selenium 4, ChromeOptions doesn't extend DesiredCapabilities anymore.

The goal is to make this code compilable:

```java
SelenideConfig selenideConfig = new SelenideConfig();
selenideConfig.browserCapabilities(new ChromeOptions());  // doesn't compile with Selenide 6.0.3
```
