### PR TITLE
fix flaky test `FileDownloadToFolderTest.download_byExtension()`

### DIFF
--- a/modules/proxy/src/test/java/integration/FileDownloadViaProxyTest.java
+++ b/modules/proxy/src/test/java/integration/FileDownloadViaProxyTest.java
@@ -130,7 +130,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
   public void download_byExtension() throws FileNotFoundException {
     File downloadedFile = $(byText("Download me slowly")).download(2000, withExtension("txt"));
 
-    assertThat(downloadedFile).hasName("hello_world.txt");
+    assertThat(downloadedFile.getName()).matches("hello_world.*\\.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
   }
 

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -117,7 +117,7 @@ final class FileDownloadToFolderTest extends IntegrationTest {
   public void download_byExtension() throws FileNotFoundException {
     File downloadedFile = $(byText("Download me")).download(withExtension("txt"));
 
-    assertThat(downloadedFile).hasName("hello_world.txt");
+    assertThat(downloadedFile.getName()).matches("hello_world.*\\.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
   }
 


### PR DESCRIPTION
The problem to investigate:

sometimes browser downloads file "hello_world (1).txt" instead of "hello_world.txt".
