### PR TITLE
#1878 support mobile apps when checking webdriver health

### DIFF
--- a/src/main/java/com/codeborne/selenide/drivercommands/BrowserHealthChecker.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/BrowserHealthChecker.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.drivercommands;
 
 import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.NoSuchWindowException;
+import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.slf4j.Logger;
@@ -16,6 +17,10 @@ public class BrowserHealthChecker {
   public boolean isBrowserStillOpen(WebDriver webDriver) {
     try {
       webDriver.getTitle();
+      return true;
+    }
+    catch (UnsupportedCommandException notSupportedButAlive) {
+      log.debug("getTitle() is not supported by webdriver: {}", notSupportedButAlive.toString());
       return true;
     }
     catch (UnreachableBrowserException e) {

--- a/src/main/java/com/codeborne/selenide/drivercommands/package-info.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Selenide internal code for operating with webdriver: create, close etc.
+ */
+package com.codeborne.selenide.drivercommands;

--- a/src/test/java/com/codeborne/selenide/impl/BrowserHealthCheckerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/BrowserHealthCheckerTest.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.drivercommands.BrowserHealthChecker;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.NoSuchWindowException;
+import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 
@@ -42,5 +43,12 @@ final class BrowserHealthCheckerTest {
     doThrow(new NoSuchSessionException("oops")).when(webdriver).getTitle();
 
     assertThat(checker.isBrowserStillOpen(webdriver)).isFalse();
+  }
+
+  @Test
+  void isBrowserStillOpen_UnsupportedCommandException_means_webdriverIsStillAlive() {
+    doThrow(new UnsupportedCommandException("this is Appium")).when(webdriver).getTitle();
+
+    assertThat(checker.isBrowserStillOpen(webdriver)).isTrue();
   }
 }


### PR DESCRIPTION
Appium drivers do not support `getTitle()` command.
Fortunately, receiving such an exception means that the driver and appium server are still alive.
