### PR TITLE
Using junit5 soft assertAll instead of hard multi asserts

### DIFF
--- a/src/test/java/com/codeborne/selenide/BrowserTest.java
+++ b/src/test/java/com/codeborne/selenide/BrowserTest.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import org.eclipse.jetty.server.Authentication;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Browsers.CHROME;
@@ -8,6 +9,7 @@ import static com.codeborne.selenide.Browsers.FIREFOX;
 import static com.codeborne.selenide.Browsers.IE;
 import static com.codeborne.selenide.Browsers.INTERNET_EXPLORER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class BrowserTest {
   @Test
@@ -20,11 +22,14 @@ final class BrowserTest {
 
   @Test
   void chromiumBrowserTest() {
-    assertThat(new Browser(CHROME, false).isChromium()).isTrue();
-    assertThat(new Browser(EDGE, false).isChromium()).isTrue();
-    assertThat(new Browser(FIREFOX, false).isChromium()).isFalse();
-    assertThat(new Browser(IE, false).isChromium()).isFalse();
-    assertThat(new Browser(INTERNET_EXPLORER, false).isChromium()).isFalse();
+    assertAll(
+      "Browser is Chromium",
+      () -> assertTrue(new Browser(CHROME, false).isChromium(), CHROME),
+      () -> assertTrue(new Browser(EDGE, false).isChromium(), EDGE),
+      () -> assertFalse(new Browser(FIREFOX, false).isChromium(), FIREFOX),
+      () -> assertFalse(new Browser(IE, false).isChromium(), IE),
+      () -> assertFalse(new Browser(INTERNET_EXPLORER, false).isChromium(), INTERNET_EXPLORER)
+    );
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/BrowserTest.java
+++ b/src/test/java/com/codeborne/selenide/BrowserTest.java
@@ -1,6 +1,5 @@
 package com.codeborne.selenide;
 
-import org.eclipse.jetty.server.Authentication;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Browsers.CHROME;

--- a/src/test/java/com/codeborne/selenide/BrowserTest.java
+++ b/src/test/java/com/codeborne/selenide/BrowserTest.java
@@ -22,7 +22,7 @@ final class BrowserTest {
   @Test
   void chromiumBrowserTest() {
     assertAll(
-      "Browser is Chromium",
+      "Test if browser is Chromium",
       () -> assertTrue(new Browser(CHROME, false).isChromium(), CHROME),
       () -> assertTrue(new Browser(EDGE, false).isChromium(), EDGE),
       () -> assertFalse(new Browser(FIREFOX, false).isChromium(), FIREFOX),


### PR DESCRIPTION
## Problem

We currently use multi "hard" asserts in our tests such as below. This cause two problems:

1. If any of these tests fail, it does not allow other assertions to complete (even when they are independent of each other - as in the case of example below).
2. If there are more than one failures, we would only know about the next failure after fixing first and rerunning again. 
3. In case of boolean mismatches, the error messages are vague and not too readable. 

Original test example here: Here I am changing expectations for the first and the third test but the assertion stops after first failure and the error message is not too detailed.

```
@Test
  void chromiumBrowserTestModified() {
    assertThat(new Browser(CHROME, false).isChromium()).isFalse();
    assertThat(new Browser(EDGE, false).isChromium()).isTrue();
    assertThat(new Browser(FIREFOX, false).isChromium()).isTrue();
    assertThat(new Browser(IE, false).isChromium()).isFalse();
    assertThat(new Browser(INTERNET_EXPLORER, false).isChromium()).isFalse();
  }
```
Gives below error. 
```
Expecting value to be false but was true
org.opentest4j.AssertionFailedError: 
Expecting value to be false but was true
	at java.base@17.0.5/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base@17.0.5/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base@17.0.5/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base@17.0.5/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at app//com.codeborne.selenide.BrowserTest.chromiumBrowserTest_old(BrowserTest.java:36)
```

## Proposed Solution:
Considering we are using Junit5, we can use its soft assert method - assertAll - for writing multiple assert statements that are independent of each other. Benefits are:

1. In case of multiple failures, all the asserts will run irrespective if there are other failures in assertAll. Giving us an immediate feedback on all the broken asserts at the same time rather than one at a time.
2. In case of failure, we get all related errors neatly packaged under one group as below (compared to what we see above).

Comparing this to below test:

```
@Test
  void chromiumBrowserTest() {
    assertAll(
      "Test if browser is Chromium",
      () -> assertFalse(new Browser(CHROME, false).isChromium(), CHROME),
      () -> assertTrue(new Browser(EDGE, false).isChromium(), EDGE),
      () -> assertTrue(new Browser(FIREFOX, false).isChromium(), FIREFOX),
      () -> assertFalse(new Browser(IE, false).isChromium(), IE),
      () -> assertTrue(new Browser(INTERNET_EXPLORER, false).isChromium(), INTERNET_EXPLORER)
    );
  }
```
and below error message:

```
Test if browser is Chromium (3 failures)
	org.opentest4j.AssertionFailedError: chrome ==> expected: <false> but was: <true>
	org.opentest4j.AssertionFailedError: firefox ==> expected: <true> but was: <false>
	org.opentest4j.AssertionFailedError: internet explorer ==> expected: <true> but was: <false>
```
Not only all our assertions ran in one go but we also get useful error messages that shows what is wrong with each assertion. 

## Clarification
At this moment, I changed only one test to serve as a POC and to ask if this is seen as an acceptable and desirable solution. If yes, I would be happy to refactor all hard multi assert tests to convert them to junit5 soft multi assert tests. 

## Some references
- https://junit.org/junit5/docs/current/user-guide/#writing-tests-assertions  (we can do both multiple grouped assertions and multiple dependent assertions using Junit5)
- https://www.baeldung.com/junit5-assertall-vs-multiple-assertions (another good article to show the use case I shared in this PR)

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

P.S: I ran the command `gradlew check chrome_headless firefox_headless` and there are multiple errors even when I comment the test. So these appears to be pre existing. 
```
BUILD FAILED in 1m 28s
68 actionable tasks: 30 executed, 38 up-to-date
pramodyadav@Pramods-MBP selenide % 
```
