### PR TITLE
#2311 fix appium combined locator in reports

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/selector/ByTagAndAttribute.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/selector/ByTagAndAttribute.java
@@ -23,6 +23,8 @@ public class ByTagAndAttribute extends By.ByXPath {
   @CheckReturnValue
   @Nonnull
   public String toString() {
-    return "by tag: " + tag + "; by attribute: " + attributeName + "; by value: " + attributeValue;
+    return "*".equals(tag) ?
+      String.format("[%s=%s]", attributeName, attributeValue) :
+      String.format("%s[%s=%s]", tag, attributeName, attributeValue);
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/selector/CombinedBy.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/selector/CombinedBy.java
@@ -54,4 +54,18 @@ public class CombinedBy extends By {
     }
     throw new UnsupportedOperationException("Unsupported webdriver: " + WebDriverRunner.getWebDriver());
   }
+
+  @Override
+  public String toString() {
+    if (androidSelector != null && iosSelector != null) {
+      return String.format("[android:%s, ios:%s]", androidSelector, iosSelector);
+    }
+    if (androidSelector != null) {
+      return androidSelector.toString();
+    }
+    if (iosSelector != null) {
+      return iosSelector.toString();
+    }
+    return "CombinedBy: null";
+  }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/selector/WithTagAndAttribute.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/selector/WithTagAndAttribute.java
@@ -23,6 +23,8 @@ public class WithTagAndAttribute extends By.ByXPath {
   @CheckReturnValue
   @Nonnull
   public String toString() {
-    return "by tag: " + tag + "; by attribute: " + attributeName + "; with value: " + attributeValue;
+    return "*".equals(tag) ?
+      String.format("[%s*=%s]", attributeName, attributeValue) :
+      String.format("%s[%s*=%s]", tag, attributeName, attributeValue);
   }
 }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumSelectorsTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumSelectorsTest.java
@@ -12,7 +12,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.byTagAndText("*", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: text; by value: selen'ide-app'ium");
+      .hasToString("[text=selen'ide-app'ium]");
   }
 
   @Test
@@ -20,7 +20,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.byText("selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: text; by value: selen'ide-app'ium");
+      .hasToString("[text=selen'ide-app'ium]");
   }
 
   @Test
@@ -28,7 +28,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.withTagAndText("*", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: text; with value: selen'ide-app'ium");
+      .hasToString("[text*=selen'ide-app'ium]");
   }
 
   @Test
@@ -36,7 +36,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.withText("selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: text; with value: selen'ide-app'ium");
+      .hasToString("[text*=selen'ide-app'ium]");
   }
 
   @Test
@@ -44,7 +44,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.byTagAndName("*", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: name; by value: selen'ide-app'ium");
+      .hasToString("[name=selen'ide-app'ium]");
   }
 
   @Test
@@ -52,7 +52,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.byName("selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: name; by value: selen'ide-app'ium");
+      .hasToString("[name=selen'ide-app'ium]");
   }
 
   @Test
@@ -60,7 +60,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.withTagAndName("*", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: name; with value: selen'ide-app'ium");
+      .hasToString("[name*=selen'ide-app'ium]");
   }
 
   @Test
@@ -68,7 +68,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.withName("selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: name; with value: selen'ide-app'ium");
+      .hasToString("[name*=selen'ide-app'ium]");
   }
 
   @Test
@@ -76,7 +76,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.byTagAndAttribute("*", "text", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: text; by value: selen'ide-app'ium");
+      .hasToString("[text=selen'ide-app'ium]");
   }
 
   @Test
@@ -84,7 +84,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.byAttribute("text", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: text; by value: selen'ide-app'ium");
+      .hasToString("[text=selen'ide-app'ium]");
   }
 
   @Test
@@ -92,7 +92,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.withTagAndAttribute("*", "text", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: text; with value: selen'ide-app'ium");
+      .hasToString("[text*=selen'ide-app'ium]");
   }
 
   @Test
@@ -100,7 +100,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.withAttribute("text", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: text; with value: selen'ide-app'ium");
+      .hasToString("[text*=selen'ide-app'ium]");
   }
 
   @Test
@@ -108,15 +108,18 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.byTagAndContentDescription("*", "selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: content-desc; by value: selen'ide-app'ium");
+      .hasToString("[content-desc=selen'ide-app'ium]");
   }
 
   @Test
   void testWithTagAndContentDescriptionSelector() {
-    By by = AppiumSelectors.withTagAndContentDescription("*", "selen'ide-app'ium");
-    assertThat(by)
+    assertThat(AppiumSelectors.withTagAndContentDescription("*", "selen'ide-app'ium"))
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: content-desc; with value: selen'ide-app'ium");
+      .hasToString("[content-desc*=selen'ide-app'ium]");
+
+    assertThat(AppiumSelectors.withTagAndContentDescription("android.widget.TextView", "selen'ide-app'ium"))
+      .isInstanceOf(By.ByXPath.class)
+      .hasToString("android.widget.TextView[content-desc*=selen'ide-app'ium]");
   }
 
   @Test
@@ -124,7 +127,7 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.byContentDescription("selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: content-desc; by value: selen'ide-app'ium");
+      .hasToString("[content-desc=selen'ide-app'ium]");
   }
 
   @Test
@@ -132,6 +135,6 @@ class AppiumSelectorsTest {
     By by = AppiumSelectors.withContentDescription("selen'ide-app'ium");
     assertThat(by)
       .isInstanceOf(By.ByXPath.class)
-      .hasToString("by tag: *; by attribute: content-desc; with value: selen'ide-app'ium");
+      .hasToString("[content-desc*=selen'ide-app'ium]");
   }
 }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/ByTagAndAttributeTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/ByTagAndAttributeTest.java
@@ -1,0 +1,14 @@
+package com.codeborne.selenide.appium.selector;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.appium.AppiumSelectors.byTagAndAttribute;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ByTagAndAttributeTest {
+  @Test
+  void testToString() {
+    assertThat(byTagAndAttribute("div", "accessibility-id", "hello"))
+      .hasToString("div[accessibility-id=hello]");
+  }
+}

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/ByTagAndTextTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/ByTagAndTextTest.java
@@ -1,0 +1,14 @@
+package com.codeborne.selenide.appium.selector;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.appium.AppiumSelectors.byTagAndText;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ByTagAndTextTest {
+  @Test
+  void testToString() {
+    assertThat(byTagAndText("div", "Hello"))
+      .hasToString("div[text=Hello]");
+  }
+}

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/ByTextTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/ByTextTest.java
@@ -1,0 +1,13 @@
+package com.codeborne.selenide.appium.selector;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.appium.AppiumSelectors.byText;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ByTextTest {
+  @Test
+  void testToString() {
+    assertThat(byText("Hello")).hasToString("[text=Hello]");
+  }
+}

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/WithTagAndAttributeTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/WithTagAndAttributeTest.java
@@ -1,0 +1,14 @@
+package com.codeborne.selenide.appium.selector;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.appium.AppiumSelectors.withTagAndAttribute;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WithTagAndAttributeTest {
+  @Test
+  void testToString() {
+    assertThat(withTagAndAttribute("div", "accessibility-id", "hello"))
+      .hasToString("div[accessibility-id*=hello]");
+  }
+}

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/WithTagAndTextTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/WithTagAndTextTest.java
@@ -1,0 +1,14 @@
+package com.codeborne.selenide.appium.selector;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.appium.AppiumSelectors.withTagAndText;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WithTagAndTextTest {
+  @Test
+  void testToString() {
+    assertThat(withTagAndText("div", "Hello"))
+      .hasToString("div[text*=Hello]");
+  }
+}

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/WithTextTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/selector/WithTextTest.java
@@ -1,0 +1,13 @@
+package com.codeborne.selenide.appium.selector;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.appium.AppiumSelectors.withText;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WithTextTest {
+  @Test
+  void testToString() {
+    assertThat(withText("Hello")).hasToString("[text*=Hello]");
+  }
+}

--- a/modules/appium/src/test/java/it/mobile/android/AndroidSelectorsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AndroidSelectorsTest.java
@@ -26,7 +26,6 @@ import static com.codeborne.selenide.appium.selector.CombinedBy.android;
 class AndroidSelectorsTest extends BaseApiDemosTest {
 
   private static final String VIEWS = "Views";
-  private static final String GRAPHICS_PARTIAL_STRING = "Graphi";
 
   @BeforeEach
   void setUp() {
@@ -35,7 +34,7 @@ class AndroidSelectorsTest extends BaseApiDemosTest {
   }
 
   @Test
-  void testAppiumSelectorsInAndroidApp() {
+  void appiumSelectorsInAndroidApp() {
     $(byAttribute("content-desc", VIEWS)).click();
     back();
     $(byContentDescription(VIEWS)).click();
@@ -48,17 +47,17 @@ class AndroidSelectorsTest extends BaseApiDemosTest {
     back();
     $(byText(VIEWS)).click();
     back();
-    $(withAttribute("text", GRAPHICS_PARTIAL_STRING)).click();
+    $(withAttribute("text", "Graphi")).click();
     back();
-    $(withContentDescription(GRAPHICS_PARTIAL_STRING)).click();
+    $(withContentDescription("Graphi")).click();
     back();
-    $(withTagAndAttribute("*", "text", GRAPHICS_PARTIAL_STRING)).click();
+    $(withTagAndAttribute("*", "text", "Graphi")).click();
     back();
-    $(withTagAndContentDescription("*", GRAPHICS_PARTIAL_STRING)).click();
+    $(withTagAndContentDescription("*", "Graphi")).click();
     back();
-    $(withTagAndText("android.widget.TextView", GRAPHICS_PARTIAL_STRING)).click();
+    $(withTagAndText("android.widget.TextView", "Graphi")).click();
     back();
-    $(android(withText(GRAPHICS_PARTIAL_STRING)).ios(By.xpath("")))
-      .shouldHave(text("Graphics"));
+    $(android(withText("Graphi")).ios(By.xpath("/"))).shouldHave(text("Graphics"));
+    $(android(byText("Graphics")).ios(By.xpath("/"))).shouldHave(text("Graphics"));
   }
 }

--- a/modules/appium/src/test/java/it/mobile/ios/IosSelectorsTest.java
+++ b/modules/appium/src/test/java/it/mobile/ios/IosSelectorsTest.java
@@ -8,10 +8,12 @@ import static com.codeborne.selenide.appium.AppiumSelectors.*;
 
 class IosSelectorsTest extends BaseIosCalculatorTest {
   @Test
-  void testAppiumSelectorsInIosApp() {
+  void appiumSelectorsInIosApp() {
     $(byTagAndName("*", "IntegerA")).setValue("2");
     $(byName("IntegerB")).setValue("4");
     $(withName("ComputeSum")).click();
     $(withTagAndName("*", "Answ")).shouldHave(text("6"));
+    $(withTagAndName("XCUIElementTypeStaticText", "Answ")).shouldHave(text("6"));
+    $(byTagAndName("XCUIElementTypeStaticText", "Answer")).shouldHave(text("6"));
   }
 }


### PR DESCRIPTION
fix for #2311 

now the report will look better:

```
| [android:by [text=Graphi], ios:By.xpath:/]    | should have(text "Graphics") | PASS      | 1098       |
| [name*=ComputeSum]                            | click()                      | PASS      | 918        |
| [name*=Answ]                                  | should have(text "6")        | PASS      | 361        |
| XCUIElementTypeStaticText[name*=Answ]         | should have(text "6")        | PASS      | 306        |
| XCUIElementTypeStaticText[name=Answer]        | should have(text "6")        | PASS      | 313        |
```