### PR TITLE
Check that element is <select> in methods $.getSelectedText(), getSelectedValue()

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,5 +1,7 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.commands.GetSelectedOptionText;
+import com.codeborne.selenide.commands.GetSelectedOptionValue;
 import com.codeborne.selenide.files.FileFilter;
 import com.codeborne.selenide.impl.WebElementSource;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -927,10 +929,18 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   /**
    * Get value of selected option in select field
    *
-   * @see com.codeborne.selenide.commands.GetSelectedValue
+   * @see GetSelectedOptionValue
    * @return null if the selected option doesn't have "value" attribute (or the select doesn't have options at all)
    * @see <a href="https://github.com/selenide/selenide/wiki/do-not-use-getters-in-tests">NOT RECOMMENDED</a>
    */
+  @CheckReturnValue
+  @Nullable
+  String getSelectedOptionValue();
+
+  /**
+   * @deprecated Use {@link #getSelectedOptionValue()} instead
+   */
+  @Deprecated
   @CheckReturnValue
   @Nullable
   String getSelectedValue();
@@ -938,9 +948,18 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   /**
    * Get text of selected option in select field
    * @return null if there is no selected options (or the select doesn't have options at all)
-   * @see com.codeborne.selenide.commands.GetSelectedText
+   * @throws IllegalArgumentException if the element type is not <select/>
+   * @see GetSelectedOptionText
    * @see <a href="https://github.com/selenide/selenide/wiki/do-not-use-getters-in-tests">NOT RECOMMENDED</a>
    */
+  @CheckReturnValue
+  @Nullable
+  String getSelectedOptionText();
+
+  /**
+   * @deprecated Use {@link #getSelectedOptionText()} instead
+   */
+  @Deprecated
   @CheckReturnValue
   @Nullable
   String getSelectedText();

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -119,8 +119,10 @@ public class Commands {
   private void addSelectCommands() {
     add("getSelectedOption", new GetSelectedOption());
     add("getSelectedOptions", new GetSelectedOptions());
-    add("getSelectedText", new GetSelectedText());
-    add("getSelectedValue", new GetSelectedValue());
+    add("getSelectedText", new GetSelectedOptionText());
+    add("getSelectedOptionText", new GetSelectedOptionText());
+    add("getSelectedValue", new GetSelectedOptionValue());
+    add("getSelectedOptionValue", new GetSelectedOptionValue());
     add("selectOption", new SelectOptionByTextOrIndex());
     add("selectOptionContainingText", new SelectOptionContainingText());
     add("selectOptionByValue", new SelectOptionByValue());

--- a/src/main/java/com/codeborne/selenide/commands/GetSelectedOptionText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSelectedOptionText.java
@@ -2,21 +2,27 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.JavaScript;
 import com.codeborne.selenide.impl.WebElementSource;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 
 @ParametersAreNonnullByDefault
-public class GetSelectedValue implements Command<String> {
+public class GetSelectedOptionText implements Command<String> {
+  private final JavaScript js = new JavaScript("get-selected-option-text.js");
+
   @Override
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   public String execute(SelenideElement proxy, WebElementSource selectElement, @Nullable Object[] args) {
-    return selectElement.driver().executeJavaScript(
-      "return arguments[0].options[arguments[0].selectedIndex]?.value",
-      selectElement.getWebElement()
-    );
+    List<String> result = js.execute(selectElement.driver(), selectElement.getWebElement());
+    if (result.get(1) != null) {
+      throw new IllegalArgumentException(result.get(1));
+    }
+    return result.get(0);
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/GetSelectedOptionValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSelectedOptionValue.java
@@ -2,22 +2,26 @@ package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.JavaScript;
 import com.codeborne.selenide.impl.WebElementSource;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 
 @ParametersAreNonnullByDefault
-public class GetSelectedText implements Command<String> {
+public class GetSelectedOptionValue implements Command<String> {
+  private final JavaScript js = new JavaScript("get-selected-option-value.js");
+
   @Override
   @CheckReturnValue
-  @Nonnull
+  @Nullable
   public String execute(SelenideElement proxy, WebElementSource selectElement, @Nullable Object[] args) {
-    return selectElement.driver().executeJavaScript(
-      "return arguments[0].options[arguments[0].selectedIndex]?.text",
-      selectElement.getWebElement()
-    );
+    List<String> result = js.execute(selectElement.driver(), selectElement.getWebElement());
+    if (result.get(1) != null) {
+      throw new IllegalArgumentException(result.get(1));
+    }
+    return result.get(0);
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/GetText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetText.java
@@ -12,14 +12,14 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class GetText implements Command<String> {
-  private final GetSelectedText getSelectedText;
+  private final GetSelectedOptionText getSelectedOptionText;
 
   public GetText() {
-    this(new GetSelectedText());
+    this(new GetSelectedOptionText());
   }
 
-  GetText(GetSelectedText getSelectedtext) {
-    this.getSelectedText = getSelectedtext;
+  GetText(GetSelectedOptionText getSelectedtextOption) {
+    this.getSelectedOptionText = getSelectedtextOption;
   }
 
   @Override
@@ -28,7 +28,7 @@ public class GetText implements Command<String> {
   public String execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     WebElement element = locator.getWebElement();
     return "select".equalsIgnoreCase(element.getTagName()) ?
-        getSelectedText.execute(proxy, locator, args) :
-        element.getText();
+      getSelectedOptionText.execute(proxy, locator, args) :
+      element.getText();
   }
 }

--- a/src/main/resources/get-selected-option-text.js
+++ b/src/main/resources/get-selected-option-text.js
@@ -1,0 +1,10 @@
+(function(select) {
+  if (select.tagName.toLowerCase() !== 'select') {
+    return ['', `Expected <select>, but received: <${select.tagName.toLowerCase()}>`]
+  }
+  if (!select.options) {
+    return ['', 'Select has no options']
+  }
+  return [select.options[select.selectedIndex]?.text, null]
+})(arguments[0]);
+

--- a/src/main/resources/get-selected-option-text.js
+++ b/src/main/resources/get-selected-option-text.js
@@ -1,10 +1,12 @@
 (function(select) {
   if (select.tagName.toLowerCase() !== 'select') {
-    return ['', `Expected <select>, but received: <${select.tagName.toLowerCase()}>`]
+    return ['', 'Expected <select>, but received: <' + select.tagName.toLowerCase() + '>']
   }
   if (!select.options) {
     return ['', 'Select has no options']
   }
-  return [select.options[select.selectedIndex]?.text, null]
+  let option = select.options[select.selectedIndex];
+  let text = !option ? null : option?.text;
+  return [text, null]
 })(arguments[0]);
 

--- a/src/main/resources/get-selected-option-value.js
+++ b/src/main/resources/get-selected-option-value.js
@@ -1,10 +1,12 @@
 (function(select) {
   if (select.tagName.toLowerCase() !== 'select') {
-    return ['', `Expected <select>, but received: <${select.tagName.toLowerCase()}>`]
+    return ['', 'Expected <select>, but received: <' + select.tagName.toLowerCase() + '>']
   }
   if (!select.options) {
     return ['', 'Select has no options']
   }
-  return [select.options[select.selectedIndex]?.value, null]
+  let option = select.options[select.selectedIndex];
+  let value = !option ? null : option.value;
+  return [value, null]
 })(arguments[0]);
 

--- a/src/main/resources/get-selected-option-value.js
+++ b/src/main/resources/get-selected-option-value.js
@@ -1,0 +1,10 @@
+(function(select) {
+  if (select.tagName.toLowerCase() !== 'select') {
+    return ['', `Expected <select>, but received: <${select.tagName.toLowerCase()}>`]
+  }
+  if (!select.options) {
+    return ['', 'Select has no options']
+  }
+  return [select.options[select.selectedIndex]?.value, null]
+})(arguments[0]);
+

--- a/src/test/java/com/codeborne/selenide/commands/GetTextCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetTextCommandTest.java
@@ -15,8 +15,8 @@ final class GetTextCommandTest {
   private final SelenideElement proxy = mock(SelenideElement.class);
   private final WebElementSource locator = mock(WebElementSource.class);
   private final SelenideElement mockedElement = mock(SelenideElement.class);
-  private final GetSelectedText getSelectedTextCommand = mock(GetSelectedText.class);
-  private final GetText command = new GetText(getSelectedTextCommand);
+  private final GetSelectedOptionText getSelectedOptionTextCommand = mock(GetSelectedOptionText.class);
+  private final GetText command = new GetText(getSelectedOptionTextCommand);
 
   @BeforeEach
   void setup() {
@@ -26,11 +26,11 @@ final class GetTextCommandTest {
   @Test
   void selectElement() {
     when(mockedElement.getTagName()).thenReturn("select");
-    when(getSelectedTextCommand.execute(any(), any(), any())).thenReturn("Selected Text");
+    when(getSelectedOptionTextCommand.execute(any(), any(), any())).thenReturn("Selected Text");
 
     assertThat(command.execute(proxy, locator, null)).isEqualTo("Selected Text");
 
-    verify(getSelectedTextCommand).execute(proxy, locator, null);
+    verify(getSelectedOptionTextCommand).execute(proxy, locator, null);
   }
 
   @Test

--- a/src/test/java/integration/DynamicSelectsTest.java
+++ b/src/test/java/integration/DynamicSelectsTest.java
@@ -22,9 +22,9 @@ final class DynamicSelectsTest extends ITest {
 
     SelenideElement select = $("#language");
     select.getSelectedOption().shouldBe(selected);
-    assertThat(select.getSelectedValue())
+    assertThat(select.getSelectedOptionValue())
       .isEqualTo("'eng'");
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("l'a \"English\"");
   }
 
@@ -34,16 +34,16 @@ final class DynamicSelectsTest extends ITest {
 
     SelenideElement select = $("#language");
     select.getSelectedOption().shouldBe(selected);
-    assertThat(select.getSelectedValue())
+    assertThat(select.getSelectedOptionValue())
       .isEqualTo("\"est\"");
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("l'a \"Eesti\"");
   }
 
   @Test
   void selectByXPath() {
     $(By.xpath("html/body/div[1]/form[1]/label[1]/select[1]")).selectOption("l'a \"English\"");
-    assertThat($(By.xpath("html/body/div[1]/form[1]/label[1]/select[1]")).getSelectedText())
+    assertThat($(By.xpath("html/body/div[1]/form[1]/label[1]/select[1]")).getSelectedOptionText())
       .isEqualTo("l'a \"English\"");
   }
 

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -33,9 +33,9 @@ final class SelectsTest extends IntegrationTest {
     select.selectOptionByValue("myrambler.ru");
 
     select.getSelectedOption().shouldBe(selected);
-    assertThat(select.getSelectedValue())
+    assertThat(select.getSelectedOptionValue())
       .isEqualTo("myrambler.ru");
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("@myrambler.ru");
   }
 
@@ -65,36 +65,36 @@ final class SelectsTest extends IntegrationTest {
 
   @Test
   void userCanGetSelectedOptionValue_none() {
-    assertThat($("select#hero").getSelectedValue()).isEqualTo("");
-    assertThat($("select#gender").getSelectedValue()).isEqualTo("");
+    assertThat($("select#hero").getSelectedOptionValue()).isEqualTo("");
+    assertThat($("select#gender").getSelectedOptionValue()).isEqualTo("");
   }
 
   @Test
   void userCanGetSelectedOptionValue_selectHasNoOptions() {
-    assertThat($("select#empty-select").getSelectedValue()).isNull();
+    assertThat($("select#empty-select").getSelectedOptionValue()).isNull();
   }
 
   @Test
   void userCanGetSelectedOptionValue_selectNotFound() {
-    assertThatThrownBy(() -> $("select#missing-select").getSelectedValue())
+    assertThatThrownBy(() -> $("select#missing-select").getSelectedOptionValue())
       .isInstanceOf(ElementNotFound.class)
       .hasMessageStartingWith("Element not found {select#missing-select}");
   }
 
   @Test
   void userCanGetSelectedOptionText_none() {
-    assertThat($("select#hero").getSelectedText()).isEqualTo("-- Select your hero --");
-    assertThat($("select#gender").getSelectedText()).isEqualTo("");
+    assertThat($("select#hero").getSelectedOptionText()).isEqualTo("-- Select your hero --");
+    assertThat($("select#gender").getSelectedOptionText()).isEqualTo("");
   }
 
   @Test
   void userCanGetSelectedOptionText_selectHasNoOptions() {
-    assertThat($("select#empty-select").getSelectedText()).isNull();
+    assertThat($("select#empty-select").getSelectedOptionText()).isNull();
   }
 
   @Test
   void userCanGetSelectedOptionText_selectNotFound() {
-    assertThatThrownBy(() -> $("select#missing-select").getSelectedText())
+    assertThatThrownBy(() -> $("select#missing-select").getSelectedOptionText())
       .isInstanceOf(ElementNotFound.class)
       .hasMessageStartingWith("Element not found {select#missing-select}");
   }
@@ -124,19 +124,19 @@ final class SelectsTest extends IntegrationTest {
     SelenideElement select = $(By.xpath("//select[@name='domain']"));
 
     select.selectOption(0);
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("@livemail.ru");
 
     select.selectOption(1);
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("@myrambler.ru");
 
     select.selectOption(2);
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("@rusmail.ru");
 
     select.selectOption(3);
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("@мыло.ру");
   }
 
@@ -162,9 +162,9 @@ final class SelectsTest extends IntegrationTest {
     select.selectOption("@мыло.ру");
 
     select.getSelectedOption().shouldBe(selected);
-    assertThat(select.getSelectedValue())
+    assertThat(select.getSelectedOptionValue())
       .isEqualTo("мыло.ру");
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("@мыло.ру");
   }
 
@@ -173,19 +173,19 @@ final class SelectsTest extends IntegrationTest {
     SelenideElement select = $(By.xpath("//select[@name='domain']"));
     select.selectOptionContainingText("ыло.р");
 
-    assertThat(select.getSelectedText())
+    assertThat(select.getSelectedOptionText())
       .isEqualTo("@мыло.ру");
   }
 
   @Test
   void getSelectedText_cannotBeNull() {
     SelenideElement select = $("select#gender");
-    assertThat(select.getSelectedText()).isEqualTo("");
+    assertThat(select.getSelectedOptionText()).isEqualTo("");
 
     select.selectOptionContainingText("emal");
-    assertThat(select.getSelectedText()).isEqualTo("Female");
+    assertThat(select.getSelectedOptionText()).isEqualTo("Female");
 
-    assertThatThrownBy(() -> $("select#missing").getSelectedText())
+    assertThatThrownBy(() -> $("select#missing").getSelectedOptionText())
       .isInstanceOf(ElementNotFound.class);
   }
 
@@ -298,5 +298,19 @@ final class SelectsTest extends IntegrationTest {
 
     $(By.xpath("//select[@name='domain']")).selectOptionByValue("myrambler.ru");
     $("#selectedDomain").shouldHave(text("@myrambler.ru"));
+  }
+
+  @Test
+  void getSelectedOptionText_isOnlyApplicableToSelect() {
+    assertThatThrownBy(() -> $("h1").getSelectedOptionText())
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageStartingWith("Expected <select>, but received: <h1>");
+  }
+
+  @Test
+  void getSelectedOptionValue_isOnlyApplicableToSelect() {
+    assertThatThrownBy(() -> $("h1").getSelectedOptionValue())
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageStartingWith("Expected <select>, but received: <h1>");
   }
 }


### PR DESCRIPTION
1. renamed `$.getSelectedText()` to `$.getSelectedOptionText()`
2. renamed `getSelectedValue()` to `getSelectedOptionValue()`
3. Now these method verify that the element is `<select>`. Otherwise they throw an `IllegalArgumentException` with message `Expected <select>, but received: <div>`. 
4. Fixed these methods in IE (it seems they never worked correctly in IE).
