### PR TITLE
Add basic webdriver cookie conditions

### DIFF
--- a/src/main/java/com/codeborne/selenide/WebDriverConditions.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverConditions.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.conditions.webdriver.CookieObject;
 import com.codeborne.selenide.conditions.webdriver.CookieWithName;
 import com.codeborne.selenide.conditions.webdriver.CookieWithNameAndValue;
 import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrl;
@@ -10,6 +11,7 @@ import com.codeborne.selenide.conditions.webdriver.Title;
 import com.codeborne.selenide.conditions.webdriver.Url;
 import com.codeborne.selenide.conditions.webdriver.UrlContaining;
 import com.codeborne.selenide.conditions.webdriver.UrlStartingWith;
+import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 
 import javax.annotation.CheckReturnValue;
@@ -85,5 +87,11 @@ public class WebDriverConditions {
   @Nonnull
   public static ObjectCondition<WebDriver> cookie(String name, String value) {
     return new CookieWithNameAndValue(name, value);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> cookie(Cookie cookie) {
+    return new CookieObject(cookie);
   }
 }

--- a/src/main/java/com/codeborne/selenide/WebDriverConditions.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverConditions.java
@@ -1,5 +1,7 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.conditions.webdriver.CookieWithName;
+import com.codeborne.selenide.conditions.webdriver.CookieWithNameAndValue;
 import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrl;
 import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrlContaining;
 import com.codeborne.selenide.conditions.webdriver.CurrentFrameUrlStartingWith;
@@ -17,59 +19,71 @@ import javax.annotation.Nonnull;
  * @since 5.23.0
  */
 public class WebDriverConditions {
-  @CheckReturnValue
-  @Nonnull
-  public static ObjectCondition<WebDriver> url(String expectedUrl) {
-    return new Url(expectedUrl);
-  }
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> url(String expectedUrl) {
+        return new Url(expectedUrl);
+    }
 
-  @CheckReturnValue
-  @Nonnull
-  public static ObjectCondition<WebDriver> urlStartingWith(String expectedUrl) {
-    return new UrlStartingWith(expectedUrl);
-  }
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> urlStartingWith(String expectedUrl) {
+        return new UrlStartingWith(expectedUrl);
+    }
 
-  @CheckReturnValue
-  @Nonnull
-  public static ObjectCondition<WebDriver> urlContaining(String expectedUrl) {
-    return new UrlContaining(expectedUrl);
-  }
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> urlContaining(String expectedUrl) {
+        return new UrlContaining(expectedUrl);
+    }
 
-  @CheckReturnValue
-  @Nonnull
-  public static ObjectCondition<WebDriver> currentFrameUrl(String expectedUrl) {
-    return new CurrentFrameUrl(expectedUrl);
-  }
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> currentFrameUrl(String expectedUrl) {
+        return new CurrentFrameUrl(expectedUrl);
+    }
 
-  @CheckReturnValue
-  @Nonnull
-  public static ObjectCondition<WebDriver> currentFrameUrlStartingWith(String expectedUrl) {
-    return new CurrentFrameUrlStartingWith(expectedUrl);
-  }
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> currentFrameUrlStartingWith(String expectedUrl) {
+        return new CurrentFrameUrlStartingWith(expectedUrl);
+    }
 
-  @CheckReturnValue
-  @Nonnull
-  public static ObjectCondition<WebDriver> currentFrameUrlContaining(String expectedUrl) {
-    return new CurrentFrameUrlContaining(expectedUrl);
-  }
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> currentFrameUrlContaining(String expectedUrl) {
+        return new CurrentFrameUrlContaining(expectedUrl);
+    }
 
-  /**
-   * Check that the number of windows/tabs in the browser is as expected.
-   * Example:
-   * {@code webdriver().shouldHave(numberOfWindows(2)) }
-   */
-  @CheckReturnValue
-  @Nonnull
-  public static ObjectCondition<WebDriver> numberOfWindows(int numberOfWindows) {
-    return new NumberOfWindows(numberOfWindows);
-  }
+    /**
+     * Check that the number of windows/tabs in the browser is as expected.
+     * Example:
+     * {@code webdriver().shouldHave(numberOfWindows(2)) }
+     */
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> numberOfWindows(int numberOfWindows) {
+        return new NumberOfWindows(numberOfWindows);
+    }
 
-  /**
-   * @since 5.25.0
-   */
-  @CheckReturnValue
-  @Nonnull
-  public static ObjectCondition<WebDriver> title(String expectedTitle) {
-    return new Title(expectedTitle);
-  }
+    /**
+     * @since 5.25.0
+     */
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> title(String expectedTitle) {
+        return new Title(expectedTitle);
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> cookieWithName(String name) {
+        return new CookieWithName(name);
+    }
+
+    @CheckReturnValue
+    @Nonnull
+    public static ObjectCondition<WebDriver> cookieWithNameAndValue(String name, String value) {
+        return new CookieWithNameAndValue(name, value);
+    }
 }

--- a/src/main/java/com/codeborne/selenide/WebDriverConditions.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverConditions.java
@@ -19,71 +19,71 @@ import javax.annotation.Nonnull;
  * @since 5.23.0
  */
 public class WebDriverConditions {
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> url(String expectedUrl) {
-        return new Url(expectedUrl);
-    }
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> url(String expectedUrl) {
+    return new Url(expectedUrl);
+  }
 
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> urlStartingWith(String expectedUrl) {
-        return new UrlStartingWith(expectedUrl);
-    }
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> urlStartingWith(String expectedUrl) {
+    return new UrlStartingWith(expectedUrl);
+  }
 
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> urlContaining(String expectedUrl) {
-        return new UrlContaining(expectedUrl);
-    }
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> urlContaining(String expectedUrl) {
+    return new UrlContaining(expectedUrl);
+  }
 
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> currentFrameUrl(String expectedUrl) {
-        return new CurrentFrameUrl(expectedUrl);
-    }
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> currentFrameUrl(String expectedUrl) {
+    return new CurrentFrameUrl(expectedUrl);
+  }
 
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> currentFrameUrlStartingWith(String expectedUrl) {
-        return new CurrentFrameUrlStartingWith(expectedUrl);
-    }
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> currentFrameUrlStartingWith(String expectedUrl) {
+    return new CurrentFrameUrlStartingWith(expectedUrl);
+  }
 
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> currentFrameUrlContaining(String expectedUrl) {
-        return new CurrentFrameUrlContaining(expectedUrl);
-    }
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> currentFrameUrlContaining(String expectedUrl) {
+    return new CurrentFrameUrlContaining(expectedUrl);
+  }
 
-    /**
-     * Check that the number of windows/tabs in the browser is as expected.
-     * Example:
-     * {@code webdriver().shouldHave(numberOfWindows(2)) }
-     */
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> numberOfWindows(int numberOfWindows) {
-        return new NumberOfWindows(numberOfWindows);
-    }
+  /**
+   * Check that the number of windows/tabs in the browser is as expected.
+   * Example:
+   * {@code webdriver().shouldHave(numberOfWindows(2)) }
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> numberOfWindows(int numberOfWindows) {
+    return new NumberOfWindows(numberOfWindows);
+  }
 
-    /**
-     * @since 5.25.0
-     */
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> title(String expectedTitle) {
-        return new Title(expectedTitle);
-    }
+  /**
+   * @since 5.25.0
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> title(String expectedTitle) {
+    return new Title(expectedTitle);
+  }
 
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> cookieWithName(String name) {
-        return new CookieWithName(name);
-    }
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> cookieWithName(String name) {
+    return new CookieWithName(name);
+  }
 
-    @CheckReturnValue
-    @Nonnull
-    public static ObjectCondition<WebDriver> cookieWithNameAndValue(String name, String value) {
-        return new CookieWithNameAndValue(name, value);
-    }
+  @CheckReturnValue
+  @Nonnull
+  public static ObjectCondition<WebDriver> cookieWithNameAndValue(String name, String value) {
+    return new CookieWithNameAndValue(name, value);
+  }
 }

--- a/src/main/java/com/codeborne/selenide/WebDriverConditions.java
+++ b/src/main/java/com/codeborne/selenide/WebDriverConditions.java
@@ -77,13 +77,13 @@ public class WebDriverConditions {
 
   @CheckReturnValue
   @Nonnull
-  public static ObjectCondition<WebDriver> cookieWithName(String name) {
+  public static ObjectCondition<WebDriver> cookie(String name) {
     return new CookieWithName(name);
   }
 
   @CheckReturnValue
   @Nonnull
-  public static ObjectCondition<WebDriver> cookieWithNameAndValue(String name, String value) {
+  public static ObjectCondition<WebDriver> cookie(String name, String value) {
     return new CookieWithNameAndValue(name, value);
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieObject.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieObject.java
@@ -1,0 +1,61 @@
+package com.codeborne.selenide.conditions.webdriver;
+
+import com.codeborne.selenide.ObjectCondition;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class CookieObject implements ObjectCondition<WebDriver> {
+
+  private final Cookie cookie;
+
+  public CookieObject(Cookie cookie) {
+    this.cookie = cookie;
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String description() {
+    return String.format("should have cookie \"%s\"", cookie);
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String negativeDescription() {
+    return String.format("should not have cookie \"%s\"", cookie);
+  }
+
+  @CheckReturnValue
+  @Override
+  public boolean test(WebDriver webDriver) {
+    return webDriver.manage().getCookies().contains(cookie);
+  }
+
+  @Nullable
+  @CheckReturnValue
+  @Override
+  public String actualValue(WebDriver webDriver) {
+    return String.format("Available cookies: %s", webDriver.manage().getCookies());
+  }
+
+  @Nullable
+  @CheckReturnValue
+  @Override
+  public String expectedValue() {
+    return String.format("cookie \"%s\"", cookie);
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String describe(@Nonnull WebDriver webDriver) {
+    return "webdriver";
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithName.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithName.java
@@ -7,56 +7,55 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.text.MessageFormat;
 import java.util.Objects;
 
 @ParametersAreNonnullByDefault
 public class CookieWithName implements ObjectCondition<WebDriver> {
 
-    private final String name;
+  private final String name;
 
-    public CookieWithName(String name) {
-        this.name = name;
-    }
+  public CookieWithName(String name) {
+    this.name = name;
+  }
 
-    @Nonnull
-    @CheckReturnValue
-    @Override
-    public String description() {
-        return String.format("should have cookie with name \"%s\"", name);
-    }
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String description() {
+    return String.format("should have cookie with name \"%s\"", name);
+  }
 
-    @Nonnull
-    @CheckReturnValue
-    @Override
-    public String negativeDescription() {
-        return String.format("should not have cookie with name \"%s\"", name);
-    }
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String negativeDescription() {
+    return String.format("should not have cookie with name \"%s\"", name);
+  }
 
-    @CheckReturnValue
-    @Override
-    public boolean test(WebDriver webDriver) {
-        return Objects.nonNull(webDriver.manage().getCookieNamed(name));
-    }
+  @CheckReturnValue
+  @Override
+  public boolean test(WebDriver webDriver) {
+    return Objects.nonNull(webDriver.manage().getCookieNamed(name));
+  }
 
-    @Nullable
-    @CheckReturnValue
-    @Override
-    public String actualValue(WebDriver webDriver) {
-        return String.format("Available cookies: %s", webDriver.manage().getCookies());
-    }
+  @Nullable
+  @CheckReturnValue
+  @Override
+  public String actualValue(WebDriver webDriver) {
+    return String.format("Available cookies: %s", webDriver.manage().getCookies());
+  }
 
-    @Nullable
-    @CheckReturnValue
-    @Override
-    public String expectedValue() {
-        return String.format("cookie with name \"%s\"", name);
-    }
+  @Nullable
+  @CheckReturnValue
+  @Override
+  public String expectedValue() {
+    return String.format("cookie with name \"%s\"", name);
+  }
 
-    @Nonnull
-    @CheckReturnValue
-    @Override
-    public String describe(@Nonnull WebDriver webDriver) {
-        return "webdriver";
-    }
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String describe(@Nonnull WebDriver webDriver) {
+    return "webdriver";
+  }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithName.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithName.java
@@ -1,0 +1,62 @@
+package com.codeborne.selenide.conditions.webdriver;
+
+import com.codeborne.selenide.ObjectCondition;
+import org.openqa.selenium.WebDriver;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.text.MessageFormat;
+import java.util.Objects;
+
+@ParametersAreNonnullByDefault
+public class CookieWithName implements ObjectCondition<WebDriver> {
+
+    private final String name;
+
+    public CookieWithName(String name) {
+        this.name = name;
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    @Override
+    public String description() {
+        return String.format("should have cookie with name \"%s\"", name);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    @Override
+    public String negativeDescription() {
+        return String.format("should not have cookie with name \"%s\"", name);
+    }
+
+    @CheckReturnValue
+    @Override
+    public boolean test(WebDriver webDriver) {
+        return Objects.nonNull(webDriver.manage().getCookieNamed(name));
+    }
+
+    @Nullable
+    @CheckReturnValue
+    @Override
+    public String actualValue(WebDriver webDriver) {
+        return String.format("Available cookies: %s", webDriver.manage().getCookies());
+    }
+
+    @Nullable
+    @CheckReturnValue
+    @Override
+    public String expectedValue() {
+        return String.format("cookie with name \"%s\"", name);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    @Override
+    public String describe(@Nonnull WebDriver webDriver) {
+        return "webdriver";
+    }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithNameAndValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithNameAndValue.java
@@ -12,52 +12,52 @@ import java.util.Objects;
 @ParametersAreNonnullByDefault
 public class CookieWithNameAndValue implements ObjectCondition<WebDriver> {
 
-    private final String name;
-    private final String value;
+  private final String name;
+  private final String value;
 
-    public CookieWithNameAndValue(String name, String value) {
-        this.name = name;
-        this.value = value;
-    }
+  public CookieWithNameAndValue(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
 
-    @Nonnull
-    @CheckReturnValue
-    @Override
-    public String description() {
-        return String.format("should have cookie with name \"%s\" and value \"%s\"", name, value);
-    }
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String description() {
+    return String.format("should have cookie with name \"%s\" and value \"%s\"", name, value);
+  }
 
-    @Nonnull
-    @CheckReturnValue
-    @Override
-    public String negativeDescription() {
-        return String.format("should not have cookie with name \"%s\" and value \"%s\"", name, value);
-    }
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String negativeDescription() {
+    return String.format("should not have cookie with name \"%s\" and value \"%s\"", name, value);
+  }
 
-    @CheckReturnValue
-    @Override
-    public boolean test(WebDriver webDriver) {
-        return Objects.equals(webDriver.manage().getCookieNamed(name).getValue(), value);
-    }
+  @CheckReturnValue
+  @Override
+  public boolean test(WebDriver webDriver) {
+    return Objects.equals(webDriver.manage().getCookieNamed(name).getValue(), value);
+  }
 
-    @Nullable
-    @CheckReturnValue
-    @Override
-    public String actualValue(WebDriver webDriver) {
-        return String.format("Available cookies: %s", webDriver.manage().getCookies());
-    }
+  @Nullable
+  @CheckReturnValue
+  @Override
+  public String actualValue(WebDriver webDriver) {
+    return String.format("Available cookies: %s", webDriver.manage().getCookies());
+  }
 
-    @Nullable
-    @CheckReturnValue
-    @Override
-    public String expectedValue() {
-        return String.format("cookie with name \"%s\" and value \"%s\"", name, value);
-    }
+  @Nullable
+  @CheckReturnValue
+  @Override
+  public String expectedValue() {
+    return String.format("cookie with name \"%s\" and value \"%s\"", name, value);
+  }
 
-    @Nonnull
-    @CheckReturnValue
-    @Override
-    public String describe(@Nonnull WebDriver webDriver) {
-        return "webdriver";
-    }
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String describe(@Nonnull WebDriver webDriver) {
+    return "webdriver";
+  }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithNameAndValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithNameAndValue.java
@@ -1,0 +1,63 @@
+package com.codeborne.selenide.conditions.webdriver;
+
+import com.codeborne.selenide.ObjectCondition;
+import org.openqa.selenium.WebDriver;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Objects;
+
+@ParametersAreNonnullByDefault
+public class CookieWithNameAndValue implements ObjectCondition<WebDriver> {
+
+    private final String name;
+    private final String value;
+
+    public CookieWithNameAndValue(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    @Override
+    public String description() {
+        return String.format("should have cookie with name \"%s\" and value \"%s\"", name, value);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    @Override
+    public String negativeDescription() {
+        return String.format("should not have cookie with name \"%s\" and value \"%s\"", name, value);
+    }
+
+    @CheckReturnValue
+    @Override
+    public boolean test(WebDriver webDriver) {
+        return Objects.equals(webDriver.manage().getCookieNamed(name).getValue(), value);
+    }
+
+    @Nullable
+    @CheckReturnValue
+    @Override
+    public String actualValue(WebDriver webDriver) {
+        return String.format("Available cookies: %s", webDriver.manage().getCookies());
+    }
+
+    @Nullable
+    @CheckReturnValue
+    @Override
+    public String expectedValue() {
+        return String.format("cookie with name \"%s\" and value \"%s\"", name, value);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    @Override
+    public String describe(@Nonnull WebDriver webDriver) {
+        return "webdriver";
+    }
+}

--- a/src/test/resources/cookies.html
+++ b/src/test/resources/cookies.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+    <title>Test cookies</title>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+</head>
+<body>
+<h2>Test cookies</h2>
+
+<label for="debug">cookies content:</label><textarea id="debug"></textarea>
+<button id="button-put">put</button>
+<button id="button-remove">remove</button>
+
+<script type="text/javascript">
+    (function () {
+        const name = "TEST_COOKIE";
+        const value = "AF33892F98ABC39A";
+        const days = 3;
+
+        function putCookie() {
+            let date = new Date();
+            date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+            let expires = "expires=" + date.toUTCString();
+
+            document.cookie = `${name}=${value}; ${expires}; path=/`;
+            document.getElementById('debug').innerText = document.cookie;
+        }
+
+        function removeCookie() {
+            document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`;
+            document.getElementById('debug').innerText = document.cookie;
+        }
+
+        document.getElementById('button-put').addEventListener("click", putCookie)
+        document.getElementById('button-remove').addEventListener("click", removeCookie)
+    })();
+</script>
+</body>
+</html>

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -5,6 +5,7 @@ import com.codeborne.selenide.ex.ConditionMetException;
 import com.codeborne.selenide.ex.ConditionNotMetException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 
 import javax.annotation.CheckReturnValue;
@@ -14,8 +15,11 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static com.codeborne.selenide.Configuration.baseUrl;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.clearBrowserCookies;
 import static com.codeborne.selenide.Selenide.switchTo;
 import static com.codeborne.selenide.Selenide.webdriver;
+import static com.codeborne.selenide.WebDriverConditions.cookieWithName;
+import static com.codeborne.selenide.WebDriverConditions.cookieWithNameAndValue;
 import static com.codeborne.selenide.WebDriverConditions.currentFrameUrl;
 import static com.codeborne.selenide.WebDriverConditions.currentFrameUrlContaining;
 import static com.codeborne.selenide.WebDriverConditions.currentFrameUrlStartingWith;
@@ -231,5 +235,47 @@ final class WebDriverConditionsTest extends IntegrationTest {
         return "webdriver";
       }
     };
+  }
+
+  @Test
+  void assertPresenceOfCookieInWebDriver() {
+    openFile("cookies.html");
+
+    $("#button-put").click();
+    webdriver().shouldHave(cookieWithName("TEST_COOKIE"));
+    clearBrowserCookies();
+  }
+
+  @Test
+  void assertCookieValue() {
+    openFile("cookies.html");
+
+    $("#button-put").click();
+    webdriver().shouldHave(cookieWithNameAndValue("TEST_COOKIE", "AF33892F98ABC39A"));
+    clearBrowserCookies();
+  }
+
+  @Test
+  void assertAbsenceOfCookieInWebDriver() {
+    openFile("cookies.html");
+
+    addCustomCookie();
+    $("#button-remove").click();
+    webdriver().shouldNotHave(cookieWithName("TEST_COOKIE"));
+    clearBrowserCookies();
+  }
+
+  @Test
+  void assertAbsenceOfCookieWithValueInWebDriver() {
+    openFile("cookies.html");
+
+    addCustomCookie();
+    $("#button-remove").click();
+    webdriver().shouldNotHave(cookieWithNameAndValue("TEST_COOKIE", "AF33892F98ABC39A"));
+    clearBrowserCookies();
+  }
+
+  private static void addCustomCookie() {
+    webdriver().driver().getWebDriver().manage().addCookie(new Cookie("TEST_COOKIE", "AF33892F98ABC39A"));
   }
 }

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -240,7 +240,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
-  void assertPresenceOfCookieInWebDriver() {
+  void assertPresenceOfCookieWithGivenName() {
     openFile("cookies.html");
 
     $("#button-put").click();
@@ -249,7 +249,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
-  void assertCookieValue() {
+  void assertPresenceOfCookieWithGivenNameAndValue() {
     openFile("cookies.html");
 
     $("#button-put").click();
@@ -258,7 +258,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
-  void assertCookieObject() {
+  void assertPresenceOfGivenCookieObject() {
     openFile("cookies.html");
 
     final var expectedCookie = getExpectedCookie();
@@ -270,7 +270,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
-  void assertAbsenceOfCookieInWebDriver() {
+  void assertAbsenceOfCookieWithGivenName() {
     openFile("cookies.html");
 
     addCustomCookie();
@@ -280,7 +280,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
-  void assertAbsenceOfCookieWithValueInWebDriver() {
+  void assertAbsenceOfCookieWithGivenNameAndValue() {
     openFile("cookies.html");
 
     addCustomCookie();
@@ -290,7 +290,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
-  void assertAbsenceOfCookieObjectInWebDriver() {
+  void assertAbsenceOfGivenCookieObject() {
     openFile("cookies.html");
 
     final var expectedCookie = getExpectedCookie();

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -263,7 +263,6 @@ final class WebDriverConditionsTest extends IntegrationTest {
 
     final var expectedCookie = getExpectedCookie();
 
-    addCustomCookie();
     $("#button-put").click();
     webdriver().shouldHave(WebDriverConditions.cookie(expectedCookie));
     clearBrowserCookies();

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -1,6 +1,7 @@
 package integration;
 
 import com.codeborne.selenide.ObjectCondition;
+import com.codeborne.selenide.WebDriverConditions;
 import com.codeborne.selenide.ex.ConditionMetException;
 import com.codeborne.selenide.ex.ConditionNotMetException;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,8 +19,6 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.clearBrowserCookies;
 import static com.codeborne.selenide.Selenide.switchTo;
 import static com.codeborne.selenide.Selenide.webdriver;
-import static com.codeborne.selenide.WebDriverConditions.cookieWithName;
-import static com.codeborne.selenide.WebDriverConditions.cookieWithNameAndValue;
 import static com.codeborne.selenide.WebDriverConditions.currentFrameUrl;
 import static com.codeborne.selenide.WebDriverConditions.currentFrameUrlContaining;
 import static com.codeborne.selenide.WebDriverConditions.currentFrameUrlStartingWith;
@@ -32,250 +31,250 @@ import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class WebDriverConditionsTest extends IntegrationTest {
-  @BeforeEach
-  void openTestPage() {
-    openFile("page_with_frames_with_delays.html");
-  }
+    @BeforeEach
+    void openTestPage() {
+        openFile("page_with_frames_with_delays.html");
+    }
 
-  @Test
-  void waitForUrl() {
-    webdriver().shouldHave(url(baseUrl + "/page_with_frames.html"), ofMillis(2000));
-  }
+    @Test
+    void waitForUrl() {
+        webdriver().shouldHave(url(baseUrl + "/page_with_frames.html"), ofMillis(2000));
+    }
 
-  @Test
-  void errorMessageForWrongUrl() {
-    assertThatThrownBy(() ->
-      webdriver().shouldHave(url("page_with_frames.html"), ofMillis(10))
-    )
-      .isInstanceOf(ConditionNotMetException.class)
-      .hasMessageStartingWith("webdriver should have url page_with_frames.html")
-      .hasMessageContaining("Screenshot: ")
-      .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 10 ms.");
-  }
+    @Test
+    void errorMessageForWrongUrl() {
+        assertThatThrownBy(() ->
+                webdriver().shouldHave(url("page_with_frames.html"), ofMillis(10))
+        )
+                .isInstanceOf(ConditionNotMetException.class)
+                .hasMessageStartingWith("webdriver should have url page_with_frames.html")
+                .hasMessageContaining("Screenshot: ")
+                .hasMessageContaining("Page source: ")
+                .hasMessageContaining("Timeout: 10 ms.");
+    }
 
-  @Test
-  void errorMessageWhenWebdriverShouldNotHaveUrl() {
-    openFile("page_with_frames.html");
-    String url = baseUrl + "/page_with_frames.html";
+    @Test
+    void errorMessageWhenWebdriverShouldNotHaveUrl() {
+        openFile("page_with_frames.html");
+        String url = baseUrl + "/page_with_frames.html";
 
-    assertThatThrownBy(() ->
-      webdriver().shouldNotHave(urlStartingWith(url), ofMillis(11))
-    )
-      .isInstanceOf(ConditionMetException.class)
-      .hasMessageStartingWith("webdriver should not have url starting with " + url)
-      .hasMessageContaining("Actual value: " + url)
-      .hasMessageContaining("Screenshot: ")
-      .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 11 ms.");
-  }
+        assertThatThrownBy(() ->
+                webdriver().shouldNotHave(urlStartingWith(url), ofMillis(11))
+        )
+                .isInstanceOf(ConditionMetException.class)
+                .hasMessageStartingWith("webdriver should not have url starting with " + url)
+                .hasMessageContaining("Actual value: " + url)
+                .hasMessageContaining("Screenshot: ")
+                .hasMessageContaining("Page source: ")
+                .hasMessageContaining("Timeout: 11 ms.");
+    }
 
-  @Test
-  void waitForUrlStartingWith() {
-    webdriver().shouldHave(urlStartingWith(baseUrl + "/page_with_"), ofMillis(2000));
-  }
+    @Test
+    void waitForUrlStartingWith() {
+        webdriver().shouldHave(urlStartingWith(baseUrl + "/page_with_"), ofMillis(2000));
+    }
 
-  @Test
-  void waitForUrlContaining() {
-    webdriver().shouldHave(urlContaining("_with_"), ofMillis(2000));
-  }
+    @Test
+    void waitForUrlContaining() {
+        webdriver().shouldHave(urlContaining("_with_"), ofMillis(2000));
+    }
 
-  @Test
-  void errorMessageForWrongUrlStartingWith() {
-    assertThatThrownBy(() ->
-      webdriver().shouldHave(urlStartingWith("https://google.ee/"), ofMillis(10))
-    )
-      .isInstanceOf(ConditionNotMetException.class)
-      .hasMessageStartingWith("webdriver should have url starting with https://google.ee/")
-      .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-      .hasMessageContaining("Screenshot: ")
-      .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 10 ms.");
-  }
+    @Test
+    void errorMessageForWrongUrlStartingWith() {
+        assertThatThrownBy(() ->
+                webdriver().shouldHave(urlStartingWith("https://google.ee/"), ofMillis(10))
+        )
+                .isInstanceOf(ConditionNotMetException.class)
+                .hasMessageStartingWith("webdriver should have url starting with https://google.ee/")
+                .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+                .hasMessageContaining("Screenshot: ")
+                .hasMessageContaining("Page source: ")
+                .hasMessageContaining("Timeout: 10 ms.");
+    }
 
-  @Test
-  void waitForCurrentFrameUrl() {
-    webdriver().shouldHave(currentFrameUrl(baseUrl + "/page_with_frames.html"), ofMillis(2000));
-  }
+    @Test
+    void waitForCurrentFrameUrl() {
+        webdriver().shouldHave(currentFrameUrl(baseUrl + "/page_with_frames.html"), ofMillis(2000));
+    }
 
-  @Test
-  void errorMessageForWrongCurrentFrameUrl() {
-    assertThatThrownBy(() ->
-      webdriver().shouldHave(currentFrameUrl("https://google.ee/"), ofMillis(20))
-    )
-      .isInstanceOf(ConditionNotMetException.class)
-      .hasMessageStartingWith("current frame should have url https://google.ee/")
-      .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-      .hasMessageContaining("Screenshot: ")
-      .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 20 ms.");
-  }
+    @Test
+    void errorMessageForWrongCurrentFrameUrl() {
+        assertThatThrownBy(() ->
+                webdriver().shouldHave(currentFrameUrl("https://google.ee/"), ofMillis(20))
+        )
+                .isInstanceOf(ConditionNotMetException.class)
+                .hasMessageStartingWith("current frame should have url https://google.ee/")
+                .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+                .hasMessageContaining("Screenshot: ")
+                .hasMessageContaining("Page source: ")
+                .hasMessageContaining("Timeout: 20 ms.");
+    }
 
-  @Test
-  void waitForUrlCurrentFrameStartingWith() {
-    webdriver().shouldHave(currentFrameUrlStartingWith(baseUrl + "/page_with_"), ofMillis(2000));
-  }
+    @Test
+    void waitForUrlCurrentFrameStartingWith() {
+        webdriver().shouldHave(currentFrameUrlStartingWith(baseUrl + "/page_with_"), ofMillis(2000));
+    }
 
-  @Test
-  void waitForUrlCurrentFrameContaining() {
-    webdriver().shouldHave(currentFrameUrlContaining("e_with_"), ofMillis(2000));
-  }
+    @Test
+    void waitForUrlCurrentFrameContaining() {
+        webdriver().shouldHave(currentFrameUrlContaining("e_with_"), ofMillis(2000));
+    }
 
-  @Test
-  void errorMessageForWrongCurrentFrameUrlStartingWith() {
-    assertThatThrownBy(() ->
-      webdriver().shouldHave(currentFrameUrlStartingWith("https://google.ee/"), ofMillis(5))
-    )
-      .isInstanceOf(ConditionNotMetException.class)
-      .hasMessageStartingWith("current frame should have url starting with https://google.ee/")
-      .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-      .hasMessageContaining("Screenshot: ")
-      .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 5 ms.");
-  }
+    @Test
+    void errorMessageForWrongCurrentFrameUrlStartingWith() {
+        assertThatThrownBy(() ->
+                webdriver().shouldHave(currentFrameUrlStartingWith("https://google.ee/"), ofMillis(5))
+        )
+                .isInstanceOf(ConditionNotMetException.class)
+                .hasMessageStartingWith("current frame should have url starting with https://google.ee/")
+                .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+                .hasMessageContaining("Screenshot: ")
+                .hasMessageContaining("Page source: ")
+                .hasMessageContaining("Timeout: 5 ms.");
+    }
 
-  @Test
-  void checkNumberOfOpenWindows() {
-    openFile("page_with_tabs.html");
+    @Test
+    void checkNumberOfOpenWindows() {
+        openFile("page_with_tabs.html");
 
-    webdriver().shouldHave(numberOfWindows(1));
-    $(byText("Page4: same title")).click();
-    webdriver().shouldHave(numberOfWindows(2));
-    $(byText("Page5: same title")).click();
-    webdriver().shouldHave(numberOfWindows(3));
+        webdriver().shouldHave(numberOfWindows(1));
+        $(byText("Page4: same title")).click();
+        webdriver().shouldHave(numberOfWindows(2));
+        $(byText("Page5: same title")).click();
+        webdriver().shouldHave(numberOfWindows(3));
 
-    switchTo().window(2).close();
-    webdriver().shouldHave(numberOfWindows(2));
-    switchTo().window(1).close();
-    webdriver().shouldHave(numberOfWindows(1));
-    switchTo().window(0);
-  }
+        switchTo().window(2).close();
+        webdriver().shouldHave(numberOfWindows(2));
+        switchTo().window(1).close();
+        webdriver().shouldHave(numberOfWindows(1));
+        switchTo().window(0);
+    }
 
-  @Test
-  void errorMessageForNumberOfWindows() {
-    assertThatThrownBy(() ->
-      webdriver().shouldHave(numberOfWindows(2)))
-      .isInstanceOf(ConditionNotMetException.class)
-      .hasMessageContaining("webdriver should have 2 window(s)")
-      .hasMessageContaining("Actual value: 1");
+    @Test
+    void errorMessageForNumberOfWindows() {
+        assertThatThrownBy(() ->
+                webdriver().shouldHave(numberOfWindows(2)))
+                .isInstanceOf(ConditionNotMetException.class)
+                .hasMessageContaining("webdriver should have 2 window(s)")
+                .hasMessageContaining("Actual value: 1");
 
-    assertThatThrownBy(() ->
-      webdriver().shouldNotHave(numberOfWindows(1)))
-      .isInstanceOf(ConditionMetException.class)
-      .hasMessageContaining("webdriver should not have 1 window(s)")
-      .hasMessageContaining("Actual value: 1");
-  }
+        assertThatThrownBy(() ->
+                webdriver().shouldNotHave(numberOfWindows(1)))
+                .isInstanceOf(ConditionMetException.class)
+                .hasMessageContaining("webdriver should not have 1 window(s)")
+                .hasMessageContaining("Actual value: 1");
+    }
 
-  @Test
-  void checkForPageTitle() {
-    webdriver().shouldHave(title("Test::frames with delays"), ofMillis(10));
-  }
+    @Test
+    void checkForPageTitle() {
+        webdriver().shouldHave(title("Test::frames with delays"), ofMillis(10));
+    }
 
-  @Test
-  void errorMessageForWrongTitle() {
-    assertThatThrownBy(() ->
-      webdriver().shouldHave(title("Selenide-test-page"), ofMillis(10))
-    )
-      .isInstanceOf(ConditionNotMetException.class)
-      .hasMessageContaining("Actual value: Test::frames with delays");
-  }
+    @Test
+    void errorMessageForWrongTitle() {
+        assertThatThrownBy(() ->
+                webdriver().shouldHave(title("Selenide-test-page"), ofMillis(10))
+        )
+                .isInstanceOf(ConditionNotMetException.class)
+                .hasMessageContaining("Actual value: Test::frames with delays");
+    }
 
-  @Test
-  void errorMessageWhenWebdriverShouldNotHaveTitle() {
-    assertThatThrownBy(() ->
-      webdriver().shouldNotHave(title("Test::frames with delays"), ofMillis(10))
-    )
-      .isInstanceOf(ConditionMetException.class)
-      .hasMessageStartingWith("Page should not have title Test::frames with delays")
-      .hasMessageContaining("Actual value: Test::frames with delays");
-  }
+    @Test
+    void errorMessageWhenWebdriverShouldNotHaveTitle() {
+        assertThatThrownBy(() ->
+                webdriver().shouldNotHave(title("Test::frames with delays"), ofMillis(10))
+        )
+                .isInstanceOf(ConditionMetException.class)
+                .hasMessageStartingWith("Page should not have title Test::frames with delays")
+                .hasMessageContaining("Actual value: Test::frames with delays");
+    }
 
-  @Test
-  void userCanDefineCustomConditions() {
-    webdriver().shouldHave(cookie("session_id"));
-    webdriver().shouldNotHave(cookie("nonexistent_cookie"));
-  }
+    @Test
+    void userCanDefineCustomConditions() {
+        webdriver().shouldHave(cookie("session_id"));
+        webdriver().shouldNotHave(cookie("nonexistent_cookie"));
+    }
 
-  @ParametersAreNonnullByDefault
-  private ObjectCondition<WebDriver> cookie(String expectedCookieName) {
-    return new ObjectCondition<WebDriver>() {
-      @Nonnull
-      @Override
-      public String description() {
-        return "should have a cookie with name '" + expectedCookieName + "'";
-      }
+    @ParametersAreNonnullByDefault
+    private ObjectCondition<WebDriver> cookie(String expectedCookieName) {
+        return new ObjectCondition<WebDriver>() {
+            @Nonnull
+            @Override
+            public String description() {
+                return "should have a cookie with name '" + expectedCookieName + "'";
+            }
 
-      @Nonnull
-      @Override
-      public String negativeDescription() {
-        return "should not have a cookie with name '" + expectedCookieName + "'";
-      }
+            @Nonnull
+            @Override
+            public String negativeDescription() {
+                return "should not have a cookie with name '" + expectedCookieName + "'";
+            }
 
-      @CheckReturnValue
-      @Override
-      public boolean test(WebDriver webdriver) {
-        return webdriver.manage().getCookieNamed(expectedCookieName) != null;
-      }
+            @CheckReturnValue
+            @Override
+            public boolean test(WebDriver webdriver) {
+                return webdriver.manage().getCookieNamed(expectedCookieName) != null;
+            }
 
-      @Nonnull
-      @Override
-      public String actualValue(WebDriver webdriver) {
-        return "Available cookies: " + webdriver.manage().getCookies();
-      }
+            @Nonnull
+            @Override
+            public String actualValue(WebDriver webdriver) {
+                return "Available cookies: " + webdriver.manage().getCookies();
+            }
 
-      @Override
-      @CheckReturnValue
-      public String expectedValue() {
-        return expectedCookieName;
-      }
+            @Override
+            @CheckReturnValue
+            public String expectedValue() {
+                return expectedCookieName;
+            }
 
-      @Nonnull
-      @Override
-      public String describe(WebDriver object) {
-        return "webdriver";
-      }
-    };
-  }
+            @Nonnull
+            @Override
+            public String describe(WebDriver object) {
+                return "webdriver";
+            }
+        };
+    }
 
-  @Test
-  void assertPresenceOfCookieInWebDriver() {
-    openFile("cookies.html");
+    @Test
+    void assertPresenceOfCookieInWebDriver() {
+        openFile("cookies.html");
 
-    $("#button-put").click();
-    webdriver().shouldHave(cookieWithName("TEST_COOKIE"));
-    clearBrowserCookies();
-  }
+        $("#button-put").click();
+        webdriver().shouldHave(WebDriverConditions.cookie("TEST_COOKIE"));
+        clearBrowserCookies();
+    }
 
-  @Test
-  void assertCookieValue() {
-    openFile("cookies.html");
+    @Test
+    void assertCookieValue() {
+        openFile("cookies.html");
 
-    $("#button-put").click();
-    webdriver().shouldHave(cookieWithNameAndValue("TEST_COOKIE", "AF33892F98ABC39A"));
-    clearBrowserCookies();
-  }
+        $("#button-put").click();
+        webdriver().shouldHave(WebDriverConditions.cookie("TEST_COOKIE", "AF33892F98ABC39A"));
+        clearBrowserCookies();
+    }
 
-  @Test
-  void assertAbsenceOfCookieInWebDriver() {
-    openFile("cookies.html");
+    @Test
+    void assertAbsenceOfCookieInWebDriver() {
+        openFile("cookies.html");
 
-    addCustomCookie();
-    $("#button-remove").click();
-    webdriver().shouldNotHave(cookieWithName("TEST_COOKIE"));
-    clearBrowserCookies();
-  }
+        addCustomCookie();
+        $("#button-remove").click();
+        webdriver().shouldNotHave(WebDriverConditions.cookie("TEST_COOKIE"));
+        clearBrowserCookies();
+    }
 
-  @Test
-  void assertAbsenceOfCookieWithValueInWebDriver() {
-    openFile("cookies.html");
+    @Test
+    void assertAbsenceOfCookieWithValueInWebDriver() {
+        openFile("cookies.html");
 
-    addCustomCookie();
-    $("#button-remove").click();
-    webdriver().shouldNotHave(cookieWithNameAndValue("TEST_COOKIE", "AF33892F98ABC39A"));
-    clearBrowserCookies();
-  }
+        addCustomCookie();
+        $("#button-remove").click();
+        webdriver().shouldNotHave(WebDriverConditions.cookie("TEST_COOKIE", "AF33892F98ABC39A"));
+        clearBrowserCookies();
+    }
 
-  private static void addCustomCookie() {
-    webdriver().driver().getWebDriver().manage().addCookie(new Cookie("TEST_COOKIE", "AF33892F98ABC39A"));
-  }
+    private static void addCustomCookie() {
+        webdriver().driver().getWebDriver().manage().addCookie(new Cookie("TEST_COOKIE", "AF33892F98ABC39A"));
+    }
 }

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -47,13 +47,13 @@ final class WebDriverConditionsTest extends IntegrationTest {
   @Test
   void errorMessageForWrongUrl() {
     assertThatThrownBy(() ->
-        webdriver().shouldHave(url("page_with_frames.html"), ofMillis(10))
+      webdriver().shouldHave(url("page_with_frames.html"), ofMillis(10))
     )
-        .isInstanceOf(ConditionNotMetException.class)
-        .hasMessageStartingWith("webdriver should have url page_with_frames.html")
-        .hasMessageContaining("Screenshot: ")
-        .hasMessageContaining("Page source: ")
-        .hasMessageContaining("Timeout: 10 ms.");
+      .isInstanceOf(ConditionNotMetException.class)
+      .hasMessageStartingWith("webdriver should have url page_with_frames.html")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 10 ms.");
   }
 
   @Test
@@ -62,14 +62,14 @@ final class WebDriverConditionsTest extends IntegrationTest {
     String url = baseUrl + "/page_with_frames.html";
 
     assertThatThrownBy(() ->
-        webdriver().shouldNotHave(urlStartingWith(url), ofMillis(11))
+      webdriver().shouldNotHave(urlStartingWith(url), ofMillis(11))
     )
-        .isInstanceOf(ConditionMetException.class)
-        .hasMessageStartingWith("webdriver should not have url starting with " + url)
-        .hasMessageContaining("Actual value: " + url)
-        .hasMessageContaining("Screenshot: ")
-        .hasMessageContaining("Page source: ")
-        .hasMessageContaining("Timeout: 11 ms.");
+      .isInstanceOf(ConditionMetException.class)
+      .hasMessageStartingWith("webdriver should not have url starting with " + url)
+      .hasMessageContaining("Actual value: " + url)
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 11 ms.");
   }
 
   @Test
@@ -85,14 +85,14 @@ final class WebDriverConditionsTest extends IntegrationTest {
   @Test
   void errorMessageForWrongUrlStartingWith() {
     assertThatThrownBy(() ->
-        webdriver().shouldHave(urlStartingWith("https://google.ee/"), ofMillis(10))
+      webdriver().shouldHave(urlStartingWith("https://google.ee/"), ofMillis(10))
     )
-        .isInstanceOf(ConditionNotMetException.class)
-        .hasMessageStartingWith("webdriver should have url starting with https://google.ee/")
-        .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-        .hasMessageContaining("Screenshot: ")
-        .hasMessageContaining("Page source: ")
-        .hasMessageContaining("Timeout: 10 ms.");
+      .isInstanceOf(ConditionNotMetException.class)
+      .hasMessageStartingWith("webdriver should have url starting with https://google.ee/")
+      .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 10 ms.");
   }
 
   @Test
@@ -103,14 +103,14 @@ final class WebDriverConditionsTest extends IntegrationTest {
   @Test
   void errorMessageForWrongCurrentFrameUrl() {
     assertThatThrownBy(() ->
-        webdriver().shouldHave(currentFrameUrl("https://google.ee/"), ofMillis(20))
+      webdriver().shouldHave(currentFrameUrl("https://google.ee/"), ofMillis(20))
     )
-        .isInstanceOf(ConditionNotMetException.class)
-        .hasMessageStartingWith("current frame should have url https://google.ee/")
-        .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-        .hasMessageContaining("Screenshot: ")
-        .hasMessageContaining("Page source: ")
-        .hasMessageContaining("Timeout: 20 ms.");
+      .isInstanceOf(ConditionNotMetException.class)
+      .hasMessageStartingWith("current frame should have url https://google.ee/")
+      .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 20 ms.");
   }
 
   @Test
@@ -126,14 +126,14 @@ final class WebDriverConditionsTest extends IntegrationTest {
   @Test
   void errorMessageForWrongCurrentFrameUrlStartingWith() {
     assertThatThrownBy(() ->
-        webdriver().shouldHave(currentFrameUrlStartingWith("https://google.ee/"), ofMillis(5))
+      webdriver().shouldHave(currentFrameUrlStartingWith("https://google.ee/"), ofMillis(5))
     )
-        .isInstanceOf(ConditionNotMetException.class)
-        .hasMessageStartingWith("current frame should have url starting with https://google.ee/")
-        .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-        .hasMessageContaining("Screenshot: ")
-        .hasMessageContaining("Page source: ")
-        .hasMessageContaining("Timeout: 5 ms.");
+      .isInstanceOf(ConditionNotMetException.class)
+      .hasMessageStartingWith("current frame should have url starting with https://google.ee/")
+      .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 5 ms.");
   }
 
   @Test
@@ -156,16 +156,16 @@ final class WebDriverConditionsTest extends IntegrationTest {
   @Test
   void errorMessageForNumberOfWindows() {
     assertThatThrownBy(() ->
-        webdriver().shouldHave(numberOfWindows(2)))
-        .isInstanceOf(ConditionNotMetException.class)
-        .hasMessageContaining("webdriver should have 2 window(s)")
-        .hasMessageContaining("Actual value: 1");
+      webdriver().shouldHave(numberOfWindows(2)))
+      .isInstanceOf(ConditionNotMetException.class)
+      .hasMessageContaining("webdriver should have 2 window(s)")
+      .hasMessageContaining("Actual value: 1");
 
     assertThatThrownBy(() ->
-        webdriver().shouldNotHave(numberOfWindows(1)))
-        .isInstanceOf(ConditionMetException.class)
-        .hasMessageContaining("webdriver should not have 1 window(s)")
-        .hasMessageContaining("Actual value: 1");
+      webdriver().shouldNotHave(numberOfWindows(1)))
+      .isInstanceOf(ConditionMetException.class)
+      .hasMessageContaining("webdriver should not have 1 window(s)")
+      .hasMessageContaining("Actual value: 1");
   }
 
   @Test
@@ -176,20 +176,20 @@ final class WebDriverConditionsTest extends IntegrationTest {
   @Test
   void errorMessageForWrongTitle() {
     assertThatThrownBy(() ->
-        webdriver().shouldHave(title("Selenide-test-page"), ofMillis(10))
+      webdriver().shouldHave(title("Selenide-test-page"), ofMillis(10))
     )
-        .isInstanceOf(ConditionNotMetException.class)
-        .hasMessageContaining("Actual value: Test::frames with delays");
+      .isInstanceOf(ConditionNotMetException.class)
+      .hasMessageContaining("Actual value: Test::frames with delays");
   }
 
   @Test
   void errorMessageWhenWebdriverShouldNotHaveTitle() {
     assertThatThrownBy(() ->
-        webdriver().shouldNotHave(title("Test::frames with delays"), ofMillis(10))
+      webdriver().shouldNotHave(title("Test::frames with delays"), ofMillis(10))
     )
-        .isInstanceOf(ConditionMetException.class)
-        .hasMessageStartingWith("Page should not have title Test::frames with delays")
-        .hasMessageContaining("Actual value: Test::frames with delays");
+      .isInstanceOf(ConditionMetException.class)
+      .hasMessageStartingWith("Page should not have title Test::frames with delays")
+      .hasMessageContaining("Actual value: Test::frames with delays");
   }
 
   @Test

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -12,6 +12,9 @@ import org.openqa.selenium.WebDriver;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 
 import static com.codeborne.selenide.Configuration.baseUrl;
 import static com.codeborne.selenide.Selectors.byText;
@@ -31,250 +34,282 @@ import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class WebDriverConditionsTest extends IntegrationTest {
-    @BeforeEach
-    void openTestPage() {
-        openFile("page_with_frames_with_delays.html");
-    }
+  @BeforeEach
+  void openTestPage() {
+    openFile("page_with_frames_with_delays.html");
+  }
 
-    @Test
-    void waitForUrl() {
-        webdriver().shouldHave(url(baseUrl + "/page_with_frames.html"), ofMillis(2000));
-    }
+  @Test
+  void waitForUrl() {
+    webdriver().shouldHave(url(baseUrl + "/page_with_frames.html"), ofMillis(2000));
+  }
 
-    @Test
-    void errorMessageForWrongUrl() {
-        assertThatThrownBy(() ->
-                webdriver().shouldHave(url("page_with_frames.html"), ofMillis(10))
-        )
-                .isInstanceOf(ConditionNotMetException.class)
-                .hasMessageStartingWith("webdriver should have url page_with_frames.html")
-                .hasMessageContaining("Screenshot: ")
-                .hasMessageContaining("Page source: ")
-                .hasMessageContaining("Timeout: 10 ms.");
-    }
+  @Test
+  void errorMessageForWrongUrl() {
+    assertThatThrownBy(() ->
+        webdriver().shouldHave(url("page_with_frames.html"), ofMillis(10))
+    )
+        .isInstanceOf(ConditionNotMetException.class)
+        .hasMessageStartingWith("webdriver should have url page_with_frames.html")
+        .hasMessageContaining("Screenshot: ")
+        .hasMessageContaining("Page source: ")
+        .hasMessageContaining("Timeout: 10 ms.");
+  }
 
-    @Test
-    void errorMessageWhenWebdriverShouldNotHaveUrl() {
-        openFile("page_with_frames.html");
-        String url = baseUrl + "/page_with_frames.html";
+  @Test
+  void errorMessageWhenWebdriverShouldNotHaveUrl() {
+    openFile("page_with_frames.html");
+    String url = baseUrl + "/page_with_frames.html";
 
-        assertThatThrownBy(() ->
-                webdriver().shouldNotHave(urlStartingWith(url), ofMillis(11))
-        )
-                .isInstanceOf(ConditionMetException.class)
-                .hasMessageStartingWith("webdriver should not have url starting with " + url)
-                .hasMessageContaining("Actual value: " + url)
-                .hasMessageContaining("Screenshot: ")
-                .hasMessageContaining("Page source: ")
-                .hasMessageContaining("Timeout: 11 ms.");
-    }
+    assertThatThrownBy(() ->
+        webdriver().shouldNotHave(urlStartingWith(url), ofMillis(11))
+    )
+        .isInstanceOf(ConditionMetException.class)
+        .hasMessageStartingWith("webdriver should not have url starting with " + url)
+        .hasMessageContaining("Actual value: " + url)
+        .hasMessageContaining("Screenshot: ")
+        .hasMessageContaining("Page source: ")
+        .hasMessageContaining("Timeout: 11 ms.");
+  }
 
-    @Test
-    void waitForUrlStartingWith() {
-        webdriver().shouldHave(urlStartingWith(baseUrl + "/page_with_"), ofMillis(2000));
-    }
+  @Test
+  void waitForUrlStartingWith() {
+    webdriver().shouldHave(urlStartingWith(baseUrl + "/page_with_"), ofMillis(2000));
+  }
 
-    @Test
-    void waitForUrlContaining() {
-        webdriver().shouldHave(urlContaining("_with_"), ofMillis(2000));
-    }
+  @Test
+  void waitForUrlContaining() {
+    webdriver().shouldHave(urlContaining("_with_"), ofMillis(2000));
+  }
 
-    @Test
-    void errorMessageForWrongUrlStartingWith() {
-        assertThatThrownBy(() ->
-                webdriver().shouldHave(urlStartingWith("https://google.ee/"), ofMillis(10))
-        )
-                .isInstanceOf(ConditionNotMetException.class)
-                .hasMessageStartingWith("webdriver should have url starting with https://google.ee/")
-                .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-                .hasMessageContaining("Screenshot: ")
-                .hasMessageContaining("Page source: ")
-                .hasMessageContaining("Timeout: 10 ms.");
-    }
+  @Test
+  void errorMessageForWrongUrlStartingWith() {
+    assertThatThrownBy(() ->
+        webdriver().shouldHave(urlStartingWith("https://google.ee/"), ofMillis(10))
+    )
+        .isInstanceOf(ConditionNotMetException.class)
+        .hasMessageStartingWith("webdriver should have url starting with https://google.ee/")
+        .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+        .hasMessageContaining("Screenshot: ")
+        .hasMessageContaining("Page source: ")
+        .hasMessageContaining("Timeout: 10 ms.");
+  }
 
-    @Test
-    void waitForCurrentFrameUrl() {
-        webdriver().shouldHave(currentFrameUrl(baseUrl + "/page_with_frames.html"), ofMillis(2000));
-    }
+  @Test
+  void waitForCurrentFrameUrl() {
+    webdriver().shouldHave(currentFrameUrl(baseUrl + "/page_with_frames.html"), ofMillis(2000));
+  }
 
-    @Test
-    void errorMessageForWrongCurrentFrameUrl() {
-        assertThatThrownBy(() ->
-                webdriver().shouldHave(currentFrameUrl("https://google.ee/"), ofMillis(20))
-        )
-                .isInstanceOf(ConditionNotMetException.class)
-                .hasMessageStartingWith("current frame should have url https://google.ee/")
-                .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-                .hasMessageContaining("Screenshot: ")
-                .hasMessageContaining("Page source: ")
-                .hasMessageContaining("Timeout: 20 ms.");
-    }
+  @Test
+  void errorMessageForWrongCurrentFrameUrl() {
+    assertThatThrownBy(() ->
+        webdriver().shouldHave(currentFrameUrl("https://google.ee/"), ofMillis(20))
+    )
+        .isInstanceOf(ConditionNotMetException.class)
+        .hasMessageStartingWith("current frame should have url https://google.ee/")
+        .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+        .hasMessageContaining("Screenshot: ")
+        .hasMessageContaining("Page source: ")
+        .hasMessageContaining("Timeout: 20 ms.");
+  }
 
-    @Test
-    void waitForUrlCurrentFrameStartingWith() {
-        webdriver().shouldHave(currentFrameUrlStartingWith(baseUrl + "/page_with_"), ofMillis(2000));
-    }
+  @Test
+  void waitForUrlCurrentFrameStartingWith() {
+    webdriver().shouldHave(currentFrameUrlStartingWith(baseUrl + "/page_with_"), ofMillis(2000));
+  }
 
-    @Test
-    void waitForUrlCurrentFrameContaining() {
-        webdriver().shouldHave(currentFrameUrlContaining("e_with_"), ofMillis(2000));
-    }
+  @Test
+  void waitForUrlCurrentFrameContaining() {
+    webdriver().shouldHave(currentFrameUrlContaining("e_with_"), ofMillis(2000));
+  }
 
-    @Test
-    void errorMessageForWrongCurrentFrameUrlStartingWith() {
-        assertThatThrownBy(() ->
-                webdriver().shouldHave(currentFrameUrlStartingWith("https://google.ee/"), ofMillis(5))
-        )
-                .isInstanceOf(ConditionNotMetException.class)
-                .hasMessageStartingWith("current frame should have url starting with https://google.ee/")
-                .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
-                .hasMessageContaining("Screenshot: ")
-                .hasMessageContaining("Page source: ")
-                .hasMessageContaining("Timeout: 5 ms.");
-    }
+  @Test
+  void errorMessageForWrongCurrentFrameUrlStartingWith() {
+    assertThatThrownBy(() ->
+        webdriver().shouldHave(currentFrameUrlStartingWith("https://google.ee/"), ofMillis(5))
+    )
+        .isInstanceOf(ConditionNotMetException.class)
+        .hasMessageStartingWith("current frame should have url starting with https://google.ee/")
+        .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+        .hasMessageContaining("Screenshot: ")
+        .hasMessageContaining("Page source: ")
+        .hasMessageContaining("Timeout: 5 ms.");
+  }
 
-    @Test
-    void checkNumberOfOpenWindows() {
-        openFile("page_with_tabs.html");
+  @Test
+  void checkNumberOfOpenWindows() {
+    openFile("page_with_tabs.html");
 
-        webdriver().shouldHave(numberOfWindows(1));
-        $(byText("Page4: same title")).click();
-        webdriver().shouldHave(numberOfWindows(2));
-        $(byText("Page5: same title")).click();
-        webdriver().shouldHave(numberOfWindows(3));
+    webdriver().shouldHave(numberOfWindows(1));
+    $(byText("Page4: same title")).click();
+    webdriver().shouldHave(numberOfWindows(2));
+    $(byText("Page5: same title")).click();
+    webdriver().shouldHave(numberOfWindows(3));
 
-        switchTo().window(2).close();
-        webdriver().shouldHave(numberOfWindows(2));
-        switchTo().window(1).close();
-        webdriver().shouldHave(numberOfWindows(1));
-        switchTo().window(0);
-    }
+    switchTo().window(2).close();
+    webdriver().shouldHave(numberOfWindows(2));
+    switchTo().window(1).close();
+    webdriver().shouldHave(numberOfWindows(1));
+    switchTo().window(0);
+  }
 
-    @Test
-    void errorMessageForNumberOfWindows() {
-        assertThatThrownBy(() ->
-                webdriver().shouldHave(numberOfWindows(2)))
-                .isInstanceOf(ConditionNotMetException.class)
-                .hasMessageContaining("webdriver should have 2 window(s)")
-                .hasMessageContaining("Actual value: 1");
+  @Test
+  void errorMessageForNumberOfWindows() {
+    assertThatThrownBy(() ->
+        webdriver().shouldHave(numberOfWindows(2)))
+        .isInstanceOf(ConditionNotMetException.class)
+        .hasMessageContaining("webdriver should have 2 window(s)")
+        .hasMessageContaining("Actual value: 1");
 
-        assertThatThrownBy(() ->
-                webdriver().shouldNotHave(numberOfWindows(1)))
-                .isInstanceOf(ConditionMetException.class)
-                .hasMessageContaining("webdriver should not have 1 window(s)")
-                .hasMessageContaining("Actual value: 1");
-    }
+    assertThatThrownBy(() ->
+        webdriver().shouldNotHave(numberOfWindows(1)))
+        .isInstanceOf(ConditionMetException.class)
+        .hasMessageContaining("webdriver should not have 1 window(s)")
+        .hasMessageContaining("Actual value: 1");
+  }
 
-    @Test
-    void checkForPageTitle() {
-        webdriver().shouldHave(title("Test::frames with delays"), ofMillis(10));
-    }
+  @Test
+  void checkForPageTitle() {
+    webdriver().shouldHave(title("Test::frames with delays"), ofMillis(10));
+  }
 
-    @Test
-    void errorMessageForWrongTitle() {
-        assertThatThrownBy(() ->
-                webdriver().shouldHave(title("Selenide-test-page"), ofMillis(10))
-        )
-                .isInstanceOf(ConditionNotMetException.class)
-                .hasMessageContaining("Actual value: Test::frames with delays");
-    }
+  @Test
+  void errorMessageForWrongTitle() {
+    assertThatThrownBy(() ->
+        webdriver().shouldHave(title("Selenide-test-page"), ofMillis(10))
+    )
+        .isInstanceOf(ConditionNotMetException.class)
+        .hasMessageContaining("Actual value: Test::frames with delays");
+  }
 
-    @Test
-    void errorMessageWhenWebdriverShouldNotHaveTitle() {
-        assertThatThrownBy(() ->
-                webdriver().shouldNotHave(title("Test::frames with delays"), ofMillis(10))
-        )
-                .isInstanceOf(ConditionMetException.class)
-                .hasMessageStartingWith("Page should not have title Test::frames with delays")
-                .hasMessageContaining("Actual value: Test::frames with delays");
-    }
+  @Test
+  void errorMessageWhenWebdriverShouldNotHaveTitle() {
+    assertThatThrownBy(() ->
+        webdriver().shouldNotHave(title("Test::frames with delays"), ofMillis(10))
+    )
+        .isInstanceOf(ConditionMetException.class)
+        .hasMessageStartingWith("Page should not have title Test::frames with delays")
+        .hasMessageContaining("Actual value: Test::frames with delays");
+  }
 
-    @Test
-    void userCanDefineCustomConditions() {
-        webdriver().shouldHave(cookie("session_id"));
-        webdriver().shouldNotHave(cookie("nonexistent_cookie"));
-    }
+  @Test
+  void userCanDefineCustomConditions() {
+    webdriver().shouldHave(cookie("session_id"));
+    webdriver().shouldNotHave(cookie("nonexistent_cookie"));
+  }
 
-    @ParametersAreNonnullByDefault
-    private ObjectCondition<WebDriver> cookie(String expectedCookieName) {
-        return new ObjectCondition<WebDriver>() {
-            @Nonnull
-            @Override
-            public String description() {
-                return "should have a cookie with name '" + expectedCookieName + "'";
-            }
+  @ParametersAreNonnullByDefault
+  private ObjectCondition<WebDriver> cookie(String expectedCookieName) {
+    return new ObjectCondition<WebDriver>() {
+      @Nonnull
+      @Override
+      public String description() {
+        return "should have a cookie with name '" + expectedCookieName + "'";
+      }
 
-            @Nonnull
-            @Override
-            public String negativeDescription() {
-                return "should not have a cookie with name '" + expectedCookieName + "'";
-            }
+      @Nonnull
+      @Override
+      public String negativeDescription() {
+        return "should not have a cookie with name '" + expectedCookieName + "'";
+      }
 
-            @CheckReturnValue
-            @Override
-            public boolean test(WebDriver webdriver) {
-                return webdriver.manage().getCookieNamed(expectedCookieName) != null;
-            }
+      @CheckReturnValue
+      @Override
+      public boolean test(WebDriver webdriver) {
+        return webdriver.manage().getCookieNamed(expectedCookieName) != null;
+      }
 
-            @Nonnull
-            @Override
-            public String actualValue(WebDriver webdriver) {
-                return "Available cookies: " + webdriver.manage().getCookies();
-            }
+      @Nonnull
+      @Override
+      public String actualValue(WebDriver webdriver) {
+        return "Available cookies: " + webdriver.manage().getCookies();
+      }
 
-            @Override
-            @CheckReturnValue
-            public String expectedValue() {
-                return expectedCookieName;
-            }
+      @Override
+      @CheckReturnValue
+      public String expectedValue() {
+        return expectedCookieName;
+      }
 
-            @Nonnull
-            @Override
-            public String describe(WebDriver object) {
-                return "webdriver";
-            }
-        };
-    }
+      @Nonnull
+      @Override
+      public String describe(WebDriver object) {
+        return "webdriver";
+      }
+    };
+  }
 
-    @Test
-    void assertPresenceOfCookieInWebDriver() {
-        openFile("cookies.html");
+  @Test
+  void assertPresenceOfCookieInWebDriver() {
+    openFile("cookies.html");
 
-        $("#button-put").click();
-        webdriver().shouldHave(WebDriverConditions.cookie("TEST_COOKIE"));
-        clearBrowserCookies();
-    }
+    $("#button-put").click();
+    webdriver().shouldHave(WebDriverConditions.cookie("TEST_COOKIE"));
+    clearBrowserCookies();
+  }
 
-    @Test
-    void assertCookieValue() {
-        openFile("cookies.html");
+  @Test
+  void assertCookieValue() {
+    openFile("cookies.html");
 
-        $("#button-put").click();
-        webdriver().shouldHave(WebDriverConditions.cookie("TEST_COOKIE", "AF33892F98ABC39A"));
-        clearBrowserCookies();
-    }
+    $("#button-put").click();
+    webdriver().shouldHave(WebDriverConditions.cookie("TEST_COOKIE", "AF33892F98ABC39A"));
+    clearBrowserCookies();
+  }
 
-    @Test
-    void assertAbsenceOfCookieInWebDriver() {
-        openFile("cookies.html");
+  @Test
+  void assertCookieObject() {
+    openFile("cookies.html");
 
-        addCustomCookie();
-        $("#button-remove").click();
-        webdriver().shouldNotHave(WebDriverConditions.cookie("TEST_COOKIE"));
-        clearBrowserCookies();
-    }
+    final var expectedCookie = getExpectedCookie();
 
-    @Test
-    void assertAbsenceOfCookieWithValueInWebDriver() {
-        openFile("cookies.html");
+    addCustomCookie();
+    $("#button-put").click();
+    webdriver().shouldHave(WebDriverConditions.cookie(expectedCookie));
+    clearBrowserCookies();
+  }
 
-        addCustomCookie();
-        $("#button-remove").click();
-        webdriver().shouldNotHave(WebDriverConditions.cookie("TEST_COOKIE", "AF33892F98ABC39A"));
-        clearBrowserCookies();
-    }
+  @Test
+  void assertAbsenceOfCookieInWebDriver() {
+    openFile("cookies.html");
 
-    private static void addCustomCookie() {
-        webdriver().driver().getWebDriver().manage().addCookie(new Cookie("TEST_COOKIE", "AF33892F98ABC39A"));
-    }
+    addCustomCookie();
+    $("#button-remove").click();
+    webdriver().shouldNotHave(WebDriverConditions.cookie("TEST_COOKIE"));
+    clearBrowserCookies();
+  }
+
+  @Test
+  void assertAbsenceOfCookieWithValueInWebDriver() {
+    openFile("cookies.html");
+
+    addCustomCookie();
+    $("#button-remove").click();
+    webdriver().shouldNotHave(WebDriverConditions.cookie("TEST_COOKIE", "AF33892F98ABC39A"));
+    clearBrowserCookies();
+  }
+
+  @Test
+  void assertAbsenceOfCookieObjectInWebDriver() {
+    openFile("cookies.html");
+
+    final var expectedCookie = getExpectedCookie();
+
+    addCustomCookie();
+    $("#button-remove").click();
+    webdriver().shouldNotHave(WebDriverConditions.cookie(expectedCookie));
+    clearBrowserCookies();
+  }
+
+  private static void addCustomCookie() {
+    final var expectedCookie = getExpectedCookie();
+
+    webdriver().driver().getWebDriver().manage().addCookie(expectedCookie);
+  }
+
+  private static Cookie getExpectedCookie() {
+    final var expiry = Date.from(Instant.now().plus(Duration.ofDays(3)));
+
+    return new Cookie("TEST_COOKIE", "AF33892F98ABC39A", "/", expiry);
+  }
 }


### PR DESCRIPTION
Added three conditions for checking cookies: the presence of a cookie with a given name, the value of a cookie with a given name, and the presence of exactly the same Selenium Cookie object. Written checks are covered by unit tests.