### PR TITLE
adding a unique test run directory to  Configuration.reportsFolder directory

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/TestRun.java
+++ b/statics/src/main/java/com/codeborne/selenide/TestRun.java
@@ -18,7 +18,7 @@ public class TestRun {
    */
   public static String getUniqueTestRunName() {
     // Idea is that a user typically would not have more than one month data, so starting with a month name, should keep data well sorted.
-    // Also, any typical test run would last for more than a month, so there is no need to add, milli or micro seconds in the name.
+    // Also, any typical test run would last for more than a second, so there is no need to add, milli or micro seconds in the name.
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("MMM-dd-yyyy-HH-mm-ss");
     return getUniqueTestRunName(dateTimeFormatter);
   }

--- a/statics/src/main/java/com/codeborne/selenide/TestRun.java
+++ b/statics/src/main/java/com/codeborne/selenide/TestRun.java
@@ -17,7 +17,8 @@ public class TestRun {
    * Since a test run is unique for all tests in a run, we only need to set this value once and as static - final.
    */
   public static String getUniqueTestRunName() {
-    //
+    // Idea is that a user typically would not have more than one month data, so starting with a month name, should keep data well sorted.
+    // Also, any typical test run would last for more than a month, so there is no need to add, milli or micro seconds in the name.
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("MMM-dd-yyyy-HH-mm-ss");
     return getUniqueTestRunName(dateTimeFormatter);
   }

--- a/statics/src/main/java/com/codeborne/selenide/TestRun.java
+++ b/statics/src/main/java/com/codeborne/selenide/TestRun.java
@@ -1,0 +1,41 @@
+package com.codeborne.selenide;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TestRun {
+  private static final Logger log = LoggerFactory.getLogger(TestRun.class);
+
+  private TestRun() {
+    throw new IllegalStateException("Util class");
+  }
+
+  /**
+   * Since a test run is unique for all tests in a run, we only need to set this value once and as static - final.
+   */
+  public static String getUniqueTestRunName() {
+    //
+    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("MMM-dd-yyyy-HH-mm-ss");
+    return getUniqueTestRunName(dateTimeFormatter);
+  }
+
+  /**
+   * Convenience method to allow for a different test run formatting then the one provided by default.
+   */
+  public static String getUniqueTestRunName(DateTimeFormatter dateTimeFormatter) {
+    String testRun = getFormattedDate(dateTimeFormatter);
+
+    log.info("Test run name: {}", testRun);
+    return testRun;
+  }
+
+  public static String getFormattedDate(DateTimeFormatter dateTimeFormatter) {
+    LocalDateTime localDateTime = LocalDateTime.now();
+    log.debug("Before formatting: {}", localDateTime);
+
+    return localDateTime.format(dateTimeFormatter);
+  }
+}

--- a/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
+++ b/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
@@ -103,7 +103,7 @@ public class ScreenShooterExtension implements BeforeEachCallback, AfterEachCall
    * @return
    */
   @Nonnull
-  public ScreenShooterExtension to(final String folderWithScreenshots, final DateTimeFormatter testRunDateTimeFormat ) {
+  public ScreenShooterExtension to(final String folderWithScreenshots, final DateTimeFormatter testRunDateTimeFormat) {
     Configuration.reportsFolder = String.format("%s/%s", folderWithScreenshots, getUniqueTestRunName(testRunDateTimeFormat));
     return this;
   }

--- a/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
+++ b/statics/src/main/java/com/codeborne/selenide/junit5/ScreenShooterExtension.java
@@ -12,7 +12,10 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.lang.reflect.Method;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
+
+import static com.codeborne.selenide.TestRun.getUniqueTestRunName;
 
 /**
  * Use this class to automatically take screenshots in case of ANY errors in tests (not only Selenide errors).
@@ -53,11 +56,11 @@ import java.util.Optional;
  * </pre>
  *
  * <p>
- *   Restrictions:
+ * Restrictions:
  * </p>
  * <p>
- *   This extension can only take screenshots for "static" webdriver managed by Selenide.
- *   It doesn't take screenshots for webdrivers created by your code, e.g. using {@code new SelenideDriver()}.
+ * This extension can only take screenshots for "static" webdriver managed by Selenide.
+ * It doesn't take screenshots for webdrivers created by your code, e.g. using {@code new SelenideDriver()}.
  * </p>
  *
  * @author Aliaksandr Rasolka
@@ -88,7 +91,20 @@ public class ScreenShooterExtension implements BeforeEachCallback, AfterEachCall
    */
   @Nonnull
   public ScreenShooterExtension to(final String folderWithScreenshots) {
-    Configuration.reportsFolder = folderWithScreenshots;
+    DateTimeFormatter testRunDateTimeFormat = DateTimeFormatter.ofPattern("MMM-dd-yyyy-HH-mm-ss");
+    to(folderWithScreenshots, testRunDateTimeFormat);
+    return this;
+  }
+
+  /**
+   * To provide a different date time format than the default one (above), if desired.
+   * @param folderWithScreenshots
+   * @param testRunDateTimeFormat
+   * @return
+   */
+  @Nonnull
+  public ScreenShooterExtension to(final String folderWithScreenshots, final DateTimeFormatter testRunDateTimeFormat ) {
+    Configuration.reportsFolder = String.format("%s/%s", folderWithScreenshots, getUniqueTestRunName(testRunDateTimeFormat));
     return this;
   }
 


### PR DESCRIPTION
## Issue
Currently the concept of a `unique test run` for all tests in a run is missing in the implementation for `Configuration.reportsFolder`. 

And although the user can easily implement this at users end by creating a static final constant to provide a test-run-id as here `Jan-12-2023-23-50-23`, considering a unique test run is a core testing concept, we are better off providing it our users from Selenide itself.

### Current implementation.

#### Case 1: User does not use ScreenShooterExtension.class
If a user takes examples from [here](as shown here: https://selenide.org/documentation/screenshots.html), they will often end up creating a static reports directory path either in the selenide.properties file or via program something like "test-result/test-runs"

After only a few test runs, this results into a lot of screenshots directly placed under one repository with no direct traceability on which screenshots belong to which test run. Example below.

<img width="226" alt="Screenshot 2023-01-13 at 01 20 29" src="https://user-images.githubusercontent.com/11694972/212208613-7848bc69-da73-458f-9453-72d7f12bba3c.png">

#### Case 2: Even if user uses ScreenShooterExtension.class, in just a few runs, the failures will keep accommodating under the same test runs, with no direct traceability from the reportsDirectory on which screenshots belong to which run. The only possibility is if user goes into logs and see one by one which screenshot is for which failure - which would be very time consuming. This situation is shown below. 
<img width="653" alt="Screenshot 2023-01-13 at 01 28 23" src="https://user-images.githubusercontent.com/11694972/212209438-c0a47de7-33ff-4a22-bfcd-3c2f4b6c5129.png">

## Proposed changes
Now we can easily deal with this traceability issue for each run by adding a `unique test run id` to the `Configuration.reportsFolder` where ever we first initialise it. This unique run id will then create a dynamic directory insider the static path of reportsFolder provided by the user to add all failures for a run inside that directory. This would then result in a situation as below where each run is unique and if a user runs tests multiple times, he/she exactly knows which screenshots are for the latest test run failures, without any need to go start looking for those inside the logs. As a side benefit, user now also gets a nice trend line based on date-time, that if user desires, can go and see exactly which run has what failures at what moment (without any confusion or mixing results from different runs)
 
<img width="665" alt="Screenshot 2023-01-13 at 01 33 36" src="https://user-images.githubusercontent.com/11694972/212210200-329d61bf-03d3-4fab-950a-5953c68d2f6c.png">

NOTE: At this moment, I have only created a PR for ScreenShooterExtension.class but if this PR and/or the concept is excepted, we would need to do the same for all places where we set  `Configuration.reportsFolder`. If you like this proposal, I can also create more PRs to make the behaviour uniform across app (with or without ScreenShooterExtension class).

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
     - No they didn't. Considering I saw the same errors with my another PR that involves a typo fix in a PR template, I think these failures already exist from some other PR from past.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have added necessary documentation (if appropriate)
