### PR TITLE
Add selenide's create driver log

### DIFF
--- a/src/test/java/integration/LogEventListenerTest.java
+++ b/src/test/java/integration/LogEventListenerTest.java
@@ -41,12 +41,13 @@ final class LogEventListenerTest extends BaseIntegrationTest {
     sa.assertThat(beforeEvents).hasSize(1);
     sa.assertThat(beforeEvents.get(0)).isEqualTo("before: $(#remove) click()");
 
-    sa.assertThat(afterEvents).hasSize(4);
+    sa.assertThat(afterEvents).hasSize(5);
 
-    sa.assertThat(afterEvents.get(0)).startsWith("after: $(open)");
-    sa.assertThat(afterEvents.get(1)).isEqualTo("after: $(#remove) should be(visible)");
-    sa.assertThat(afterEvents.get(2)).isEqualTo("after: $(#remove) click()");
-    sa.assertThat(afterEvents.get(3)).isEqualTo("after: $(#remove) should not be(visible)");
+    sa.assertThat(afterEvents.get(0)).startsWith("after: $(webdriver)");
+    sa.assertThat(afterEvents.get(1)).startsWith("after: $(open)");
+    sa.assertThat(afterEvents.get(2)).isEqualTo("after: $(#remove) should be(visible)");
+    sa.assertThat(afterEvents.get(3)).isEqualTo("after: $(#remove) click()");
+    sa.assertThat(afterEvents.get(4)).isEqualTo("after: $(#remove) should not be(visible)");
 
     sa.assertAll();
   }


### PR DESCRIPTION
## Proposed changes
In Selenide report is impossible to get information when the browser was created(or recreated) and how much time the test spend on this action. I think that it can be useful as other logs, generated by Selenide. 
log example: 
![image](https://user-images.githubusercontent.com/42538985/151550508-c919bd66-26eb-44b6-b366-c08e1274a367.png)


## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
