### PR TITLE
setBinary is supported by Edge

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -58,7 +58,7 @@ public class EdgeDriverFactory extends AbstractChromiumDriverFactory {
 
     if (isNotEmpty(config.browserBinary())) {
       log.info("Using browser binary: {}", config.browserBinary());
-      log.warn("Changing browser binary not supported in Edge, setting will be ignored.");
+      options.setBinary(config.browserBinary());
     }
 
     options.addArguments(createEdgeArguments(config));


### PR DESCRIPTION
Ignoring `setBinary` was implemented in Edge–WebKit times. Current Crome-based Edge is supporting `setBinary`.

## Proposed changes
Now system property `selenide.browserBinary` will also work for Edge browser.
(Until now, it only worked for Chrome and Firefox).
