### PR TITLE
#1834 downgrade TestNG from 7.5 to 7.4.0

### DIFF
--- a/modules/testng/build.gradle
+++ b/modules/testng/build.gradle
@@ -1,6 +1,6 @@
 ext {
   artifactId = 'selenide-testng'
-  testngVersion = '7.5'
+  testngVersion = '7.4.0'
 }
 
 dependencies {


### PR DESCRIPTION
TestNG 7.5 and 7.6.0 have a bug https://github.com/cbeust/testng/issues/2771 which break Selenide soft asserts. We may upgrade to a newer TestNG only when this issues gets fixed.
