### PR TITLE
add cachelookup annotation support

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/ElementsContainerCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementsContainerCollection.java
@@ -4,52 +4,49 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.ElementsContainer;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.PageObjectException;
-import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.AbstractList;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.impl.Alias.NONE;
-import static com.codeborne.selenide.impl.Plugins.inject;
 
 @ParametersAreNonnullByDefault
 public class ElementsContainerCollection extends AbstractList<ElementsContainer> {
-  private final WebElementSelector elementSelector = inject(WebElementSelector.class);
   private final PageObjectFactory pageFactory;
   private final Driver driver;
-  private final WebElementSource parent;
   private final Field field;
   private final Class<?> listType;
   private final Type[] genericTypes;
-  private final By selector;
+  private final CollectionSource collection;
 
-  public ElementsContainerCollection(PageObjectFactory pageFactory, Driver driver, @Nullable WebElementSource parent,
-                                     Field field, Class<?> listType, Type[] genericTypes, By selector) {
+  public ElementsContainerCollection(PageObjectFactory pageFactory,
+                                     Driver driver,
+                                     Field field,
+                                     Class<?> listType,
+                                     Type[] genericTypes,
+                                     CollectionSource collection) {
     this.pageFactory = pageFactory;
     this.driver = driver;
-    this.parent = parent;
     this.field = field;
     this.listType = listType;
     this.genericTypes = genericTypes;
-    this.selector = selector;
+    this.collection = collection;
   }
 
   @CheckReturnValue
   @Nonnull
   @Override
   public ElementsContainer get(int index) {
-    WebElementSource self = new ElementFinder(driver, parent, selector, index);
+    WebElementSource self = new WebElementWrapper(driver, collection.getElement(index));
     try {
       return pageFactory.initElementsContainer(driver, field, self, listType, genericTypes);
-    }
-    catch (ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException e) {
       throw new PageObjectException("Failed to initialize field " + field, e);
     }
   }
@@ -58,10 +55,9 @@ public class ElementsContainerCollection extends AbstractList<ElementsContainer>
   @Override
   public int size() {
     try {
-      return elementSelector.findElements(driver, parent, selector).size();
-    }
-    catch (NoSuchElementException e) {
-      throw new ElementNotFound(NONE, selector.toString(), exist, e);
+      return collection.getElements().size();
+    } catch (NoSuchElementException e) {
+      throw new ElementNotFound(NONE, collection.getSearchCriteria(), exist, e);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/LazyCollectionSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyCollectionSnapshot.java
@@ -22,9 +22,10 @@ public class LazyCollectionSnapshot implements CollectionSource {
   @Nonnull
   @Override
   public List<WebElement> getElements() {
-    return elementsSnapshot = (elementsSnapshot == null) ?
-      new ArrayList<>(delegate.getElements()) :
-      elementsSnapshot;
+    if (elementsSnapshot == null) {
+      elementsSnapshot = new ArrayList<>(delegate.getElements());
+    }
+    return elementsSnapshot;
   }
 
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/impl/LazyCollectionSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyCollectionSnapshot.java
@@ -22,9 +22,9 @@ public class LazyCollectionSnapshot implements CollectionSource {
   @Nonnull
   @Override
   public List<WebElement> getElements() {
-    return elementsSnapshot != null ?
-      elementsSnapshot :
-      (elementsSnapshot = new ArrayList<>(delegate.getElements()));
+    return elementsSnapshot = (elementsSnapshot == null) ?
+      new ArrayList<>(delegate.getElements()) :
+      elementsSnapshot;
   }
 
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/impl/LazyCollectionSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyCollectionSnapshot.java
@@ -1,0 +1,58 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.Driver;
+import org.openqa.selenium.WebElement;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class LazyCollectionSnapshot implements CollectionSource {
+
+  private final CollectionSource delegate;
+
+  private List<WebElement> elementsSnapshot;
+
+  LazyCollectionSnapshot(CollectionSource delegate) {
+    this.delegate = delegate;
+  }
+
+  @Nonnull
+  @Override
+  public List<WebElement> getElements() {
+    return elementsSnapshot != null ?
+      elementsSnapshot :
+      (elementsSnapshot = new ArrayList<>(delegate.getElements()));
+  }
+
+  @Nonnull
+  @Override
+  public WebElement getElement(int index) {
+    return this.getElements().get(index);
+  }
+
+  @Nonnull
+  @Override
+  public String getSearchCriteria() {
+    return delegate.getSearchCriteria();
+  }
+
+  @Nonnull
+  @Override
+  public Driver driver() {
+    return delegate.driver();
+  }
+
+  @Nonnull
+  @Override
+  public Alias getAlias() {
+    return delegate.getAlias();
+  }
+
+  @Override
+  public void setAlias(String alias) {
+    delegate.setAlias(alias);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
@@ -1,0 +1,91 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import org.openqa.selenium.WebElement;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class LazyWebElementSnapshot extends WebElementSource {
+
+  public static SelenideElement wrap(WebElementSource delegate) {
+    return (SelenideElement) Proxy.newProxyInstance(
+      Thread.currentThread().getContextClassLoader(),
+      new Class<?>[] {SelenideElement.class},
+      new SelenideElementProxy(new LazyWebElementSnapshot(delegate))
+    );
+  }
+
+  private final WebElementSource delegate;
+
+  private WebElement snapshot;
+
+  LazyWebElementSnapshot(WebElementSource delegate) {
+    this.delegate = delegate;
+  }
+
+  @Nonnull
+  @Override
+  public Driver driver() {
+    return delegate.driver();
+  }
+
+  @Nonnull
+  @Override
+  public WebElement getWebElement() {
+    return snapshot != null ? snapshot : (snapshot = delegate.getWebElement());
+  }
+
+  @Nonnull
+  @Override
+  public String getSearchCriteria() {
+    return delegate.getSearchCriteria();
+  }
+
+  @Override
+  public void setAlias(String alias) {
+    delegate.setAlias(alias);
+  }
+
+  @Nonnull
+  @Override
+  public Alias getAlias() {
+    return delegate.getAlias();
+  }
+
+  @Nonnull
+  @Override
+  public String description() {
+    return delegate.description();
+  }
+
+  @Nonnull
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+
+  @Nonnull
+  @Override
+  public SelenideElement find(SelenideElement proxy, Object arg, int index) {
+    return delegate.find(proxy, arg, index);
+  }
+
+  @Nonnull
+  @Override
+  public List<WebElement> findAll() throws IndexOutOfBoundsException {
+    return delegate.findAll();
+  }
+
+  @Nonnull
+  @Override
+  public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
+    return delegate.createElementNotFoundError(condition, lastError);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
@@ -39,7 +39,9 @@ public class LazyWebElementSnapshot extends WebElementSource {
   @Nonnull
   @Override
   public WebElement getWebElement() {
-    return snapshot != null ? snapshot : (snapshot = delegate.getWebElement());
+    return snapshot = (snapshot == null) ?
+      delegate.getWebElement() :
+      snapshot;
   }
 
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
@@ -39,9 +39,10 @@ public class LazyWebElementSnapshot extends WebElementSource {
   @Nonnull
   @Override
   public WebElement getWebElement() {
-    return snapshot = (snapshot == null) ?
-      delegate.getWebElement() :
-      snapshot;
+    if (snapshot == null) {
+      snapshot = delegate.getWebElement();
+    }
+    return snapshot;
   }
 
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
@@ -94,7 +94,7 @@ public class SelenidePageFactory implements PageObjectFactory {
     return new Annotations(field).buildBy();
   }
 
-  private boolean shouldCache(Field field) {
+  protected boolean shouldCache(Field field) {
     return new Annotations(field).isLookupCached();
   }
 

--- a/src/test/java/com/codeborne/selenide/impl/LazyCollectionSnapshotTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/LazyCollectionSnapshotTest.java
@@ -1,0 +1,68 @@
+package com.codeborne.selenide.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LazyCollectionSnapshotTest {
+
+  private final CollectionSource collectionSource = mock(CollectionSource.class);
+
+  @BeforeEach
+  void setUp() {
+    when(collectionSource.getElements()).thenAnswer(invocation -> Lists.list(
+      mock(WebElement.class),
+      mock(WebElement.class))
+    );
+  }
+
+  @Test
+  void testShouldCacheAllElements() {
+    // Given
+    LazyCollectionSnapshot lazyCollectionSnapshot = new LazyCollectionSnapshot(collectionSource);
+
+    // When
+    List<WebElement> elements1 = lazyCollectionSnapshot.getElements();
+    List<WebElement> elements2 = lazyCollectionSnapshot.getElements();
+
+    //Then
+    assertThat(elements1).isNotEmpty().isSameAs(elements2);
+    verify(collectionSource, times(1)).getElements();
+  }
+
+  @Test
+  void testShouldCacheIndexedElement() {
+    // Given
+    LazyCollectionSnapshot lazyCollectionSnapshot = new LazyCollectionSnapshot(collectionSource);
+
+    // When
+    WebElement element1 = lazyCollectionSnapshot.getElement(0);
+    WebElement element2 = lazyCollectionSnapshot.getElement(0);
+
+    // Then
+    assertThat(element1).isNotNull().isSameAs(element2);
+    verify(collectionSource, times(1)).getElements();
+  }
+
+  @Test
+  void testShouldNotCacheDifferentIndexedElements() {
+    // Given
+    LazyCollectionSnapshot lazyCollectionSnapshot = new LazyCollectionSnapshot(collectionSource);
+
+    // When
+    WebElement element1 = lazyCollectionSnapshot.getElement(0);
+    WebElement element2 = lazyCollectionSnapshot.getElement(1);
+
+    // Then
+    assertThat(element1).isNotNull().isNotSameAs(element2);
+    verify(collectionSource, times(1)).getElements();
+  }
+}

--- a/src/test/java/com/codeborne/selenide/impl/LazyWebElementSnapshotTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/LazyWebElementSnapshotTest.java
@@ -1,0 +1,30 @@
+package com.codeborne.selenide.impl;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LazyWebElementSnapshotTest {
+
+  private final WebElementSource source = mock(WebElementSource.class);
+
+  @Test
+  void testElementShouldBeCached() {
+    // Given
+    when(source.getWebElement()).thenAnswer(invocation -> mock(WebElement.class));
+    LazyWebElementSnapshot cachedSource = new LazyWebElementSnapshot(source);
+
+    // When
+    WebElement webElement1 = cachedSource.getWebElement();
+    WebElement webElement2 = cachedSource.getWebElement();
+
+    // Then
+    assertThat(webElement1).isNotNull().isSameAs(webElement2);
+    verify(source, times(1)).getWebElement();
+  }
+}

--- a/statics/src/test/java/integration/pageobjects/CacheLookupPageObjectTest.java
+++ b/statics/src/test/java/integration/pageobjects/CacheLookupPageObjectTest.java
@@ -1,0 +1,162 @@
+package integration.pageobjects;
+
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.ElementsContainer;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementNotFound;
+import com.codeborne.selenide.ex.ElementShould;
+import integration.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.CacheLookup;
+import org.openqa.selenium.support.FindBy;
+
+import java.util.List;
+
+import static com.codeborne.selenide.Selenide.executeJavaScript;
+import static com.codeborne.selenide.Selenide.page;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class CacheLookupPageObjectTest extends IntegrationTest {
+
+  private SelectsPage pageWithSelects;
+
+  @BeforeEach
+  void openTestPage() {
+    openFile("page_with_selects_without_jquery.html");
+    pageWithSelects = page(SelectsPage.class);
+  }
+
+  @Test
+  void testCachedWebElementShouldThrowStaleElementReferenceException() {
+    assertThatCode(() -> pageWithSelects.webElement.getText()).doesNotThrowAnyException();
+
+    removeElements(SelectsPage.WEB_ELEMENT_LOCATOR);
+
+    assertThatExceptionOfType(ElementNotFound.class)
+      .isThrownBy(() -> pageWithSelects.webElement.getText())
+      .withRootCauseInstanceOf(StaleElementReferenceException.class);
+  }
+
+  @Test
+  void testCachedSelenideElementShouldThrowStaleElementReferenceException() {
+    assertThatCode(() -> pageWithSelects.selenideElement.getText()).doesNotThrowAnyException();
+
+    removeElements(SelectsPage.SELENIDE_ELEMENT_LOCATOR);
+
+    assertThatExceptionOfType(ElementNotFound.class)
+      .isThrownBy(() -> pageWithSelects.selenideElement.getText())
+      .withRootCauseInstanceOf(StaleElementReferenceException.class);
+  }
+
+  @Test
+  void testCachedElementContainerShouldThrowStaleElementReferenceException() {
+    assertThatCode(() -> pageWithSelects.elementsContainer.getSelf().getText()).doesNotThrowAnyException();
+
+    removeElements(SelectsPage.ELEMENTS_CONTAINER_LOCATOR);
+
+    assertThatExceptionOfType(ElementNotFound.class)
+      .isThrownBy(() -> pageWithSelects.elementsContainer.getSelf().getText())
+      .withRootCauseInstanceOf(StaleElementReferenceException.class);
+
+    assertThatExceptionOfType(ElementShould.class)
+      .isThrownBy(() -> pageWithSelects.elementsContainer.lastLogin.getText())
+      .withMessageContaining(StaleElementReferenceException.class.getSimpleName());
+  }
+
+  @Test
+  void testCachedElementsCollectionElementsShouldThrowStaleElementReferenceException() {
+    assertThat(pageWithSelects.elementsCollection.asDynamicIterable()).isNotEmpty();
+
+    removeElements(SelectsPage.ELEMENTS_COLLECTION_LOCATOR);
+
+    assertThat(pageWithSelects.elementsCollection.asDynamicIterable())
+      .isNotEmpty()
+      .allSatisfy(
+        it -> assertThatExceptionOfType(ElementNotFound.class)
+          .isThrownBy(it::getText)
+          .withRootCauseInstanceOf(StaleElementReferenceException.class)
+      );
+  }
+
+  @Test
+  void testCachedElementsContainerCollectionShouldThrowStaleElementReferenceException() {
+    assertThat(pageWithSelects.elementsContainerCollection).isNotEmpty();
+
+    removeElements(SelectsPage.ELEMENTS_CONTAINER_COLLECTION_LOCATOR);
+
+    assertThat(pageWithSelects.elementsContainerCollection)
+      .isNotEmpty()
+      .allSatisfy(it -> {
+        assertThatExceptionOfType(ElementNotFound.class)
+          .isThrownBy(() -> it.getSelf().getText())
+          .withRootCauseInstanceOf(StaleElementReferenceException.class);
+
+        assertThatExceptionOfType(ElementShould.class)
+          .isThrownBy(() -> it.firstName.getText())
+          .withMessageContaining(StaleElementReferenceException.class.getSimpleName());
+      });
+  }
+
+  private static void removeElements(String locator) {
+    executeJavaScript("document.querySelectorAll(arguments[0]).forEach(it => it.remove());", locator);
+  }
+
+  private static class SelectsPage {
+
+    static final String WEB_ELEMENT_LOCATOR = "#non-clickable-element";
+
+    @CacheLookup
+    @FindBy(css = WEB_ELEMENT_LOCATOR)
+    WebElement webElement;
+
+    static final String SELENIDE_ELEMENT_LOCATOR = "#clickable-element";
+
+    @CacheLookup
+    @FindBy(css = SELENIDE_ELEMENT_LOCATOR)
+    SelenideElement selenideElement;
+
+    static final String ELEMENTS_COLLECTION_LOCATOR = "h1";
+
+    @CacheLookup
+    @FindBy(css = ELEMENTS_COLLECTION_LOCATOR)
+    ElementsCollection elementsCollection;
+
+    static final String ELEMENTS_CONTAINER_LOCATOR = "#status";
+
+    @CacheLookup
+    @FindBy(css = ELEMENTS_CONTAINER_LOCATOR)
+    StatusBlock elementsContainer;
+
+    static final String ELEMENTS_CONTAINER_COLLECTION_LOCATOR = "#user-table tbody tr";
+
+    @CacheLookup
+    @FindBy(css = ELEMENTS_CONTAINER_COLLECTION_LOCATOR)
+    List<UserInfo> elementsContainerCollection;
+  }
+
+  static class StatusBlock extends ElementsContainer {
+
+    @FindBy(className = "name")
+    SelenideElement name;
+
+    @FindBy(className = "last-login")
+    SelenideElement lastLogin;
+  }
+
+  static class UserInfo extends ElementsContainer {
+
+    @FindBy(className = "firstname")
+    SelenideElement firstName;
+
+    @FindBy(className = "lastname")
+    SelenideElement lastName;
+
+    @FindBy(className = "age")
+    SelenideElement age;
+  }
+}


### PR DESCRIPTION
## Proposed changes
Added support of [@CachedLookup](https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/CacheLookup.html) selenium annotation for page objects:

```java
public class SelectsPage {

    @CacheLookup
    @FindBy(xpath = "//select[@name='domain']")
    WebElement domainSelect;

    @CacheLookup
    @FindBy(tagName = "h1")
    SelenideElement h1;

    @CacheLookup
    @FindBy(tagName = "h2")
    List<SelenideElement> h2s;

    @CacheLookup
    @FindBy(tagName = "h2")
    ElementsCollection h2sElementsCollection;

    @CacheLookup
    @FindBy(id = "status")
    StatusBlock status;

    @CacheLookup
    @FindBy(css = "#user-table tbody tr")
    List<UserInfo> userInfoList;

  }
```

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
