### PR TITLE
made setvalueoptions contructor as protected to reuse in selenide-appium

### DIFF
--- a/src/main/java/com/codeborne/selenide/SetValueOptions.java
+++ b/src/main/java/com/codeborne/selenide/SetValueOptions.java
@@ -17,7 +17,7 @@ public class SetValueOptions {
   private final CharSequence displayedText;
   private final SetValueMethod method;
 
-  private SetValueOptions(SetValueMethod method, CharSequence value, CharSequence displayedText) {
+  protected SetValueOptions(SetValueMethod method, CharSequence value, CharSequence displayedText) {
     this.method = method;
     this.value = value;
     this.displayedText = displayedText;


### PR DESCRIPTION
## Proposed changes
I wanted to extend SetValueOptions class with AppiumSetValueOptions. Hence changing the access modifier to protected.

For more details about the change - https://github.com/selenide/selenide-appium/pull/119

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
