### PR TITLE
Add own text case-sensitive condition

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -27,6 +27,7 @@ import com.codeborne.selenide.conditions.NamedCondition;
 import com.codeborne.selenide.conditions.Not;
 import com.codeborne.selenide.conditions.Or;
 import com.codeborne.selenide.conditions.OwnText;
+import com.codeborne.selenide.conditions.OwnTextCaseSensitive;
 import com.codeborne.selenide.conditions.PseudoElementPropertyWithValue;
 import com.codeborne.selenide.conditions.Readonly;
 import com.codeborne.selenide.conditions.Selected;
@@ -383,6 +384,21 @@ public abstract class Condition {
   @Nonnull
   public static Condition ownText(String text) {
     return new OwnText(text);
+  }
+
+  /**
+   * Assert that element contains given text (without checking child elements).
+   * <p>Sample: {@code $("h1").shouldHave(ownTextCaseSensitive("Hello"))}</p>
+   *
+   * <p>Case sensitive</p>
+   * <p>NB! Ignores multiple whitespaces between words</p>
+   *
+   * @param text expected text of HTML element without its children
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition ownTextCaseSensitive(String text) {
+    return new OwnTextCaseSensitive(text);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/conditions/OwnTextCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/conditions/OwnTextCaseSensitive.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.impl.Html;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import org.openqa.selenium.WebElement;
+import static com.codeborne.selenide.commands.GetOwnText.getOwnText;
+
+public class OwnTextCaseSensitive extends TextCondition{
+
+  public OwnTextCaseSensitive(String expectedText) {
+    super("own text case sensitive", expectedText);
+  }
+
+  @CheckReturnValue
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    return Html.text.containsCaseSensitive(actualText, expectedText);
+  }
+
+  @Nullable
+  @CheckReturnValue
+  @Override
+  protected String getText(Driver driver, WebElement element) {
+    return getOwnText(driver, element);
+  }
+}

--- a/statics/src/test/java/integration/ElementTextTest.java
+++ b/statics/src/test/java/integration/ElementTextTest.java
@@ -9,6 +9,7 @@ import static com.codeborne.selenide.Condition.exactOwnText;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Condition.matchText;
 import static com.codeborne.selenide.Condition.ownText;
+import static com.codeborne.selenide.Condition.ownTextCaseSensitive;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,6 +65,19 @@ final class ElementTextTest extends IntegrationTest {
     $("#parent_div").shouldNotHave(exactOwnText("papa"));
     $("#parent_div").shouldNotHave(exactOwnText("Son"));
     $("#parent_div").shouldNotHave(exactOwnText("Daughter"));
+  }
+
+  @Test
+  void canCheckCaseSensitiveTextOfElementWithoutChildren() {
+    $("#child_div1").shouldHave(ownTextCaseSensitive("Son"));
+    $("#child_div1").shouldHave(ownTextCaseSensitive("So"));
+    $("#child_div1").shouldNotHave(ownTextCaseSensitive("son"));
+    $("#child_div2").shouldHave(ownTextCaseSensitive("Daughter"));
+    $("#parent_div").shouldNotHave(ownTextCaseSensitive("Big Papa"));
+    $("#parent_div").shouldNotHave(ownTextCaseSensitive("Papa"));
+    $("#parent_div").shouldHave(ownTextCaseSensitive("papa"));
+    $("#parent_div").shouldNotHave(ownTextCaseSensitive("Son"));
+    $("#parent_div").shouldNotHave(ownTextCaseSensitive("Daughter"));
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes
I couldn't find an implementation of case-sensitive own text element condition. So I added it

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
