### PR TITLE
fix ClearWithShortcut when using EventFiringDriver

### DIFF
--- a/modules/clear-with-shortcut/src/main/java/com/codeborne/selenide/clearwithshortcut/ClearWithShortcut.java
+++ b/modules/clear-with-shortcut/src/main/java/com/codeborne/selenide/clearwithshortcut/ClearWithShortcut.java
@@ -4,9 +4,11 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.commands.Clear;
 import com.codeborne.selenide.impl.WebElementSource;
-import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
+import org.openqa.selenium.JavascriptExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +77,12 @@ public class ClearWithShortcut extends Clear {
   @Nonnull
   @CheckReturnValue
   protected Platform getPlatform(Driver driver) {
-    if (!(driver.getWebDriver() instanceof JavascriptExecutor)) {
+    WebDriver webDriver = driver.getWebDriver();
+
+    if (webDriver instanceof WrapsDriver)
+      webDriver = ((WrapsDriver) webDriver).getWrappedDriver();
+
+    if (!(webDriver instanceof JavascriptExecutor)) {
       return Platform.UNKNOWN;
     }
     try {


### PR DESCRIPTION
## Proposed changes
In case when we are using WebDriverListeners, getWebDriver return instance of WrapsDriver, which are not instances of Javascript executor. We need to call getWrappedDriver() to get an actual driver instance. 
Similar problem was in com.codeborne.selenide.Driver#getSessionId method. Probably this check should be included in getWebDriver method

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
