### PR TITLE
Add remote read timeout as configurable parameter

### DIFF
--- a/src/main/java/com/codeborne/selenide/Config.java
+++ b/src/main/java/com/codeborne/selenide/Config.java
@@ -35,4 +35,5 @@ public interface Config {
   boolean proxyEnabled();
   String proxyHost();
   int proxyPort();
+  long remoteReadTimeout();
 }

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -44,6 +44,7 @@ public class SelenideConfig implements Config {
   private boolean proxyEnabled = Boolean.parseBoolean(getProperty("selenide.proxyEnabled", "false"));
   private String proxyHost = getProperty("selenide.proxyHost", null);
   private int proxyPort = Integer.parseInt(getProperty("selenide.proxyPort", "0"));
+  private long remoteReadTimeout = Long.parseLong(getProperty("selenide.remoteReadTimeout", "90000"));
 
   @Override
   public String baseUrl() {
@@ -363,4 +364,12 @@ public class SelenideConfig implements Config {
     return value;
   }
 
+  public long remoteReadTimeout() {
+    return remoteReadTimeout;
+  }
+
+  public SelenideConfig remoteReadTimeout(long remoteReadTimeout) {
+    this.remoteReadTimeout = remoteReadTimeout;
+    return this;
+  }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/HttpClientTimeouts.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/HttpClientTimeouts.java
@@ -13,5 +13,5 @@ import java.time.Duration;
  */
 @ParametersAreNonnullByDefault
 public class HttpClientTimeouts {
-  public static Duration defaultReadTimeout = Duration.ofSeconds(90);
+  public static Duration defaultLocalReadTimeout = Duration.ofSeconds(90);
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/RemoteDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/RemoteDriverFactory.java
@@ -16,13 +16,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 
-import static com.codeborne.selenide.webdriver.HttpClientTimeouts.defaultReadTimeout;
-
 @ParametersAreNonnullByDefault
 public class RemoteDriverFactory {
   public WebDriver create(Config config, MutableCapabilities capabilities) {
     try {
-      CommandExecutor commandExecutor = createExecutor(config, defaultReadTimeout);
+      CommandExecutor commandExecutor = createExecutor(config);
       RemoteWebDriver webDriver = new RemoteWebDriver(commandExecutor, capabilities);
       webDriver.setFileDetector(new LocalFileDetector());
       return webDriver;
@@ -34,10 +32,10 @@ public class RemoteDriverFactory {
 
   @Nonnull
   @CheckReturnValue
-  private CommandExecutor createExecutor(Config config, Duration readTimeout) throws MalformedURLException {
+  private CommandExecutor createExecutor(Config config) throws MalformedURLException {
     ClientConfig clientConfig = ClientConfig.defaultConfig()
       .baseUrl(new URL(config.remote()))
-      .readTimeout(readTimeout);
+      .readTimeout(Duration.ofMillis(config.remoteReadTimeout()));
 
     return new HttpCommandExecutor(clientConfig);
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/SelenideNettyClientFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/SelenideNettyClientFactory.java
@@ -8,7 +8,7 @@ import org.openqa.selenium.remote.http.netty.NettyClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.codeborne.selenide.webdriver.HttpClientTimeouts.defaultReadTimeout;
+import static com.codeborne.selenide.webdriver.HttpClientTimeouts.defaultLocalReadTimeout;
 
 @AutoService(HttpClient.Factory.class)
 @HttpClientName("selenide-netty-client-factory")
@@ -17,7 +17,7 @@ public class SelenideNettyClientFactory extends NettyClient.Factory {
 
   @Override
   public HttpClient createClient(ClientConfig config) {
-    ClientConfig configWithShorterTimeout = config.readTimeout(defaultReadTimeout);
+    ClientConfig configWithShorterTimeout = config.readTimeout(defaultLocalReadTimeout);
     logger.info("Changed readTimeout from {} to {}", config.readTimeout(), configWithShorterTimeout.readTimeout());
     return super.createClient(configWithShorterTimeout);
   }

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -350,4 +350,14 @@ public class Configuration {
    */
   public static String browserBinary = defaults.browserBinary();
 
+  /**
+   * Sets read timeout in milliseconds for remote browser connections.
+   * Applies only when remote is specified.
+   * Can be configured either programmatically, via selenide.properties file
+   * or by system property "-Dselenide.remoteReadTimeout=180000"
+   * <br>
+   * Default: 90000
+   */
+  public static long remoteReadTimeout = defaults.remoteReadTimeout();
+
 }

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticConfig.java
@@ -113,6 +113,11 @@ class StaticConfig implements Config {
   }
 
   @Override
+  public long remoteReadTimeout() {
+    return Configuration.remoteReadTimeout;
+  }
+
+  @Override
   public String browser() {
     return Configuration.browser;
   }


### PR DESCRIPTION
## Proposed changes
I have quiet a small number of executors in my Selenium Grid (and in Browserstack too) and long running tests, so sometimes tests need to wait for the new browser session for more than 90 seconds.
In this pull-request I add new variable remoteReadTimeout to configuration with default value of 90000 ms, so I can configure read timeout from properties or command-line
Read timeout for local browsers is still 90 seconds and is not configurable (it seems reasonable).

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works. Are there any tests required for this code? 
- [x] I have added necessary documentation (if appropriate) - I have added JavaDoc to Configuration class. Are there any more changes required?
