### PR TITLE
#2007 make $.click(options) chainable

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1132,7 +1132,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    *
    * @see com.codeborne.selenide.commands.Click
    */
-  void click(ClickOptions clickOption);
+  SelenideElement click(ClickOptions clickOption);
 
   /**
    * Click the element

--- a/src/main/java/com/codeborne/selenide/commands/Click.java
+++ b/src/main/java/com/codeborne/selenide/commands/Click.java
@@ -19,12 +19,12 @@ import java.util.Arrays;
 import static com.codeborne.selenide.commands.Util.firstOf;
 
 @ParametersAreNonnullByDefault
-public class Click implements Command<Void> {
+public class Click implements Command<SelenideElement> {
   private final JavaScript jsSource = new JavaScript("click.js");
 
   @Override
   @Nullable
-  public Void execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     WebElement webElement = findElement(locator);
 
     if (args == null || args.length == 0) {
@@ -37,7 +37,7 @@ public class Click implements Command<Void> {
     else {
       throw new IllegalArgumentException("Unsupported click arguments: " + Arrays.toString(args));
     }
-    return null;
+    return proxy;
   }
 
   @Nonnull

--- a/statics/src/test/java/integration/ClickRelativeTest.java
+++ b/statics/src/test/java/integration/ClickRelativeTest.java
@@ -28,7 +28,10 @@ final class ClickRelativeTest extends IntegrationTest {
   void userCanClickElementWithOffsetPosition_withActions() {
     Configuration.clickViaJs = false;
 
-    $("#page").click(usingDefaultMethod().offset(123, 222));
+    $("#page")
+      .click(usingDefaultMethod())
+      .click(usingDefaultMethod().offset(10, 10))
+      .click(usingDefaultMethod().offset(123, 222));
 
     $("#coords").shouldHave(exactText("(523, 522)"));
   }


### PR DESCRIPTION
Unfortunately, we cannot make $.click() chainable because it's inherited from WebDriver.
So you cannot write 
> $.click().pressEnter();

But at least you can write
> $.click(withOffset(0, 0)).pressEnter();