### PR TITLE
#2087 support @As annotation for page object fields

### DIFF
--- a/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
+++ b/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
@@ -15,6 +15,7 @@ import org.openqa.selenium.support.FindBy;
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.Selenide.page;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -64,6 +65,30 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
       );
   }
 
+  @Test
+  void fieldWithDollarAndAlias() {
+    assertThatThrownBy(() ->
+      $(page.header4).shouldHave(text("expected text"))
+    )
+      .isInstanceOf(ElementShould.class)
+      .hasMessageStartingWith("""
+          Element "Dollar header" should have text "expected text" {h1}
+          """.trim()
+      );
+  }
+
+  @Test
+  void collectionWithDollarAndAlias() {
+    assertThatThrownBy(() ->
+      page.header5.shouldHave(size(666))
+    )
+      .isInstanceOf(ListSizeMismatch.class)
+      .hasMessageStartingWith("""
+          List size mismatch: expected: = 666, actual: 4, collection: Dollar collection {h2}
+          """.trim()
+      );
+  }
+
   static class PageObject {
     @As("Large header")
     @FindBy(tagName = "h1")
@@ -76,5 +101,11 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
     @As("Tiny header")
     @FindBy(tagName = "h6")
     WebElement header3;
+
+    @As("Dollar header")
+    SelenideElement header4 = $("h1");
+
+    @As("Dollar collection")
+    ElementsCollection header5 = $$("h2");
   }
 }


### PR DESCRIPTION
... not annotated by @FindBy, but initialized with $ or $$.

This pull request allows to declare page object fields with `$` or `$$`, but mark them with annotation `@As`:

```java
static class PageObject {
    @As("Dollar header")
    SelenideElement header4 = $("h1");

    @As("Dollar collection")
    ElementsCollection header5 = $$("h2");
}
```

@PramodKumarYadav