### PR TITLE
add repo context

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,6 @@ Describe the big picture of your changes here to communicate to the maintainers 
 If it fixes a bug or resolves a feature request, be sure to link to that issue.
 
 ## Checklist
-- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
+- [ ] Checkstyle and unit tests are passed locally with my changes by running `./gradlew check chrome_headless firefox_headless` command
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation (if appropriate)


### PR DESCRIPTION
## Issue
Running the command mentinoed on checklist item one gives below error.

```
pramodyadav@Pramods-MBP selenide % gradlew check chrome_headless firefox_headless
zsh: command not found: gradlew
```

## Proposed changes
Running this command with current repo context works fine (as below).

```
pramodyadav@Pramods-MBP selenide % ./gradlew check chrome_headless firefox_headless
Configuration on demand is an incubating feature.

> Task :modules:core:compileJava
Jabel: initialized
```

> Note: This maybe a tiny thing to know for gradle users but it can throw a new gradle user off; unnecessary making them spend time trying to troubleshoot/fix this issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command 
     - No they didn't. Considering my current change is a typo fix in a PR template, I think these failures already exist from some other PR from past. 
- [ ] I have added tests that prove my fix is effective or that my feature works
     - NA.
- [ ] I have added necessary documentation (if appropriate)
    - NA.
