### PR TITLE
Don't change pageLoadTimeout if it is negative. It allows to get rid of spam in error log on appium.

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -77,6 +77,9 @@ public class WebDriverFactory {
   }
 
   private void setLoadTimeout(Config config, WebDriver webdriver) {
+    if (config.pageLoadTimeout() < 0) {
+      return;
+    }
     try {
       webdriver.manage().timeouts().pageLoadTimeout(Duration.ofMillis(config.pageLoadTimeout()));
     }

--- a/statics/src/test/java/integration/PageLoadTimeoutTest.java
+++ b/statics/src/test/java/integration/PageLoadTimeoutTest.java
@@ -1,0 +1,37 @@
+package integration;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.WebDriverRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PageLoadTimeoutTest extends IntegrationTest {
+  @BeforeEach
+  void setUp() {
+    closeWebDriver();
+  }
+
+  @Test
+  void canChangeTimeout() {
+    Configuration.pageLoadTimeout = 666L;
+    openFile("page_with_selects_without_jquery.html");
+    assertThat(pageLoadTimeout())
+      .isEqualTo(666L);
+  }
+
+  @Test
+  void dontChangeTimeoutIfNegative() {
+    Configuration.pageLoadTimeout = -1L;
+    openFile("page_with_selects_without_jquery.html");
+    assertThat(pageLoadTimeout())
+      .describedAs("300000L is default page load timeout value from Selenium")
+      .isEqualTo(300000L);
+  }
+
+  private long pageLoadTimeout() {
+    return WebDriverRunner.getWebDriver().manage().timeouts().getPageLoadTimeout().toMillis();
+  }
+}


### PR DESCRIPTION
It is annoying to see for each test:
```
    [Test worker] INFO com.codeborne.selenide.webdriver.WebDriverFactory - Failed to set page load timeout to 30000 ms: 
org.openqa.selenium.UnsupportedCommandException: {"value":{"error":"unknown method","message":"Not implemented yet for pageLoad."
,"stacktrace":"NotImplementedError: Not implemented yet for pageLoad.
at AndroidUiautomator2Driver.pageLoadTimeoutW3C (/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/basedriver/commands/timeout.js:83:9)\n    
at AndroidUiautomator2Driver.timeouts 
(/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/basedriver/commands/timeout.js:40:16)\n    
at commandExecutor (/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/basedriver/driver.js:335:9)\n    at /usr/local/lib/node_modules/appium/node_modules/async-lock/lib/index.js:146:12\n    
at AsyncLock._promiseTry (/usr/local/lib/node_modules/appium/node_modules/async-lock/lib/index.js:280:31)\n    at exec (/usr/local/lib/node_modules/appium/node_modules/async-lock/lib/index.js:145:9)\n    
at AsyncLock.acquire (/usr/local/lib/node_modules/appium/node_modules/async-lock/lib/index.js:162:3)\n   
 at AndroidUiautomator2Driver.executeCommand (/usr/local/lib/node_modules/appium/node_modules/appium-base-driver/lib/basedriver/driver.js:348:39)\n    at AppiumDriver.executeCommand (/usr/local/lib/node_modules/appium/lib/appiu
```