### PR TITLE
#1433 remove code that was not needed after introducing SelenideNettyClientFactory

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/HttpClientTimeouts.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/HttpClientTimeouts.java
@@ -1,77 +1,17 @@
 package com.codeborne.selenide.webdriver;
 
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.CommandExecutor;
-import org.openqa.selenium.remote.HttpCommandExecutor;
-import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.remote.http.ClientConfig;
-import org.openqa.selenium.remote.http.HttpClient;
-import org.openqa.selenium.remote.http.netty.NettyClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.lang.reflect.Field;
 import java.time.Duration;
 
 /**
  * A temporary workaround to override default timeouts of NettyClient used in Selenium.
  *
- * Its default timeouts are too long:
- * 1) connectTimeout = 10 seconds  (Selenide sets to 10 seconds)
- * 2) readTimeout = 3 minutes      (Selenide sets to 90 seconds)
+ * Its default read timeout 3 minutes is too long.
+ * Selenide sets to 1.5 minutes.
  *
  * @since 5.22.0
  */
 @ParametersAreNonnullByDefault
 class HttpClientTimeouts {
-  private static final Logger logger = LoggerFactory.getLogger(HttpClientTimeouts.class);
   public static Duration defaultReadTimeout = Duration.ofSeconds(90);
-
-  public void setup(WebDriver webDriver) {
-    setup(webDriver, defaultReadTimeout);
-  }
-
-  public void setup(WebDriver webDriver, Duration readTimeout) {
-    if (webDriver instanceof RemoteWebDriver) {
-      try {
-        setupTimeouts((RemoteWebDriver) webDriver, readTimeout);
-      }
-      catch (Exception e) {
-        throw new IllegalStateException("Failed to setup Selenium HttpClient timeouts", e);
-      }
-    }
-  }
-
-  private void setupTimeouts(RemoteWebDriver webDriver, Duration readTimeout) throws Exception {
-    CommandExecutor executor = webDriver.getCommandExecutor();
-    if (executor instanceof HttpCommandExecutor) {
-      setupTimeouts((HttpCommandExecutor) executor, readTimeout);
-    }
-  }
-
-  private void setupTimeouts(HttpCommandExecutor executor, Duration readTimeout) throws Exception {
-    Field clientField = HttpCommandExecutor.class.getDeclaredField("client");
-    clientField.setAccessible(true);
-    HttpClient client = (HttpClient) clientField.get(executor);
-    if (client instanceof NettyClient) {
-      setupTimeouts((NettyClient) client, readTimeout);
-    }
-  }
-
-  private void setupTimeouts(NettyClient client, Duration readTimeout) throws Exception {
-    Field configField = NettyClient.class.getDeclaredField("config");
-    configField.setAccessible(true);
-    Object config = configField.get(client);
-    if (config instanceof ClientConfig) {
-      setupTimeouts((ClientConfig) config, readTimeout);
-    }
-  }
-  private void setupTimeouts(ClientConfig config, Duration readTimeout) {
-    Duration previousConnectTimeout = config.connectionTimeout();
-    Duration previousReadTimeout = config.readTimeout();
-    config.readTimeout(readTimeout);
-    logger.info("Changed connectTimeout from {} to {}", previousConnectTimeout, config.connectionTimeout());
-    logger.info("Changed readTimeout from {} to {}", previousReadTimeout, config.readTimeout());
-  }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/SelenideNettyClientFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/SelenideNettyClientFactory.java
@@ -5,16 +5,20 @@ import org.openqa.selenium.remote.http.ClientConfig;
 import org.openqa.selenium.remote.http.HttpClient;
 import org.openqa.selenium.remote.http.HttpClientName;
 import org.openqa.selenium.remote.http.netty.NettyClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.codeborne.selenide.webdriver.HttpClientTimeouts.defaultReadTimeout;
 
 @AutoService(HttpClient.Factory.class)
 @HttpClientName("selenide-netty-client-factory")
 public class SelenideNettyClientFactory extends NettyClient.Factory {
+  private static final Logger logger = LoggerFactory.getLogger(SelenideNettyClientFactory.class);
 
   @Override
   public HttpClient createClient(ClientConfig config) {
     ClientConfig configWithShorterTimeout = config.readTimeout(defaultReadTimeout);
+    logger.info("Changed readTimeout from {} to {}", config.readTimeout(), configWithShorterTimeout.readTimeout());
     return super.createClient(configWithShorterTimeout);
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -38,7 +38,6 @@ public class WebDriverFactory {
   private final Map<String, Class<? extends AbstractDriverFactory>> factories = factories();
   private final RemoteDriverFactory remoteDriverFactory = new RemoteDriverFactory();
   private final BrowserResizer browserResizer = new BrowserResizer();
-  private final HttpClientTimeouts httpClientTimeouts = new HttpClientTimeouts();
 
   @CheckReturnValue
   @Nonnull
@@ -106,9 +105,7 @@ public class WebDriverFactory {
         webdriverFactory.setupWebdriverBinary();
       }
       System.setProperty("webdriver.http.factory", "selenide-netty-client-factory");
-      WebDriver webDriver = webdriverFactory.create(config, browser, proxy, browserDownloadsFolder);
-      httpClientTimeouts.setup(webDriver);
-      return webDriver;
+      return webdriverFactory.create(config, browser, proxy, browserDownloadsFolder);
     }
   }
 


### PR DESCRIPTION
and didn't work anyway because method `config.readTimeout(readTimeout)` returns a new instance.
