### PR TITLE
#1885 make type of setValue() parameter String again

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -44,16 +44,16 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement setValue(@Nullable CharSequence text);
+  SelenideElement setValue(@Nullable String text);
 
   /**
-   * Same as {@link #setValue(java.lang.CharSequence)}
+   * Same as {@link #setValue(java.lang.String)}
    *
    * @see com.codeborne.selenide.commands.Val
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement val(@Nullable CharSequence text);
+  SelenideElement val(@Nullable String text);
 
   /**
    * @see com.codeborne.selenide.commands.SetValue


### PR DESCRIPTION
it allows writing `el.value = "Hello"` instead of `el.setValue("Hello")` in Kotlin.

Though, I personally think it's a misuse of setValue method. It was never meant to be a _property_. User can perform some interactions with web elements, not change properties of web elements.

