### PR TITLE
make HttpClientTimeouts public

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/HttpClientTimeouts.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/HttpClientTimeouts.java
@@ -12,6 +12,6 @@ import java.time.Duration;
  * @since 5.22.0
  */
 @ParametersAreNonnullByDefault
-class HttpClientTimeouts {
+public class HttpClientTimeouts {
   public static Duration defaultReadTimeout = Duration.ofSeconds(90);
 }


### PR DESCRIPTION
otherwise it's not possible for users to change the timeout.
