### PR TITLE
truncate only WebDriverException message

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/Cleanup.java
+++ b/src/main/java/com/codeborne/selenide/impl/Cleanup.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.impl;
 
 import org.openqa.selenium.InvalidSelectorException;
+import org.openqa.selenium.WebDriverException;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -21,7 +22,9 @@ public class Cleanup {
   @CheckReturnValue
   @Nonnull
   public String webdriverExceptionMessage(Throwable webDriverException) {
-    return requireNonNull(webdriverExceptionMessage(webDriverException.toString()));
+    return webDriverException instanceof WebDriverException ?
+      requireNonNull(webdriverExceptionMessage(webDriverException.toString())) :
+      webDriverException.toString();
   }
 
   @CheckReturnValue


### PR DESCRIPTION
* the initial intention was only to truncate long and non-information messages of WebDriverException like "(WARNING: The server did not provide...)"
* but now I see we truncate other exceptions also (probably containing useful multi-line error messages) that we shouldn't really truncate.
