### PR TITLE
#1850 don't include Mockito & AssertJ in all modules

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,6 +24,10 @@ subprojects {
     annotationProcessor("net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}")
     compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabelVersion}")
     testCompileOnly("com.github.bsideup.jabel:jabel-javac-plugin:${jabelVersion}")
+    compileOnly("net.bytebuddy:byte-buddy:${byteBuddyVersion}")
+    compileOnly("net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}")
+    testCompileOnly("net.bytebuddy:byte-buddy:${byteBuddyVersion}")
+    testCompileOnly("net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}")
 
     api("org.seleniumhq.selenium:selenium-java:$seleniumVersion") {
       exclude group: 'io.opentelemetry'
@@ -38,8 +42,6 @@ subprojects {
     testImplementation("io.netty:netty-codec:$nettyVersion")
     testImplementation("org.eclipse.jetty:jetty-servlet:${jettyVersion}")
     testImplementation("commons-fileupload:commons-fileupload:${commonsFileuploadVersion}")
-    testImplementation("org.mockito:mockito-core:$mockitoVersion")
-    testImplementation("org.assertj:assertj-core:$assertjVersion")
     api("org.slf4j:slf4j-api:$slf4jVersion")
     testRuntimeOnly("org.slf4j:slf4j-simple:$slf4jVersion")
   }

--- a/modules/clear-with-shortcut/build.gradle
+++ b/modules/clear-with-shortcut/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testImplementation("org.junit.platform:junit-platform-suite-engine:1.9.1")
+  testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
 }
 
 apply from: rootProject.file('gradle/publish-module.gradle')

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 
   compileOnly("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+
+  testImplementation("org.mockito:mockito-core:$mockitoVersion")
+  testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
 }
 
 apply from: rootProject.file('gradle/publish-module.gradle')

--- a/modules/full-screenshot/build.gradle
+++ b/modules/full-screenshot/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   testImplementation("org.junit.platform:junit-platform-suite-engine:1.9.1")
+  testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
 }
 
 apply from: rootProject.file('gradle/publish-module.gradle')

--- a/modules/full-screenshot/src/test/java/integration/ScreenshotTestHelper.java
+++ b/modules/full-screenshot/src/test/java/integration/ScreenshotTestHelper.java
@@ -11,8 +11,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.fail;
-
 public class ScreenshotTestHelper {
   private static final Logger log = LoggerFactory.getLogger(ScreenshotTestHelper.class);
 
@@ -30,7 +28,7 @@ public class ScreenshotTestHelper {
       File archivedFile = new File(Configuration.reportsFolder, UUID.randomUUID() + ".png");
       FileUtils.copyFile(screenshot, archivedFile);
       log.info("Screenshot does not match {}x{} size: {}", width, height, archivedFile.getAbsolutePath());
-      fail(String.format("Screenshot %s is expected to have size %sx%s, but actual size: %sx%s",
+      throw new AssertionError(String.format("Screenshot %s is expected to have size %sx%s, but actual size: %sx%s",
         archivedFile.getAbsolutePath(), width, height, img.getWidth(), img.getHeight()));
     }
   }

--- a/modules/grid/build.gradle
+++ b/modules/grid/build.gradle
@@ -11,4 +11,5 @@ dependencies {
   testImplementation("org.seleniumhq.selenium:selenium-grid:$seleniumVersion") {
     exclude group: 'org.slf4j'
   }
+  testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
 }

--- a/modules/junit4/src/test/java/integration/SoftAssertJUnit4Test.java
+++ b/modules/junit4/src/test/java/integration/SoftAssertJUnit4Test.java
@@ -1,13 +1,19 @@
 package integration;
 
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.junit.SoftAsserts;
 import com.codeborne.selenide.junit.TextReport;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.openqa.selenium.support.events.AbstractWebDriverEventListener;
+import org.openqa.selenium.support.events.WebDriverListener;
+
+import java.lang.reflect.Method;
 
 import static com.codeborne.selenide.AssertionMode.SOFT;
 import static com.codeborne.selenide.AssertionMode.STRICT;
@@ -22,6 +28,21 @@ public class SoftAssertJUnit4Test extends IntegrationTest {
 
   @Rule @SuppressWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
   public final TextReport textReport = new TextReport();
+
+  private static final WebDriverListener listener1 = new WebDriverListener() {
+    @Override
+    public void beforeAnyCall(Object target, Method method, Object[] args) {
+    }
+  };
+  private static final AbstractWebDriverEventListener listener2 = new AbstractWebDriverEventListener() {
+  };
+
+  @BeforeClass
+  public static void beforeClass() {
+    closeWebDriver();
+    WebDriverRunner.addListener(listener1);
+    WebDriverRunner.addListener(listener2);
+  }
 
   @Before
   public void setUp() {
@@ -47,13 +68,16 @@ public class SoftAssertJUnit4Test extends IntegrationTest {
   @After
   public void tearDown() {
     // uncomment to trigger test failure
-    // assertThat("male").isEqualTo("female");
+    // assertEquals("male", "female");
   }
 
   @AfterClass
   public static void afterAll() {
     Configuration.assertionMode = STRICT;
     $("#soft-assert-logout").shouldNot(exist);
+
+    WebDriverRunner.removeListener(listener1);
+    WebDriverRunner.removeListener(listener2);
     closeWebDriver();
   }
 }

--- a/modules/proxy/build.gradle
+++ b/modules/proxy/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   testImplementation project(':modules:core').sourceSets.test.output
   testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+  testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
 }
 
 apply from: rootProject.file('gradle/publish-module.gradle')

--- a/modules/testng/build.gradle
+++ b/modules/testng/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     exclude(group: 'org.apache.ant')
     exclude(group: 'com.google.inject')
   }
+  testImplementation("org.mockito:mockito-core:$mockitoVersion")
 }
 
 tasks.withType(Test) {

--- a/modules/testng/src/test/java/com/codeborne/selenide/testng/SoftAssertsTest.java
+++ b/modules/testng/src/test/java/com/codeborne/selenide/testng/SoftAssertsTest.java
@@ -11,7 +11,6 @@ import org.testng.annotations.Test;
 import org.testng.internal.ConstructorOrMethod;
 
 import static com.codeborne.selenide.logevents.ErrorsCollector.LISTENER_SOFT_ASSERT;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
@@ -20,6 +19,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.ITestResult.FAILURE;
 
 public final class SoftAssertsTest {
@@ -32,25 +35,23 @@ public final class SoftAssertsTest {
 
   @Test
   void findsListenersAnnotationFromParentClass() {
-    assertThat(listener.getListenersAnnotation(BaseSoftTest.class)).isNotNull();
-    assertThat(listener.getListenersAnnotation(SoftTest.class)).isNotNull();
-    assertThat(listener.getListenersAnnotation(BaseHardTest.class)).isNotNull();
-    assertThat(listener.getListenersAnnotation(HardTest.class)).isNotNull();
-    assertThat(listener.getListenersAnnotation(AnotherTest.class)).isNull();
+    assertNotNull(listener.getListenersAnnotation(BaseSoftTest.class));
+    assertNotNull(listener.getListenersAnnotation(SoftTest.class));
+    assertNotNull(listener.getListenersAnnotation(BaseHardTest.class));
+    assertNotNull(listener.getListenersAnnotation(HardTest.class));
+    assertNull(listener.getListenersAnnotation(AnotherTest.class));
   }
 
   @Test
   void interceptsTestMethod_ifTestClassHasDeclaredSoftAssertListener() {
-    assertThat(listener.isTestClassApplicableForSoftAsserts(SoftTest.class)).isTrue();
-    assertThat(listener.isTestClassApplicableForSoftAsserts(HardTest.class)).isFalse();
+    assertTrue(listener.isTestClassApplicableForSoftAsserts(SoftTest.class));
+    assertFalse(listener.isTestClassApplicableForSoftAsserts(HardTest.class));
   }
 
   @Test
   void shouldNotInterceptTestMethod_withDeclaredExpectedExceptions() throws NoSuchMethodException {
-    assertThat(listener.isTestMethodApplicableForSoftAsserts(SoftTest.class.getMethod("someTestMethod")))
-      .isTrue();
-    assertThat(listener.isTestMethodApplicableForSoftAsserts(SoftTest.class.getMethod("testWithExpectedException")))
-      .isFalse();
+    assertTrue(listener.isTestMethodApplicableForSoftAsserts(SoftTest.class.getMethod("someTestMethod")));
+    assertFalse(listener.isTestMethodApplicableForSoftAsserts(SoftTest.class.getMethod("testWithExpectedException")));
   }
 
   @Test
@@ -59,7 +60,7 @@ public final class SoftAssertsTest {
 
     listener.addSelenideErrorListener(result);
 
-    assertThat(SelenideLogger.hasListener(LISTENER_SOFT_ASSERT)).isTrue();
+    assertTrue(SelenideLogger.hasListener(LISTENER_SOFT_ASSERT));
   }
 
   private ITestResult mockTestResult(Class<?> testClass, String methodName) throws Exception {
@@ -83,7 +84,7 @@ public final class SoftAssertsTest {
 
     listener.addSelenideErrorListener(result);
 
-    assertThat(SelenideLogger.hasListener(LISTENER_SOFT_ASSERT)).isFalse();
+    assertFalse(SelenideLogger.hasListener(LISTENER_SOFT_ASSERT));
   }
 
   @Test
@@ -100,7 +101,7 @@ public final class SoftAssertsTest {
     verify(result).setStatus(FAILURE);
     verify(result).setThrowable(softAssertionError);
     verify(errorsCollector).cleanAndGetAssertionError("com.codeborne.selenide.testng.SoftAssertsTest$SoftTest.someTestMethod", null);
-    assertThat(SelenideLogger.hasListener(LISTENER_SOFT_ASSERT)).isFalse();
+    assertFalse(SelenideLogger.hasListener(LISTENER_SOFT_ASSERT));
   }
 
   @Test

--- a/modules/testng/src/test/java/com/codeborne/selenide/testng/TextReportTest.java
+++ b/modules/testng/src/test/java/com/codeborne/selenide/testng/TextReportTest.java
@@ -3,32 +3,33 @@ package com.codeborne.selenide.testng;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public final class TextReportTest {
   private final TextReport listener = new TextReport();
 
   @Test
   void classesMarkedWith_TextReport_shouldGeneratedReport() {
-    assertThat(listener.isClassAnnotatedWithReport(BaseTestWithTextReport.class)).isTrue();
-    assertThat(listener.isClassAnnotatedWithReport(BaseTestWithGlobalTextReport.class)).isTrue();
-    assertThat(listener.isClassAnnotatedWithReport(TestWithCustomTextReport.class)).isTrue();
+    assertTrue(listener.isClassAnnotatedWithReport(BaseTestWithTextReport.class));
+    assertTrue(listener.isClassAnnotatedWithReport(BaseTestWithGlobalTextReport.class));
+    assertTrue(listener.isClassAnnotatedWithReport(TestWithCustomTextReport.class));
   }
 
   @Test
   void classesNotMarkedWith_TextReport_shouldNotGeneratedReport() {
-    assertThat(listener.isClassAnnotatedWithReport(AnotherTestWithoutTextReport.class)).isFalse();
+    assertFalse(listener.isClassAnnotatedWithReport(AnotherTestWithoutTextReport.class));
   }
 
   @Test
   void allChildrenClassesInherit_TextReport() {
-    assertThat(listener.isClassAnnotatedWithReport(SomeTestWithTextReport.class)).isTrue();
-    assertThat(listener.isClassAnnotatedWithReport(TestWithOwnListeners.class)).isTrue();
+    assertTrue(listener.isClassAnnotatedWithReport(SomeTestWithTextReport.class));
+    assertTrue(listener.isClassAnnotatedWithReport(TestWithOwnListeners.class));
   }
 
   @Test
   void allChildrenClassesInherit_GlobalTextReport() {
-    assertThat(listener.isClassAnnotatedWithReport(SomeTestWithGlobalTextReport.class)).isTrue();
+    assertTrue(listener.isClassAnnotatedWithReport(SomeTestWithGlobalTextReport.class));
   }
 
   @Listeners(TextReport.class)

--- a/modules/testng/src/test/java/integration/TestNgSoftTest.java
+++ b/modules/testng/src/test/java/integration/TestNgSoftTest.java
@@ -1,26 +1,52 @@
 package integration;
 
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.WebDriverRunner;
+import org.openqa.selenium.support.events.AbstractWebDriverEventListener;
+import org.openqa.selenium.support.events.WebDriverListener;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
 
 import static com.codeborne.selenide.AssertionMode.SOFT;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.open;
 
 public class TestNgSoftTest extends BaseTest {
+
+  private final WebDriverListener listener1 = new WebDriverListener() {
+    @Override
+    public void beforeAnyCall(Object target, Method method, Object[] args) {
+    }
+  };
+  private final AbstractWebDriverEventListener listener2 = new AbstractWebDriverEventListener() {
+  };
+
   @Override
   @BeforeSuite
   final void setupAsserts() {
     Configuration.assertionMode = SOFT;
+    closeWebDriver();
+    WebDriverRunner.addListener(listener1);
+    WebDriverRunner.addListener(listener2);
   }
 
   @BeforeMethod
   public void setUp() {
     open("/page_with_selects_without_jquery.html?browser=" + Configuration.browser);
+  }
+
+  @AfterClass
+  public void afterClass() {
+    WebDriverRunner.removeListener(listener1);
+    WebDriverRunner.removeListener(listener2);
+    closeWebDriver();
   }
 
   @Test

--- a/statics/build.gradle
+++ b/statics/build.gradle
@@ -8,6 +8,8 @@ dependencies {
   compileOnly("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+  testImplementation("org.mockito:mockito-core:$mockitoVersion")
+  testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
 }
 
 apply from: rootProject.file('gradle/publish-module.gradle')


### PR DESCRIPTION
This PR to guarantee #1850 will never happen again. 


Now we have at least two module (junit4) without both Mockito and AssertJ dependencies. This will verify that Selenide works without them (at least Selenium listeners need byte-buddy).

The case #1850 was that we removed byte-buddy dependency, and Selenide didn't work without it. But our tests didn't show the problem because we occasionally fetched transitive byte-buddy dependency from Mockito or AssertJ.

