### PR TITLE
Add support for custom duration in `switchTo().frame()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * add support for BEARER token authentication
 * upgrade to Selenium 4.1.2
 * #1433 fix overriding default timeout for Selenium http client
+* add support for custom duration in `switchTo().frame()`
 
 ## 6.2.1 (released 19.01.2022)
 * #1702 Ignore whitespaces for filename in Content-Disposition header  --  thanks Yevgeniy Mikhailov for PR #1702

--- a/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
+++ b/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
@@ -41,12 +41,57 @@ public class SelenideTargetLocator implements TargetLocator {
     this.delegate = webDriver.switchTo();
   }
 
+  /**
+   * Switch to frame by index
+   * NB! Order of framew can be different in different browsers, see Selenide tests.
+   *
+   * @param index index of frame (0-based)
+   */
   @Override
   @Nonnull
   public WebDriver frame(int index) {
+    return frame(Wait(), index);
+  }
+
+  /**
+   * Switch to frame by index with a configurable timeout
+   * NB! Order of frames can be different in different browsers, see Selenide tests.
+   *
+   * @param index    index of frame (0-based)
+   * @param timeout the timeout duration. It overrides default Config.timeout()
+   */
+  @Nonnull
+  public WebDriver frame(int index, Duration timeout) {
+    return frame(Wait(timeout), index);
+  }
+
+  /**
+   * Switch to frame by name or id
+   *
+   * @param nameOrId name or id of frame
+   */
+  @Override
+  @Nonnull
+  public WebDriver frame(String nameOrId) {
+    return frame(Wait(), nameOrId);
+  }
+
+  /**
+   * Switch to frame by name or id with a configurable timeout
+   *
+   * @param nameOrId name or id of frame
+   * @param timeout            the timeout duration. It overrides default Config.timeout()
+   */
+  @Nonnull
+  public WebDriver frame(String nameOrId, Duration timeout) {
+    return frame(Wait(timeout), nameOrId);
+  }
+
+  @Nonnull
+  private WebDriver frame(SelenideWait wait, int index) {
     return SelenideLogger.get(String.format("frame(index: %s)", index), SWITCH_TO, () -> {
       try {
-        return Wait().until(frameToBeAvailableAndSwitchToIt(index));
+        return wait.until(frameToBeAvailableAndSwitchToIt(index));
       }
       catch (NoSuchElementException | TimeoutException e) {
         throw frameNotFoundError("No frame found with index: " + index, e);
@@ -60,12 +105,11 @@ public class SelenideTargetLocator implements TargetLocator {
     });
   }
 
-  @Override
   @Nonnull
-  public WebDriver frame(String nameOrId) {
+  private WebDriver frame(SelenideWait wait, String nameOrId) {
     return SelenideLogger.get("frame(" + nameOrId + ")", SWITCH_TO, () -> {
       try {
-        return Wait().until(frameToBeAvailableAndSwitchToIt(nameOrId));
+        return wait.until(frameToBeAvailableAndSwitchToIt(nameOrId));
       }
       catch (NoSuchElementException | TimeoutException e) {
         throw frameNotFoundError("No frame found with id/name: " + nameOrId, e);

--- a/src/test/java/integration/FramesCustomWaitTest.java
+++ b/src/test/java/integration/FramesCustomWaitTest.java
@@ -1,0 +1,40 @@
+package integration;
+
+import static com.codeborne.selenide.Condition.text;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.codeborne.selenide.ex.FrameNotFoundException;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class FramesCustomWaitTest extends ITest {
+
+  @BeforeEach
+  void setUp() {
+    openFile("page_with_frames_with_big_delays.html");
+  }
+
+  @Test
+  void waitsUntilFrameAppears_withCustomTimeout() {
+    setTimeout(1000);
+    $("#btn").click();
+    switchTo().frame("ifrm", Duration.ofSeconds(6));
+    $("body").shouldBe(text("This is last frame!"));
+  }
+
+  @Test
+  void waitsUntilFrameAppears_withoutCustomTimeout() {
+    $("#btn").click();
+    assertThatThrownBy(() -> switchTo().frame(1))
+      .isInstanceOf(FrameNotFoundException.class);
+  }
+
+  @Test
+  void waitsUntilFrameAppears_withLowerTimeout() {
+    $("#btn").click();
+    assertThatThrownBy(() -> switchTo().frame(1, Duration.ofSeconds(1)))
+      .isInstanceOf(FrameNotFoundException.class);
+  }
+
+}

--- a/src/test/resources/page_with_frames_with_big_delays.html
+++ b/src/test/resources/page_with_frames_with_big_delays.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+  <script language="javascript">
+    function showFrame()
+    {var iframe = document.createElement('iframe');
+      iframe.setAttribute('id', 'ifrm'); // assign an id
+      iframe.src = 'child_frame.txt';
+      document.getElementById("info").appendChild(iframe);
+    }
+    function showFrameWithDelay()
+    {setTimeout(showFrame, 5000);}
+  </script>
+</head>
+<body>
+<div>
+  <input type="button" id="btn" value="frame" OnClick="showFrameWithDelay();">
+</div>
+<div id="info"></div>
+</body>
+</html>


### PR DESCRIPTION
## Proposed changes
Add support for custom duration in `switchTo().frame()`

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
