### PR TITLE
#1886 decode downloaded file name if it's base64-encoded

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/HttpHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/HttpHelper.java
@@ -8,12 +8,14 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang3.StringUtils.left;
@@ -55,9 +57,15 @@ public class HttpHelper {
     if (!regex.matches()) {
       return Optional.empty();
     }
-    String fileName = regex.replaceFirst("$3");
-    String encoding = defaultIfEmpty(regex.replaceFirst("$2"), regex.replaceFirst("$5"));
-    return Optional.of(decodeHttpHeader(fileName, encoding));
+    String fileNamePart = regex.replaceFirst("$3");
+    String encodingPart = defaultIfEmpty(regex.replaceFirst("$2"), regex.replaceFirst("$5"));
+    String filename = decodeHttpHeader(fileNamePart, encodingPart);
+    try {
+      return Optional.of(new String(Base64.getDecoder().decode(filename), UTF_8));
+    }
+    catch (IllegalArgumentException notBase64Encoded) {
+      return Optional.of(filename);
+    }
   }
 
   @CheckReturnValue

--- a/src/test/java/com/codeborne/selenide/impl/HttpHelperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/HttpHelperTest.java
@@ -95,6 +95,16 @@ final class HttpHelperTest {
   }
 
   @Test
+  void decodesBase64EncodedFileName() {
+    assertThat(helper.getFileNameFromContentDisposition(
+      "Content-Disposition", "attachment; " +
+        "filename=\"4oSWIDg0MjMg0L7RgiAxMSDQvNCw0Y8gMjAyMiDQsy5wZGY=\"; " +
+        "filename*=UTF-8''4oSWIDg0MjMg0L7RgiAxMSDQvNCw0Y8gMjAyMiDQsy5wZGY%3D"))
+      .get()
+      .isEqualTo("№ 8423 от 11 мая 2022 г.pdf");
+  }
+
+  @Test
   void fileNameIsNone_ifContentDispositionHeaderIsEmpty() {
     assertThat(helper.getFileNameFromContentDisposition("Content-Disposition", null).isPresent())
       .isFalse();


### PR DESCRIPTION
In this case, the header in server response looked like this:
```
Content-Disposition: attachment; filename="4oSWIDg0MjMg0L7RgiAxMSDQvNCw0Y8gMjAyMiDQsy5wZGY="; filename*=UTF-8''4oSWIDg0MjMg0L7RgiAxMSDQvNCw0Y8gMjAyMiDQsy5wZGY%3D
```
