### PR TITLE
use built-in action `gradle-build-action`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         shell: pwsh
         run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: ${{ matrix.gradle-task }} --no-parallel --no-daemon --console=plain -i
       - uses: actions/upload-artifact@v3
@@ -55,7 +55,7 @@ jobs:
         if: ${{ matrix.gradle-task != 'check' }}
         uses: browser-actions/setup-firefox@latest
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: ${{ matrix.gradle-task }} --no-parallel --no-daemon --console=plain -i
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,9 @@ jobs:
         shell: pwsh
         run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
       - name: Build with Gradle
-        run: ./gradlew ${{ matrix.gradle-task }} --no-parallel --no-daemon --console=plain -i
+        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f
+        with:
+          arguments: ${{ matrix.gradle-task }} --no-parallel --no-daemon --console=plain -i
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -52,16 +54,10 @@ jobs:
       - name: Setup Firefox
         if: ${{ matrix.gradle-task != 'check' }}
         uses: browser-actions/setup-firefox@latest
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Build with Gradle
-        run: ./gradlew ${{ matrix.gradle-task }} --no-parallel --no-daemon --console=plain -i
+        uses: gradle/gradle-build-action@6095a76664413da4c8c134ee32e8a8ae900f0f1f
+        with:
+          arguments: ${{ matrix.gradle-task }} --no-parallel --no-daemon --console=plain -i
       - uses: actions/upload-artifact@v3
         if: failure()
         with:


### PR DESCRIPTION
... instead of just command line task `./gradlew test`

I hope it should be faster (probably because it can cache something smarter?)

+ remove action `actions/cache@v3` which is not needed anymore (I guess?)
