### PR TITLE
fixed #1656 checking for empty string

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -97,7 +97,7 @@ public class WebDriverFactory {
                                             @Nullable File browserDownloadsFolder) {
     DriverFactory webdriverFactory = findFactory(browser);
 
-    if (config.remote() != null) {
+    if (config.remote() != null && !config.remote().equals("")) {
       MutableCapabilities capabilities = webdriverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
       return remoteDriverFactory.create(config, capabilities);
     }


### PR DESCRIPTION
Fix for #1656. if config is empty string, it should be ignored.