### PR TITLE
#1780 verify the whole text in `$.shouldHave(text)`, not a substring

### DIFF
--- a/modules/proxy/src/test/java/integration/BasicAuthViaProxyTest.java
+++ b/modules/proxy/src/test/java/integration/BasicAuthViaProxyTest.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.Credentials;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.AuthenticationType.BASIC;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
@@ -13,39 +14,39 @@ public class BasicAuthViaProxyTest extends ProxyIntegrationTest {
   @Test
   void canPassBasicAuth_via_proxy() {
     open("/basic-auth/hello", "", "scott", "tiger");
-    $("body").shouldHave(text("Hello, scott:tiger!"));
+    $("#greeting").shouldHave(text("Hello, scott:tiger!"));
   }
 
   @Test
   void canAuthUsingProxyWithLoginAndPassword() {
     open("/basic-auth/hello", BASIC, "scott", "tiger");
-    $("body").shouldHave(text("Hello, scott:tiger!"));
+    $("#greeting").shouldHave(text("Hello, scott:tiger!"));
   }
 
   @Test
   void canAuthUsingProxyWithCredentials() {
     Credentials credentials = new BasicAuthCredentials("scott", "tiger");
     open("/basic-auth/hello", BASIC, credentials);
-    $("body").shouldHave(text("Hello, scott:tiger!"));
+    $("#greeting").shouldHave(text("Hello, scott:tiger!"));
     $("#bye").click();
-    $("body").shouldHave(text("bye, scott:tiger!"));
+    $("#greeting").shouldHave(text("bye, scott:tiger!"));
   }
 
   @Test
   void canSwitchToAnotherBasicAuth() {
     open("/basic-auth/hello", BASIC, new BasicAuthCredentials("scott", "tiger"));
-    $("body").shouldHave(text("Hello, scott:tiger!"));
+    $("#greeting").shouldHave(text("Hello, scott:tiger!"));
     open("/basic-auth/hello2", BASIC, new BasicAuthCredentials("scott2", "tiger2"));
-    $("body").shouldHave(text("Hello2, scott2:tiger2!"));
+    $("#greeting").shouldHave(text("Hello2, scott2:tiger2!"));
   }
 
   @Test
   void removesPreviousBasicAuthHeaders() {
     open("/basic-auth/hello", BASIC, new BasicAuthCredentials("scott", "tiger"));
-    $("body").shouldHave(text("Hello, scott:tiger!"));
+    $("#greeting").shouldHave(text("Hello, scott:tiger!"));
     open("/headers/hello3");
     $("body")
-      .shouldHave(text("Hello3"), text("Accept="), text("User-Agent="))
-      .shouldNotHave(text("Authorization="));
+      .shouldHave(partialText("Hello3"), partialText("Accept="), partialText("User-Agent="))
+      .shouldNotHave(partialText("Authorization="));
   }
 }

--- a/modules/proxy/src/test/java/integration/BearerTokenAuthViaProxyTest.java
+++ b/modules/proxy/src/test/java/integration/BearerTokenAuthViaProxyTest.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.Credentials;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.AuthenticationType.BEARER;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
@@ -14,27 +15,27 @@ public class BearerTokenAuthViaProxyTest extends ProxyIntegrationTest {
   void canAuthUsingProxyWithCredentials() {
     Credentials credentials = new BearerTokenCredentials("token-123");
     open("/bearer-token-auth/hello", BEARER, credentials);
-    $("body").shouldHave(text("Hello, token-123!"));
+    $("#greeting").shouldHave(text("Hello, token-123!"));
     $("#bye").click();
-    $("body").shouldHave(text("bye, token-123!"));
+    $("#greeting").shouldHave(text("bye, token-123!"));
   }
 
   @Test
   void canSwitchToAnotherBearerToken() {
     open("/bearer-token-auth/hello", BEARER, new BearerTokenCredentials("token-123"));
-    $("body").shouldHave(text("Hello, token-123!"));
+    $("#greeting").shouldHave(text("Hello, token-123!"));
     open("/bearer-token-auth/hello2", BEARER, new BearerTokenCredentials("token-456"));
-    $("body").shouldHave(text("Hello2, token-456!"));
+    $("#greeting").shouldHave(text("Hello2, token-456!"));
   }
 
   @Test
   void removesPreviousAuthHeaders() {
     open("/bearer-token-auth/hello", BEARER, new BearerTokenCredentials("token-123"));
-    $("body").shouldHave(text("Hello, token-123!"));
+    $("#greeting").shouldHave(text("Hello, token-123!"));
     open("/headers/hello3");
     $("body")
-      .shouldHave(text("Hello3"), text("Accept="), text("User-Agent="))
-      .shouldNotHave(text("Authorization="));
+      .shouldHave(partialText("Hello3"), partialText("Accept="), partialText("User-Agent="))
+      .shouldNotHave(partialText("Authorization="));
   }
 
   @Test

--- a/modules/proxy/src/test/java/integration/CustomWebdriverProviderWithSelenideProxyTest.java
+++ b/modules/proxy/src/test/java/integration/CustomWebdriverProviderWithSelenideProxyTest.java
@@ -45,7 +45,7 @@ final class CustomWebdriverProviderWithSelenideProxyTest extends ProxyIntegratio
     Configuration.browser = MyWebDriverProvider.class.getName();
 
     open("/basic-auth/hello", BASIC, new BasicAuthCredentials("scott", "tiger"));
-    $("body").shouldHave(text("Hello, scott:tiger!"));
+    $("#greeting").shouldHave(text("Hello, scott:tiger!"));
   }
 
   @ParametersAreNonnullByDefault

--- a/modules/proxy/src/test/java/integration/CustomWebdriverWithSelenideProxyTest.java
+++ b/modules/proxy/src/test/java/integration/CustomWebdriverWithSelenideProxyTest.java
@@ -14,7 +14,7 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 
 import static com.codeborne.selenide.AuthenticationType.BASIC;
-import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.open;
@@ -41,7 +41,7 @@ final class CustomWebdriverWithSelenideProxyTest extends ProxyIntegrationTest {
         WebDriverRunner.setWebDriver(webDriver, proxy);
 
         open("/basic-auth/hello", BASIC, new BasicAuthCredentials("scott", "tiger"));
-        $("body").shouldHave(text("Hello, scott:tiger!"));
+        $("body").shouldHave(partialText("Hello, scott:tiger!"));
       }
       finally {
         closeWebDriver();

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -5,6 +5,8 @@ import com.codeborne.selenide.conditions.Attribute;
 import com.codeborne.selenide.conditions.AttributeWithValue;
 import com.codeborne.selenide.conditions.CaseSensitiveText;
 import com.codeborne.selenide.conditions.Checked;
+import com.codeborne.selenide.conditions.PartialText;
+import com.codeborne.selenide.conditions.PartialTextCaseSensitive;
 import com.codeborne.selenide.conditions.CssClass;
 import com.codeborne.selenide.conditions.CssValue;
 import com.codeborne.selenide.conditions.CustomMatch;
@@ -305,6 +307,32 @@ public abstract class Condition {
   @Nonnull
   public static Condition matchText(String regex) {
     return new MatchText(regex);
+  }
+
+  /**
+   * Assert that given element's text CONTAINS given text
+   *
+   * <p>Sample: <code>$("h1").shouldHave(partialText("ello Joh"))</code></p>
+   *
+   * @since 6.5.0
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition partialText(String regex) {
+    return new PartialText(regex);
+  }
+
+  /**
+   * Assert that given element's text CONTAINS given text (case-sensitive)
+   *
+   * <p>Sample: <code>$("h1").should(partialTextCaseSensitive("ELLO jOH"))</code></p>
+   *
+   * @since 6.5.0
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition partialTextCaseSensitive(String regex) {
+    return new PartialTextCaseSensitive(regex);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -314,7 +314,7 @@ public abstract class Condition {
    *
    * <p>Sample: <code>$("h1").shouldHave(partialText("ello Joh"))</code></p>
    *
-   * @since 6.5.0
+   * @since 6.7.0
    */
   @CheckReturnValue
   @Nonnull
@@ -327,7 +327,7 @@ public abstract class Condition {
    *
    * <p>Sample: <code>$("h1").should(partialTextCaseSensitive("ELLO jOH"))</code></p>
    *
-   * @since 6.5.0
+   * @since 6.7.0
    */
   @CheckReturnValue
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/Config.java
+++ b/src/main/java/com/codeborne/selenide/Config.java
@@ -28,6 +28,7 @@ public interface Config {
   String downloadsFolder();
   String reportsUrl();
   boolean fastSetValue();
+  TextCheck textCheck();
   SelectorMode selectorMode();
   AssertionMode assertionMode();
   FileDownloadMode fileDownload();

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -37,6 +37,7 @@ public class SelenideConfig implements Config {
   private String downloadsFolder = getProperty("selenide.downloadsFolder", "build/downloads");
   private String reportsUrl = new CiReportUrl().getReportsUrl(getProperty("selenide.reportsUrl", null));
   private boolean fastSetValue = Boolean.parseBoolean(getProperty("selenide.fastSetValue", "false"));
+  private TextCheck textCheck = TextCheck.valueOf(getProperty("selenide.textCheck", TextCheck.FULL_TEXT.name()));
   private SelectorMode selectorMode = SelectorMode.valueOf(getProperty("selenide.selectorMode", CSS.name()));
   private AssertionMode assertionMode = AssertionMode.valueOf(getProperty("selenide.assertionMode", STRICT.name()));
   private FileDownloadMode fileDownload = FileDownloadMode.valueOf(getProperty("selenide.fileDownload", HTTPGET.name()));
@@ -159,8 +160,18 @@ public class SelenideConfig implements Config {
     return fastSetValue;
   }
 
+  @Override
+  public TextCheck textCheck() {
+    return textCheck;
+  }
+
   public SelenideConfig fastSetValue(boolean fastSetValue) {
     this.fastSetValue = fastSetValue;
+    return this;
+  }
+
+  public SelenideConfig textCheck(TextCheck textCheck) {
+    this.textCheck = textCheck;
     return this;
   }
 

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -1,12 +1,12 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.impl.CiReportUrl;
+import org.openqa.selenium.MutableCapabilities;
+
 import static com.codeborne.selenide.AssertionMode.STRICT;
 import static com.codeborne.selenide.Browsers.CHROME;
 import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.SelectorMode.CSS;
-
-import com.codeborne.selenide.impl.CiReportUrl;
-import org.openqa.selenium.MutableCapabilities;
 
 public class SelenideConfig implements Config {
   private final PropertiesReader properties = new PropertiesReader("selenide.properties");
@@ -37,7 +37,7 @@ public class SelenideConfig implements Config {
   private String downloadsFolder = getProperty("selenide.downloadsFolder", "build/downloads");
   private String reportsUrl = new CiReportUrl().getReportsUrl(getProperty("selenide.reportsUrl", null));
   private boolean fastSetValue = Boolean.parseBoolean(getProperty("selenide.fastSetValue", "false"));
-  private TextCheck textCheck = TextCheck.valueOf(getProperty("selenide.textCheck", TextCheck.FULL_TEXT.name()));
+  private TextCheck textCheck = TextCheck.valueOf(getProperty("selenide.textCheck", TextCheck.PARTIAL_TEXT.name()));
   private SelectorMode selectorMode = SelectorMode.valueOf(getProperty("selenide.selectorMode", CSS.name()));
   private AssertionMode assertionMode = AssertionMode.valueOf(getProperty("selenide.assertionMode", STRICT.name()));
   private FileDownloadMode fileDownload = FileDownloadMode.valueOf(getProperty("selenide.fileDownload", HTTPGET.name()));

--- a/src/main/java/com/codeborne/selenide/TextCheck.java
+++ b/src/main/java/com/codeborne/selenide/TextCheck.java
@@ -1,0 +1,25 @@
+package com.codeborne.selenide;
+
+/**
+ * @since 6.5.0
+ */
+public enum TextCheck {
+  /**
+   * <p>Match the full text.</p>
+   * <p>
+   * It's a new default behaviour of {@code $.shouldHave(text)} since Selenide 6.5.0
+   * </p>
+   */
+  FULL_TEXT,
+
+  /**
+   * <p>Match the partial text</p>
+   * <p>
+   * It was the default behaviour of {@code $.shouldHave(text)} until Selenide 6.4.0.
+   * </p>
+   * <p>Left here for compatibility:
+   * use it if you have you too many failing tests after upgrading to Selenide 6.5.0.
+   * </p>
+   */
+  PARTIAL_TEXT
+}

--- a/src/main/java/com/codeborne/selenide/TextCheck.java
+++ b/src/main/java/com/codeborne/selenide/TextCheck.java
@@ -1,7 +1,7 @@
 package com.codeborne.selenide;
 
 /**
- * @since 6.5.0
+ * @since 6.7.0
  */
 public enum TextCheck {
   /**

--- a/src/main/java/com/codeborne/selenide/conditions/CaseInsensitiveTextCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CaseInsensitiveTextCondition.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.TextCheck;
+import com.codeborne.selenide.impl.Html;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+abstract class CaseInsensitiveTextCondition extends TextCondition {
+  protected CaseInsensitiveTextCondition(String name, String expectedText) {
+    super(name, expectedText);
+  }
+
+  @CheckReturnValue
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    return switch (textCheck) {
+      case FULL_TEXT -> Html.text.equals(actualText, expectedText);
+      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText);
+    };
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
@@ -4,14 +4,10 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.Select;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.List;
-
-import static java.util.stream.Collectors.joining;
 
 @ParametersAreNonnullByDefault
 public class CaseSensitiveText extends TextCondition {
@@ -40,10 +36,5 @@ public class CaseSensitiveText extends TextCondition {
     return "select".equalsIgnoreCase(element.getTagName()) ?
       getSelectedOptionsTexts(element) :
       element.getText();
-  }
-
-  private String getSelectedOptionsTexts(WebElement element) {
-    List<WebElement> selectedOptions = new Select(element).getAllSelectedOptions();
-    return selectedOptions.stream().map(WebElement::getText).collect(joining());
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
@@ -21,7 +22,15 @@ public class CaseSensitiveText extends TextCondition {
 
   @Override
   protected boolean match(String actualText, String expectedText) {
-    return Html.text.containsCaseSensitive(actualText, expectedText);
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    return switch (textCheck) {
+      case FULL_TEXT -> Html.text.equalsCaseSensitive(actualText, expectedText);
+      case PARTIAL_TEXT -> Html.text.containsCaseSensitive(actualText, expectedText);
+    };
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveText.java
@@ -1,8 +1,6 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.TextCheck;
-import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -10,23 +8,10 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class CaseSensitiveText extends TextCondition {
+public class CaseSensitiveText extends CaseSensitiveTextCondition {
 
   public CaseSensitiveText(String expectedText) {
     super("text case sensitive", expectedText);
-  }
-
-  @Override
-  protected boolean match(String actualText, String expectedText) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
-    return switch (textCheck) {
-      case FULL_TEXT -> Html.text.equalsCaseSensitive(actualText, expectedText);
-      case PARTIAL_TEXT -> Html.text.containsCaseSensitive(actualText, expectedText);
-    };
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveTextCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CaseSensitiveTextCondition.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.TextCheck;
+import com.codeborne.selenide.impl.Html;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+abstract class CaseSensitiveTextCondition extends TextCondition {
+  protected CaseSensitiveTextCondition(String name, String expectedText) {
+    super(name, expectedText);
+  }
+
+  @CheckReturnValue
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    return switch (textCheck) {
+      case FULL_TEXT -> Html.text.equalsCaseSensitive(actualText, expectedText);
+      case PARTIAL_TEXT -> Html.text.containsCaseSensitive(actualText, expectedText);
+    };
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/MatchText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/MatchText.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide.conditions;
 
+import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 
 import javax.annotation.CheckReturnValue;
@@ -20,6 +21,14 @@ public class MatchText extends TextCondition {
   @CheckReturnValue
   @Override
   protected boolean match(String actualText, String expectedText) {
-    return Html.text.matches(actualText, expectedText);
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    return switch (textCheck) {
+      case FULL_TEXT -> Html.text.matches(actualText, expectedText);
+      case PARTIAL_TEXT -> Html.text.matchesSubstring(actualText, expectedText);
+    };
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/OwnText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/OwnText.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
@@ -24,7 +25,15 @@ public class OwnText extends TextCondition {
   @CheckReturnValue
   @Override
   protected boolean match(String actualText, String expectedText) {
-    return Html.text.contains(actualText, expectedText);
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    return switch (textCheck) {
+      case FULL_TEXT -> Html.text.equals(actualText, expectedText);
+      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText);
+    };
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/OwnText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/OwnText.java
@@ -1,8 +1,6 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.TextCheck;
-import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -13,27 +11,13 @@ import static com.codeborne.selenide.commands.GetOwnText.getOwnText;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
-public class OwnText extends TextCondition {
+public class OwnText extends CaseInsensitiveTextCondition {
   public OwnText(String expectedText) {
     super("own text", expectedText);
     if (isEmpty(expectedText)) {
       throw new IllegalArgumentException("Argument must not be null or empty string. " +
         "Use $.shouldHave(exactOwnText(\"\").");
     }
-  }
-
-  @CheckReturnValue
-  @Override
-  protected boolean match(String actualText, String expectedText) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
-    return switch (textCheck) {
-      case FULL_TEXT -> Html.text.equals(actualText, expectedText);
-      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText);
-    };
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/PartialText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PartialText.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.WebElement;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import static java.util.Locale.ROOT;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
@@ -23,7 +24,7 @@ public class PartialText extends TextCondition {
 
   @Override
   protected boolean match(String actualText, String expectedText) {
-    return Html.text.contains(actualText, expectedText.toLowerCase());
+    return Html.text.contains(actualText, expectedText.toLowerCase(ROOT));
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/PartialText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PartialText.java
@@ -1,22 +1,19 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
-import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Locale;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
-public class Text extends TextCondition {
+public class PartialText extends TextCondition {
 
-  public Text(final String text) {
-    super("text", text);
+  public PartialText(String text) {
+    super("partial text", text);
 
     if (isEmpty(text)) {
       throw new IllegalArgumentException("Argument must not be null or empty string. " +
@@ -24,22 +21,12 @@ public class Text extends TextCondition {
     }
   }
 
-  @CheckReturnValue
   @Override
   protected boolean match(String actualText, String expectedText) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
-    return switch (textCheck) {
-      case FULL_TEXT -> Html.text.equals(actualText, expectedText.toLowerCase());
-      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText.toLowerCase(Locale.ROOT));
-    };
+    return Html.text.contains(actualText, expectedText.toLowerCase());
   }
 
   @Nullable
-  @CheckReturnValue
   @Override
   protected String getText(Driver driver, WebElement element) {
     return "select".equalsIgnoreCase(element.getTagName()) ?

--- a/src/main/java/com/codeborne/selenide/conditions/PartialText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PartialText.java
@@ -7,7 +7,6 @@ import org.openqa.selenium.WebElement;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import static java.util.Locale.ROOT;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
@@ -24,7 +23,7 @@ public class PartialText extends TextCondition {
 
   @Override
   protected boolean match(String actualText, String expectedText) {
-    return Html.text.contains(actualText, expectedText.toLowerCase(ROOT));
+    return Html.text.contains(actualText, expectedText);
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/PartialTextCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PartialTextCaseSensitive.java
@@ -1,22 +1,19 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
-import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Locale;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
-public class Text extends TextCondition {
+public class PartialTextCaseSensitive extends TextCondition {
 
-  public Text(final String text) {
-    super("text", text);
+  public PartialTextCaseSensitive(String text) {
+    super("partial text case sensitive", text);
 
     if (isEmpty(text)) {
       throw new IllegalArgumentException("Argument must not be null or empty string. " +
@@ -24,22 +21,12 @@ public class Text extends TextCondition {
     }
   }
 
-  @CheckReturnValue
   @Override
   protected boolean match(String actualText, String expectedText) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
-    return switch (textCheck) {
-      case FULL_TEXT -> Html.text.equals(actualText, expectedText.toLowerCase());
-      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText.toLowerCase(Locale.ROOT));
-    };
+    return Html.text.containsCaseSensitive(actualText, expectedText);
   }
 
   @Nullable
-  @CheckReturnValue
   @Override
   protected String getText(Driver driver, WebElement element) {
     return "select".equalsIgnoreCase(element.getTagName()) ?

--- a/src/main/java/com/codeborne/selenide/conditions/SelectedText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/SelectedText.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 import com.codeborne.selenide.impl.JavaScript;
 import org.openqa.selenium.WebElement;
@@ -20,7 +21,15 @@ public class SelectedText extends TextCondition {
   @CheckReturnValue
   @Override
   protected boolean match(String actualText, String expectedText) {
-    return Html.text.containsCaseSensitive(actualText, expectedText);
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    return switch (textCheck) {
+      case FULL_TEXT -> Html.text.equalsCaseSensitive(actualText, expectedText);
+      case PARTIAL_TEXT -> Html.text.containsCaseSensitive(actualText, expectedText);
+    };
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/SelectedText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/SelectedText.java
@@ -1,8 +1,6 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.TextCheck;
-import com.codeborne.selenide.impl.Html;
 import com.codeborne.selenide.impl.JavaScript;
 import org.openqa.selenium.WebElement;
 
@@ -11,25 +9,11 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class SelectedText extends TextCondition {
+public class SelectedText extends CaseSensitiveTextCondition {
   private final JavaScript js = new JavaScript("get-selected-text.js");
 
   public SelectedText(String expectedText) {
     super("selected text", expectedText);
-  }
-
-  @CheckReturnValue
-  @Override
-  protected boolean match(String actualText, String expectedText) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
-    return switch (textCheck) {
-      case FULL_TEXT -> Html.text.equalsCaseSensitive(actualText, expectedText);
-      case PARTIAL_TEXT -> Html.text.containsCaseSensitive(actualText, expectedText);
-    };
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/Text.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Text.java
@@ -8,8 +8,8 @@ import org.openqa.selenium.WebElement;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Locale;
 
+import static java.util.Locale.ROOT;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
@@ -33,8 +33,8 @@ public class Text extends TextCondition {
   @Override
   protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
     return switch (textCheck) {
-      case FULL_TEXT -> Html.text.equals(actualText, expectedText.toLowerCase());
-      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText.toLowerCase(Locale.ROOT));
+      case FULL_TEXT -> Html.text.equals(actualText, expectedText.toLowerCase(ROOT));
+      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText.toLowerCase(ROOT));
     };
   }
 

--- a/src/main/java/com/codeborne/selenide/conditions/Text.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Text.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
@@ -29,7 +30,15 @@ public class Text extends TextCondition {
   @CheckReturnValue
   @Override
   protected boolean match(String actualText, String expectedText) {
-    return Html.text.contains(actualText, expectedText.toLowerCase(Locale.ROOT));
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    return switch (textCheck) {
+      case FULL_TEXT -> Html.text.equals(actualText, expectedText.toLowerCase());
+      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText.toLowerCase(Locale.ROOT));
+    };
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/Text.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Text.java
@@ -1,8 +1,6 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.TextCheck;
-import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -12,7 +10,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
-public class Text extends TextCondition {
+public class Text extends CaseInsensitiveTextCondition {
 
   public Text(final String text) {
     super("text", text);
@@ -21,20 +19,6 @@ public class Text extends TextCondition {
       throw new IllegalArgumentException("Argument must not be null or empty string. " +
         "Use $.shouldBe(empty) or $.shouldHave(exactText(\"\").");
     }
-  }
-
-  @CheckReturnValue
-  @Override
-  protected boolean match(String actualText, String expectedText) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
-    return switch (textCheck) {
-      case FULL_TEXT -> Html.text.equals(actualText, expectedText);
-      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText);
-    };
   }
 
   @Nullable

--- a/src/main/java/com/codeborne/selenide/conditions/Text.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Text.java
@@ -9,7 +9,6 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import static java.util.Locale.ROOT;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
@@ -33,8 +32,8 @@ public class Text extends TextCondition {
   @Override
   protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
     return switch (textCheck) {
-      case FULL_TEXT -> Html.text.equals(actualText, expectedText.toLowerCase(ROOT));
-      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText.toLowerCase(ROOT));
+      case FULL_TEXT -> Html.text.equals(actualText, expectedText);
+      case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText);
     };
   }
 

--- a/src/main/java/com/codeborne/selenide/conditions/TextCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/TextCondition.java
@@ -5,11 +5,15 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.TextCheck;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
 
 @ParametersAreNonnullByDefault
 public abstract class TextCondition extends Condition {
@@ -46,5 +50,10 @@ public abstract class TextCondition extends Condition {
   @Override
   public final String toString() {
     return String.format("%s \"%s\"", getName(), expectedText);
+  }
+
+  protected String getSelectedOptionsTexts(WebElement element) {
+    List<WebElement> selectedOptions = new Select(element).getAllSelectedOptions();
+    return selectedOptions.stream().map(WebElement::getText).collect(joining());
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/TextCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/TextCondition.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.conditions;
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.TextCheck;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -21,6 +22,9 @@ public abstract class TextCondition extends Condition {
 
   @CheckReturnValue
   protected abstract boolean match(String actualText, String expectedText);
+  protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    return match(actualText, expectedText);
+  }
 
   @Nullable
   @CheckReturnValue
@@ -33,7 +37,8 @@ public abstract class TextCondition extends Condition {
   @Override
   public CheckResult check(Driver driver, WebElement element) {
     String elementText = getText(driver, element);
-    return new CheckResult(match(elementText, expectedText), String.format("text=\"%s\"", elementText));
+    boolean match = match(driver.config().textCheck(), elementText, expectedText);
+    return new CheckResult(match, String.format("text=\"%s\"", elementText));
   }
 
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/conditions/Value.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Value.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.conditions;
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
@@ -25,7 +26,14 @@ public class Value extends Condition {
   public CheckResult check(Driver driver, WebElement element) {
     String value = getValueAttribute(element);
     String actualValue = String.format("%s=\"%s\"", getName(), value);
-    return new CheckResult(Html.text.contains(value, expectedValue), actualValue);
+    return new CheckResult(match(driver.config().textCheck(), value), actualValue);
+  }
+
+  private boolean match(TextCheck textCheck, String value) {
+    return switch (textCheck) {
+      case FULL_TEXT -> Html.text.equals(value, expectedValue);
+      case PARTIAL_TEXT -> Html.text.contains(value, expectedValue);
+    };
   }
 
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/impl/Html.java
+++ b/src/main/java/com/codeborne/selenide/impl/Html.java
@@ -12,6 +12,10 @@ public class Html {
   public static Html text = new Html();
 
   public boolean matches(String text, String regex) {
+    return Pattern.compile(regex, DOTALL).matcher(text).matches();
+  }
+
+  public boolean matchesSubstring(String text, String regex) {
     return Pattern.compile(".*" + regex + ".*", DOTALL).matcher(text).matches();
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/Html.java
+++ b/src/main/java/com/codeborne/selenide/impl/Html.java
@@ -1,9 +1,9 @@
 package com.codeborne.selenide.impl;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Locale;
 import java.util.regex.Pattern;
 
+import static java.util.Locale.ROOT;
 import static java.util.regex.Pattern.DOTALL;
 
 @ParametersAreNonnullByDefault
@@ -20,7 +20,7 @@ public class Html {
   }
 
   public boolean contains(String text, String subtext) {
-    return reduceSpaces(text.toLowerCase(Locale.ROOT)).contains(reduceSpaces(subtext.toLowerCase(Locale.ROOT)));
+    return reduceSpaces(text.toLowerCase(ROOT)).contains(reduceSpaces(subtext.toLowerCase(ROOT)));
   }
 
   public boolean containsCaseSensitive(String text, String subtext) {

--- a/src/main/java/com/codeborne/selenide/logevents/SelenideLogger.java
+++ b/src/main/java/com/codeborne/selenide/logevents/SelenideLogger.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.FAIL;
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
+import static java.util.Locale.ROOT;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -66,7 +67,7 @@ public class SelenideLogger {
   @CheckReturnValue
   @Nonnull
   static String readableMethodName(String methodName) {
-    return REGEX_UPPER_CASE.matcher(methodName).replaceAll(" $1").toLowerCase();
+    return REGEX_UPPER_CASE.matcher(methodName).replaceAll(" $1").toLowerCase(ROOT);
   }
 
   @CheckReturnValue

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -30,6 +30,7 @@ import static com.codeborne.selenide.Condition.type;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Mocks.elementWithAttribute;
+import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
@@ -39,7 +40,7 @@ import static org.mockito.Mockito.when;
 final class ConditionTest {
   private final WebDriver webDriver = new DummyWebDriver();
   private final SelenideProxyServer proxy = mock(SelenideProxyServer.class);
-  private final SelenideConfig config = new SelenideConfig();
+  private final SelenideConfig config = new SelenideConfig().textCheck(PARTIAL_TEXT);
   private final Driver driver = new DriverStub(config, new Browser("opera", false), webDriver, proxy);
 
   @Test

--- a/src/test/java/com/codeborne/selenide/DriverStub.java
+++ b/src/test/java/com/codeborne/selenide/DriverStub.java
@@ -25,11 +25,19 @@ public class DriverStub implements Driver {
   private final DownloadsFolder browserDownloadsFolder;
 
   public DriverStub() {
-    this("zopera");
+    this("netscape navigator");
   }
 
   public DriverStub(String browser) {
-    this(browser, new SharedDownloadsFolder("build/downloads/" + randomUUID()));
+    this(new SelenideConfig(), browser);
+  }
+
+  public DriverStub(Config config) {
+    this(config, "netscape navigator");
+  }
+
+  DriverStub(Config config, String browser) {
+    this(config, new Browser(browser, false), new DummyWebDriver(), null, new SharedDownloadsFolder("build/downloads/" + randomUUID()));
   }
 
   public DriverStub(String browser, DownloadsFolder downloadsFolder) {

--- a/src/test/java/com/codeborne/selenide/SelenideTargetLocatorTest.java
+++ b/src/test/java/com/codeborne/selenide/SelenideTargetLocatorTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 final class SelenideTargetLocatorTest {
   private final Config config = new SelenideConfig();
   private final WebDriver webdriver = mock(WebDriver.class);
-  private final DriverStub driver = new DriverStub(config, new Browser("zopera", true), webdriver, null);
+  private final DriverStub driver = new DriverStub(config, new Browser("netscape navigator", true), webdriver, null);
   private final SelenideTargetLocator switchTo = new SelenideTargetLocator(driver);
   private final TargetLocator targetLocator = mock(TargetLocator.class);
 

--- a/src/test/java/com/codeborne/selenide/conditions/CaseSensitiveTextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/CaseSensitiveTextTest.java
@@ -3,7 +3,7 @@ package com.codeborne.selenide.conditions;
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
-import com.codeborne.selenide.Mocks;
+import com.codeborne.selenide.SelenideConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -11,13 +11,15 @@ import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.Mocks.mockWebElement;
+import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class CaseSensitiveTextTest {
-  private final Driver driver = new DriverStub();
-  private final WebElement element = Mocks.mockWebElement("div", "");
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(PARTIAL_TEXT));
+  private final WebElement element = mockWebElement("div", "");
 
   private final CaseSensitiveText condition = new CaseSensitiveText("John Malkovich");
 

--- a/src/test/java/com/codeborne/selenide/conditions/ExactTextCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/ExactTextCaseSensitiveTest.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ import static org.mockito.Mockito.when;
 
 class ExactTextCaseSensitiveTest {
 
-  private final Driver driver = mock(Driver.class);
+  private final Driver driver = new DriverStub();
   private final WebElement element = mock(WebElement.class);
 
   private final ExactTextCaseSensitive condition = new ExactTextCaseSensitive("John Malkovich");
@@ -29,7 +30,7 @@ class ExactTextCaseSensitiveTest {
 
   @AfterEach
   void verifyNoMoreInteractions() {
-    Mockito.verifyNoMoreInteractions(driver, element);
+    Mockito.verifyNoMoreInteractions(element);
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/conditions/ExactTextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/ExactTextTest.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -15,14 +16,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ExactTextTest {
-  private final Driver driver = mock(Driver.class);
+  private final Driver driver = new DriverStub();
   private final WebElement element = mock(WebElement.class);
 
   private final ExactText condition = new ExactText("John Malkovich");
 
   @AfterEach
   void verifyNoMoreInteractions() {
-    Mockito.verifyNoMoreInteractions(driver, element);
+    Mockito.verifyNoMoreInteractions(element);
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/conditions/MatchTextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/MatchTextTest.java
@@ -2,11 +2,14 @@ package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -14,7 +17,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 final class MatchTextTest {
-  private final Driver driver = mock(Driver.class);
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(PARTIAL_TEXT));
 
   @Test
   void shouldMatchWholeString() {
@@ -60,7 +63,7 @@ final class MatchTextTest {
 
     assertThat(checkResult.actualValue()).isEqualTo("text=\"Chuck Norris' gmail account\"");
     verify(element).getText();
-    verifyNoMoreInteractions(driver, element);
+    verifyNoMoreInteractions(element);
   }
 
   private WebElement element(String text) {

--- a/src/test/java/com/codeborne/selenide/conditions/TextCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/TextCaseSensitiveTest.java
@@ -1,6 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
@@ -9,12 +11,12 @@ import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 import static com.codeborne.selenide.Mocks.mockElement;
 import static com.codeborne.selenide.Mocks.mockSelect;
 import static com.codeborne.selenide.Mocks.option;
+import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 final class TextCaseSensitiveTest {
 
-  private final Driver driver = mock(Driver.class);
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(PARTIAL_TEXT));
   private final WebElement elementShort = mockElement("One");
   private final WebElement elementLong = mockElement("ZeroOneTwo");
   private final WebElement singleSelectElement = mockSelect(option("One", true), option("Two"), option("Three"));

--- a/src/test/java/com/codeborne/selenide/conditions/TextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/TextTest.java
@@ -2,6 +2,8 @@ package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.SelenideElement;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
@@ -11,14 +13,14 @@ import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 import static com.codeborne.selenide.Mocks.mockElement;
 import static com.codeborne.selenide.Mocks.mockSelect;
 import static com.codeborne.selenide.Mocks.option;
+import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 final class TextTest {
-  private final Driver driver = mock(Driver.class);
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(PARTIAL_TEXT));
 
   @Test
   void apply_for_textInput() {
@@ -94,7 +96,7 @@ final class TextTest {
     assertThat(checkResult.actualValue()).isEqualTo("text=\"Hello World\"");
     verify(element).getTagName();
     verify(element).getText();
-    verifyNoMoreInteractions(driver, element);
+    verifyNoMoreInteractions(element);
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/SelenidePageFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenidePageFactoryTest.java
@@ -33,7 +33,7 @@ final class SelenidePageFactoryTest {
   private final TestPage page = new TestPage();
   private final Config config = new SelenideConfig();
   private final WebDriver webDriver = mock(WebDriver.class);
-  private final Driver driver = new DriverStub(config, new Browser("zopera", false), webDriver, null);
+  private final Driver driver = new DriverStub(config, new Browser("netscape navigator", false), webDriver, null);
   private final SelenidePageFactory pageFactory = new SelenidePageFactory();
   private final ClassLoader cl = getClass().getClassLoader();
 

--- a/src/test/java/com/codeborne/selenide/impl/WebElementSelectorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebElementSelectorTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 
 final class WebElementSelectorTest {
   private final WebElementSelector selector = new WebElementSelector();
-  private final Browser browser = new Browser("zopera", false);
+  private final Browser browser = new Browser("netscape navigator", false);
   private final JSWebDriver webDriver = mock(JSWebDriver.class);
   private final WebElementSource parent = mock(WebElementSource.class);
 
@@ -113,7 +113,7 @@ final class WebElementSelectorTest {
 
   @Test
   void findElement_insideElement_cannotUseXpathStartingWithSlash() {
-    Driver driver = new DriverStub("zopera");
+    Driver driver = new DriverStub();
     SelenideElement parentElement = mockElement("div", "whatever");
     when(parent.getWebElement()).thenReturn(parentElement);
 
@@ -124,7 +124,7 @@ final class WebElementSelectorTest {
 
   @Test
   void findElements_insideElement_cannotUseXpathStartingWithSlash() {
-    Driver driver = new DriverStub("zopera");
+    Driver driver = new DriverStub();
     SelenideElement parentElement = mockElement("div", "whatever");
     when(parent.getWebElement()).thenReturn(parentElement);
 

--- a/src/test/java/integration/ByTextTest.java
+++ b/src/test/java/integration/ByTextTest.java
@@ -96,8 +96,8 @@ final class ByTextTest extends ITest {
 
   @Test
   void canFindElementsByI18nText() {
-    $(byText("Маргарита")).shouldHave(text("Маргарита"));
-    $(withText("Марг")).shouldHave(text("Маргарита"));
+    $(byText("Маргарита")).shouldHave(attribute("id", "radioButtons"));
+    $(withText("Марг")).shouldHave(attribute("id", "radioButtons"));
     $(byText("Кот \"Бегемот\"")).click();
     $(withText("т \"Бегемот\"")).click();
     $(byTextCaseInsensitive("КОТ \"бЕГЕмот\"")).click();

--- a/src/test/java/integration/CollectionMethodsTest.java
+++ b/src/test/java/integration/CollectionMethodsTest.java
@@ -39,6 +39,7 @@ import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Condition.and;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Condition.visible;
@@ -192,24 +193,26 @@ final class CollectionMethodsTest extends ITest {
   @Test
   void userCanFilterOutMatchingElements() {
     $$("#multirowTable tr").shouldHave(size(2));
-    $$("#multirowTable tr").filterBy(text("Norris")).shouldHave(size(1));
+    $$("#multirowTable tr").filterBy(partialText("Norris")).shouldHave(size(1));
     $$("#multirowTable tr").filterBy(cssClass("inexisting")).shouldHave(size(0));
   }
 
   @Test
   void userCanExcludeMatchingElements() {
     $$("#multirowTable tr").shouldHave(size(2));
-    $$("#multirowTable tr").excludeWith(text("Chack")).shouldHave(size(0));
+    $$("#multirowTable tr").excludeWith(partialText("Chack")).shouldHave(size(0));
     $$("#multirowTable tr").excludeWith(cssClass("inexisting")).shouldHave(size(2));
   }
 
   @Test
   void errorMessageShouldShowFullAndConditionDescription() {
     ElementsCollection filteredRows = $$("#multirowTable tr")
-      .filterBy(and("condition name", text("Chack"), text("Baskerville")));
+      .filterBy(and("condition name", partialText("Chack"), partialText("Baskerville")));
 
     assertThatThrownBy(() -> filteredRows.shouldHave(size(0)))
-      .hasMessageContaining("collection: #multirowTable tr.filter(condition name: text \"Chack\" and text \"Baskerville\"");
+      .isInstanceOf(ListSizeMismatch.class)
+      .hasMessageContaining("collection: #multirowTable " +
+        "tr.filter(condition name: partial text \"Chack\" and partial text \"Baskerville\"");
   }
 
   @Test
@@ -226,7 +229,7 @@ final class CollectionMethodsTest extends ITest {
 
   @Test
   void userCanFindMatchingElementFromList() {
-    $$("#multirowTable tr").findBy(text("Norris")).shouldHave(text("Norris"));
+    $$("#multirowTable tr").findBy(partialText("Norris")).shouldHave(text("Chack Norris"));
   }
 
   @Test
@@ -240,7 +243,7 @@ final class CollectionMethodsTest extends ITest {
   @Test
   void collectionMethodsCanBeChained() {
     $$("#multirowTable tr").shouldHave(size(2))
-      .filterBy(text("Norris")).shouldHave(size(1));
+      .filterBy(partialText("Norris")).shouldHave(size(1));
   }
 
   @Test
@@ -339,7 +342,7 @@ final class CollectionMethodsTest extends ITest {
   @Test
   void canGetElementByIndex_fromFirstNElements_ofFilteredCollection() {
     ElementsCollection collection = $$x("//select[@name='domain']/option")
-      .filterBy(text(".ru"))
+      .filterBy(partialText(".ru"))
       .first(2)
       .shouldHave(size(2));
 
@@ -370,7 +373,7 @@ final class CollectionMethodsTest extends ITest {
   @Test
   void canGetElementByIndex_fromLastNElements_ofFilteredCollection() {
     ElementsCollection collection = $$x("//select[@name='domain']/option")
-      .filterBy(text(".ru"))
+      .filterBy(partialText(".ru"))
       .last(2)
       .shouldHave(size(2));
 

--- a/src/test/java/integration/CollectionWithChangingTextsTest.java
+++ b/src/test/java/integration/CollectionWithChangingTextsTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,9 +26,9 @@ final class CollectionWithChangingTextsTest extends ITest {
     Iterator<SelenideElement> it = $$("#collection li").snapshot()
       .shouldHave(size(3))
       .iterator();
-    it.next().shouldHave(text("Item #1"));
-    it.next().shouldHave(text("Item #2"));
-    it.next().shouldHave(text("Item #3"));
+    it.next().shouldHave(partialText("Item #1"));
+    it.next().shouldHave(partialText("Item #2"));
+    it.next().shouldHave(partialText("Item #3"));
     assertThat(it.hasNext()).isFalse();
   }
 

--- a/src/test/java/integration/ConditionsTest.java
+++ b/src/test/java/integration/ConditionsTest.java
@@ -33,6 +33,7 @@ import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.not;
 import static com.codeborne.selenide.Condition.or;
 import static com.codeborne.selenide.Condition.ownText;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.type;
 import static com.codeborne.selenide.Condition.value;
@@ -86,14 +87,14 @@ final class ConditionsTest extends ITest {
       be(visible),
       not(hidden),
       have(cssClass("multirow_table")),
-      have(text("Baskerville")),
+      have(partialText("Baskerville")),
       be(enabled),
       not(disabled),
       have(attribute("class", "table multirow_table")),
       have(href("https://nope.lt"))
     ))).isInstanceOf(ElementShould.class)
       .hasMessageStartingWith("Element should be satisfied: be visible and not hidden and have css class \"multirow_table\"" +
-        " and have text \"Baskerville\" and be enabled and not disabled and have attribute class=\"table multirow_table\"" +
+        " and have partial text \"Baskerville\" and be enabled and not disabled and have attribute class=\"table multirow_table\"" +
         " and have attribute href=\"https://nope.lt\" {#multirowTable}")
       .hasMessageContaining("Actual value: href=\"\"");
   }
@@ -127,16 +128,15 @@ final class ConditionsTest extends ITest {
 
   @Test
   void userCanUseOrCondition() {
-    Condition one_of_conditions = or("baskerville", text("Basker"), text("Walle"));
+    Condition one_of_conditions = or("baskerville", partialText("Basker"), partialText("Walle"));
     $("#baskerville").shouldBe(one_of_conditions);
 
-    Condition all_of_conditions = or("baskerville", text("Basker"), text("rville"));
+    Condition all_of_conditions = or("baskerville", partialText("Basker"), partialText("rville"));
     $("#baskerville").shouldBe(all_of_conditions);
 
-    Condition none_of_conditions = or("baskerville", text("pasker"), text("wille"));
+    Condition none_of_conditions = or("baskerville", partialText("pasker"), partialText("wille"));
     $("#baskerville").shouldNotBe(none_of_conditions);
   }
-
 
   @Test
   void matchWithCustomPredicateShouldCheckCondition() {

--- a/src/test/java/integration/HoverTest.java
+++ b/src/test/java/integration/HoverTest.java
@@ -26,17 +26,17 @@ final class HoverTest extends ITest {
 
   @Test
   void canEmulateHover() {
-    $("#hoverable").hover().shouldHave(text("It's hover"));
+    $("#hoverable").hover().shouldHave(text("It's hover!"));
     verifyCoordinates(400, 200);
 
     $("h1").hover();
-    $("#hoverable").shouldHave(text("It's not hover"));
+    $("#hoverable").shouldHave(text("It's not hover."));
     $("#coords").shouldHave(exactText(""));
   }
 
   @Test
   void hoverWithOffset() {
-    $("#hoverable").hover(withOffset(123, 122)).shouldHave(text("It's hover"));
+    $("#hoverable").hover(withOffset(123, 122)).shouldHave(text("It's hover!"));
     verifyCoordinates(523, 322);
   }
 

--- a/src/test/java/integration/LogicalOperationsWithConditions.java
+++ b/src/test/java/integration/LogicalOperationsWithConditions.java
@@ -10,6 +10,7 @@ import static com.codeborne.selenide.Condition.be;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.not;
 import static com.codeborne.selenide.Condition.or;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static java.time.Duration.ofMillis;
@@ -60,12 +61,12 @@ final class LogicalOperationsWithConditions extends ITest {
 
   @Test
   void andRevertsExistingElement() {
-    $("h1").shouldHave(text("Element removed"), text("from DOM"));
-    $("h1").shouldHave(and("2 texts", text("Element removed"), text("from DOM")));
-    $("h1").shouldNotHave(and("2 texts", text("Lasnamäe"), text("from DOM")));
-    $("h1").shouldNotHave(and("2 texts", text("Element removed"), text("Lasnamäe")));
+    $("h1").shouldHave(partialText("Element removed"), partialText("from DOM"));
+    $("h1").shouldHave(and("2 texts", partialText("Element removed"), partialText("from DOM")));
+    $("h1").shouldNotHave(and("2 texts", partialText("Lasnamäe"), partialText("from DOM")));
+    $("h1").shouldNotHave(and("2 texts", partialText("Element removed"), partialText("Lasnamäe")));
 
-    assertThatThrownBy(() -> $("h1").shouldNotHave(and("2 texts", text("Element removed"), text("from DOM"))))
+    assertThatThrownBy(() -> $("h1").shouldNotHave(and("2 texts", partialText("Element removed"), partialText("from DOM"))))
       .isInstanceOf(ElementShouldNot.class);
   }
 
@@ -73,19 +74,19 @@ final class LogicalOperationsWithConditions extends ITest {
   void orRevertsExistingElement() {
     String text1 = "Element removed";
     String text2 = "from DOM";
-    $("h1").shouldHave(or("2 texts", text(text1), text(text2)));
-    $("h1").shouldHave(or("2 texts", text("Lasnamäe"), text(text2)));
-    $("h1").shouldHave(or("2 texts", text(text1), text("Lasnamäe")));
-    $("h1").shouldNotHave(or("2 texts", text("Tallinn"), text("Lasnamäe")));
+    $("h1").shouldHave(or("2 texts", partialText(text1), partialText(text2)));
+    $("h1").shouldHave(or("2 texts", partialText("Lasnamäe"), partialText(text2)));
+    $("h1").shouldHave(or("2 texts", partialText(text1), partialText("Lasnamäe")));
+    $("h1").shouldNotHave(or("2 texts", partialText("Tallinn"), partialText("Lasnamäe")));
 
     assertThatThrownBy(() ->
-      $("h1").shouldNotHave(or("2 texts", text(text1), text(text2))))
+      $("h1").shouldNotHave(or("2 texts", partialText(text1), partialText(text2))))
       .isInstanceOf(ElementShouldNot.class);
     assertThatThrownBy(() ->
-      $("h1").shouldNotHave(or("2 texts", text("Lasnamäe"), text(text2))))
+      $("h1").shouldNotHave(or("2 texts", partialText("Lasnamäe"), partialText(text2))))
       .isInstanceOf(ElementShouldNot.class);
     assertThatThrownBy(() ->
-      $("h1").shouldNotHave(or("2 texts", text(text1), text("Lasnamäe"))))
+      $("h1").shouldNotHave(or("2 texts", partialText(text1), partialText("Lasnamäe"))))
       .isInstanceOf(ElementShouldNot.class);
   }
 }

--- a/src/test/java/integration/LongRunningAjaxRequestTest.java
+++ b/src/test/java/integration/LongRunningAjaxRequestTest.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.exist;
-import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byText;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,7 @@ final class LongRunningAjaxRequestTest extends ITest {
 
   @Test
   void dollarWaitsForElementWithIndex() {
-    $("#results li", 1).shouldHave(text("Result 2"));
+    $("#results li", 1).shouldHave(partialText("Result 2"));
   }
 
   @Test
@@ -67,12 +67,12 @@ final class LongRunningAjaxRequestTest extends ITest {
 
   @Test
   void shouldWaitsForCondition() {
-    $("#results").shouldHave(text("Result 1"));
+    $("#results").shouldHave(partialText("Result 1"));
   }
 
   @Test
   void shouldWaitsForAllConditions() {
-    $("#results").shouldHave(text("Result 1"), text("Result 2"));
+    $("#results").shouldHave(partialText("Result 1"), partialText("Result 2"));
   }
 
   @Test

--- a/src/test/java/integration/SelectorsTest.java
+++ b/src/test/java/integration/SelectorsTest.java
@@ -8,6 +8,7 @@ import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selectors.byAttribute;
@@ -57,20 +58,20 @@ final class SelectorsTest extends ITest {
 
   @Test
   void canFindElementById() {
-    $(byId("status")).shouldHave(text("Username:"));
+    $(byId("status")).shouldHave(partialText("Username:"));
   }
 
   @Test
   void canFindSelenideElementByXpath() {
     $x("//h1").shouldHave(text("Page with selects"));
-    $x("//*[@id='status']").shouldHave(text("Username:"));
+    $x("//*[@id='status']").shouldHave(partialText("Username:"));
     $x("//*[@name='domain']").shouldBe(visible);
   }
 
   @Test
   void canFindElementsCollectionByXpath() {
     $$x("//h1").get(0).shouldHave(text("Page with selects"));
-    $$x("//*[@id='status']").get(0).shouldHave(text("Username:"));
+    $$x("//*[@id='status']").get(0).shouldHave(partialText("Username:"));
     $$x("//*[@name='domain']").get(0).shouldBe(visible);
   }
 

--- a/src/test/java/integration/SizzleSelectorsTest.java
+++ b/src/test/java/integration/SizzleSelectorsTest.java
@@ -36,7 +36,7 @@ final class SizzleSelectorsTest extends BaseIntegrationTest {
     driver.$("input:last").shouldHave(attribute("id", "some-button"));
     driver.$("input[name!='username'][name!='password']").shouldHave(attribute("name", "rememberMe"));
     driver.$(":header").shouldHave(text("Page with JQuery"));
-    driver.$(":header", 1).shouldHave(text("Now typing"));
+    driver.$(":header", 1).shouldHave(text("Now typing:"));
     driver.$("label:contains('assword')").shouldHave(text("Password:"));
     assertThat(driver.$(":parent:not('html'):not('head')").getTagName()).isEqualTo("title");
   }

--- a/src/test/java/integration/server/BasicAuthHandler.java
+++ b/src/test/java/integration/server/BasicAuthHandler.java
@@ -26,7 +26,9 @@ class BasicAuthHandler extends BaseHandler {
     byte[] userPasswordBytes = Base64.getDecoder().decode(userPasswordBase64);
     String userPassword = new String(userPasswordBytes, UTF_8);
     String path = request.getPathInfo().replace("/", "");
-    String html = String.format("<html><body>%s, %s!" +
+    String html = String.format("<html><body>" +
+      "<div id=\"greeting\">%s, %s!</div>" +
+      "<br>" +
       "<br>" +
       "<a id=\"bye\" href=\"/basic-auth/bye\">bye!</a></body></html>", path, userPassword);
 

--- a/src/test/java/integration/server/BearerTokenHandler.java
+++ b/src/test/java/integration/server/BearerTokenHandler.java
@@ -31,7 +31,9 @@ class BearerTokenHandler extends BaseHandler {
       return new Result(SC_UNAUTHORIZED, CONTENT_TYPE_HTML_TEXT, "UNAUTHORIZED: Invalid bearer token " + bearerToken);
     }
     String path = request.getPathInfo().replace("/", "");
-    String html = String.format("<html><body>%s, %s!" +
+    String html = String.format("<html><body>" +
+      "<div id=\"greeting\">%s, %s!</div>" +
+      "<br>" +
       "<br>" +
       "<a id=\"bye\" href=\"/bearer-token-auth/bye\">bye!</a></body></html>", path, bearerToken);
 

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -229,6 +229,13 @@ public class Configuration {
   public static boolean fastSetValue = defaults.fastSetValue();
 
   /**
+   * Define behaviour of {@code $.shouldHave(text)}: full text or partial text.
+   *
+   * @since 6.5.0
+   */
+  public static TextCheck textCheck = defaults.textCheck();
+
+  /**
    * <p>Choose how Selenide should retrieve web elements: using default CSS or Sizzle (CSS3).</p>
    * <br>
    * <p>

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -231,7 +231,7 @@ public class Configuration {
   /**
    * Define behaviour of {@code $.shouldHave(text)}: full text or partial text.
    *
-   * @since 6.5.0
+   * @since 6.7.0
    */
   public static TextCheck textCheck = defaults.textCheck();
 

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.Config;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.FileDownloadMode;
 import com.codeborne.selenide.SelectorMode;
+import com.codeborne.selenide.TextCheck;
 import org.openqa.selenium.MutableCapabilities;
 
 /**
@@ -74,6 +75,11 @@ class StaticConfig implements Config {
   @Override
   public boolean fastSetValue() {
     return Configuration.fastSetValue;
+  }
+
+  @Override
+  public TextCheck textCheck() {
+    return Configuration.textCheck;
   }
 
   @Override

--- a/statics/src/test/java/integration/BasicAuthTest.java
+++ b/statics/src/test/java/integration/BasicAuthTest.java
@@ -11,6 +11,6 @@ final class BasicAuthTest extends IntegrationTest {
   void canPassBasicAuth_via_URL() {
     useProxy(false);
     open("/basic-auth/hello", "", "scott", "tiger");
-    $("body").shouldHave(text("Hello, scott:tiger!"));
+    $("#greeting").shouldHave(text("Hello, scott:tiger!"));
   }
 }

--- a/statics/src/test/java/integration/ClickWithTimeoutTest.java
+++ b/statics/src/test/java/integration/ClickWithTimeoutTest.java
@@ -19,9 +19,9 @@ import static java.time.Duration.ofSeconds;
 final class ClickWithTimeoutTest extends IntegrationTest {
   @BeforeEach
   void openTestPage() {
+    openFile("page_with_link_to_slow_page.html");
     Configuration.timeout = 100;
     Configuration.pageLoadTimeout = 200;
-    openFile("page_with_link_to_slow_page.html");
   }
 
   @Test

--- a/statics/src/test/java/integration/ElementTextTest.java
+++ b/statics/src/test/java/integration/ElementTextTest.java
@@ -14,6 +14,7 @@ import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.ownText;
 import static com.codeborne.selenide.Condition.ownTextCaseSensitive;
 import static com.codeborne.selenide.Condition.partialText;
+import static com.codeborne.selenide.Condition.partialTextCaseSensitive;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.textCaseSensitive;
 import static com.codeborne.selenide.Selenide.$;
@@ -158,8 +159,12 @@ final class ElementTextTest extends IntegrationTest {
   void text_ignoresCase() {
     $("#upper-case").shouldHave(text("this is sparta!"));
     $("#upper-case").shouldHave(text("THIS IS SPARTA!"));
-    $("#upper-case").shouldHave(text("IS IS SPA"));
-    $("#upper-case").shouldHave(text("is is spa"));
+  }
+
+  @Test
+  void partialText_ignoresCase() {
+    $("#upper-case").shouldHave(partialText("IS IS SPA"));
+    $("#upper-case").shouldHave(partialText("is is spa"));
   }
 
   @Test
@@ -173,7 +178,12 @@ final class ElementTextTest extends IntegrationTest {
   void text_caseSensitive() {
     $("#upper-case").shouldNotHave(textCaseSensitive("This is Sparta!"));
     $("#upper-case").shouldHave(textCaseSensitive("THIS IS SPARTA!"));
-    $("#upper-case").shouldHave(textCaseSensitive("IS IS SPA"));
+    $("#upper-case").shouldNotHave(textCaseSensitive("IS IS SPA"));
+  }
+
+  @Test
+  void partialText_caseSensitive() {
+    $("#upper-case").shouldHave(partialTextCaseSensitive("IS IS SPA"));
   }
 
   @Test

--- a/statics/src/test/java/integration/ElementTextTest.java
+++ b/statics/src/test/java/integration/ElementTextTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.codeborne.selenide.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,9 +13,11 @@ import static com.codeborne.selenide.Condition.exactTextCaseSensitive;
 import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.ownText;
 import static com.codeborne.selenide.Condition.ownTextCaseSensitive;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.textCaseSensitive;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -25,7 +28,13 @@ final class ElementTextTest extends IntegrationTest {
   }
 
   @Test
-  void canGetTextOfElement() {
+  void canCheckTextOfElement() {
+    $("#child_div1").shouldHave(text("Son"));
+    $("#grandchild_div").shouldHave(exactText("Granddaughter"));
+  }
+  @Test
+  void canCheckTextOfElement_partial() {
+    Configuration.textCheck = PARTIAL_TEXT;
     $("#child_div1").shouldHave(text("Son"));
     $("#grandchild_div").shouldHave(exactText("Granddaughter"));
   }
@@ -36,6 +45,14 @@ final class ElementTextTest extends IntegrationTest {
       "Son\n" +
       "Daughter\n" +
       "Granddaughter"));
+  }
+
+  @Test
+  void canGetTextOfElementWithChildren_partial() {
+    $("#parent_div").shouldHave(partialText("g papa\n" +
+      "Son\n" +
+      "Daughter\n" +
+      "Grand"));
   }
 
   @Test
@@ -55,9 +72,19 @@ final class ElementTextTest extends IntegrationTest {
     $("#child_div1").shouldHave(ownText("Son"));
     $("#child_div2").shouldHave(ownText("Daughter"));
     $("#parent_div").shouldHave(ownText("Big papa"));
-    $("#parent_div").shouldHave(ownText("papa"));
+    $("#parent_div").shouldNotHave(ownText("papa"));
     $("#parent_div").shouldNotHave(ownText("Son"));
     $("#parent_div").shouldNotHave(ownText("Daughter"));
+  }
+
+  @Test
+  void canCheckTextOfElementWithoutChildren_partial() {
+    Configuration.textCheck = PARTIAL_TEXT;
+    $("#child_div1").shouldHave(ownText("So"));
+    $("#child_div2").shouldHave(ownText("Daugh"));
+    $("#parent_div").shouldHave(ownText("ig pap"));
+    $("#parent_div").shouldNotHave(ownText("on"));
+    $("#parent_div").shouldNotHave(ownText("aughte"));
   }
 
   @Test
@@ -82,7 +109,7 @@ final class ElementTextTest extends IntegrationTest {
     $("#parent_div").shouldNotHave(ownTextCaseSensitive("Son"));
     $("#parent_div").shouldNotHave(ownTextCaseSensitive("Daughter"));
   }
-  
+
   @Test
   void canCheckExactTextCaseSensitiveOfElementWithoutChildren() {
     $("#child_div1").shouldHave(exactOwnTextCaseSensitive("Son"));
@@ -100,8 +127,18 @@ final class ElementTextTest extends IntegrationTest {
   @Test
   void canCheckTextByRegularExpression() {
     $("#child_div1").should(matchText("Son"));
+    $("#child_div1").should(matchText("S.n"));
     $("#child_div1").should(matchText("So.+"));
     $("#child_div1").should(matchText("So\\w"));
+    $("#child_div1").should(matchText("S\\wn"));
+  }
+
+  @Test
+  void canCheckTextByRegularExpression_partial() {
+    Configuration.textCheck = PARTIAL_TEXT;
+    $("#child_div1").should(matchText("So"));
+    $("#child_div1").should(matchText("S."));
+    $("#child_div1").should(matchText("\\wn"));
   }
 
   @Test

--- a/statics/src/test/java/integration/GetSetValueTest.java
+++ b/statics/src/test/java/integration/GetSetValueTest.java
@@ -71,8 +71,8 @@ final class GetSetValueTest extends IntegrationTest {
     $(By.name("password")).setValue("john   \u00a0 Malkovich");
     $(By.name("password")).shouldHave(value("john Malkovich"));
 
-    $("#text-area").setValue("john   \u00a0 \r\nMalkovich\n");
-    $("#text-area").shouldHave(value("john Malkovich"));
+    $("#empty-text-area").setValue("john   \u00a0 \r\nMalkovich\n");
+    $("#empty-text-area").shouldHave(value("john Malkovich"));
   }
 
   @Test

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -24,6 +24,7 @@ import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
 import static com.codeborne.selenide.Selenide.executeJavaScript;
 import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.TextCheck.FULL_TEXT;
 import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.hasWebDriverStarted;
 import static com.codeborne.selenide.WebDriverRunner.isIE;
@@ -80,6 +81,7 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     Configuration.proxyHost = "";
     Configuration.fileDownload = HTTPGET;
     Configuration.reopenBrowserOnFail = Boolean.parseBoolean(System.getProperty("selenide.reopenBrowserOnFail", "false"));
+    Configuration.textCheck = FULL_TEXT;
   }
 
   protected void openFile(String fileName) {

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -9,6 +9,8 @@ import org.openqa.selenium.By;
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Condition.partialText;
+import static com.codeborne.selenide.Condition.partialTextCaseSensitive;
 import static com.codeborne.selenide.Condition.selected;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.textCaseSensitive;
@@ -228,10 +230,18 @@ final class SelectsTest extends IntegrationTest {
   void shouldHaveTextChecksSelectedOptions() {
     $("#cars").selectOptionByValue("saab", "audi");
 
-    $("#cars").shouldHave(text("audi").because("Option with text `Audi` is selected"));
-    $("#cars").shouldHave(text("saab").because("Option with text `Saab` is selected"));
-    $("#cars").shouldHave(textCaseSensitive("Audi").because("Option with text `Audi` is selected"));
-    $("#cars").shouldHave(textCaseSensitive("Saab").because("Option with text `Saab` is selected"));
+    $("#cars").shouldHave(text("saabaudi").because("Options `Audi` and `Saab` are selected"));
+    $("#cars").shouldHave(textCaseSensitive("SaabAudi").because("Options `Audi` and `Saab` are selected"));
+  }
+
+  @Test
+  void shouldHaveTextChecksSelectedOptions_partial() {
+    $("#cars").selectOptionByValue("saab", "audi");
+
+    $("#cars").shouldHave(partialText("audi").because("Option with text `Audi` is selected"));
+    $("#cars").shouldHave(partialText("saab").because("Option with text `Saab` is selected"));
+    $("#cars").shouldHave(partialTextCaseSensitive("Audi").because("Option with text `Audi` is selected"));
+    $("#cars").shouldHave(partialTextCaseSensitive("Saab").because("Option with text `Saab` is selected"));
   }
 
   @Test()

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -29,6 +29,7 @@ import static com.codeborne.selenide.Condition.have;
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.id;
 import static com.codeborne.selenide.Condition.name;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.readonly;
 import static com.codeborne.selenide.Condition.selected;
 import static com.codeborne.selenide.Condition.text;
@@ -213,10 +214,11 @@ final class SelenideMethodsTest extends IntegrationTest {
     assertThat($("#radioButtons").text())
       .isEqualTo("Radio buttons\nМастер Маргарита Кот \"Бегемот\" Theodor Woland");
 
-    $("h1").shouldHave(text("Page "));
+    $("h1").shouldHave(partialText("Page "));
     $("h2").shouldHave(text("Dropdown list"));
-    $(By.name("domain")).find("option").shouldHave(text("vemail.r"));
-    $("#radioButtons").shouldHave(text("buttons"), text("Мастер"), text("Маргарита"));
+    $(By.name("domain")).find("option").shouldHave(text("@livemail.ru"));
+    $(By.name("domain")).find("option").shouldHave(partialText("vemail.r"));
+    $("#radioButtons").shouldHave(partialText("buttons"), partialText("Мастер"), partialText("Маргарита"));
   }
 
   @Test
@@ -421,7 +423,7 @@ final class SelenideMethodsTest extends IntegrationTest {
   void userCanCheckConditions() {
     assertThat($("#login").is(visible))
       .isTrue();
-    assertThat($("#multirowTable").has(text("Chack")))
+    assertThat($("#multirowTable").has(partialText("Chack")))
       .isTrue();
 
     assertThat($(".non-existing-element").has(text("Ninja")))

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -52,8 +52,6 @@ import static com.codeborne.selenide.Selenide.title;
 import static com.codeborne.selenide.Selenide.webdriver;
 import static com.codeborne.selenide.WebDriverConditions.urlContaining;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
-import static com.codeborne.selenide.WebDriverRunner.isChrome;
-import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -195,12 +193,9 @@ final class SelenideMethodsTest extends IntegrationTest {
     $("#username").sendKeys(" x ");
     $("#username").pressTab();
 
-    if (!isChrome() && !isFirefox()) {
-      // fails in Chrome for unknown reason. In Firefox, it's just unstable.
-      $("#password").shouldBe(focused);
-      $("#username-mirror").shouldHave(text(" x "));
-      $("#username-blur-counter").shouldHave(text("blur: "));
-    }
+    $("#password").shouldBe(focused);
+    $("#username-mirror").shouldHave(text("x (1)"));
+    $("#username-blur-counter").shouldHave(text("blur: 1"));
   }
 
   @Test

--- a/statics/src/test/java/integration/SetDateValueTest.java
+++ b/statics/src/test/java/integration/SetDateValueTest.java
@@ -20,13 +20,13 @@ final class SetDateValueTest extends IntegrationTest {
   void canSetDateValue_sendKeys() {
     LocalDate birthday = LocalDate.parse("1979-12-31");
     $("#birthday").setValue(withDate(birthday));
-    $("#user-summary").shouldHave(text("User birthday: "), text("1979-12-31"));
+    $("#user-summary").shouldHave(text("User birthday: 1979-12-31"));
   }
 
   @Test
   void canSetDateValue_usingJavascript() {
     LocalDate birthday = LocalDate.parse("1978-11-30");
     $("#birthday").setValue(withDate(birthday).usingMethod(JS));
-    $("#user-summary").shouldHave(text("User birthday: "), text("1978-11-30"));
+    $("#user-summary").shouldHave(text("User birthday: 1978-11-30"));
   }
 }

--- a/statics/src/test/java/integration/errormessages/ErrorMsgWithScreenshotsTest.java
+++ b/statics/src/test/java/integration/errormessages/ErrorMsgWithScreenshotsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchElementException;
 
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
@@ -88,12 +89,12 @@ final class ErrorMsgWithScreenshotsTest extends IntegrationTest {
   void elementNotFoundInsideParent() {
     assertThatThrownBy(() -> $("#multirowTable")
       .findAll("tbody tr")
-      .findBy(text("Norris"))
+      .findBy(partialText("Norris"))
       .find(".second_row")
       .shouldBe(visible)
     )
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageStartingWith("Element not found {#multirowTable/tbody tr.findBy(text \"Norris\")/.second_row}");
+      .hasMessageStartingWith("Element not found {#multirowTable/tbody tr.findBy(partial text \"Norris\")/.second_row}");
   }
 
   @Test

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnElementPassesOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnElementPassesOnTest.java
@@ -33,7 +33,7 @@ final class MethodCalledOnElementPassesOnTest extends IntegrationTest {
   void shouldCondition_When$Element() {
     SelenideElement element = $("ul li");
 
-    element.shouldHave(text("Miller"));
+    element.shouldHave(text("Miller detective"));
   }
 
   @Test
@@ -54,7 +54,7 @@ final class MethodCalledOnElementPassesOnTest extends IntegrationTest {
   void shouldCondition_WhenCollectionElementByIndex() {
     SelenideElement element = $$("ul li").get(0);
 
-    element.shouldHave(text("Miller"));
+    element.shouldHave(text("Miller detective"));
   }
 
   @Test

--- a/statics/src/test/java/integration/errormessages/ShouldMethodWithTimeoutFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/ShouldMethodWithTimeoutFailsOnTest.java
@@ -66,9 +66,9 @@ final class ShouldMethodWithTimeoutFailsOnTest extends IntegrationTest {
   void should_not_have_with_timeout() {
     SelenideElement element = $(".detective").shouldBe(visible);
 
-    assertThatThrownBy(() -> element.shouldNotHave(text("Miller"), Duration.ofNanos(20001000)))
+    assertThatThrownBy(() -> element.shouldNotHave(text("Miller detective"), Duration.ofNanos(20001000)))
       .isInstanceOf(ElementShouldNot.class)
-      .hasMessageStartingWith("Element should not have text \"Miller\" {.detective}")
+      .hasMessageStartingWith("Element should not have text \"Miller detective\" {.detective}")
       .hasMessageContaining("Timeout: 20 ms.");
   }
 }

--- a/statics/src/test/java/integration/errormessages/WaitMethodFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/WaitMethodFailsOnTest.java
@@ -63,8 +63,8 @@ final class WaitMethodFailsOnTest extends IntegrationTest {
   void wait_while_has_text() {
     SelenideElement element = $(".detective").shouldBe(visible);
 
-    assertThatThrownBy(() -> element.shouldNot(have(text("Miller")), Duration.ofMillis(42)))
+    assertThatThrownBy(() -> element.shouldNot(have(text("Miller detective")), Duration.ofMillis(42)))
       .isInstanceOf(ElementShouldNot.class)
-      .hasMessageStartingWith("Element should not have text \"Miller\" {.detective}");
+      .hasMessageStartingWith("Element should not have text \"Miller detective\" {.detective}");
   }
 }


### PR DESCRIPTION
## Given a html:
```html
<div id="hello"> / World / </div>
```

## Before this change:
```java
  $("#hello").shouldHave(text(" / World / ")); // ok
  $("#hello").shouldHave(text("World")); // ok
```

## After this change:
```java
  $("#hello").shouldHave(text(" / World / ")); // ok
  $("#hello").shouldHave(text("World")); // NOK
  $("#hello").shouldHave(partialText("World")); // ok
```

See https://github.com/selenide/selenide/issues/1780