### PR TITLE
Add cause to collection errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle-task: [ 'check', 'edge_headless' ]
+        gradle-task: [ 'check', 'edge_headless_smoke' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
           cache: 'gradle'
           java-version: '17'
       - name: Setup Edge
-        if: ${{ matrix.gradle-task == 'edge_headless' }}
+        if: ${{ contains(matrix.gradle-task, 'edge') }}
         uses: browser-actions/setup-edge@latest
       - name: Set-DisplayResolution
         shell: pwsh

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -32,6 +32,15 @@ subprojects {
     outputs.upToDateWhen {false}
   }
 
+  tasks.register("edge_headless_smoke", Test) {
+    systemProperties['selenide.browser'] = 'edge'
+    systemProperties['selenide.headless'] = 'true'
+    include 'integration/**/*Download*'
+    exclude 'com/codeborne/selenide/**/*'
+    exclude 'org/selenide/**/*'
+    outputs.upToDateWhen {false}
+  }
+
   tasks.register("chrome", Test) {
     systemProperties['selenide.browser'] = 'chrome'
     include 'integration/**/*'

--- a/src/main/java/com/codeborne/selenide/CollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/CollectionCondition.java
@@ -34,7 +34,7 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
 
   public abstract void fail(CollectionSource collection,
                             @Nullable List<WebElement> elements,
-                            @Nullable Exception lastError,
+                            @Nullable Exception cause,
                             long timeoutMs);
 
   public static CollectionCondition empty = size(0);
@@ -317,9 +317,9 @@ public abstract class CollectionCondition implements Predicate<List<WebElement>>
     @Override
     public void fail(CollectionSource collection,
                      @Nullable List<WebElement> elements,
-                     @Nullable Exception lastError,
+                     @Nullable Exception cause,
                      long timeoutMs) {
-      delegate.fail(collection, elements, lastError, timeoutMs);
+      delegate.fail(collection, elements, cause, timeoutMs);
     }
 
     @Override

--- a/src/main/java/com/codeborne/selenide/collections/Attributes.java
+++ b/src/main/java/com/codeborne/selenide/collections/Attributes.java
@@ -49,10 +49,10 @@ public class Attributes extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
     if (elements == null || elements.isEmpty()) {
-      throw new ElementNotFound(collection, toString(), timeoutMs, lastError);
+      throw new ElementNotFound(collection, toString(), timeoutMs, cause);
     } else if (elements.size() != expectedValues.size()) {
       throw new AttributesSizeMismatch(collection.driver(), attribute, collection, expectedValues,
         ElementsCollection.attributes(attribute, elements), explanation, timeoutMs);

--- a/src/main/java/com/codeborne/selenide/collections/Attributes.java
+++ b/src/main/java/com/codeborne/selenide/collections/Attributes.java
@@ -23,7 +23,7 @@ public class Attributes extends CollectionCondition {
 
   public Attributes(String attribute, List<String> expectedValues) {
     if (expectedValues.isEmpty()) {
-      throw new IllegalArgumentException("No expected values given");
+      throw new IllegalArgumentException("No expected values given for attribute " + attribute);
     }
     this.expectedValues = unmodifiableList(expectedValues);
     this.attribute = attribute;
@@ -55,10 +55,10 @@ public class Attributes extends CollectionCondition {
       throw new ElementNotFound(collection, toString(), timeoutMs, cause);
     } else if (elements.size() != expectedValues.size()) {
       throw new AttributesSizeMismatch(collection.driver(), attribute, collection, expectedValues,
-        ElementsCollection.attributes(attribute, elements), explanation, timeoutMs);
+        ElementsCollection.attributes(attribute, elements), explanation, timeoutMs, cause);
     } else {
       throw new AttributesMismatch(collection.driver(), attribute, collection, expectedValues,
-        ElementsCollection.attributes(attribute, elements), explanation, timeoutMs);
+        ElementsCollection.attributes(attribute, elements), explanation, timeoutMs, cause);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/ContainExactTextsCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/collections/ContainExactTextsCaseSensitive.java
@@ -46,10 +46,10 @@ public class ContainExactTextsCaseSensitive extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
     if (elements == null || elements.isEmpty()) {
-      throw new ElementNotFound(collection, toString(), timeoutMs, lastError);
+      throw new ElementNotFound(collection, toString(), timeoutMs, cause);
     }
     else {
       List<String> actualTexts = ElementsCollection.texts(elements);
@@ -57,7 +57,7 @@ public class ContainExactTextsCaseSensitive extends CollectionCondition {
       difference.removeAll(actualTexts);
       throw new DoesNotContainTextsError(collection,
         expectedTexts, actualTexts, difference, explanation,
-        timeoutMs, lastError);
+        timeoutMs, cause);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
@@ -58,10 +58,10 @@ public class ExactTexts extends CollectionCondition {
       throw new ElementNotFound(collection, toString(), timeoutMs, cause);
     }
     else if (elements.size() != expectedTexts.size()) {
-      throw new TextsSizeMismatch(collection, expectedTexts, ElementsCollection.texts(elements), explanation, timeoutMs);
+      throw new TextsSizeMismatch(collection, expectedTexts, ElementsCollection.texts(elements), explanation, timeoutMs, cause);
     }
     else {
-      throw new TextsMismatch(collection, expectedTexts, ElementsCollection.texts(elements), explanation, timeoutMs);
+      throw new TextsMismatch(collection, expectedTexts, ElementsCollection.texts(elements), explanation, timeoutMs, cause);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTexts.java
@@ -52,10 +52,10 @@ public class ExactTexts extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
     if (elements == null || elements.isEmpty()) {
-      throw new ElementNotFound(collection, toString(), timeoutMs, lastError);
+      throw new ElementNotFound(collection, toString(), timeoutMs, cause);
     }
     else if (elements.size() != expectedTexts.size()) {
       throw new TextsSizeMismatch(collection, expectedTexts, ElementsCollection.texts(elements), explanation, timeoutMs);

--- a/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
+++ b/src/main/java/com/codeborne/selenide/collections/ItemWithText.java
@@ -33,10 +33,10 @@ public class ItemWithText extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
     throw new ElementWithTextNotFound(
-      collection, singletonList(expectedText), ElementsCollection.texts(elements), explanation, timeoutMs, lastError);
+      collection, singletonList(expectedText), ElementsCollection.texts(elements), explanation, timeoutMs, cause);
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/collections/ListSize.java
+++ b/src/main/java/com/codeborne/selenide/collections/ListSize.java
@@ -27,9 +27,9 @@ public class ListSize extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
-    throw new ListSizeMismatch("=", expectedSize, explanation, collection, elements, lastError, timeoutMs);
+    throw new ListSizeMismatch("=", expectedSize, explanation, collection, elements, cause, timeoutMs);
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/collections/PredicateCollectionCondition.java
+++ b/src/main/java/com/codeborne/selenide/collections/PredicateCollectionCondition.java
@@ -31,16 +31,16 @@ public abstract class PredicateCollectionCondition extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
     if (elements == null || elements.isEmpty()) {
-      throw new ElementNotFound(collection, toString(), timeoutMs, lastError);
+      throw new ElementNotFound(collection, toString(), timeoutMs, cause);
     } else {
       String expected = String.format("%s of elements to match [%s] predicate", matcher, description);
       throw new MatcherError(explanation,
         expected,
         describe.fully(collection.driver(), elements),
-        collection, lastError, timeoutMs);
+        collection, cause, timeoutMs);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/collections/SizeGreaterThan.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeGreaterThan.java
@@ -25,9 +25,9 @@ public class SizeGreaterThan extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
-    throw new ListSizeMismatch(">", expectedSize, explanation, collection, elements, lastError, timeoutMs);
+    throw new ListSizeMismatch(">", expectedSize, explanation, collection, elements, cause, timeoutMs);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/collections/SizeGreaterThanOrEqual.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeGreaterThanOrEqual.java
@@ -25,9 +25,9 @@ public class SizeGreaterThanOrEqual extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
-    throw new ListSizeMismatch(">=", expectedSize, explanation, collection, elements, lastError, timeoutMs);
+    throw new ListSizeMismatch(">=", expectedSize, explanation, collection, elements, cause, timeoutMs);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/collections/SizeLessThan.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeLessThan.java
@@ -25,9 +25,9 @@ public class SizeLessThan extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
-    throw new ListSizeMismatch("<", expectedSize, explanation, collection, elements, lastError, timeoutMs);
+    throw new ListSizeMismatch("<", expectedSize, explanation, collection, elements, cause, timeoutMs);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/collections/SizeLessThanOrEqual.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeLessThanOrEqual.java
@@ -25,9 +25,9 @@ public class SizeLessThanOrEqual extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
-    throw new ListSizeMismatch("<=", expectedSize, explanation, collection, elements, lastError, timeoutMs);
+    throw new ListSizeMismatch("<=", expectedSize, explanation, collection, elements, cause, timeoutMs);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/collections/SizeNotEqual.java
+++ b/src/main/java/com/codeborne/selenide/collections/SizeNotEqual.java
@@ -25,9 +25,9 @@ public class SizeNotEqual extends CollectionCondition {
   @Override
   public void fail(CollectionSource collection,
                    @Nullable List<WebElement> elements,
-                   @Nullable Exception lastError,
+                   @Nullable Exception cause,
                    long timeoutMs) {
-    throw new ListSizeMismatch("<>", expectedSize, explanation, collection, elements, lastError, timeoutMs);
+    throw new ListSizeMismatch("<>", expectedSize, explanation, collection, elements, cause, timeoutMs);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/ex/AttributesMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/AttributesMismatch.java
@@ -13,13 +13,13 @@ import static java.lang.System.lineSeparator;
 public class AttributesMismatch extends UIAssertionError {
   public AttributesMismatch(Driver driver, String attribute, CollectionSource collection,
                             List<String> expectedValues, List<String> actualValues,
-                            @Nullable String explanation, long timeoutMs) {
+                            @Nullable String explanation, long timeoutMs, @Nullable Exception cause) {
     super(driver,
       "Attribute '" + attribute + "' values mismatch" +
         lineSeparator() + "Actual: " + actualValues +
         lineSeparator() + "Expected: " + expectedValues +
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
         lineSeparator() + "Collection: " + collection.description(),
-      expectedValues, actualValues, timeoutMs);
+      expectedValues, actualValues, cause, timeoutMs);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/AttributesSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/AttributesSizeMismatch.java
@@ -13,14 +13,14 @@ import static java.lang.System.lineSeparator;
 public class AttributesSizeMismatch extends UIAssertionError {
   public AttributesSizeMismatch(Driver driver, String attribute, CollectionSource collection,
                                 List<String> expectedValues, List<String> actualValues,
-                                @Nullable String explanation, long timeoutMs) {
+                                @Nullable String explanation, long timeoutMs, @Nullable Exception cause) {
     super(driver,
       "Attribute '" + attribute + "' values size mismatch" +
         lineSeparator() + "Actual: " + actualValues + ", List size: " + actualValues.size() +
         lineSeparator() + "Expected: " + expectedValues + ", List size: " + expectedValues.size() +
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
         lineSeparator() + "Collection: " + collection.description(),
-      expectedValues, actualValues, timeoutMs
+      expectedValues, actualValues, cause, timeoutMs
     );
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/DoesNotContainTextsError.java
+++ b/src/main/java/com/codeborne/selenide/ex/DoesNotContainTextsError.java
@@ -13,7 +13,7 @@ public class DoesNotContainTextsError extends UIAssertionError {
 
   public DoesNotContainTextsError(CollectionSource collection,
                                   List<String> expectedTexts, List<String> actualTexts, List<String> difference,
-                                  @Nullable String explanation, long timeoutMs, @Nullable Throwable lastError) {
+                                  @Nullable String explanation, long timeoutMs, @Nullable Throwable cause) {
     super(collection.driver(),
       "The collection with text elements: " + actualTexts +
         lineSeparator() + "should contain all of the following text elements: " + expectedTexts +
@@ -22,7 +22,7 @@ public class DoesNotContainTextsError extends UIAssertionError {
         lineSeparator() + "Collection: " + collection.description(),
       expectedTexts,
       actualTexts,
-      lastError,
+      cause,
       timeoutMs);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
@@ -22,20 +22,20 @@ public class ElementNotFound extends UIAssertionError {
   }
 
   public ElementNotFound(Driver driver, Alias alias, String searchCriteria, Condition expectedCondition,
-                         @Nullable Throwable lastError) {
+                         @Nullable Throwable cause) {
     super(driver, String.format("Element%s not found {%s}" +
-      "%nExpected: %s", alias.appendable(), searchCriteria, expectedCondition), lastError);
+      "%nExpected: %s", alias.appendable(), searchCriteria, expectedCondition), cause);
   }
 
-  public ElementNotFound(CollectionSource collection, List<String> expectedTexts, @Nullable Throwable lastError) {
+  public ElementNotFound(CollectionSource collection, List<String> expectedTexts, @Nullable Throwable cause) {
     super(collection.driver(), String.format("Element%s not found {%s}" +
-      "%nExpected: %s", collection.getAlias().appendable(), collection.getSearchCriteria(), expectedTexts), lastError);
+      "%nExpected: %s", collection.getAlias().appendable(), collection.getSearchCriteria(), expectedTexts), cause);
   }
 
-  public ElementNotFound(CollectionSource collection, String description, long timeoutMs, @Nullable Throwable lastError) {
+  public ElementNotFound(CollectionSource collection, String description, long timeoutMs, @Nullable Throwable cause) {
     super(collection.driver(), String.format("Element%s not found {%s}%nExpected: %s",
         collection.getAlias().appendable(), collection.getSearchCriteria(), description),
       timeoutMs,
-      lastError);
+      cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementShould.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShould.java
@@ -19,7 +19,7 @@ public class ElementShould extends UIAssertionError {
 
   public ElementShould(Driver driver, Alias alias, String searchCriteria, String prefix,
                        Condition expectedCondition, @Nullable CheckResult lastCheckResult,
-                       WebElement element, @Nullable Throwable lastError) {
+                       WebElement element, @Nullable Throwable cause) {
     super(
       driver,
       join(
@@ -29,6 +29,6 @@ public class ElementShould extends UIAssertionError {
       ),
       expectedCondition,
       lastCheckResult == null ? null : lastCheckResult.actualValue(),
-      lastError);
+      cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
@@ -19,7 +19,7 @@ public class ElementShouldNot extends UIAssertionError {
 
   public ElementShouldNot(Driver driver, Alias alias, String searchCriteria, String prefix,
                           Condition expectedCondition, @Nullable CheckResult lastCheckResult,
-                          WebElement element, @Nullable Throwable lastError) {
+                          WebElement element, @Nullable Throwable cause) {
     super(
       driver,
       join(
@@ -29,6 +29,6 @@ public class ElementShouldNot extends UIAssertionError {
       ),
       expectedCondition,
       lastCheckResult == null ? null : lastCheckResult.actualValue(),
-      lastError);
+      cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementWithTextNotFound.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementWithTextNotFound.java
@@ -14,7 +14,7 @@ public class ElementWithTextNotFound extends UIAssertionError {
   public ElementWithTextNotFound(CollectionSource collection,
                                  List<String> expectedTexts, List<String> actualTexts,
                                  @Nullable String explanation,
-                                 long timeoutMs, @Nullable Throwable lastError) {
+                                 long timeoutMs, @Nullable Throwable cause) {
     super(
       collection.driver(),
       "Element with text not found" +
@@ -24,7 +24,7 @@ public class ElementWithTextNotFound extends UIAssertionError {
         lineSeparator() + "Collection: " + collection.description(),
       expectedTexts,
       actualTexts,
-      lastError,
+      cause,
       timeoutMs);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ListSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/ListSizeMismatch.java
@@ -21,7 +21,7 @@ public class ListSizeMismatch extends UIAssertionError {
                           @Nullable String explanation,
                           CollectionSource collection,
                           @Nullable List<WebElement> actualElements,
-                          @Nullable Exception lastError,
+                          @Nullable Exception cause,
                           long timeoutMs) {
     super(
       collection.driver(),
@@ -32,7 +32,7 @@ public class ListSizeMismatch extends UIAssertionError {
         lineSeparator() + "Elements: " + describe.fully(collection.driver(), actualElements),
       expectedSize,
       sizeOf(actualElements),
-      lastError,
+      cause,
       timeoutMs
     );
   }

--- a/src/main/java/com/codeborne/selenide/ex/MatcherError.java
+++ b/src/main/java/com/codeborne/selenide/ex/MatcherError.java
@@ -13,7 +13,7 @@ public class MatcherError extends UIAssertionError {
   public MatcherError(@Nullable String explanation,
                       String expected, String actual,
                       CollectionSource collection,
-                      @Nullable Exception lastError,
+                      @Nullable Exception cause,
                       long timeoutMs) {
     super(
       collection.driver(),
@@ -23,7 +23,7 @@ public class MatcherError extends UIAssertionError {
         lineSeparator() + "Collection: " + collection.description() +
         lineSeparator() + "Elements: " + actual,
       expected, "Elements: " + actual,
-      lastError,
+      cause,
       timeoutMs
     );
   }

--- a/src/main/java/com/codeborne/selenide/ex/TextsMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsMismatch.java
@@ -12,7 +12,8 @@ import static java.lang.System.lineSeparator;
 public class TextsMismatch extends UIAssertionError {
   public TextsMismatch(CollectionSource collection,
                        List<String> expectedTexts, List<String> actualTexts,
-                       @Nullable String explanation, long timeoutMs) {
+                       @Nullable String explanation, long timeoutMs,
+                       @Nullable Throwable cause) {
     super(
       collection.driver(),
       "Texts mismatch" +
@@ -21,6 +22,7 @@ public class TextsMismatch extends UIAssertionError {
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
         lineSeparator() + "Collection: " + collection.description(),
       expectedTexts, actualTexts,
+      cause,
       timeoutMs);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsSizeMismatch.java
@@ -12,7 +12,8 @@ import static java.lang.System.lineSeparator;
 public class TextsSizeMismatch extends UIAssertionError {
   public TextsSizeMismatch(CollectionSource collection,
                            List<String> expectedTexts, List<String> actualTexts,
-                           @Nullable String explanation, long timeoutMs) {
+                           @Nullable String explanation, long timeoutMs,
+                           @Nullable Throwable cause) {
     super(
       collection.driver(),
       "Texts size mismatch" +
@@ -21,6 +22,7 @@ public class TextsSizeMismatch extends UIAssertionError {
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
         lineSeparator() + "Collection: " + collection.description(),
       expectedTexts, actualTexts,
+      cause,
       timeoutMs
     );
   }

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
@@ -56,10 +56,10 @@ public class CollectionElement extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
+  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
     if (collection.getElements().isEmpty()) {
-      return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, lastError);
+      return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, cause);
     }
-    return super.createElementNotFoundError(condition, lastError);
+    return super.createElementNotFoundError(condition, cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
@@ -134,12 +134,12 @@ public class ElementFinder extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
+  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
     if (parent != null) {
       parent.checkCondition("", exist, false);
     }
 
-    return super.createElementNotFoundError(condition, lastError);
+    return super.createElementNotFoundError(condition, cause);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/ExceptionWrapper.java
+++ b/src/main/java/com/codeborne/selenide/impl/ExceptionWrapper.java
@@ -18,20 +18,20 @@ import static com.codeborne.selenide.Condition.exist;
 class ExceptionWrapper {
   @CheckReturnValue
   @Nonnull
-  Throwable wrap(Throwable lastError, WebElementSource webElementSource) {
-    if (lastError instanceof UIAssertionError) {
-      return lastError;
+  Throwable wrap(Throwable error, WebElementSource webElementSource) {
+    if (error instanceof UIAssertionError) {
+      return error;
     }
-    else if (lastError instanceof InvalidElementStateException) {
-      return new InvalidStateException(webElementSource.driver(), webElementSource.description(), lastError);
+    else if (error instanceof InvalidElementStateException) {
+      return new InvalidStateException(webElementSource.driver(), webElementSource.description(), error);
     }
-    else if (isElementNotClickableException(lastError)) {
-      return new ElementIsNotClickableException(webElementSource.driver(), webElementSource.description(), lastError);
+    else if (isElementNotClickableException(error)) {
+      return new ElementIsNotClickableException(webElementSource.driver(), webElementSource.description(), error);
     }
-    else if (lastError instanceof StaleElementReferenceException || lastError instanceof NotFoundException) {
-      return webElementSource.createElementNotFoundError(exist, lastError);
+    else if (error instanceof StaleElementReferenceException || error instanceof NotFoundException) {
+      return webElementSource.createElementNotFoundError(exist, error);
     }
-    return lastError;
+    return error;
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/impl/JSElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/JSElementFinder.java
@@ -60,9 +60,9 @@ public class JSElementFinder extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
+  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
     parent.checkCondition("", exist, false);
-    return super.createElementNotFoundError(condition, lastError);
+    return super.createElementNotFoundError(condition, cause);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
@@ -56,10 +56,10 @@ public class LastCollectionElement extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
+  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
     if (collection.getElements().isEmpty()) {
-      return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, lastError);
+      return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, cause);
     }
-    return super.createElementNotFoundError(condition, lastError);
+    return super.createElementNotFoundError(condition, cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
@@ -88,7 +88,7 @@ public class LazyWebElementSnapshot extends WebElementSource {
 
   @Nonnull
   @Override
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
-    return delegate.createElementNotFoundError(condition, lastError);
+  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
+    return delegate.createElementNotFoundError(condition, cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -84,11 +84,11 @@ public abstract class WebElementSource {
 
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable lastError) {
-    if (lastError instanceof UIAssertionError) {
-      throw new IllegalArgumentException("Unexpected UIAssertionError as a cause of ElementNotFound: " + lastError, lastError);
+  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
+    if (cause instanceof UIAssertionError) {
+      throw new IllegalArgumentException("Unexpected UIAssertionError as a cause of ElementNotFound: " + cause, cause);
     }
-    return new ElementNotFound(driver(), alias, getSearchCriteria(), condition, lastError);
+    return new ElementNotFound(driver(), alias, getSearchCriteria(), condition, cause);
   }
 
   @CheckReturnValue

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveTest.java
@@ -91,7 +91,8 @@ final class ExactTextsCaseSensitiveTest {
         "Actual: [Hello]%n" +
         "Expected: [One]%n" +
         "Collection: Collection description%n" +
-        "Timeout: 10 s."));
+        "Timeout: 10 s.%n" +
+        "Caused by: java.lang.Exception: Exception method"));
   }
 
   @Test
@@ -109,7 +110,8 @@ final class ExactTextsCaseSensitiveTest {
         "Actual: [One]%n" +
         "Expected: [ONE]%n" +
         "Collection: Collection description%n" +
-        "Timeout: 10 s."));
+        "Timeout: 10 s.%n" +
+        "Caused by: java.lang.Exception: Exception method"));
   }
 
   @Test
@@ -124,7 +126,9 @@ final class ExactTextsCaseSensitiveTest {
       .isInstanceOf(TextsSizeMismatch.class)
       .hasMessageContaining("Actual: [One], List size: 1")
       .hasMessageContaining("Expected: [One, Two], List size: 2")
-      .hasMessageEndingWith(String.format("Collection: Collection description%nTimeout: 10 s."));
+      .hasMessageContaining("Collection: Collection description")
+      .hasMessageContaining("Timeout: 10 s.")
+      .hasMessageEndingWith("Caused by: java.lang.Exception: Exception method");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
+++ b/src/test/java/com/codeborne/selenide/collections/ExactTextsTest.java
@@ -91,7 +91,8 @@ final class ExactTextsTest {
         "Actual: [Hello]%n" +
         "Expected: [One]%n" +
         "Collection: Collection description%n" +
-        "Timeout: 10 s."));
+        "Timeout: 10 s.%n" +
+        "Caused by: java.lang.Exception: Exception method"));
   }
 
   @Test
@@ -106,7 +107,9 @@ final class ExactTextsTest {
       .isInstanceOf(TextsSizeMismatch.class)
       .hasMessageContaining("Actual: [One], List size: 1")
       .hasMessageContaining("Expected: [One, Two], List size: 2")
-      .hasMessageEndingWith(String.format("Collection: Collection description%nTimeout: 10 s."));
+      .hasMessageContaining("Collection: Collection description")
+      .hasMessageContaining("Timeout: 10 s.")
+      .hasMessageEndingWith("Caused by: java.lang.Exception: Exception method");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/ex/TextMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextMismatchTest.java
@@ -25,7 +25,7 @@ final class TextMismatchTest {
 
   @Test
   void toString_withoutExplanation() {
-    TextsMismatch textsMismatch = new TextsMismatch(collection, expectedTexts, actualTexts, null, timeoutMs);
+    TextsMismatch textsMismatch = new TextsMismatch(collection, expectedTexts, actualTexts, null, timeoutMs, null);
 
     assertThat(textsMismatch).hasMessage(String.format("Texts mismatch%n" +
       "Actual: [One, Two, Three]%n" +
@@ -36,7 +36,7 @@ final class TextMismatchTest {
 
   @Test
   void toString_withExplanation() {
-    TextsMismatch textsMismatch = new TextsMismatch(collection, expectedTexts, actualTexts, "it's said in doc", timeoutMs);
+    TextsMismatch textsMismatch = new TextsMismatch(collection, expectedTexts, actualTexts, "it's said in doc", timeoutMs, null);
 
     assertThat(textsMismatch).hasMessage(String.format("Texts mismatch%n" +
       "Actual: [One, Two, Three]%n" +

--- a/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
@@ -16,7 +16,7 @@ final class TextsMismatchTest {
   void errorMessage() {
     TextsMismatch textsMismatch = new TextsMismatch(mockCollection(".characters"),
         expectedTexts, actualTexts,
-        null, 9000);
+        null, 9000, null);
 
     assertThat(textsMismatch).hasMessage(String.format("Texts mismatch%n" +
       "Actual: [Niff, Naff, Nuff]%n" +
@@ -29,7 +29,7 @@ final class TextsMismatchTest {
   void errorMessage_withExplanation() {
     TextsMismatch textsMismatch = new TextsMismatch(mockCollection(".characters"),
         expectedTexts, actualTexts,
-        "we expect favorite characters", 9000);
+        "we expect favorite characters", 9000, null);
 
     assertThat(textsMismatch).hasMessage(String.format("Texts mismatch%n" +
       "Actual: [Niff, Naff, Nuff]%n" +

--- a/src/test/java/com/codeborne/selenide/ex/TextsSizeMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsSizeMismatchTest.java
@@ -16,7 +16,7 @@ final class TextsSizeMismatchTest {
   void errorMessage() {
     TextsSizeMismatch textsMismatch = new TextsSizeMismatch(mockCollection(".characters"),
         expectedTexts, actualTexts,
-        null, 9000);
+        null, 9000, null);
 
     assertThat(textsMismatch).hasMessage(String.format("Texts size mismatch%n" +
       "Actual: [Niff, Naff, Nuff%%], List size: 3%n" +
@@ -29,7 +29,7 @@ final class TextsSizeMismatchTest {
   void errorMessage_withExplanation() {
     TextsSizeMismatch textsMismatch = new TextsSizeMismatch(mockCollection(".characters"),
         expectedTexts, actualTexts,
-        "we expect favorite characters", 9000);
+        "we expect favorite characters", 9000, null);
 
     assertThat(textsMismatch).hasMessage(String.format("Texts size mismatch%n" +
       "Actual: [Niff, Naff, Nuff%%], List size: 3%n" +

--- a/statics/src/test/java/integration/CustomCollectionConditionTest.java
+++ b/statics/src/test/java/integration/CustomCollectionConditionTest.java
@@ -57,7 +57,7 @@ final class CustomCollectionConditionTest extends IntegrationTest {
       @Override
       public void fail(CollectionSource collection,
                        @Nullable List<WebElement> elements,
-                       @Nullable Exception lastError,
+                       @Nullable Exception cause,
                        long timeoutMs) {
         List<String> actualTexts = ElementsCollection.texts(elements);
         String expected = "prefix \"" + prefix + '"';


### PR DESCRIPTION
The case was that innocent check like `$$.shouldHave(attributes(...))` failed because Appium could not read Android-specific attribute on iOS app.

But this exception was not visible in the assertion error. :(