### PR TITLE
#2270 don't add `--no-sandbox` automatically

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -38,7 +38,6 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
     List<String> arguments = new ArrayList<>();
     arguments.add("--proxy-bypass-list=<-loopback>");
     arguments.add("--disable-dev-shm-usage");
-    arguments.add("--no-sandbox");
     arguments.addAll(parseArguments(externalArguments));
     arguments.addAll(createHeadlessArguments(config));
     if (config.browserSize() != null && BrowserResizer.isValidDimension(config.browserSize())) {

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -173,7 +173,25 @@ final class ChromeDriverFactoryTest {
   }
 
   @Test
-  void disablesSandbox() {
+  void doesNotDisableSandboxByDefault() {
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
+    List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
+
+    assertThat(optionArguments).doesNotContain("--no-sandbox");
+  }
+
+  @Test
+  void canDisableSandbox_withArgument() {
+    config.browserCapabilities(new ChromeOptions().addArguments("--no-sandbox"));
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
+    List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
+
+    assertThat(optionArguments).contains("--no-sandbox");
+  }
+
+  @Test
+  void canDisableSandbox_withSystemProperty() {
+    System.setProperty("chromeoptions.args", "foo,--no-sandbox,bar");
     Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     List<String> optionArguments = getBrowserLaunchArgs(ChromeOptions.CAPABILITY, chromeOptions);
 

--- a/src/test/java/com/codeborne/selenide/webdriver/EdgeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/EdgeDriverFactoryTest.java
@@ -54,7 +54,6 @@ class EdgeDriverFactoryTest {
       "--remote-allow-origins=*",
       "--proxy-bypass-list=<-loopback>",
       "--disable-dev-shm-usage",
-      "--no-sandbox",
       "--window-size=1366,768"
     );
 


### PR DESCRIPTION
it may leave Chrome process hanging on the background after closing the webdriver.

NB! Afaik, without this argument Chrome cannot start in docker. But this is easily solvable by adding `--no-sandbox` in capabilities or system property.

