### PR TITLE
#2135 #2133 fix double-click with offset

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1277,6 +1277,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * </p>
    *
    * @see com.codeborne.selenide.commands.DoubleClick
+   * @since 6.13.0
    */
   @Nonnull
   @CanIgnoreReturnValue

--- a/src/main/java/com/codeborne/selenide/commands/Click.java
+++ b/src/main/java/com/codeborne/selenide/commands/Click.java
@@ -23,7 +23,7 @@ public class Click implements Command<SelenideElement> {
   private final JavaScript jsSource = new JavaScript("click.js");
 
   @Override
-  @Nullable
+  @Nonnull
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
     WebElement webElement = findElement(locator);
 
@@ -51,7 +51,7 @@ public class Click implements Command<SelenideElement> {
       clickViaJS(driver, element, 0, 0);
     }
     else {
-      defaultClick(element, driver);
+      defaultClick(driver, element);
     }
   }
 
@@ -93,7 +93,7 @@ public class Click implements Command<SelenideElement> {
     }
   }
 
-  protected void defaultClick(WebElement element, Driver driver) {
+  protected void defaultClick(Driver driver, WebElement element) {
     element.click();
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/DoubleClick.java
+++ b/src/main/java/com/codeborne/selenide/commands/DoubleClick.java
@@ -1,13 +1,9 @@
 package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.JavaScript;
-import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -16,23 +12,22 @@ public class DoubleClick extends Click {
   private final JavaScript jsSource = new JavaScript("dblclick.js");
 
   @Override
-  @Nonnull
-  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
-    return super.execute(proxy, locator, args);
-  }
-
-  @Override
   protected void clickViaJS(Driver driver, WebElement element, int offsetX, int offsetY) {
     jsSource.execute(driver, element, offsetX, offsetY);
   }
 
   @Override
-  protected void defaultClick(WebElement element, Driver driver) {
-    driver.actions().doubleClick(element).build().perform();
+  protected void defaultClick(Driver driver, WebElement element) {
+    driver.actions()
+      .doubleClick(element)
+      .build().perform();
   }
 
   @Override
   protected void defaultClick(Driver driver, WebElement element, int offsetX, int offsetY) {
-    driver.actions().moveByOffset(offsetX, offsetY).doubleClick(element).build().perform();
+    driver.actions()
+      .moveToElement(element, offsetX, offsetY)
+      .doubleClick()
+      .build().perform();
   }
 }

--- a/src/test/java/integration/Coordinates.java
+++ b/src/test/java/integration/Coordinates.java
@@ -1,0 +1,52 @@
+package integration;
+
+import com.codeborne.selenide.CheckResult;
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.Driver;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static java.lang.Integer.parseInt;
+
+@ParametersAreNonnullByDefault
+class Coordinates extends Condition {
+  private static final Pattern regex = Pattern.compile("\\((\\d+), (\\d+)\\)");
+  private final int expectedX;
+  private final int expectedY;
+
+  private Coordinates(int expectedX, int expectedY) {
+    super(String.format("coordinates %sx%s", expectedX, expectedY));
+    this.expectedX = expectedX;
+    this.expectedY = expectedY;
+  }
+
+  @Nonnull
+  @Override
+  public CheckResult check(Driver driver, WebElement element) {
+    String text = element.getText();
+    Matcher matcher = regex.matcher(text);
+    if (!matcher.matches()) {
+      return new CheckResult(REJECT, text);
+    }
+    int x = parseInt(matcher.replaceFirst("$1"));
+    int y = parseInt(matcher.replaceFirst("$2"));
+    if (Math.abs(x - expectedX) > 5) {
+      return new CheckResult(REJECT, text);
+    }
+    if (Math.abs(y - expectedY) > 5) {
+      return new CheckResult(REJECT, text);
+    }
+
+    return new CheckResult(ACCEPT, text);
+  }
+
+  public static Condition coordinates(int expectedX, int expectedY) {
+    return new Coordinates(expectedX, expectedY);
+  }
+}

--- a/src/test/java/integration/DoubleClickTest.java
+++ b/src/test/java/integration/DoubleClickTest.java
@@ -1,14 +1,20 @@
 package integration;
 
-import com.codeborne.selenide.ClickOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static com.codeborne.selenide.ClickOptions.usingDefaultMethod;
+import static com.codeborne.selenide.ClickOptions.usingJavaScript;
 import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.value;
+import static integration.Coordinates.coordinates;
 
+/**
+ * button size is 200x20  -> center point is at 100x10
+ * area is 800x400        -> center point is at 400x200
+ */
 final class DoubleClickTest extends ITest {
 
   @BeforeEach
@@ -28,7 +34,8 @@ final class DoubleClickTest extends ITest {
         .shouldHave(value("do not click me anymore"))
         .shouldBe(disabled);
 
-      $("h2").shouldHave(text("Double click worked"));
+      $("h2").shouldHave(text("Status: double-clicked the button"));
+      $("#coords").shouldHave(coordinates(100, 10));
     });
   }
 
@@ -40,11 +47,12 @@ final class DoubleClickTest extends ITest {
         .shouldBe(enabled);
 
       $("#double-clickable-button")
-        .doubleClick(ClickOptions.usingJavaScript())
+        .doubleClick(usingJavaScript())
         .shouldHave(value("do not click me anymore"))
         .shouldBe(disabled);
 
-      $("h2").shouldHave(text("Double click worked"));
+      $("h2").shouldHave(text("Status: double-clicked the button"));
+      $("#coords").shouldHave(coordinates(100, 10));
     });
   }
 
@@ -56,11 +64,40 @@ final class DoubleClickTest extends ITest {
         .shouldBe(enabled);
 
       $("#double-clickable-button")
-        .doubleClick(ClickOptions.usingDefaultMethod())
+        .doubleClick(usingDefaultMethod())
         .shouldHave(value("do not click me anymore"))
         .shouldBe(disabled);
 
-      $("h2").shouldHave(text("Double click worked"));
+      $("h2").shouldHave(text("Status: double-clicked the button"));
+      $("#coords").shouldHave(coordinates(100, 10));
     });
+  }
+
+  @Test
+  void userCanDoubleClickElement() {
+    $("#double-clickable-area").doubleClick(usingDefaultMethod());
+    $("h2").shouldHave(text("Status: double-clicked the area"));
+    $("#coords").shouldHave(coordinates(400, 200));
+  }
+
+  @Test
+  void userCanDoubleClickElement_usingJavaScript() {
+    $("#double-clickable-area").doubleClick(usingJavaScript());
+    $("h2").shouldHave(text("Status: double-clicked the area"));
+    $("#coords").shouldHave(coordinates(400, 200));
+  }
+
+  @Test
+  void userCanDoubleClickElement_withOffset() {
+    $("#double-clickable-area").doubleClick(usingDefaultMethod().offset(66, 33));
+    $("h2").shouldHave(text("Status: double-clicked the area"));
+    $("#coords").shouldHave(coordinates(466, 233));
+  }
+
+  @Test
+  void userCanDoubleClickElement_withOffset_usingJavaScript() {
+    $("#double-clickable-area").doubleClick(usingJavaScript().offset(66, 33));
+    $("h2").shouldHave(text("Status: double-clicked the area"));
+    $("#coords").shouldHave(coordinates(466, 233));
   }
 }

--- a/src/test/resources/page_with_double_clickable_button.html
+++ b/src/test/resources/page_with_double_clickable_button.html
@@ -4,29 +4,80 @@
   <title>Test::double-clickable-button</title>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <style>
+    #button-container {
+      width: 400px;
+    }
+    #double-clickable-button {
+      width: 200px;
+      height: 20px;
+    }
+    #double-clickable-area {
+      display: none;
+      position: relative;
+      width: 800px;
+      height: 400px;
+      left: 100px;
+      top: 50px;
+      border: 1px solid lightgreen;
+      text-align: center;
+    }
+    #double-clickable-area .marker {
+      position: absolute;
+      top: 66px;
+      left: 333px;
+      border: 1px solid darkgreen;
+    }
+  </style>
 </head>
 <body>
   <h1>Page with double-clickable button</h1>
+  <h2>Status: not clicked yet</h2>
+  <span id="coords"></span>
 
   <br/>
-  <div style="width: 400px">
+  <div id="button-container">
     <form>
       <input type="button" id="double-clickable-button" value="double click me" disabled>
     </form>
   </div>
-  <h2>not clicked yet</h2>
+
+  <div id="double-clickable-area">
+    <div>Double-click me if you can.</div>
+    <div>Area size: 800x400.</div>
+    <div class="marker">My coordinates are [333, 66]</div>
+  </div>
 
   <script>
     function onDbClickButton(event) {
-      var e = event || window.event;
-      document.querySelector('h2').innerText = 'Double click worked';
+      const e = event || window.event;
       e.target.value = 'do not click me anymore';
       e.target.disabled = true;
       e.stopImmediatePropagation();
+      document.querySelector('h2').innerText = 'Status: double-clicked the button';
+      document.querySelector('#coords').innerText = `(${event.offsetX}, ${event.offsetY})`;
     }
 
-    document.querySelector('#double-clickable-button').addEventListener('dblclick', onDbClickButton);
-    document.querySelector('#double-clickable-button').disabled = false;
+    const button = document.querySelector('#double-clickable-button');
+    button.addEventListener('dblclick', onDbClickButton);
+    button.disabled = false;
+  </script>
+
+  <script>
+    const area = document.querySelector('#double-clickable-area');
+
+    function onDbClickArea(event) {
+      const e = event || window.event;
+      e.stopImmediatePropagation();
+      const areaRect = area.getBoundingClientRect();
+      const x = Math.round(event.clientX - areaRect.left);
+      const y = Math.round(event.clientY - areaRect.top);
+      document.querySelector('h2').innerText = `Status: double-clicked the area at`;
+      document.querySelector('#coords').innerText = `(${x}, ${y})`;
+    }
+
+    area.addEventListener('dblclick', onDbClickArea);
+    area.style.display = 'block';
   </script>
 </body>
 </html>

--- a/statics/src/test/java/integration/ClickRelativeTest.java
+++ b/statics/src/test/java/integration/ClickRelativeTest.java
@@ -6,16 +6,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.interactions.MoveTargetOutOfBoundsException;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static com.codeborne.selenide.ClickOptions.*;
-import static com.codeborne.selenide.Condition.matchText;
+import static com.codeborne.selenide.ClickOptions.usingDefaultMethod;
+import static com.codeborne.selenide.ClickOptions.usingJavaScript;
+import static com.codeborne.selenide.ClickOptions.withOffset;
 import static com.codeborne.selenide.Selenide.$;
-import static java.lang.Integer.parseInt;
-import static org.assertj.core.api.Assertions.assertThat;
+import static integration.Coordinates.coordinates;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.data.Offset.offset;
 
 /**
  * Click with offset - calculates offset from the center of clicked element.
@@ -89,12 +85,6 @@ final class ClickRelativeTest extends IntegrationTest {
   }
 
   private void verifyCoordinates(int expectedX, int expectedY) {
-    String regex = "\\((\\d+), (\\d+)\\)";
-    $("#coords").shouldHave(matchText(regex));
-    Matcher matcher = Pattern.compile(regex).matcher($("#coords").text());
-    int x = parseInt(matcher.replaceFirst("$1"));
-    int y = parseInt(matcher.replaceFirst("$2"));
-    assertThat(x).isCloseTo(expectedX, offset(5));
-    assertThat(y).isCloseTo(expectedY, offset(5));
+    $("#coords").shouldHave(coordinates(expectedX, expectedY));
   }
 }


### PR DESCRIPTION
fixes https://github.com/selenide/selenide/pull/2135

it didn't really use given offset because method `Actions.doubleClick(element)` moves cursor to the center point of the element.

