### PR TITLE
Refactor API for switching context in mobile app

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -69,16 +69,16 @@ public class SelenideAppium {
     Selenide.back();
   }
 
-  public static void setContext(String contextName) {
-    new SelenideAppiumTargetLocator().setContext(contextName);
+  public static SelenideAppiumTargetLocator switchTo() {
+    return new SelenideAppiumTargetLocator(WebDriverRunner.driver());
   }
 
   public static Set<String> getContextHandles() {
-    return new SelenideAppiumTargetLocator().getContextHandles();
+    return switchTo().getContextHandles();
   }
 
   public static String getCurrentContext() {
-    return new SelenideAppiumTargetLocator().getCurrentContext();
+    return switchTo().getCurrentContext();
   }
 
   @CheckReturnValue

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumTargetLocator.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumTargetLocator.java
@@ -1,30 +1,37 @@
 package com.codeborne.selenide.appium;
 
-import com.codeborne.selenide.WebDriverRunner;
+import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.logevents.SelenideLogger;
 import org.openqa.selenium.ContextAware;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Set;
 
+@ParametersAreNonnullByDefault
 public class SelenideAppiumTargetLocator {
+  private final Driver driver;
 
-  public void setContext(String contextName) {
+  SelenideAppiumTargetLocator(Driver driver) {
+    this.driver = driver;
+  }
+
+  public void context(String contextName) {
     SelenideLogger.run("set context", contextName, () -> {
-      (WebdriverUnwrapper.cast(WebDriverRunner.getWebDriver(), ContextAware.class))
+      WebdriverUnwrapper.cast(driver, ContextAware.class)
         .map(contextAware -> contextAware.context(contextName))
         .orElseThrow(() -> new UnsupportedOperationException("Context not found" + contextName));
     });
   }
 
   public Set<String> getContextHandles() {
-    return (WebdriverUnwrapper.cast(WebDriverRunner.getWebDriver(), ContextAware.class))
+    return WebdriverUnwrapper.cast(driver, ContextAware.class)
       .map(ContextAware::getContextHandles)
       .orElseThrow(() -> new UnsupportedOperationException("Cannot get contexts from mobile driver"));
   }
 
   public String getCurrentContext() {
-    return (WebdriverUnwrapper.cast(WebDriverRunner.getWebDriver(), ContextAware.class))
+    return WebdriverUnwrapper.cast(driver, ContextAware.class)
       .map(ContextAware::getContext)
-      .orElseThrow(() -> new UnsupportedOperationException("Cannot get contexts from mobile driver"));
+      .orElseThrow(() -> new UnsupportedOperationException("Cannot get current context from mobile driver"));
   }
 }

--- a/modules/appium/src/test/java/it/mobile/android/ContextTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/ContextTest.java
@@ -11,7 +11,7 @@ import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static com.codeborne.selenide.appium.SelenideAppium.getContextHandles;
 import static com.codeborne.selenide.appium.SelenideAppium.getCurrentContext;
 import static com.codeborne.selenide.appium.SelenideAppium.openAndroidDeepLink;
-import static com.codeborne.selenide.appium.SelenideAppium.setContext;
+import static com.codeborne.selenide.appium.SelenideAppium.switchTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ContextTest extends BaseSwagLabsAndroidTest {
@@ -27,7 +27,7 @@ class ContextTest extends BaseSwagLabsAndroidTest {
     $(AppiumBy.accessibilityId("URL input field")).shouldBe(visible).setValue("www.google.com");
     $(AppiumBy.accessibilityId("Go To Site button")).shouldBe(visible).click();
     Stopwatch.sleepAtLeast(4000);
-    setContext("WEBVIEW_com.saucelabs.mydemoapp.rn");
+    switchTo().context("WEBVIEW_com.saucelabs.mydemoapp.rn");
 
     assertThat(getContextHandles())
       .hasSize(2)


### PR DESCRIPTION
* instead of `setContext("WEBVIEW_com.saucelabs.mydemoapp.rn")`,
* we will have `switchTo().context("WEBVIEW_com.saucelabs.mydemoapp.rn")`

This PR is further development of https://github.com/selenide/selenide-appium/pull/149