### PR TITLE
select the right window when taking screenshot via DevTools

### DIFF
--- a/modules/full-screenshot/src/main/java/com/codeborne/selenide/fullscreenshot/FullSizePhotographer.java
+++ b/modules/full-screenshot/src/main/java/com/codeborne/selenide/fullscreenshot/FullSizePhotographer.java
@@ -95,7 +95,7 @@ public class FullSizePhotographer implements Photographer {
     WD devtoolsDriver, OutputType<ResultType> outputType
   ) {
     DevTools devTools = devtoolsDriver.getDevTools();
-    devTools.createSessionIfThereIsNotOne();
+    devTools.createSessionIfThereIsNotOne(devtoolsDriver.getWindowHandle());
 
     Options options = getOptions(devtoolsDriver);
     Viewport viewport = new Viewport(0, 0, options.fullWidth(), options.fullHeight(), 1);

--- a/modules/full-screenshot/src/test/java/integration/ScreenshotTestHelper.java
+++ b/modules/full-screenshot/src/test/java/integration/ScreenshotTestHelper.java
@@ -29,7 +29,7 @@ public class ScreenshotTestHelper {
     else {
       File archivedFile = new File(Configuration.reportsFolder, UUID.randomUUID() + ".png");
       FileUtils.copyFile(screenshot, archivedFile);
-      log.info("Screenshot matches {}x{} size", width, height);
+      log.info("Screenshot does not match {}x{} size: {}", width, height, archivedFile.getAbsolutePath());
       fail(String.format("Screenshot %s is expected to have size %sx%s, but actual size: %sx%s",
         archivedFile.getAbsolutePath(), width, height, img.getWidth(), img.getHeight()));
     }

--- a/modules/grid/src/test/java/integration/FullScreenshotsGridTest.java
+++ b/modules/grid/src/test/java/integration/FullScreenshotsGridTest.java
@@ -36,11 +36,6 @@ public class FullScreenshotsGridTest extends AbstractGridTest {
     Configuration.remote = null;
   }
 
-  /*
-     In non-local browser (grid),
-     It fails or takes a screenshot of the wrong tab.
-     See https://github.com/SeleniumHQ/selenium/issues/10810
-     */
   @Test
   void canTakeFullScreenshotWithTwoTabs() throws IOException {
     openFile("page_of_fixed_size_2200x3300.html");


### PR DESCRIPTION
The issue https://github.com/SeleniumHQ/selenium/issues/10810 was fixed in Selenium 4.4.0, so we can apply the fix in Selenide.

