### PR TITLE
Add shorter syntax to click

### DIFF
--- a/src/main/java/com/codeborne/selenide/ClickOptions.java
+++ b/src/main/java/com/codeborne/selenide/ClickOptions.java
@@ -39,6 +39,18 @@ public class ClickOptions implements HasTimeout {
   }
 
   @CheckReturnValue
+  @Nonnull
+  public static ClickOptions withOffset(int offsetX, int offsetY) {
+    return new ClickOptions(DEFAULT, offsetX, offsetY, null);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  public static ClickOptions withTimeout(Duration timeout) {
+    return new ClickOptions(DEFAULT, 0, 0, timeout);
+  }
+
+  @CheckReturnValue
   public int offsetX() {
     return offsetX;
   }

--- a/statics/src/test/java/integration/ClickRelativeTest.java
+++ b/statics/src/test/java/integration/ClickRelativeTest.java
@@ -8,6 +8,7 @@ import org.openqa.selenium.interactions.MoveTargetOutOfBoundsException;
 
 import static com.codeborne.selenide.ClickOptions.usingDefaultMethod;
 import static com.codeborne.selenide.ClickOptions.usingJavaScript;
+import static com.codeborne.selenide.ClickOptions.withOffset;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Selenide.$;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,6 +38,13 @@ final class ClickRelativeTest extends IntegrationTest {
     Configuration.clickViaJs = true;
 
     $("#page").click(usingDefaultMethod().offset(123, 222));
+
+    $("#coords").shouldHave(exactText("(523, 522)"));
+  }
+
+  @Test
+  void userCanClickElementWithOffset() {
+    $("#page").click(withOffset(123, 222));
 
     $("#coords").shouldHave(exactText("(523, 522)"));
   }

--- a/statics/src/test/java/integration/ClickWithTimeoutTest.java
+++ b/statics/src/test/java/integration/ClickWithTimeoutTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.ClickOptions.usingDefaultMethod;
 import static com.codeborne.selenide.ClickOptions.usingJavaScript;
+import static com.codeborne.selenide.ClickOptions.withTimeout;
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Selenide.$;
 import static java.time.Duration.ofMillis;
@@ -38,6 +39,12 @@ final class ClickWithTimeoutTest extends IntegrationTest {
   @Test
   void canClickLinkWhichAppearsLongerThanStandardTimeout() {
     $("#slow-hidden-link").click(usingJavaScript().timeout(ofSeconds(2)));
+    $("h1").shouldHave(exactText("Selenide"), ofMillis(1_900));
+  }
+
+  @Test
+  void canClickWithCustomTimeout() {
+    $("#slow-hidden-link").click(withTimeout(ofSeconds(2)));
     $("h1").shouldHave(exactText("Selenide"), ofMillis(1_900));
   }
 }


### PR DESCRIPTION
* `$.click(withOffset(123, 222));`
* `$.click(withTimeout(...));`

before this change, you had to pick the click method first:
* `$.click(withDefaultMethod().offset(123, 222));`
* `$.click(withDefaultMethod().timeout(...));`

