### PR TITLE
fix broken tests on Windows

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/Screenshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/Screenshot.java
@@ -3,14 +3,23 @@ package com.codeborne.selenide.impl;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.File;
 
 public class Screenshot {
+  private final File imageFile;
   private final String image;
   private final String source;
 
-  public Screenshot(@Nullable String image, @Nullable String source) {
-    this.image = image;
+  public Screenshot(@Nullable File imageFile, @Nullable String imageUrl, @Nullable String source) {
+    this.imageFile = imageFile;
+    this.image = imageUrl;
     this.source = source;
+  }
+
+  @CheckReturnValue
+  @Nullable
+  File getImageFile() {
+    return imageFile;
   }
 
   @CheckReturnValue
@@ -28,7 +37,7 @@ public class Screenshot {
   @CheckReturnValue
   @Nonnull
   public static Screenshot none() {
-    return new Screenshot((String) null, null);
+    return new Screenshot(null, null, null);
   }
 
   public boolean isPresent() {

--- a/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenShotLaboratoryTest.java
@@ -81,13 +81,13 @@ final class ScreenShotLaboratoryTest {
     assertThat(screenshots.takeScreenshot(driver, true, false).getImage())
       .isEqualTo(String.format("%s/build/reports/tests/ui/MyTest/test_some_method/%s.2.png", workingDirectory, ts));
 
-    List<File> contextScreenshots = screenshots.finishContext();
+    List<Screenshot> contextScreenshots = screenshots.finishContext();
     assertThat(contextScreenshots).hasSize(3);
-    assertThat(contextScreenshots.get(0))
+    assertThat(contextScreenshots.get(0).getImageFile())
       .hasToString(dir + normalize(String.format("/build/reports/tests/ui/MyTest/test_some_method/%s.0.png", ts)));
-    assertThat(contextScreenshots.get(1))
+    assertThat(contextScreenshots.get(1).getImageFile())
       .hasToString(dir + normalize(String.format("/build/reports/tests/ui/MyTest/test_some_method/%s.1.png", ts)));
-    assertThat(contextScreenshots.get(2))
+    assertThat(contextScreenshots.get(2).getImageFile())
       .hasToString(dir + normalize(String.format("/build/reports/tests/ui/MyTest/test_some_method/%s.2.png", ts)));
   }
 

--- a/src/test/java/com/codeborne/selenide/impl/ScreenshotTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ScreenshotTest.java
@@ -2,13 +2,15 @@ package com.codeborne.selenide.impl;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+
 import static java.lang.System.lineSeparator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ScreenshotTest {
   @Test
   void summary() {
-    assertThat(new Screenshot("/home/user/shot.png", "/home/user/shot.html").summary())
+    assertThat(new Screenshot(new File("shot.png"), "/home/user/shot.png", "/home/user/shot.html").summary())
       .isEqualTo(lineSeparator() + "Screenshot: /home/user/shot.png" +
         lineSeparator() + "Page source: /home/user/shot.html");
   }
@@ -20,24 +22,24 @@ class ScreenshotTest {
 
   @Test
   void summary_with_only_image() {
-    assertThat(new Screenshot("/home/user/shot.png", null).summary())
+    assertThat(new Screenshot(new File("shot.png"), "/home/user/shot.png", null).summary())
       .isEqualTo(lineSeparator() + "Screenshot: /home/user/shot.png");
   }
 
   @Test
   void summary_with_only_page_source() {
-    assertThat(new Screenshot(null, "/home/user/shot.html").summary())
+    assertThat(new Screenshot(null, null, "/home/user/shot.html").summary())
       .isEqualTo(lineSeparator() + "Page source: /home/user/shot.html");
   }
 
   @Test
   void isPresent_ifHasImage() {
-    assertThat(new Screenshot("/home/user/shot.png", null).isPresent()).isTrue();
+    assertThat(new Screenshot(new File("shot.png"), "/home/user/shot.png", null).isPresent()).isTrue();
   }
 
   @Test
   void isPresent_ifHasSource() {
-    assertThat(new Screenshot(null, "/home/user/shot.html").isPresent()).isTrue();
+    assertThat(new Screenshot(null, null, "/home/user/shot.html").isPresent()).isTrue();
   }
 
   @Test

--- a/statics/src/main/java/com/codeborne/selenide/Screenshots.java
+++ b/statics/src/main/java/com/codeborne/selenide/Screenshots.java
@@ -89,7 +89,7 @@ public class Screenshots {
   }
 
   @Nonnull
-  public static List<File> finishContext() {
+  public static List<Screenshot> finishContext() {
     return screenshots.finishContext();
   }
 


### PR DESCRIPTION
In fact, this PR changes public API a little bit (e.g. method `finishContext()` returns `List<Screenshot>` instead of `List<File>`), but I think it's not a problem because hardly someone uses these methods. They were added a long time ago "just in case". :)