### PR TITLE
optimize dependencies

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext {
   mockitoVersion = '4.8.0'
   slf4jVersion = '2.0.2'
   browserupProxyVersion = '2.2.3'
-  littleProxyVersion = '2.0.11'
+  littleProxyVersion = '2.0.12'
   commonsFileuploadVersion = '1.4'
   jabelVersion = '0.4.2'
   byteBuddyVersion = '1.12.17'
@@ -25,7 +25,10 @@ subprojects {
     compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabelVersion}")
     testCompileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabelVersion}")
 
-    api("org.seleniumhq.selenium:selenium-java:$seleniumVersion")
+    api("org.seleniumhq.selenium:selenium-java:$seleniumVersion") {
+      exclude group: 'io.opentelemetry'
+      exclude group: 'org.slf4j'
+    }
     implementation("com.google.guava:guava:31.1-jre")
     implementation("org.apache.commons:commons-lang3:3.12.0")
     implementation("commons-io:commons-io:2.11.0")
@@ -37,7 +40,7 @@ subprojects {
     testImplementation("commons-fileupload:commons-fileupload:${commonsFileuploadVersion}")
     testImplementation("org.mockito:mockito-core:$mockitoVersion")
     testImplementation("org.assertj:assertj-core:$assertjVersion")
-    implementation("org.slf4j:slf4j-api:$slf4jVersion")
+    api("org.slf4j:slf4j-api:$slf4jVersion")
     testRuntimeOnly("org.slf4j:slf4j-simple:$slf4jVersion")
   }
 }

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     exclude group: 'com.github.docker-java'
     exclude group: 'org.rauschig'
     exclude group: 'commons-lang'
+    exclude group: 'org.slf4j'
   }
   implementation('org.apache.commons:commons-compress:1.21') {because 'used by webdrivermanager'}
 

--- a/modules/grid/build.gradle
+++ b/modules/grid/build.gradle
@@ -9,6 +9,6 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testImplementation("org.seleniumhq.selenium:selenium-grid:$seleniumVersion") {
-    exclude group: 'net.bytebuddy', module: 'byte-buddy'
+    exclude group: 'org.slf4j'
   }
 }


### PR DESCRIPTION
* bump LittleProxy from 2.0.11 to 2.0.12
* exclude 'io.opentelemetry' dependency (Selenium brings it transitively, but we really don't use it)
* make `slf4j-api` available for users - apparently all Selenide users need to use it anyway
