### PR TITLE
1903 add annotation @As for page object fields

### DIFF
--- a/src/main/java/com/codeborne/selenide/As.java
+++ b/src/main/java/com/codeborne/selenide/As.java
@@ -1,0 +1,17 @@
+package com.codeborne.selenide;
+
+import javax.annotation.Nonnull;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Human-readable alias for page object field
+ * @since 6.8.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface As {
+  @Nonnull String value();
+}

--- a/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
@@ -5,8 +5,6 @@ import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.CollectionSource;
 import org.openqa.selenium.By;
 
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
@@ -19,27 +17,21 @@ public class ElementNotFound extends UIAssertionError {
 
   public ElementNotFound(Alias alias, String searchCriteria, Condition expectedCondition) {
     super(String.format("Element%s not found {%s}" +
-      "%nExpected: %s", aliasOrBlank(alias), searchCriteria, expectedCondition));
+      "%nExpected: %s", alias.appendable(), searchCriteria, expectedCondition));
   }
 
   public ElementNotFound(Alias alias, String searchCriteria, Condition expectedCondition, @Nullable Throwable lastError) {
     super(String.format("Element%s not found {%s}" +
-      "%nExpected: %s", aliasOrBlank(alias), searchCriteria, expectedCondition), lastError);
+      "%nExpected: %s", alias.appendable(), searchCriteria, expectedCondition), lastError);
   }
 
   public ElementNotFound(CollectionSource collection, List<String> expectedTexts, @Nullable Throwable lastError) {
     super(String.format("Element%s not found {%s}" +
-      "%nExpected: %s", aliasOrBlank(collection.getAlias()), collection.getSearchCriteria(), expectedTexts), lastError);
+      "%nExpected: %s", collection.getAlias().appendable(), collection.getSearchCriteria(), expectedTexts), lastError);
   }
 
   public ElementNotFound(CollectionSource collection, String description, @Nullable Throwable lastError) {
     super(String.format("Element%s not found {%s}" +
-      "%nExpected: %s", aliasOrBlank(collection.getAlias()), collection.getSearchCriteria(), description), lastError);
-  }
-
-  @Nonnull
-  @CheckReturnValue
-  private static String aliasOrBlank(Alias alias) {
-    return alias.getText() == null ? "" : " \"" + alias.getText() + "\"";
+      "%nExpected: %s", collection.getAlias().appendable(), collection.getSearchCriteria(), description), lastError);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementShould.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShould.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.ex;
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.ElementDescriber;
 import org.openqa.selenium.WebElement;
 
@@ -16,11 +17,12 @@ import static com.codeborne.selenide.impl.Plugins.inject;
 public class ElementShould extends UIAssertionError {
   private static final ElementDescriber describe = inject(ElementDescriber.class);
 
-  public ElementShould(Driver driver, String searchCriteria, String prefix,
+  public ElementShould(Driver driver, Alias alias, String searchCriteria, String prefix,
                        Condition expectedCondition, @Nullable CheckResult lastCheckResult,
                        WebElement element, @Nullable Throwable lastError) {
     super(
-      String.format("Element should %s%s {%s}%nElement: '%s'%s",
+      String.format("Element%s should %s%s {%s}%nElement: '%s'%s",
+        alias.appendable(),
         prefix, expectedCondition, searchCriteria,
         describe.fully(driver, element),
         actualValue(expectedCondition, driver, element, lastCheckResult)

--- a/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.ex;
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.ElementDescriber;
 import org.openqa.selenium.WebElement;
 
@@ -17,11 +18,12 @@ import static java.lang.System.lineSeparator;
 public class ElementShouldNot extends UIAssertionError {
   private static final ElementDescriber describe = inject(ElementDescriber.class);
 
-  public ElementShouldNot(Driver driver, String searchCriteria, String prefix,
+  public ElementShouldNot(Driver driver, Alias alias, String searchCriteria, String prefix,
                           Condition expectedCondition, @Nullable CheckResult lastCheckResult,
                           WebElement element, @Nullable Throwable lastError) {
     super(
-      String.format("Element should not %s%s {%s}%sElement: '%s'%s",
+      String.format("Element%s should not %s%s {%s}%sElement: '%s'%s",
+        alias.appendable(),
         prefix, expectedCondition, searchCriteria, lineSeparator(),
         describe.fully(driver, element),
         actualValue(expectedCondition, driver, element, lastCheckResult)

--- a/src/main/java/com/codeborne/selenide/impl/Alias.java
+++ b/src/main/java/com/codeborne/selenide/impl/Alias.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.impl;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.function.Supplier;
@@ -22,6 +23,12 @@ public class Alias {
   @CheckReturnValue
   public String get(Supplier<String> defaultValue) {
     return text + " {" + defaultValue.get() + '}';
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  public String appendable() {
+    return getText() == null ? "" : " \"" + getText() + "\"";
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
@@ -44,16 +44,27 @@ public class ElementFinder extends WebElementSource {
 
   @CheckReturnValue
   @Nonnull
-  @SuppressWarnings("unchecked")
   public static <T extends SelenideElement> T wrap(Driver driver,
                                                    Class<T> clazz,
                                                    @Nullable WebElementSource parent,
                                                    By criteria,
                                                    int index) {
+    return wrap(driver, clazz, parent, criteria, index, null);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  @SuppressWarnings("unchecked")
+  public static <T extends SelenideElement> T wrap(Driver driver,
+                                                   Class<T> clazz,
+                                                   @Nullable WebElementSource parent,
+                                                   By criteria,
+                                                   int index,
+                                                   @Nullable String alias) {
     return (T) Proxy.newProxyInstance(
       currentThread().getContextClassLoader(),
       new Class<?>[]{clazz},
-      new SelenideElementProxy(new ElementFinder(driver, parent, criteria, index)));
+      new SelenideElementProxy(new ElementFinder(driver, parent, criteria, index, alias)));
   }
 
   @CheckReturnValue
@@ -73,10 +84,15 @@ public class ElementFinder extends WebElementSource {
   private final int index;
 
   ElementFinder(Driver driver, @Nullable WebElementSource parent, By criteria, int index) {
+    this(driver, parent, criteria, index, null);
+  }
+
+  ElementFinder(Driver driver, @Nullable WebElementSource parent, By criteria, int index, @Nullable String alias) {
     this.driver = driver;
     this.parent = parent;
     this.criteria = criteria;
     this.index = index;
+    if (alias != null) setAlias(alias);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -129,10 +129,10 @@ public abstract class WebElementSource {
       throw createElementNotFoundError(check, lastError);
     }
     else if (invert) {
-      throw new ElementShouldNot(driver(), description(), prefix, condition, checkResult, element, lastError);
+      throw new ElementShouldNot(driver(), getAlias(), getSearchCriteria(), prefix, condition, checkResult, element, lastError);
     }
     else {
-      throw new ElementShould(driver(), description(), prefix, condition, checkResult, element, lastError);
+      throw new ElementShould(driver(), getAlias(), getSearchCriteria(), prefix, condition, checkResult, element, lastError);
     }
   }
 

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.ex;
 import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.impl.Alias;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
@@ -18,7 +19,7 @@ final class ElementShouldNotTest {
   @Test
   void testToString() {
     CheckResult checkResult = new CheckResult(REJECT, "visible:false");
-    ElementShouldNot elementShould = new ElementShouldNot(driver, "by.name: selenide", "be ", visible, checkResult,
+    ElementShouldNot elementShould = new ElementShouldNot(driver, Alias.NONE, "by.name: selenide", "be ", visible, checkResult,
       mock(WebElement.class), new Throwable("Error message"));
     assertThat(elementShould).hasMessage("Element should not be visible {by.name: selenide}" + lineSeparator() +
       "Element: '<null displayed:false></null>'" + lineSeparator() +

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.Mocks;
+import com.codeborne.selenide.impl.Alias;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -23,7 +24,7 @@ final class ElementShouldTest {
     String searchCriteria = By.name("selenide").toString();
     Exception cause = new NoSuchElementException("By.name: q");
     CheckResult checkResult = new CheckResult(REJECT, "visible:false");
-    ElementShould elementShould = new ElementShould(driver, searchCriteria, "be ", visible, checkResult, webElement, cause);
+    ElementShould elementShould = new ElementShould(driver, Alias.NONE, searchCriteria, "be ", visible, checkResult, webElement, cause);
 
     assertThat(elementShould)
       .hasMessage("Element should be visible {By.name: selenide}" + lineSeparator() +

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementDescriberTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementDescriberTest.java
@@ -44,7 +44,7 @@ final class SelenideElementDescriberTest {
 
     SelenideElement selenideElement = mock(SelenideElement.class);
     when(selenideElement.toWebElement()).thenReturn(webElement);
-    doThrow(new ElementShould(driver, "div", "", visible, null, webElement, null)).when(selenideElement).getTagName();
+    doThrow(new ElementShould(driver, Alias.NONE, "div", "", visible, null, webElement, null)).when(selenideElement).getTagName();
 
     assertThat(describe.briefly(driver, selenideElement))
       .isEqualTo("Ups, failed to described the element [caused by: StaleElementReferenceException: disappeared]");

--- a/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
+++ b/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
@@ -36,7 +36,7 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
       .isInstanceOf(ElementShould.class)
       .hasMessageStartingWith("""
           Element "Tiny header" should have text "expected text" {By.tagName: h6}
-          """
+          """.trim()
       );
   }
 
@@ -48,7 +48,7 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageStartingWith("""
           Element "Large header" should not have text "Page with selects" {By.tagName: h1}
-          """
+          """.trim()
       );
   }
 
@@ -60,7 +60,7 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
       .isInstanceOf(ListSizeMismatch.class)
       .hasMessageStartingWith("""
           List size mismatch: expected: = 666, actual: 3, collection: Middle headers {By.tagName: h2}
-          """
+          """.trim()
       );
   }
 

--- a/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
+++ b/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
@@ -1,0 +1,80 @@
+package integration.pageobjects;
+
+import com.codeborne.selenide.As;
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementShould;
+import com.codeborne.selenide.ex.ElementShouldNot;
+import com.codeborne.selenide.ex.ListSizeMismatch;
+import integration.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.page;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PageObjectWithAliasesTest extends IntegrationTest {
+
+  private PageObject page;
+
+  @BeforeEach
+  void openTestPage() {
+    openFile("page_with_selects_without_jquery.html");
+    page = page(PageObject.class);
+  }
+
+  @Test
+  void fieldWithAlias_shouldHave() {
+    assertThatThrownBy(() ->
+      $(page.header3).shouldHave(text("expected text"))
+    )
+      .isInstanceOf(ElementShould.class)
+      .hasMessageStartingWith("""
+          Element "Tiny header" should have text "expected text" {By.tagName: h6}
+          """
+      );
+  }
+
+  @Test
+  void fieldWithAlias_shouldNotHave() {
+    assertThatThrownBy(() ->
+      $(page.header1).shouldNotHave(text("Page with selects"))
+    )
+      .isInstanceOf(ElementShouldNot.class)
+      .hasMessageStartingWith("""
+          Element "Large header" should not have text "Page with selects" {By.tagName: h1}
+          """
+      );
+  }
+
+  @Test
+  void collectionWithAlias() {
+    assertThatThrownBy(() ->
+      page.header2.shouldHave(size(666))
+    )
+      .isInstanceOf(ListSizeMismatch.class)
+      .hasMessageStartingWith("""
+          List size mismatch: expected: = 666, actual: 3, collection: Middle headers {By.tagName: h2}
+          """
+      );
+  }
+
+  static class PageObject {
+    @As("Large header")
+    @FindBy(tagName = "h1")
+    SelenideElement header1;
+
+    @As("Middle headers")
+    @FindBy(tagName = "h2")
+    ElementsCollection header2;
+
+    @As("Tiny header")
+    @FindBy(tagName = "h6")
+    WebElement header3;
+  }
+}


### PR DESCRIPTION
implementation of https://github.com/selenide/selenide/issues/1903

Now you can give human-readable aliases for page object fields:

```java
static class PageObject {
  @As("Large header")
  @FindBy(tagName = "h1")
  SelenideElement header1;
}
```