### PR TITLE
give user a clear hint if he occasionally passes an invalid file extension parameter

### DIFF
--- a/src/main/java/com/codeborne/selenide/files/ExtensionFilter.java
+++ b/src/main/java/com/codeborne/selenide/files/ExtensionFilter.java
@@ -6,6 +6,9 @@ class ExtensionFilter implements FileFilter {
   private final String extension;
 
   ExtensionFilter(String extension) {
+    if (extension.indexOf('.') > -1) {
+      throw new IllegalArgumentException(String.format("File extension cannot contain dot: '%s'", extension));
+    }
     this.extension = extension;
   }
 

--- a/src/test/java/com/codeborne/selenide/files/ExtensionFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/files/ExtensionFilterTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class ExtensionFilterTest {
   private static final String FILTER_DESCRIPTION = "with extension \"pdf\"";
@@ -21,6 +22,13 @@ final class ExtensionFilterTest {
     assertThat(filter.match(new DownloadedFile(new File("cv.pdf.gz"), emptyMap()))).isFalse();
     assertThat(filter.match(new DownloadedFile(new File("cv.xpdf"), emptyMap()))).isFalse();
     assertThat(filter.match(new DownloadedFile(new File("cv.pdfx"), emptyMap()))).isFalse();
+  }
+
+  @Test
+  void ignoresDotInExtension() {
+    assertThatThrownBy(() -> new ExtensionFilter(".pdf"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("File extension cannot contain dot: '.pdf'");
   }
 
   @Test


### PR DESCRIPTION
file extension cannot have a dot. E.g. ".pdf" is invalid, while "pdf" is correct.
