### PR TITLE
#2054 fail the test if unexpected alert encountered

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -9,6 +9,7 @@ import com.codeborne.selenide.ex.UIAssertionError;
 import com.codeborne.selenide.logevents.SelenideLog;
 import com.codeborne.selenide.logevents.SelenideLogger;
 import org.openqa.selenium.JavascriptException;
+import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriverException;
 
 import javax.annotation.CheckReturnValue;
@@ -163,6 +164,7 @@ class SelenideElementProxy implements InvocationHandler {
     if (e instanceof IllegalArgumentException) return false;
     if (e instanceof ReflectiveOperationException) return false;
     if (e instanceof JavascriptException) return false;
+    if (e instanceof UnhandledAlertException) return false;
 
     return e instanceof Exception || e instanceof AssertionError;
   }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -9,6 +9,7 @@ import com.codeborne.selenide.ex.ElementShould;
 import com.codeborne.selenide.ex.ElementShouldNot;
 import com.codeborne.selenide.ex.UIAssertionError;
 import org.openqa.selenium.By;
+import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
@@ -120,8 +121,16 @@ public abstract class WebElementSource {
       lastError = e;
     }
 
+    return handleError(prefix, condition, invert, check, lastError, element, checkResult);
+  }
+
+  private WebElement handleError(String prefix, Condition condition, boolean invert, Condition check,
+                                 @Nullable Throwable lastError, @Nullable WebElement element, @Nullable CheckResult checkResult) {
     if (lastError != null && Cleanup.of.isInvalidSelectorError(lastError)) {
       throw Cleanup.of.wrapInvalidSelectorException(lastError);
+    }
+    if (lastError instanceof UnhandledAlertException unhandledAlertException) {
+      throw unhandledAlertException;
     }
 
     if (element == null) {

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import static com.codeborne.selenide.impl.FileHelper.ensureFolderExists;
 import static java.lang.Integer.parseInt;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.openqa.selenium.UnexpectedAlertBehaviour.ACCEPT_AND_NOTIFY;
+import static org.openqa.selenium.UnexpectedAlertBehaviour.ACCEPT;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_VERSION;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
@@ -75,7 +75,7 @@ public abstract class AbstractDriverFactory implements DriverFactory {
     if (browser.supportsInsecureCerts()) {
       capabilities.setCapability(ACCEPT_INSECURE_CERTS, true);
     }
-    capabilities.setCapability(UNHANDLED_PROMPT_BEHAVIOUR, ACCEPT_AND_NOTIFY);
+    capabilities.setCapability(UNHANDLED_PROMPT_BEHAVIOUR, ACCEPT);
 
     transferCapabilitiesFromSystemProperties(capabilities);
 

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractDriverFactory.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import static com.codeborne.selenide.impl.FileHelper.ensureFolderExists;
 import static java.lang.Integer.parseInt;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.openqa.selenium.UnexpectedAlertBehaviour.ACCEPT_AND_NOTIFY;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_VERSION;
 import static org.openqa.selenium.remote.CapabilityType.PAGE_LOAD_STRATEGY;
@@ -74,7 +75,7 @@ public abstract class AbstractDriverFactory implements DriverFactory {
     if (browser.supportsInsecureCerts()) {
       capabilities.setCapability(ACCEPT_INSECURE_CERTS, true);
     }
-    capabilities.setCapability(UNHANDLED_PROMPT_BEHAVIOUR, "accept");
+    capabilities.setCapability(UNHANDLED_PROMPT_BEHAVIOUR, ACCEPT_AND_NOTIFY);
 
     transferCapabilitiesFromSystemProperties(capabilities);
 

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
@@ -18,6 +18,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.InvalidSelectorException;
 import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.NotFoundException;
+import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -302,6 +303,12 @@ final class SelenideElementProxyTest {
   @Test
   void shouldNotRetry_onJavaScriptException() {
     JavascriptException exception = new JavascriptException("bla");
+    assertThat(shouldRetryAfterError(exception)).isFalse();
+  }
+
+  @Test
+  void shouldNotRetry_onUnhandledAlertException() {
+    UnhandledAlertException exception = new UnhandledAlertException("unexpected alert open: {Alert text : Are you sure, Greg?}");
     assertThat(shouldRetryAfterError(exception)).isFalse();
   }
 

--- a/statics/src/test/java/integration/AlertTest.java
+++ b/statics/src/test/java/integration/AlertTest.java
@@ -4,10 +4,12 @@ import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.ex.AlertNotFoundException;
 import com.codeborne.selenide.ex.DialogTextMismatch;
+import com.codeborne.selenide.ex.UIAssertionError;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.UnhandledAlertException;
 
 import static com.codeborne.selenide.Condition.empty;
 import static com.codeborne.selenide.Condition.text;
@@ -28,6 +30,20 @@ final class AlertTest extends IntegrationTest {
   @BeforeEach
   void openTestPage() {
     openFile("page_with_alerts.html");
+  }
+
+  @Test
+  void unexpectedAlert() {
+    Configuration.timeout = 100;
+    $(By.name("username")).val("Greg");
+    $(byValue("Alert button")).click();
+    assertThatThrownBy(() -> $("#message").shouldHave(text("Hello, Greg!")))
+      .isInstanceOf(UIAssertionError.class)
+      .hasMessageStartingWith("UnhandledAlertException: ")
+      .hasMessageContaining("Are you sure, Greg?")
+      .hasMessageContaining("Screenshot:")
+      .hasMessageContaining("Page source:")
+      .hasCauseInstanceOf(UnhandledAlertException.class);
   }
 
   @Test

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -71,6 +71,7 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     Configuration.fileDownload = HTTPGET;
     Configuration.reopenBrowserOnFail = Boolean.parseBoolean(System.getProperty("selenide.reopenBrowserOnFail", "false"));
     Configuration.textCheck = FULL_TEXT;
+    Configuration.browserCapabilities = new MutableCapabilities();
   }
 
   protected void openFile(String fileName) {


### PR DESCRIPTION
By default, Selenide silently closes all unexpected alerts, and users don't have any chance to see it and know the alert message. 

Now you can catch the unexpected alerts and know their message (in order to fix the cause).
You only need to add this line to your setup:
```java
import static org.openqa.selenium.UnexpectedAlertBehaviour.ACCEPT_AND_NOTIFY;
import static org.openqa.selenium.remote.CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR;

Configuration.browserCapabilities.setCapability(UNHANDLED_PROMPT_BEHAVIOUR, ACCEPT_AND_NOTIFY);
```
