### PR TITLE
#2015 un-deprecate BasicAuthCredentials constructor without domain

### DIFF
--- a/src/main/java/com/codeborne/selenide/BasicAuthCredentials.java
+++ b/src/main/java/com/codeborne/selenide/BasicAuthCredentials.java
@@ -14,9 +14,13 @@ public class BasicAuthCredentials implements Credentials {
   public final String password;
 
   /**
-   * @deprecated Use constructor with domain, login and password
+   * Security warning:
+   * If you are using Selenide proxy, use another constructor (with domain parameter).
+   * This constructor is dangerous: without domain specified, Selenide proxy will send your credentials to ALL
+   * domains, including 3rd party services that your AUT or browser might call.
+   *
+   * If proxy is disabled, it's totally ok to use this constructor.
    */
-  @Deprecated
   public BasicAuthCredentials(String login, String password) {
     this("", login, password);
   }

--- a/src/test/java/com/codeborne/selenide/proxy/AuthenticationFilterTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/AuthenticationFilterTest.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.proxy;
 import com.browserup.bup.util.HttpMessageContents;
 import com.browserup.bup.util.HttpMessageInfo;
 import com.codeborne.selenide.BasicAuthCredentials;
+import com.codeborne.selenide.BearerTokenCredentials;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import org.junit.jupiter.api.Test;
 
@@ -87,7 +88,7 @@ final class AuthenticationFilterTest {
 
   @Test
   void shouldAddHeaderIfDomainIsEmpty_legacyMode() {
-    filter.setAuthentication(BEARER, new BasicAuthCredentials("username", "password"));
+    filter.setAuthentication(BEARER, new BearerTokenCredentials("", "password"));
     assertThat(filter.needsHeader("https://burger-queen.com")).isTrue();
     assertThat(filter.needsHeader("https://s3.aws.com")).isTrue();
     assertThat(filter.needsHeader("file:///foo/bar")).isTrue();
@@ -103,8 +104,8 @@ final class AuthenticationFilterTest {
   }
 
   private HttpMessageInfo info(String url) {
-    HttpMessageInfo info = mock(HttpMessageInfo.class);
-    when(info.getUrl()).thenReturn(url);
-    return info;
+    HttpMessageInfo messageInfo = mock(HttpMessageInfo.class);
+    when(messageInfo.getUrl()).thenReturn(url);
+    return messageInfo;
   }
 }


### PR DESCRIPTION
it's totally ok to use this constructor unless proxy is enabled.
