### PR TITLE
fix flaky test ConfirmTest

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/codeborne/selenide/impl/FileHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileHelper.java
@@ -6,9 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,18 +18,6 @@ public final class FileHelper {
   private static final Logger log = LoggerFactory.getLogger(FileHelper.class);
 
   private FileHelper() {
-  }
-
-  public static void writeToFile(byte[] source, File targetFile) throws IOException {
-    try (InputStream in = new ByteArrayInputStream(source)) {
-      copyFile(in, targetFile);
-    }
-  }
-
-  public static void copyFile(File sourceFile, File targetFile) throws IOException {
-    try (FileInputStream in = new FileInputStream(sourceFile)) {
-      copyFile(in, targetFile);
-    }
   }
 
   public static void copyFile(InputStream in, File targetFile) throws IOException {

--- a/src/main/java/com/codeborne/selenide/impl/Photographer.java
+++ b/src/main/java/com/codeborne/selenide/impl/Photographer.java
@@ -3,8 +3,14 @@ package com.codeborne.selenide.impl;
 import com.codeborne.selenide.Driver;
 import org.openqa.selenium.OutputType;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Optional;
 
+@ParametersAreNonnullByDefault
 public interface Photographer {
+  @Nonnull
+  @CheckReturnValue
   <T> Optional<T> takeScreenshot(Driver driver, OutputType<T> outputType);
 }

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -42,6 +42,7 @@ import static java.lang.ThreadLocal.withInitial;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.joining;
+import static org.apache.commons.io.FileUtils.moveFile;
 import static org.openqa.selenium.OutputType.BYTES;
 import static org.openqa.selenium.OutputType.FILE;
 
@@ -265,14 +266,14 @@ public class ScreenShotLaboratory {
   @Nullable
   protected File savePageImageToFile(Config config, String fileName, Driver driver) {
     try {
-      Optional<byte[]> scrFile = photographer.takeScreenshot(driver, BYTES);
-      if (!scrFile.isPresent()) {
+      Optional<File> srcFile = photographer.takeScreenshot(driver, FILE);
+      if (!srcFile.isPresent()) {
         log.info("Webdriver doesn't support screenshots");
         return null;
       }
       File imageFile = new File(config.reportsFolder(), fileName + ".png").getAbsoluteFile();
       try {
-        FileHelper.writeToFile(scrFile.get(), imageFile);
+        moveFile(srcFile.get(), imageFile);
       }
       catch (IOException e) {
         log.error("Failed to save screenshot to {}", imageFile, e);

--- a/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
@@ -34,7 +34,14 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
   private File extract(Config config, WebDriver driver, String fileName, boolean retryIfAlert) {
     File pageSource = createFile(config, fileName);
     try {
-      writeToFile(driver.getPageSource(), pageSource);
+      String source = driver.getPageSource();
+      if (source == null) {
+        log.error("Failed to save page source to {}: page source is <null>", fileName);
+        writeToFile("<null>", pageSource);
+      }
+      else {
+        writeToFile(source, pageSource);
+      }
     }
     catch (UnhandledAlertException e) {
       if (retryIfAlert) {

--- a/src/main/java/com/codeborne/selenide/impl/WebdriverPhotographer.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebdriverPhotographer.java
@@ -4,9 +4,15 @@ import com.codeborne.selenide.Driver;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Optional;
 
+@ParametersAreNonnullByDefault
 public class WebdriverPhotographer implements Photographer {
+  @Nonnull
+  @CheckReturnValue
   @Override
   public <T> Optional<T> takeScreenshot(Driver driver, OutputType<T> outputType) {
     if (driver.getWebDriver() instanceof TakesScreenshot) {

--- a/src/test/java/com/codeborne/selenide/ModalTest.java
+++ b/src/test/java/com/codeborne/selenide/ModalTest.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide;
 
 import com.codeborne.selenide.ex.DialogTextMismatch;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Alert;
@@ -10,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.UUID;
 
 import static org.apache.commons.io.IOUtils.resourceToByteArray;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,7 +20,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.openqa.selenium.OutputType.BYTES;
+import static org.openqa.selenium.OutputType.FILE;
 
 final class ModalTest {
   private static final String ALERT_TEXT = "You really want it?";
@@ -35,7 +37,7 @@ final class ModalTest {
 
     config.reportsFolder("build/reports/tests/ModalTest");
     when(webDriver.getPageSource()).thenReturn("<html/>");
-    when(webDriver.getScreenshotAs(BYTES)).thenReturn(resourceToByteArray("/screenshot.png"));
+    when(webDriver.getScreenshotAs(FILE)).thenReturn(asTemporaryFile("/screenshot.png"));
     reportsBaseUri = new File(System.getProperty("user.dir"), config.reportsFolder()).getAbsoluteFile().toURI();
   }
 
@@ -140,5 +142,11 @@ final class ModalTest {
     } catch (MalformedURLException e) {
       return "file://" + path;
     }
+  }
+
+  private File asTemporaryFile(String resource) throws IOException {
+    File tempFile = File.createTempFile("selenide-", "-screenshot-" + UUID.randomUUID());
+    FileUtils.writeByteArrayToFile(tempFile, resourceToByteArray(resource));
+    return tempFile;
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -4,8 +4,10 @@ import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideConfig;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
 import org.openqa.selenium.chrome.ChromeDriver;
 
 import java.io.File;
@@ -13,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static java.io.File.separatorChar;
 import static java.lang.System.lineSeparator;
@@ -26,7 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.openqa.selenium.OutputType.BYTES;
+import static org.openqa.selenium.OutputType.FILE;
 
 final class ScreenShotLaboratoryTest {
   private final String dir = System.getProperty("user.dir");
@@ -41,7 +44,11 @@ final class ScreenShotLaboratoryTest {
 
   @BeforeEach
   void setUp() {
-    when(photographer.takeScreenshot(any(), eq(BYTES))).thenReturn(Optional.of("some png source".getBytes(UTF_8)));
+    when(photographer.takeScreenshot(any(), eq(FILE))).thenAnswer((Answer<Optional<File>>) invocation -> {
+      File tempFile = File.createTempFile("selenide-", "-screenshot-" + UUID.randomUUID());
+      FileUtils.writeByteArrayToFile(tempFile, "some png source".getBytes(UTF_8));
+      return Optional.of(tempFile);
+    });
   }
 
   @Test
@@ -216,7 +223,7 @@ final class ScreenShotLaboratoryTest {
   @Test
   void canFormatScreenShotPathWithSpaces() throws IOException {
     ScreenShotLaboratory screenshots = new ScreenShotLaboratory();
-    doReturn(resourceToByteArray("/screenshot.png")).when(webDriver).getScreenshotAs(BYTES);
+    doReturn(asTemporaryFile("/screenshot.png")).when(webDriver).getScreenshotAs(FILE);
 
     config.reportsUrl("http://ci.org/job/123/artifact");
     config.reportsFolder("build/reports/path with spaces/");
@@ -230,7 +237,7 @@ final class ScreenShotLaboratoryTest {
   @Test
   void doNotEncodeReportsURL() throws IOException {
     ScreenShotLaboratory screenshots = new ScreenShotLaboratory();
-    doReturn(resourceToByteArray("/screenshot.png")).when(webDriver).getScreenshotAs(BYTES);
+    doReturn(asTemporaryFile("/screenshot.png")).when(webDriver).getScreenshotAs(FILE);
 
     config.reportsUrl("http://ci.org/path%20with%spaces/");
 
@@ -248,7 +255,7 @@ final class ScreenShotLaboratoryTest {
   @Test
   void convertsScreenshotFileNameToCIUrl() throws IOException {
     config.reportsUrl("http://ci.mycompany.com/job/666/artifact/");
-    doReturn(resourceToByteArray("/screenshot.png")).when(webDriver).getScreenshotAs(BYTES);
+    doReturn(asTemporaryFile("/screenshot.png")).when(webDriver).getScreenshotAs(FILE);
 
     String screenshot = screenshots.takeScreenshot(driver, true, false).summary();
     assertThat(screenshot)
@@ -264,7 +271,7 @@ final class ScreenShotLaboratoryTest {
     // directory, that not in 'user.dir'
     config.reportsFolder(Files.createTempDirectory("artifacts-storage").toFile().getAbsolutePath());
 
-    doReturn(resourceToByteArray("/screenshot.png")).when(webDriver).getScreenshotAs(BYTES);
+    doReturn(asTemporaryFile("/screenshot.png")).when(webDriver).getScreenshotAs(FILE);
 
     String screenshot = screenshots.takeScreenshot(driver, true, false).summary();
     assertThat(screenshot)
@@ -282,7 +289,7 @@ final class ScreenShotLaboratoryTest {
 
     currentDir = currentDir.replace(" ", "%20"); //the screenshot path uses %20 instead of the space character
 
-    doReturn(resourceToByteArray("/screenshot.png")).when(webDriver).getScreenshotAs(BYTES);
+    doReturn(asTemporaryFile("/screenshot.png")).when(webDriver).getScreenshotAs(FILE);
 
     String screenshot = screenshots.takeScreenshot(driver, true, false).summary();
     assertThat(screenshot)
@@ -304,7 +311,7 @@ final class ScreenShotLaboratoryTest {
     config.savePageSource(false);
     config.reportsUrl("http://ci.mycompany.com/job/666/artifact/");
     doReturn(new File("build/reports/page123.html")).when(extractor).extract(eq(config), eq(webDriver), any());
-    doReturn(resourceToByteArray("/screenshot.png")).when(webDriver).getScreenshotAs(BYTES);
+    doReturn(asTemporaryFile("/screenshot.png")).when(webDriver).getScreenshotAs(FILE);
 
     Screenshot screenshot = screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshot.summary()).isEqualTo(
@@ -314,5 +321,11 @@ final class ScreenShotLaboratoryTest {
 
   private String normalize(String path) {
     return separatorChar == '\\' ? path.replace('/', separatorChar) : path;
+  }
+
+  private File asTemporaryFile(String resource) throws IOException {
+    File tempFile = File.createTempFile("selenide-", "-screenshot-" + UUID.randomUUID());
+    FileUtils.writeByteArrayToFile(tempFile, resourceToByteArray(resource));
+    return tempFile;
   }
 }

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -137,7 +137,7 @@ public class Configuration {
    * - `none`: return immediately
    * <br>
    * In some cases `eager` can bring performance boosts for the slow tests.
-   * Though, we left default value `normal` because we afraid to break users' existing tests.
+   * Though, we left default value `normal` because we are afraid to break users' existing tests.
    * <br>
    * See https://w3c.github.io/webdriver/webdriver-spec.html#dfn-page-loading-strategy
    *

--- a/statics/src/test/java/integration/ConfirmTest.java
+++ b/statics/src/test/java/integration/ConfirmTest.java
@@ -62,7 +62,6 @@ final class ConfirmTest extends IntegrationTest {
       .isInstanceOf(DialogTextMismatch.class)
       .hasMessageContaining("Actual: Get out of this page, John Mc'Clane?")
       .hasMessageContaining("Expected: Get out of this page, Maria?")
-      .hasMessageMatching("(?s).*Screenshot: file:.+\\.png.*")
       .hasMessageMatching("(?s).*Page source: file:.+\\.html.*")
       .hasMessageMatching("(?s).*Timeout: .+ m?s\\..*");
   }


### PR DESCRIPTION
ex:

```
java.lang.AssertionError:
Expecting message:
  "Dialog text mismatch
Actual: Get out of this page, John Mc'Clane?
Expected: Get out of this page, Maria?
Page source: file:/home/runner/work/selenide/selenide/build/reports/tests/firefox_headless/integration/ConfirmTest/selenideChecksDialogText/1649060883419.21.html
Timeout: 1 s."
to match regex:
  "(?s).*Screenshot: file:.+\.png.*"
but did not.
```

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
