### PR TITLE
Fix an issue when a new tab size in headless chrome has incorrect size.

### DIFF
--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
   compileOnly("org.junit.jupiter:junit-jupiter-api:$junitVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+  testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
 
   testImplementation("org.mockito:mockito-core:$mockitoVersion")
   testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}

--- a/src/main/java/com/codeborne/selenide/Browser.java
+++ b/src/main/java/com/codeborne/selenide/Browser.java
@@ -31,6 +31,10 @@ public class Browser {
   }
 
   @CheckReturnValue
+  public boolean isChromium() {
+    return isChrome() || isEdge();
+  }
+  @CheckReturnValue
   public boolean isFirefox() {
     return FIREFOX.equalsIgnoreCase(name);
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -41,6 +41,9 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
     arguments.add("--no-sandbox");
     arguments.addAll(parseArguments(externalArguments));
     arguments.addAll(createHeadlessArguments(config));
+    if (config.headless() && config.browserSize() != null && BrowserResizer.isValidDimension(config.browserSize())) {
+      arguments.add(convertBrowserSizeToChromeFormat(config.browserSize()));
+    }
     return arguments;
   }
 
@@ -91,6 +94,12 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
       arguments.add("--mute-audio");
     }
     return arguments;
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  private String convertBrowserSizeToChromeFormat(String browserSize) {
+    return "--window-size=" + browserSize.replace("x", ",");
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/webdriver/BrowserResizer.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/BrowserResizer.java
@@ -5,14 +5,20 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.regex.Pattern;
 
 class BrowserResizer {
+  private static final Pattern DIMENSION_REGEX = Pattern.compile("\\d+x\\d+");
   private static final Logger log = LoggerFactory.getLogger(BrowserResizer.class);
 
   void adjustBrowserPosition(Config config, WebDriver driver) {
-    if (config.browserPosition() != null) {
-      log.info("Set browser position to {}", config.browserPosition());
-      String[] coordinates = config.browserPosition().split("x");
+    String browserPosition = config.browserPosition();
+    if (browserPosition != null) {
+      if (!isValidDimension(browserPosition)) {
+        throw new IllegalArgumentException(String.format("Browser position %s is incorrect", browserPosition));
+      }
+      log.info("Set browser position to {}", browserPosition);
+      String[] coordinates = browserPosition.split("x");
       int x = Integer.parseInt(coordinates[0]);
       int y = Integer.parseInt(coordinates[1]);
       Point target = new Point(x, y);
@@ -24,12 +30,20 @@ class BrowserResizer {
   }
 
   void adjustBrowserSize(Config config, WebDriver driver) {
-    if (config.browserSize() != null) {
-      log.info("Set browser size to {}", config.browserSize());
-      String[] dimension = config.browserSize().split("x");
+    String browserSize = config.browserSize();
+    if (browserSize != null) {
+      if (!isValidDimension(browserSize)) {
+        throw new IllegalArgumentException(String.format("Browser size %s is incorrect", browserSize));
+      }
+      log.info("Set browser size to {}", browserSize);
+      String[] dimension = browserSize.split("x");
       int width = Integer.parseInt(dimension[0]);
       int height = Integer.parseInt(dimension[1]);
       driver.manage().window().setSize(new org.openqa.selenium.Dimension(width, height));
     }
+  }
+
+  static boolean isValidDimension(String dimension) {
+    return DIMENSION_REGEX.matcher(dimension).matches();
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -65,8 +65,9 @@ public class WebDriverFactory {
 
     Browser browser = new Browser(config.browser(), config.headless());
     WebDriver webdriver = createWebDriverInstance(config, browser, proxy, browserDownloadsFolder);
-
-    browserResizer.adjustBrowserSize(config, webdriver);
+    if (needBrowserResize(webdriver)) {
+      browserResizer.adjustBrowserSize(config, webdriver);
+    }
     browserResizer.adjustBrowserPosition(config, webdriver);
     setLoadTimeout(config, webdriver);
 
@@ -75,7 +76,15 @@ public class WebDriverFactory {
     logSeleniumInfo();
     return webdriver;
   }
-
+  private boolean needBrowserResize(WebDriver webdriver) {
+    String browserName = "";
+    if (webdriver instanceof HasCapabilities) {
+      Capabilities capabilities = ((HasCapabilities) webdriver).getCapabilities();
+      browserName = capabilities.getBrowserName();
+    }
+    Browser browser = new Browser(browserName, false);
+    return !browser.isChromium();
+  }
   private void setLoadTimeout(Config config, WebDriver webdriver) {
     try {
       webdriver.manage().timeouts().pageLoadTimeout(Duration.ofMillis(config.pageLoadTimeout()));

--- a/src/test/java/com/codeborne/selenide/BrowserTest.java
+++ b/src/test/java/com/codeborne/selenide/BrowserTest.java
@@ -19,6 +19,15 @@ final class BrowserTest {
   }
 
   @Test
+  void chromiumBrowserTest() {
+    assertThat(new Browser(CHROME, false).isChromium()).isTrue();
+    assertThat(new Browser(EDGE, false).isChromium()).isTrue();
+    assertThat(new Browser(FIREFOX, false).isChromium()).isFalse();
+    assertThat(new Browser(IE, false).isChromium()).isFalse();
+    assertThat(new Browser(INTERNET_EXPLORER, false).isChromium()).isFalse();
+  }
+
+  @Test
   void mostBrowsersSupportInsecureCerts() {
     assertThat(new Browser(CHROME, false).supportsInsecureCerts()).isTrue();
     assertThat(new Browser(FIREFOX, false).supportsInsecureCerts()).isTrue();

--- a/src/test/java/com/codeborne/selenide/webdriver/BrowserResizerTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/BrowserResizerTest.java
@@ -2,10 +2,17 @@ package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.SelenideConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -32,5 +39,42 @@ final class BrowserResizerTest {
     factory.adjustBrowserPosition(config, webdriver);
 
     verify(webdriver.manage().window()).setPosition(new Point(20, 40));
+  }
+
+  @Test
+  void throwErrorIfBrowserWindowSizeIsIncorrect() {
+    config.browserSize("1600,800");
+
+    assertThatThrownBy(() -> factory.adjustBrowserSize(config, webdriver))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Browser size 1600,800 is incorrect");
+  }
+
+  @Test
+  void throwErrorIfBrowserPositionIsIncorrect() {
+    config.browserPosition("1600,800");
+
+    assertThatThrownBy(() -> factory.adjustBrowserPosition(config, webdriver))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Browser position 1600,800 is incorrect");
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSize")
+  void validateDimensionTest(String input, boolean expected) {
+    assertThat(BrowserResizer.isValidDimension(input)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> provideSize() {
+    return Stream.of(
+      Arguments.of("1920x1080", true),
+      Arguments.of("0x0", true),
+      Arguments.of("123X123", false),
+      Arguments.of("123х123", false),
+      Arguments.of("456", false),
+      Arguments.of("123,123", false),
+      Arguments.of("", false),
+      Arguments.of(" ", false)
+    );
   }
 }

--- a/statics/src/test/java/integration/ChromiumHeadlessBrowserSizeTest.java
+++ b/statics/src/test/java/integration/ChromiumHeadlessBrowserSizeTest.java
@@ -1,0 +1,33 @@
+package integration;
+
+import com.codeborne.selenide.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Dimension;
+import java.time.Duration;
+import static com.codeborne.selenide.WebDriverRunner.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+final class ChromiumHeadlessBrowserSizeTest extends IntegrationTest {
+
+  @BeforeEach
+  void setUp() {
+    assumeThat(isChrome() || isEdge()).isTrue();
+    assumeThat(Configuration.headless).isTrue();
+    closeWebDriver();
+    Configuration.browserSize = "1200x1000";
+    openFile("page_with_uploads.html");
+  }
+
+  @Test
+  void browserWindowSizeOnNewTabTest() {
+    Selenide.executeJavaScript("window.open()");
+    Selenide.Wait()
+      .withTimeout(Duration.ofSeconds(2))
+      .until(it -> it.getWindowHandles().size() == 2);
+    Selenide.switchTo().window(1);
+    Dimension newTabWindowsSize = WebDriverRunner.getWebDriver().manage().window().getSize();
+    assertThat(newTabWindowsSize).isEqualTo(new Dimension(1200, 1000));
+  }
+}


### PR DESCRIPTION
## Proposed changes

Fix an issue when a new tab size in headless chrome has incorrect size.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
