### PR TITLE
added method to return last made screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ It defines concise fluent API, natural language assertions and does some magic f
 
 Selenide is based on and is compatible to Selenium WebDriver 4.0+
 
-    @Test
-    public void login() {
-      open("/login");
-      $(By.name("user.name")).setValue("johny");
-      $("#submit").click();
-      $("#username").shouldHave(text("Hello, Johny!"));
-    }
+```java
+@Test
+public void login() {
+  open("/login");
+  $(By.name("user.name")).setValue("johny");
+  $("#submit").click();
+  $("#username").shouldHave(text("Hello, Johny!"));
+}
+```
 
 Look for [detailed comparison of Selenide and Selenium WebDriver API](https://github.com/selenide/selenide/wiki/Selenide-vs-Selenium).
 

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -62,6 +62,8 @@ public class ScreenShotLaboratory {
   private final Clock clock;
   protected final List<File> allScreenshots = new ArrayList<>();
   protected AtomicLong screenshotCounter = new AtomicLong();
+
+  protected ThreadLocal<Screenshot> lastScreenShot = new ThreadLocal<>();
   protected ThreadLocal<String> currentContext = withInitial(() -> "");
   protected ThreadLocal<List<File>> currentContextScreenshots = new ThreadLocal<>();
   protected ThreadLocal<List<File>> threadScreenshots = withInitial(ArrayList::new);
@@ -133,7 +135,9 @@ public class ScreenShotLaboratory {
     if (image != null) {
       addToHistory(image);
     }
-    return new Screenshot(toUrl(config, image), toUrl(config, source));
+    Screenshot screenshot = new Screenshot(toUrl(config, image), toUrl(config, source));
+    lastScreenShot.set(screenshot);
+    return screenshot;
   }
 
   @CheckReturnValue
@@ -338,6 +342,12 @@ public class ScreenShotLaboratory {
     synchronized (allScreenshots) {
       return allScreenshots.isEmpty() ? null : allScreenshots.get(allScreenshots.size() - 1);
     }
+  }
+
+  @CheckReturnValue
+  @Nullable
+  public Screenshot getLastScreenShot() {
+    return lastScreenShot.get();
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -257,10 +257,10 @@ public class ScreenShotLaboratory {
       currentContextScreenshots.get().add(screenshot);
     }
     synchronized (allScreenshots) {
-      allScreenshots.add(screenshot.getImage() == null ? null : new File(screenshot.getImage()));
+      allScreenshots.add(screenshot.getImage() == null ? null : fileFromUrl(screenshot.getImage()));
     }
     threadScreenshots.get().add(screenshot);
-    return screenshot.getImage() == null ? Optional.empty() : Optional.of(new File(screenshot.getImage()));
+    return screenshot.getImage() == null ? Optional.empty() : Optional.of(fileFromUrl(screenshot.getImage()));
   }
 
   @Nonnull
@@ -321,9 +321,9 @@ public class ScreenShotLaboratory {
     currentContext.set("");
     currentContextScreenshots.remove();
     return result.stream().map(screenshot -> screenshot.getImage() != null ?
-        new File(screenshot.getImage()) :
-        null
-      ).collect(Collectors.toList());
+      fileFromUrl(screenshot.getImage()) :
+      null
+    ).collect(Collectors.toList());
   }
 
   @CheckReturnValue
@@ -337,35 +337,43 @@ public class ScreenShotLaboratory {
   @CheckReturnValue
   @Nonnull
   public List<File> getThreadScreenshots() {
-    List<File> screenshots = threadScreenshots.get()
-      .stream()
-      .map(screenshot -> screenshot.getImage() == null ? null :new File(screenshot.getImage()))
-      .collect(Collectors.toList());
-    return screenshots == null ? emptyList() : unmodifiableList(screenshots);
+    List<Screenshot> screenshots = threadScreenshots.get();
+    if (screenshots == null) {
+      return emptyList();
+    } else {
+      return screenshots
+        .stream()
+        .map(screenshot -> screenshot.getImage() == null ? null : fileFromUrl(screenshot.getImage()))
+        .collect(Collectors.toList());
+    }
   }
 
   @CheckReturnValue
   @Nonnull
   public List<Screenshot> threadScreenshots() {
     List<Screenshot> screenshots = threadScreenshots.get();
-    return screenshots == null ? emptyList() : unmodifiableList(screenshots);
+    return screenshots == null ? emptyList() : screenshots;
   }
 
   @CheckReturnValue
   @Nonnull
   public List<File> getContextScreenshots() {
-    List<File> screenshots = currentContextScreenshots.get()
-      .stream()
-      .map(screenshot -> screenshot.getImage() == null ? null :new File(screenshot.getImage()))
-      .collect(Collectors.toList());
-    return screenshots == null ? emptyList() : unmodifiableList(screenshots);
+    List<Screenshot> screenshots = currentContextScreenshots.get();
+    if (screenshots == null) {
+      return emptyList();
+    } else {
+      return screenshots
+        .stream()
+        .map(screenshot -> screenshot.getImage() == null ? null : fileFromUrl(screenshot.getImage()))
+        .collect(Collectors.toList());
+    }
   }
 
   @CheckReturnValue
   @Nonnull
   public List<Screenshot> contextScreenshots() {
     List<Screenshot> screenshots = currentContextScreenshots.get();
-    return screenshots == null ? emptyList() : unmodifiableList(screenshots);
+    return screenshots == null ? emptyList() : screenshots;
   }
 
   @CheckReturnValue
@@ -447,6 +455,19 @@ public class ScreenShotLaboratory {
   }
 
   @CheckReturnValue
+  @Nullable
+  /**
+   * @param file need to be path with external form (containing protocol on start),
+   * @return instance of {@link File} without external form
+   */
+  private File fileFromUrl(String file) {
+    if (file == null) {
+      return null;
+    }
+    return new File(file.substring(file.indexOf("/")));
+  }
+
+  @CheckReturnValue
   @Nonnull
   private String formatScreenShotURL(String reportsURL, String screenshot) {
     Path current = Paths.get(System.getProperty("user.dir"));
@@ -486,8 +507,7 @@ public class ScreenShotLaboratory {
   private String encode(String str) {
     try {
       return URLEncoder.encode(str, StandardCharsets.UTF_8.name());
-    }
-    catch (UnsupportedEncodingException e) {
+    } catch (UnsupportedEncodingException e) {
       log.debug("Cannot encode path segment: {}", str, e);
       return str;
     }

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -346,7 +346,7 @@ public class ScreenShotLaboratory {
 
   @CheckReturnValue
   @Nullable
-  public Screenshot getLastScreenShot() {
+  public Screenshot getLastScreenShotAndPageSource() {
     return lastScreenShot.get();
   }
 

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -307,6 +307,14 @@ final class ScreenShotLaboratoryTest {
   }
 
   @Test
+  void gettingLastScreenshotReturnsNotNull() {
+    config.screenshots(true);
+    screenshots.takeScreenshot(driver, true, true);
+
+    assertThat(ScreenShotLaboratory.getInstance().getLastScreenShot()).isNotNull();
+  }
+
+  @Test
   void printHtmlPath_if_savePageSourceIsEnabled() throws IOException {
     config.savePageSource(false);
     config.reportsUrl("http://ci.mycompany.com/job/666/artifact/");

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -311,7 +311,7 @@ final class ScreenShotLaboratoryTest {
     config.screenshots(true);
     screenshots.takeScreenshot(driver, true, true);
 
-    assertThat(ScreenShotLaboratory.getInstance().getLastScreenShot()).isNotNull();
+    assertThat(ScreenShotLaboratory.getInstance().getLastScreenShotAndPageSource()).isNotNull();
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -435,11 +435,10 @@ final class ScreenShotLaboratoryTest {
   }
 
   @Test
-  void printHtmlPath_if_savePageSourceIsEnabled() throws IOException {
+  void printHtmlPath_if_savePageSourceIsEnabled() {
     config.savePageSource(false);
     config.reportsUrl("http://ci.mycompany.com/job/666/artifact/");
     doReturn(new File("build/reports/page123.html")).when(extractor).extract(eq(config), eq(webDriver), any());
-    doReturn(asTemporaryFile("/screenshot.png")).when(webDriver).getScreenshotAs(FILE);
 
     Screenshot screenshot = screenshots.takeScreenshot(driver, true, true);
     assertThat(screenshot.summary()).isEqualTo(String.format(

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -200,6 +200,49 @@ final class ScreenShotLaboratoryTest {
   }
 
   @Test
+  void canGetLastThreadFullScreenshot() {
+    assertThat(screenshots.lastThreadScreenshot()).isEmpty();
+
+    Screenshot screenshot1 = screenshots.takeScreenshot(driver, true, true);
+    assertThat(screenshots.lastThreadScreenshot())
+      .map(Screenshot::summary)
+      .hasValue(screenshot1.summary());
+
+    Screenshot screenshot2 = screenshots.takeScreenshot(driver, true, true);
+    assertThat(screenshots.lastThreadScreenshot())
+      .map(Screenshot::summary)
+      .hasValue(screenshot2.summary());
+
+    Screenshot screenshot3 = screenshots.takeScreenshot(driver, true, true);
+    assertThat(screenshots.lastThreadScreenshot())
+      .map(Screenshot::summary)
+      .hasValue(screenshot3.summary());
+  }
+
+  @Test
+  void canGetLastContextFullScreenshot() {
+    assertThat(screenshots.lastContextScreenshot()).isEmpty();
+
+    screenshots.startContext("ui/MyTest/test_some_method/");
+    assertThat(screenshots.lastContextScreenshot()).isEmpty();
+
+    Screenshot screenshot1 = screenshots.takeScreenshot(driver, true, true);
+    assertThat(screenshots.lastContextScreenshot())
+      .map(Screenshot::summary)
+      .hasValue(screenshot1.summary());
+
+    Screenshot screenshot2 = screenshots.takeScreenshot(driver, true, true);
+    assertThat(screenshots.lastContextScreenshot())
+      .map(Screenshot::summary)
+      .hasValue(screenshot2.summary());
+
+    Screenshot screenshot3 = screenshots.takeScreenshot(driver, true, true);
+    assertThat(screenshots.lastContextScreenshot())
+      .map(Screenshot::summary)
+      .hasValue(screenshot3.summary());
+  }
+
+  @Test
   void canGetLastContextScreenshot() {
     assertThat(screenshots.getLastContextScreenshot())
       .isEmpty();

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -307,11 +307,88 @@ final class ScreenShotLaboratoryTest {
   }
 
   @Test
-  void gettingLastScreenshotReturnsNotNull() {
+  void screenshotAddedToThreadScreenshots() {
     config.screenshots(true);
     screenshots.takeScreenshot(driver, true, true);
 
-    assertThat(ScreenShotLaboratory.getInstance().getLastScreenShotAndPageSource()).isNotNull();
+    assertThat(screenshots.threadScreenshots()).size().isEqualTo(1);
+  }
+
+  @Test
+  void imageIsAccesableFromThreadScreenshots() {
+    config.screenshots(true);
+    Screenshot screenshot = screenshots.takeScreenshot(driver, true, true);
+
+    assertThat(screenshots.threadScreenshots().get(0).getImage()).isEqualTo(screenshot.getImage());
+  }
+
+  @Test
+  void inThreadScreenshotsImageValueIsNullIfFlagWasDisabledF() {
+    config.screenshots(true);
+    screenshots.takeScreenshot(driver, false, true);
+
+    assertThat(screenshots.threadScreenshots().get(0).getImage()).isNull();
+  }
+
+  @Test
+  void inThreadScreenshotsSourceValueIsNullIfFlagWasDisabledF() {
+    config.screenshots(true);
+    screenshots.takeScreenshot(driver, true, false);
+
+    assertThat(screenshots.threadScreenshots().get(0).getSource()).isNull();
+  }
+
+  @Test
+  void sourceIsAccesableFromThreadScreenshots() {
+    config.screenshots(true);
+    Screenshot screenshot = screenshots.takeScreenshot(driver, true, true);
+
+    assertThat(screenshots.threadScreenshots().get(0).getSource()).isEqualTo(screenshot.getSource());
+  }
+
+  @Test
+  void imageIsAccesableFromCurrentContextScreenshots() {
+    config.screenshots(true);
+    screenshots.startContext("ui/MyTest/test_some_method/");
+    Screenshot screenshot = screenshots.takeScreenshot(driver, true, true);
+
+    assertThat(screenshots.contextScreenshots().get(0).getImage()).isEqualTo(screenshot.getImage());
+  }
+
+  @Test
+  void inCurrentContextScreenshotsImageValueIsNullIfFlagWasDisabledF() {
+    config.screenshots(true);
+    screenshots.startContext("ui/MyTest/test_some_method/");
+    screenshots.takeScreenshot(driver, false, true);
+
+    assertThat(screenshots.contextScreenshots().get(0).getImage()).isNull();
+  }
+
+  @Test
+  void inCurrentContextScreenshotsSourceValueIsNullIfFlagWasDisabledF() {
+    config.screenshots(true);
+    screenshots.startContext("ui/MyTest/test_some_method/");
+    screenshots.takeScreenshot(driver, true, false);
+
+    assertThat(screenshots.contextScreenshots().get(0).getSource()).isNull();
+  }
+
+  @Test
+  void sourceIsAccesableFromCurrentContextScreenshots() {
+    config.screenshots(true);
+    screenshots.startContext("ui/MyTest/test_some_method/");
+    Screenshot screenshot = screenshots.takeScreenshot(driver, true, true);
+
+    assertThat(screenshots.contextScreenshots().get(0).getSource()).isEqualTo(screenshot.getSource());
+  }
+
+  @Test
+  void screenshotAddedToCurrentContextScreenshots() {
+    config.screenshots(true);
+    screenshots.startContext("ui/MyTest/test_some_method/");
+    screenshots.takeScreenshot(driver, true, true);
+
+    assertThat(screenshots.contextScreenshots()).size().isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes
After taking screenshots (including page source) I needed functionality to get page source, but all the existing methods were returning only images. 

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added one unit test  to check that getter is returning non null value