### PR TITLE
#2318 use latest version of geckodriver for FF 102+

### DIFF
--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -5,7 +5,7 @@
 
 # Browser: Google Chrome and Chromium - Driver: chromedriver
 # Source: http://chromedriver.chromium.org/downloads
-chrome114=114.0.5735.16
+chrome114=114.0.5735.90
 chrome113=113.0.5672.63
 chrome112=112.0.5615.49
 chrome111=111.0.5563.64
@@ -66,15 +66,15 @@ firefox114=0.33.0
 firefox113=0.33.0
 firefox112=0.33.0
 firefox111=0.33.0
-firefox110=0.32.2
-firefox109=0.32.0
-firefox108=0.32.0
-firefox107=0.32.0
-firefox106=0.32.0
-firefox105=0.32.0
-firefox104=0.31.0
-firefox103=0.31.0
-firefox102=0.31.0
+firefox110=0.33.0
+firefox109=0.33.0
+firefox108=0.33.0
+firefox107=0.33.0
+firefox106=0.33.0
+firefox105=0.33.0
+firefox104=0.33.0
+firefox103=0.33.0
+firefox102=0.33.0
 firefox101=0.31.0
 firefox100=0.31.0
 firefox99=0.31.0


### PR DESCRIPTION
According to this page, geckodriver 0.33.0 should work with all versions of FireFix starting from 102: https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
