### PR TITLE
Ignore whitespaces for filename in Content-Disposition header

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/HttpHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/HttpHelper.java
@@ -22,7 +22,7 @@ import static org.apache.commons.lang3.StringUtils.left;
 public class HttpHelper {
 
   private static final Pattern FILENAME_IN_CONTENT_DISPOSITION_HEADER =
-    Pattern.compile(".*filename\\*?=\"?((.+)'')?([^\";?]*)\"?(;charset=(.*))?.*", CASE_INSENSITIVE);
+    Pattern.compile(".*filename\\*? *= *\"?((.+)'')?([^\";?]*)\"?(;charset=(.*))?.*", CASE_INSENSITIVE);
 
   private static final Pattern FILENAME_FORBIDDEN_CHARACTERS =
     Pattern.compile("[#%&{}/\\\\<>*?$!'\":@+`|=]");

--- a/src/test/java/com/codeborne/selenide/impl/HttpHelperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/HttpHelperTest.java
@@ -18,6 +18,26 @@ final class HttpHelperTest {
       .isEqualTo("statement.xls");
 
     assertThat(helper.getFileNameFromContentDisposition(
+      "Content-Disposition", "Content-Disposition=attachment; filename = statement2.xls"))
+      .get()
+      .isEqualTo("statement.xls");
+
+    assertThat(helper.getFileNameFromContentDisposition(
+      "Content-Disposition", "Content-Disposition=attachment; filename =statement.xls"))
+      .get()
+      .isEqualTo("statement.xls");
+
+    assertThat(helper.getFileNameFromContentDisposition(
+      "Content-Disposition", "Content-Disposition=attachment; filename   =   statement.xls"))
+      .get()
+      .isEqualTo("statement.xls");
+
+    assertThat(helper.getFileNameFromContentDisposition(
+      "Content-Disposition", "Content-Disposition=attachment; filename= statement.xls"))
+      .get()
+      .isEqualTo("statement.xls");
+
+    assertThat(helper.getFileNameFromContentDisposition(
       "Content-Disposition", "Content-Disposition=inline; filename=\"statement-40817810048000102279.pdf\""))
       .get()
       .isEqualTo("statement-40817810048000102279.pdf");


### PR DESCRIPTION
## Proposed changes
Current behavior: Selenide doesn't detect filenames in the `download()` method if this one has whitespaces after `filename`. For instance, `attachment; filename = testName.csv`. In that case, a filename is detected as `csv`

After that fix Selenide ignores whitespaces around `=` after `filename` in that header
