### PR TITLE
#1891 deprecate TestNG annotation @Report

### DIFF
--- a/modules/testng/src/main/java/com/codeborne/selenide/testng/GlobalTextReport.java
+++ b/modules/testng/src/main/java/com/codeborne/selenide/testng/GlobalTextReport.java
@@ -1,10 +1,5 @@
 package com.codeborne.selenide.testng;
 
-import com.codeborne.selenide.logevents.SimpleReport;
-import org.testng.IInvokedMethod;
-import org.testng.IInvokedMethodListener;
-import org.testng.ITestResult;
-
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
@@ -12,20 +7,9 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * Annotate any test class in your suite with {@code @Listeners({GlobalTextReport.class})}
  *
  * @since Selenide 3.6
- * <p>
- * Use either {@link TextReport} or {@link GlobalTextReport}, never both
+ * @deprecated This class works exactly the same as {@link TextReport} since Selenide 6.7.0 - just use {@link TextReport} instead.
  */
+@Deprecated
 @ParametersAreNonnullByDefault
-public class GlobalTextReport implements IInvokedMethodListener {
-  protected SimpleReport report = new SimpleReport();
-
-  @Override
-  public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
-    report.start();
-  }
-
-  @Override
-  public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
-    report.finish(testResult.getName());
-  }
+public class GlobalTextReport extends TextReport {
 }

--- a/modules/testng/src/main/java/com/codeborne/selenide/testng/annotations/Report.java
+++ b/modules/testng/src/main/java/com/codeborne/selenide/testng/annotations/Report.java
@@ -7,12 +7,11 @@ import java.lang.annotation.Target;
 
 /**
  * Created by vinogradov on 07.05.16.
+ *
+ * @deprecated This annotation is ignored since Selenide 6.7.0
  */
-
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-
+@Deprecated
 public @interface Report {
-
-
 }

--- a/modules/testng/src/test/java/com/codeborne/selenide/testng/SoftAssertsTest.java
+++ b/modules/testng/src/test/java/com/codeborne/selenide/testng/SoftAssertsTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.ITestResult.FAILURE;
 
-final class SoftAssertsTest {
+public final class SoftAssertsTest {
   private final SoftAsserts listener = new SoftAsserts();
 
   @AfterMethod

--- a/modules/testng/src/test/java/com/codeborne/selenide/testng/TextReportTest.java
+++ b/modules/testng/src/test/java/com/codeborne/selenide/testng/TextReportTest.java
@@ -1,0 +1,61 @@
+package com.codeborne.selenide.testng;
+
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TextReportTest {
+  private final TextReport listener = new TextReport();
+
+  @Test
+  void classesMarkedWith_TextReport_shouldGeneratedReport() {
+    assertThat(listener.isClassAnnotatedWithReport(BaseTestWithTextReport.class)).isTrue();
+    assertThat(listener.isClassAnnotatedWithReport(BaseTestWithGlobalTextReport.class)).isTrue();
+    assertThat(listener.isClassAnnotatedWithReport(TestWithCustomTextReport.class)).isTrue();
+  }
+
+  @Test
+  void classesNotMarkedWith_TextReport_shouldNotGeneratedReport() {
+    assertThat(listener.isClassAnnotatedWithReport(AnotherTestWithoutTextReport.class)).isFalse();
+  }
+
+  @Test
+  void allChildrenClassesInherit_TextReport() {
+    assertThat(listener.isClassAnnotatedWithReport(SomeTestWithTextReport.class)).isTrue();
+    assertThat(listener.isClassAnnotatedWithReport(TestWithOwnListeners.class)).isTrue();
+  }
+
+  @Test
+  void allChildrenClassesInherit_GlobalTextReport() {
+    assertThat(listener.isClassAnnotatedWithReport(SomeTestWithGlobalTextReport.class)).isTrue();
+  }
+
+  @Listeners(TextReport.class)
+  private abstract static class BaseTestWithTextReport {
+  }
+
+  private abstract static class SomeTestWithTextReport extends BaseTestWithTextReport {
+  }
+
+  @Listeners(SoftAsserts.class)
+  private abstract static class TestWithOwnListeners extends BaseTestWithTextReport {
+  }
+
+  @Listeners(CustomTextReport.class)
+  private abstract static class TestWithCustomTextReport {
+  }
+
+  @Listeners(GlobalTextReport.class)
+  private abstract static class BaseTestWithGlobalTextReport {
+  }
+
+  private abstract static class SomeTestWithGlobalTextReport extends BaseTestWithGlobalTextReport {
+  }
+
+  private abstract static class AnotherTestWithoutTextReport {
+  }
+
+  private static class CustomTextReport extends TextReport {
+  }
+}


### PR DESCRIPTION
It was not really needed and rather created a hassle (see issues #1473 and #371).

**Now text report will be generated for all classes marked with `@Listeners({TextReport.class}` and their subclasses.**
