### PR TITLE
Add exact texts case sensitive

### DIFF
--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.collections.AllMatch;
 import com.codeborne.selenide.collections.AnyMatch;
 import com.codeborne.selenide.collections.ContainExactTextsCaseSensitive;
 import com.codeborne.selenide.collections.ExactTexts;
+import com.codeborne.selenide.collections.ExactTextsCaseSensitive;
 import com.codeborne.selenide.collections.ExactTextsCaseSensitiveInAnyOrder;
 import com.codeborne.selenide.collections.ItemWithText;
 import com.codeborne.selenide.collections.ListSize;
@@ -126,6 +127,26 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
   @CheckReturnValue
   public static CollectionCondition exactTexts(List<String> expectedTexts) {
     return new ExactTexts(expectedTexts);
+  }
+
+  /**
+   * Checks that given collection has given case sensitive texts (each collection element EQUALS TO CASE SENSITIVE corresponding text)
+   *
+   * <p>NB! Ignores multiple whitespaces between words</p>
+   */
+  @CheckReturnValue
+  public static CollectionCondition exactTextsCaseSensitive(String... expectedTexts) {
+    return new ExactTextsCaseSensitive(expectedTexts);
+  }
+
+  /**
+   * Checks that given collection has given case sensitive texts (each collection element EQUALS TO CASE SENSITIVE corresponding text)
+   *
+   * <p>NB! Ignores multiple whitespaces between words</p>
+   */
+  @CheckReturnValue
+  public static CollectionCondition exactTextsCaseSensitive(List<String> expectedTexts) {
+    return new ExactTextsCaseSensitive(expectedTexts);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/collections/ExactTextsCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTextsCaseSensitive.java
@@ -1,0 +1,41 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.impl.Html;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+
+@ParametersAreNonnullByDefault
+public class ExactTextsCaseSensitive extends ExactTexts {
+  public ExactTextsCaseSensitive(String... expectedTexts) {
+    super(expectedTexts);
+  }
+
+  public ExactTextsCaseSensitive(List<String> expectedTexts) {
+    super(expectedTexts);
+  }
+
+  @CheckReturnValue
+  @Override
+  public boolean test(List<WebElement> elements) {
+    if (elements.size() != expectedTexts.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < expectedTexts.size(); i++) {
+      WebElement element = elements.get(i);
+      String expectedText = expectedTexts.get(i);
+      if (!Html.text.equalsCaseSensitive(element.getText(), expectedText)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "Exact texts case sensitive " + expectedTexts;
+  }
+}

--- a/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/CollectionConditionTest.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide;
 
 import com.codeborne.selenide.collections.ContainExactTextsCaseSensitive;
 import com.codeborne.selenide.collections.ExactTexts;
+import com.codeborne.selenide.collections.ExactTextsCaseSensitive;
 import com.codeborne.selenide.collections.ExactTextsCaseSensitiveInAnyOrder;
 import com.codeborne.selenide.collections.ListSize;
 import com.codeborne.selenide.collections.SizeGreaterThan;
@@ -89,6 +90,26 @@ final class CollectionConditionTest {
     assertThat(collectionCondition)
       .as("Exact texts content")
       .hasToString("Exact texts [One, Two, Three]");
+  }
+
+  @Test
+  void exactTextsCaseSensitiveWithObjectsList() {
+    CollectionCondition collectionCondition = CollectionCondition.exactTextsCaseSensitive("One", "Two", "Three");
+    assertThat(collectionCondition)
+      .isInstanceOf(ExactTextsCaseSensitive.class);
+    assertThat(collectionCondition)
+      .as("Exact texts case sensitive content")
+      .hasToString("Exact texts case sensitive [One, Two, Three]");
+  }
+
+  @Test
+  void exactTextsCaseSensitiveWithListOfStrings() {
+    CollectionCondition collectionCondition = CollectionCondition.exactTextsCaseSensitive(asList("One", "Two", "Three"));
+    assertThat(collectionCondition)
+      .isInstanceOf(ExactTextsCaseSensitive.class);
+    assertThat(collectionCondition)
+      .as("Exact texts case sensitive content")
+      .hasToString("Exact texts case sensitive [One, Two, Three]");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveTest.java
@@ -1,0 +1,150 @@
+package com.codeborne.selenide.collections;
+
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.TextsMismatch;
+import com.codeborne.selenide.ex.TextsSizeMismatch;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class ExactTextsCaseSensitiveTest {
+  @Test
+  void varArgsConstructor() {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("One", "Two", "Three");
+    assertThat(exactTextsCaseSensitive.expectedTexts)
+      .as("Expected texts list")
+      .isEqualTo(asList("One", "Two", "Three"));
+  }
+
+  @Test
+  void applyOnWrongSizeList() {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("One", "Two", "Three");
+
+    assertThat(exactTextsCaseSensitive.test(singletonList(mock(WebElement.class))))
+      .isFalse();
+  }
+
+  @Test
+  void applyOnCorrectSizeAndCorrectElementsText() {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("One", "Two");
+    WebElement webElement1 = mockElement("One");
+    WebElement webElement2 = mockElement("Two");
+
+    assertThat(exactTextsCaseSensitive.test(asList(webElement1, webElement2)))
+      .isTrue();
+  }
+
+  @Test
+  void applyOnCorrectListSizeButWrongElementsText() {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("One", "Two");
+    WebElement webElement1 = mockElement("One");
+    WebElement webElement2 = mockElement("One");
+
+    assertThat(exactTextsCaseSensitive.test(asList(webElement1, webElement2)))
+      .isFalse();
+  }
+
+  @Test
+  void failWithNullElementsList() {
+    failOnEmptyOrNullElementsList(null);
+  }
+
+  private void failOnEmptyOrNullElementsList(List<WebElement> elements) {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("One");
+    RuntimeException cause = new IllegalArgumentException("bad thing happened");
+
+    assertThatThrownBy(() -> exactTextsCaseSensitive.fail(mockCollection("Collection description"), elements, cause, 10000))
+      .isInstanceOf(ElementNotFound.class)
+      .hasMessage(String.format("Element not found {Collection description}%nExpected: Exact texts case sensitive [One]%n" +
+        "Timeout: 10 s.%n" +
+        "Caused by: java.lang.IllegalArgumentException: bad thing happened"));
+  }
+
+  @Test
+  void failWithEmptyElementsList() {
+    failOnEmptyOrNullElementsList(emptyList());
+  }
+
+  @Test
+  void failOnTextMismatch() {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("One");
+    Exception cause = new Exception("Exception method");
+
+    WebElement mockedWebElement = mock(WebElement.class);
+    when(mockedWebElement.getText()).thenReturn("Hello");
+
+    assertThatThrownBy(() ->
+      exactTextsCaseSensitive.fail(mockCollection("Collection description"), singletonList(mockedWebElement), cause, 10000))
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessage(String.format("Texts mismatch%n" +
+        "Actual: [Hello]%n" +
+        "Expected: [One]%n" +
+        "Collection: Collection description%n" +
+        "Timeout: 10 s."));
+  }
+
+  @Test
+  void failOnTextCaseMismatch() {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("ONE");
+    Exception cause = new Exception("Exception method");
+
+    WebElement mockedWebElement = mock(WebElement.class);
+    when(mockedWebElement.getText()).thenReturn("One");
+
+    assertThatThrownBy(() ->
+      exactTextsCaseSensitive.fail(mockCollection("Collection description"), singletonList(mockedWebElement), cause, 10000))
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessage(String.format("Texts mismatch%n" +
+        "Actual: [One]%n" +
+        "Expected: [ONE]%n" +
+        "Collection: Collection description%n" +
+        "Timeout: 10 s."));
+  }
+
+  @Test
+  void failOnTextSizeMismatch() {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("One", "Two");
+    Exception cause = new Exception("Exception method");
+    WebElement webElement = mockElement("One");
+
+    assertThatThrownBy(() -> exactTextsCaseSensitive.fail(mockCollection("Collection description"),
+      singletonList(webElement), cause, 10000)
+    )
+      .isInstanceOf(TextsSizeMismatch.class)
+      .hasMessageContaining("Actual: [One], List size: 1")
+      .hasMessageContaining("Expected: [One, Two], List size: 2")
+      .hasMessageEndingWith(String.format("Collection: Collection description%nTimeout: 10 s."));
+  }
+
+  @Test
+  void testToString() {
+    ExactTextsCaseSensitive exactTextsCaseSensitive = new ExactTextsCaseSensitive("One", "Two", "Three");
+    assertThat(exactTextsCaseSensitive)
+      .hasToString("Exact texts case sensitive [One, Two, Three]");
+  }
+
+  @Test
+  void emptyArrayIsNotAllowed() {
+    assertThatThrownBy(ExactTextsCaseSensitive::new)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("No expected texts given");
+  }
+
+  @Test
+  void emptyListIsNotAllowed() {
+    assertThatThrownBy(() -> new ExactTextsCaseSensitive(emptyList()))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("No expected texts given");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
@@ -72,7 +72,7 @@ final class ExactTextsTest {
   }
 
   @Test
-  void failWithEmptyElementsLIst() {
+  void failWithEmptyElementsList() {
     failOnEmptyOrNullElementsList(emptyList());
   }
 


### PR DESCRIPTION
## Proposed changes
Just looking to add a exact texts case sensitive collection as we often compare collections of elements and want to ensure text is in the correct case. Also made a minor change to fix a minor typo.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
