### PR TITLE
Override default Selenium http timeouts for RemoteWebDriver

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -96,19 +96,19 @@ public class WebDriverFactory {
                                             @Nullable Proxy proxy,
                                             @Nullable File browserDownloadsFolder) {
     DriverFactory webdriverFactory = findFactory(browser);
-
+    WebDriver webDriver;
     if (config.remote() != null) {
       MutableCapabilities capabilities = webdriverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
-      return remoteDriverFactory.create(config, capabilities);
+      webDriver = remoteDriverFactory.create(config, capabilities);
     }
     else {
       if (config.driverManagerEnabled()) {
         webdriverFactory.setupWebdriverBinary();
       }
-      WebDriver webDriver = webdriverFactory.create(config, browser, proxy, browserDownloadsFolder);
-      httpClientTimeouts.setup(webDriver);
-      return webDriver;
+      webDriver = webdriverFactory.create(config, browser, proxy, browserDownloadsFolder);
     }
+    httpClientTimeouts.setup(webDriver);
+    return webDriver;
   }
 
   @CheckReturnValue


### PR DESCRIPTION
Earlier in pr https://github.com/selenide/selenide/pull/1433 default Selenium http timeouts were overriden.

But it didn't work for RemoteWebDriver

Now we also set shorter timeouts (connectTimeout = 1 minute, readTimeout = 2 minutes) for remote.