### PR TITLE
Fixed a bug where selenide.holdBrowserOpen were not read correctly

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -27,7 +27,7 @@ public class SelenideConfig implements Config {
   private String baseUrl = getProperty("selenide.baseUrl", "http://localhost:8080");
   private long timeout = Long.parseLong(getProperty("selenide.timeout", "4000"));
   private long pollingInterval = Long.parseLong(getProperty("selenide.pollingInterval", "200"));
-  private boolean holdBrowserOpen = Boolean.getBoolean(getProperty("selenide.holdBrowserOpen", "false"));
+  private boolean holdBrowserOpen = Boolean.parseBoolean(getProperty("selenide.holdBrowserOpen", "false"));
   private boolean reopenBrowserOnFail = Boolean.parseBoolean(getProperty("selenide.reopenBrowserOnFail", "true"));
   private boolean clickViaJs = Boolean.parseBoolean(getProperty("selenide.clickViaJs", "false"));
   private boolean screenshots = Boolean.parseBoolean(getProperty("selenide.screenshots", "true"));

--- a/src/test/java/com/codeborne/selenide/SelenideConfigTest.java
+++ b/src/test/java/com/codeborne/selenide/SelenideConfigTest.java
@@ -33,6 +33,12 @@ final class SelenideConfigTest {
     assertThat(new SelenideConfig().remote()).isNull();
   }
 
+  @Test
+  void getsHoldBrowserOpenFromSystemProperty() {
+    System.setProperty("selenide.holdBrowserOpen", "true");
+    assertThat(new SelenideConfig().holdBrowserOpen()).isEqualTo(true);
+  }
+
   @BeforeEach
   @AfterEach
   void setUp() {
@@ -42,5 +48,6 @@ final class SelenideConfigTest {
     System.setProperty("teamcity.buildType.id", "");
     System.setProperty("build.number", "");
     System.setProperty("selenide.remote", "");
+    System.setProperty("selenide.holdBrowserOpen", "");
   }
 }


### PR DESCRIPTION
## Proposed changes
Fixed a bug that the value of holdBrowserOpen was not read.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
