### PR TITLE
Add method page() without Class argument

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -154,6 +154,20 @@ public class SelenideDriver {
     return pageFactory.page(driver(), pageObjectClass);
   }
 
+  /**
+   * @since 6.8.0
+   * @param reified Don't pass any values here. It's Java Magic :)
+   */
+  @CheckReturnValue
+  @Nonnull
+  @SuppressWarnings("unchecked")
+  public <PageObjectClass> PageObjectClass page(PageObjectClass... reified) {
+    if (reified.length > 0) {
+      throw new IllegalArgumentException("Please don't pass any values here. Java will detect page object class automagically.");
+    }
+    return pageFactory.page(driver(), (Class<PageObjectClass>) reified.getClass().getComponentType());
+  }
+
   @CheckReturnValue
   @Nonnull
   public <PageObjectClass, T extends PageObjectClass> PageObjectClass page(T pageObject) {

--- a/src/main/java/com/codeborne/selenide/impl/JSElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/JSElementFinder.java
@@ -13,13 +13,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.lang.reflect.Proxy;
 
 import static com.codeborne.selenide.Condition.exist;
-import static com.codeborne.selenide.impl.Plugins.inject;
 import static java.lang.Thread.currentThread;
 
 @ParametersAreNonnullByDefault
 public class JSElementFinder extends WebElementSource {
-  private final ElementDescriber describe = inject(ElementDescriber.class);
-
   @CheckReturnValue
   @Nonnull
   @SuppressWarnings("unchecked")

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -721,6 +721,17 @@ public class Selenide {
   }
 
   /**
+   * Create a Page Object instance
+   * @since 6.8.0
+   * @param reified Don't pass any values here. It's Java Magic :)
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static <PageObjectClass> PageObjectClass page(PageObjectClass... reified) {
+    return getSelenideDriver().page(reified);
+  }
+
+  /**
    * Initialize a given Page Object instance
    */
   @CheckReturnValue

--- a/statics/src/test/java/integration/pageobjects/PageObjectTest.java
+++ b/statics/src/test/java/integration/pageobjects/PageObjectTest.java
@@ -28,7 +28,7 @@ final class PageObjectTest extends IntegrationTest {
   @BeforeEach
   void openTestPage() {
     openFile("page_with_selects_without_jquery.html");
-    pageWithSelects = page(SelectsPage.class);
+    pageWithSelects = page();
   }
 
   @Test


### PR DESCRIPTION
Instead of 
```java
SelectsPage page = page(SelectsPage.class);
```

you can now use shorter form:

```java
SelectsPage page = page();
```

it uses the hack I discovered in Tagir Valeev post: https://twitter.com/tagir_valeev/status/1262763570904719361