### PR TITLE
#1817 add methods to copy and paste content

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -244,6 +244,27 @@ public class SelenideDriver {
     return executeJavaScript("return document.activeElement");
   }
 
+  /**
+   * Returns selected text or empty string if no text is selected.
+   *
+   * @return selected text
+   */
+  @CheckReturnValue
+  @Nonnull
+  public String getSelectedText() {
+    return this.executeJavaScript("return window.getSelection.toString()");
+  }
+
+  /**
+   * Copy selected text or empty string if no text is selected to clipboard.
+   *
+   * @see #getClipboard()
+   * @see Clipboard
+   */
+  public void copy() {
+    this.getClipboard().setText(this.getSelectedText());
+  }
+
   @CheckReturnValue
   @Nonnull
   public SelenideWait Wait() {

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -83,6 +83,16 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement append(String text);
 
   /**
+   * Append text from clipboard to the text field and trigger "change" event.
+   *
+   * @see Clipboard
+   * @see com.codeborne.selenide.commands.Paste
+   */
+  @Nonnull
+  @CanIgnoreReturnValue
+  SelenideElement paste();
+
+  /**
    * Clear the input field
    *
    * <p>Basically it's the same as {@link WebElement#clear()}, but it works. :) </p>

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -92,6 +92,7 @@ public class Commands {
     add("setValue", new SetValue());
     add("val", new Val());
     add("append", new Append());
+    add("paste", new Paste());
     add("clear", inject(Clear.class));
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/Paste.java
+++ b/src/main/java/com/codeborne/selenide/commands/Paste.java
@@ -1,0 +1,26 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.ClipboardService;
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import static com.codeborne.selenide.impl.Plugins.inject;
+
+@ParametersAreNonnullByDefault
+public class Paste implements Command<SelenideElement> {
+  @Override
+  @Nonnull
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+    WebElement input = locator.getWebElement();
+    input.sendKeys(
+      inject(ClipboardService.class).getClipboard(locator.driver()).getText()
+    );
+    return proxy;
+  }
+}

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -712,6 +712,27 @@ public class Selenide {
   }
 
   /**
+   * Returns selected text or empty string if no text is selected.
+   *
+   * @return selected text
+   */
+  @CheckReturnValue
+  @Nonnull
+  public String getSelectedText() {
+    return getSelenideDriver().getSelectedText();
+  }
+
+  /**
+   * Copy selected text or empty string if no text is selected to clipboard.
+   *
+   * @see #clipboard()
+   * @see Clipboard
+   */
+  public void copy() {
+    getSelenideDriver().copy();
+  }
+
+  /**
    * Create a Page Object instance
    */
   @CheckReturnValue


### PR DESCRIPTION
From issue #1817 

## Proposed changes
- added `getSelectedText`, `copy` methods for `SelenideDriver` class
- added `getSelectedText`, `copy` methods for `Selenide` class
- added `paste`, method for `SelenideElement` class
- added `Paste` command

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
