### PR TITLE
Extract the headless argument adding to a separate method to allow us…

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -57,7 +57,7 @@ public class ChromeDriverFactory extends AbstractChromiumDriverFactory {
 
     ChromeOptions options = new ChromeOptions();
     if (config.headless()) {
-      options.addArguments("--headless=new");
+      addHeadless(options);
     }
     if (isNotEmpty(config.browserBinary())) {
       log.info("Using browser binary: {}", config.browserBinary());
@@ -69,6 +69,10 @@ public class ChromeDriverFactory extends AbstractChromiumDriverFactory {
     setMobileEmulation(options);
 
     return options.merge(commonCapabilities);
+  }
+
+  protected void addHeadless(ChromeOptions options) {
+    options.addArguments("--headless=new");
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -53,7 +53,7 @@ public class EdgeDriverFactory extends AbstractChromiumDriverFactory {
     EdgeOptions options = createCommonCapabilities(new EdgeOptions(), config, browser, proxy);
     options.setCapability(ACCEPT_INSECURE_CERTS, true);
     if (config.headless()) {
-      options.addArguments("--headless=new");
+      addHeadless(options);
     }
 
     if (isNotEmpty(config.browserBinary())) {
@@ -64,6 +64,10 @@ public class EdgeDriverFactory extends AbstractChromiumDriverFactory {
     options.addArguments(createEdgeArguments(config));
     options.setExperimentalOption("prefs", prefs(browserDownloadsFolder, System.getProperty("edgeoptions.prefs", "")));
     return options;
+  }
+
+  protected void addHeadless(EdgeOptions options) {
+    options.addArguments("--headless=new");
   }
 
   @CheckReturnValue


### PR DESCRIPTION
Extract the headless argument adding to a separate method to allow users to override the headless flag value if necessary.