### PR TITLE
ignore binary files that we do not want to track in git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ chromedriver.log
 .settings
 integration/ScreenshotTest/canTakeScreenshotOfElement/
 classes
+
+# Ignore all binary files
+modules/*/bin
+statics/bin


### PR DESCRIPTION
## Proposed changes
There are more than 1k+ files that are shown as changed and eligible for version control in git, when in reality, I only touched two files.
<img width="524" alt="Screenshot 2023-01-13 at 00 53 13" src="https://user-images.githubusercontent.com/11694972/212205752-22a52aaa-b4eb-4156-9a29-62224cfa4e54.png">

On close inspection all (except 4 files) were binary files under below two locations. 
And ignoring below two directories changed the files from 1k+ to the ones actually changed. 
`modules/*/bin`
`statics/bin`

<img width="771" alt="Screenshot 2023-01-13 at 00 58 25" src="https://user-images.githubusercontent.com/11694972/212206190-767447b3-6669-4036-a3d2-6bfe823eca1c.png">

Considering we are not tracking binary files in GitHub, I am adding a rule to ignore them to reduce the noice while working with git. 

## Checklist
Checklist is not applicable for below change. 
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
