### PR TITLE
Add exact own text case-sensitive condition

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -12,6 +12,7 @@ import com.codeborne.selenide.conditions.Disabled;
 import com.codeborne.selenide.conditions.Editable;
 import com.codeborne.selenide.conditions.Enabled;
 import com.codeborne.selenide.conditions.ExactOwnText;
+import com.codeborne.selenide.conditions.ExactOwnTextCaseSensitive;
 import com.codeborne.selenide.conditions.ExactText;
 import com.codeborne.selenide.conditions.ExactTextCaseSensitive;
 import com.codeborne.selenide.conditions.Exist;
@@ -398,6 +399,21 @@ public abstract class Condition {
   @Nonnull
   public static Condition exactOwnText(String text) {
     return new ExactOwnText(text);
+  }
+
+  /**
+   * Assert that element has given text (without checking child elements).
+   * <p>Sample: {@code $("h1").shouldHave(exactOwnTextCaseSensitive("Hello"))}</p>
+   *
+   * <p>Case sensitive</p>
+   * <p>NB! Ignores multiple whitespaces between words</p>
+   *
+   * @param text expected text of HTML element without its children
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition exactOwnTextCaseSensitive(String text) {
+    return new ExactOwnTextCaseSensitive(text);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/conditions/ExactOwnTextCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/conditions/ExactOwnTextCaseSensitive.java
@@ -1,0 +1,29 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.impl.Html;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import org.openqa.selenium.WebElement;
+import static com.codeborne.selenide.commands.GetOwnText.getOwnText;
+
+public class ExactOwnTextCaseSensitive extends TextCondition {
+
+  public ExactOwnTextCaseSensitive(String expectedText) {
+    super("exact own text case sensitive", expectedText);
+  }
+
+  @CheckReturnValue
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    return Html.text.equalsCaseSensitive(actualText, expectedText);
+  }
+
+  @Nullable
+  @CheckReturnValue
+  @Override
+  protected String getText(Driver driver, WebElement element) {
+    return getOwnText(driver, element);
+  }
+
+}

--- a/statics/src/test/java/integration/ElementTextTest.java
+++ b/statics/src/test/java/integration/ElementTextTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.util.regex.PatternSyntaxException;
 
 import static com.codeborne.selenide.Condition.exactOwnText;
+import static com.codeborne.selenide.Condition.exactOwnTextCaseSensitive;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.ownText;
@@ -64,6 +65,20 @@ final class ElementTextTest extends IntegrationTest {
     $("#parent_div").shouldNotHave(exactOwnText("papa"));
     $("#parent_div").shouldNotHave(exactOwnText("Son"));
     $("#parent_div").shouldNotHave(exactOwnText("Daughter"));
+  }
+
+  @Test
+  void canCheckExactTextCaseSensitiveOfElementWithoutChildren() {
+    $("#child_div1").shouldHave(exactOwnTextCaseSensitive("Son"));
+    $("#child_div1").shouldNotHave(exactOwnTextCaseSensitive("son"));
+    $("#child_div1").shouldNotHave(exactOwnTextCaseSensitive("So"));
+    $("#child_div2").shouldHave(exactOwnTextCaseSensitive("Daughter"));
+    $("#parent_div").shouldHave(exactOwnTextCaseSensitive("Big papa"));
+    $("#parent_div").shouldNotHave(exactOwnTextCaseSensitive("papa"));
+    $("#parent_div").shouldNotHave(exactOwnTextCaseSensitive("Son"));
+    $("#parent_div").shouldNotHave(exactOwnTextCaseSensitive("son"));
+    $("#parent_div").shouldNotHave(exactOwnTextCaseSensitive("So"));
+    $("#parent_div").shouldNotHave(exactOwnTextCaseSensitive("Daughter"));
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes
I couldn't find an implementation of case-sensitive exact own text element condition. So I added it

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
