### PR TITLE
remove step "git checkout HEAD^2" from github actions

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -34,10 +34,6 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
           java-version: 17
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:


### PR DESCRIPTION
it's no longer necessary. Code Scanning recommends analyzing the merge commit for best results.
