### PR TITLE
#2108 fix failing tests introduced in PR #2108

### DIFF
--- a/src/test/resources/start_page.html
+++ b/src/test/resources/start_page.html
@@ -8,5 +8,10 @@
 <body>
 <h1>Selenide</h1>
 <h2 id="start-selenide">Start page</h2>
+
+<div>
+  <span id="greeting">Hello_my_friend</span>
+</div>
+
 </body>
 </html>

--- a/statics/src/test/java/integration/CopyPasteTest.java
+++ b/statics/src/test/java/integration/CopyPasteTest.java
@@ -1,10 +1,13 @@
 package integration;
 
-import com.codeborne.selenide.Selenide;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Condition.exactText;
+import static com.codeborne.selenide.Condition.value;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.clipboard;
+import static com.codeborne.selenide.Selenide.copy;
+import static com.codeborne.selenide.Selenide.getSelectedText;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class CopyPasteTest extends IntegrationTest {
@@ -17,23 +20,26 @@ final class CopyPasteTest extends IntegrationTest {
   @Test
   void copyEmptySelection() {
     openFile("start_page.html");
-    Selenide.clipboard().setText("text");
-    Selenide.copy();
-    assertThat(Selenide.clipboard().getText()).isEmpty();
+    clipboard().setText("text");
+    copy();
+    assertThat(clipboard().getText()).isEmpty();
   }
 
   @Test
   void copyNonEmptySelection() {
     openFile("start_page.html");
-    Selenide.$("h1").doubleClick();
-    Selenide.copy();
-    assertThat(Selenide.clipboard().getText()).isEqualTo("Selenide");
+    $("#greeting").doubleClick();
+    assertThat(getSelectedText()).isEqualTo("Hello_my_friend");
+    copy();
+    assertThat(clipboard().getText()).isEqualTo("Hello_my_friend");
   }
 
   @Test
   void pasteToField() {
     openFile("page_with_inputs_and_hints.html");
-    Selenide.clipboard().setText("text");
-    Selenide.$("#username").paste().shouldHave(exactText("text"));
+    clipboard().setText("text");
+    $("#username")
+      .paste()
+      .shouldHave(value("text"));
   }
 }


### PR DESCRIPTION
1. "double-click" on element "h1" didn't have any effect because it clicks the center of `<h1>`. But it's 100% width, so in the middle of it is just an empty space.
2. text of `$(#username)` is always empty because it's an input field. We need to check its value, not text.

