### PR TITLE
#2130 added allOf and anyOf conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.16.1
+* #2368 added `allOf` and `anyOf` conditions  --  see PR #2368
+
 ## 6.16.0 (released 02.07.2023)
 * #2362 Speed up collection conditions
 * #2268 Add conditions `date(...)` and `datetime(...)` to check date values  --  thanks to Maksim @Au6ojlut for PR #2281

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -637,6 +637,24 @@ public abstract class Condition {
   }
 
   /**
+   * Synonym for {@link #and(String, Condition, Condition, Condition...)}. Useful for better readability.
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition allOf(String name, Condition condition1, Condition condition2, Condition... conditions) {
+    return and(name, condition1, condition2, conditions);
+  }
+
+  /**
+   * Synonym for {@link #and(String, Condition, Condition, Condition...)} with "all of" name. Useful for better readability.
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition allOf(Condition condition1, Condition condition2, Condition... conditions) {
+    return and("all of", condition1, condition2, conditions);
+  }
+
+  /**
    * Check if element matches ANY of given conditions.
    * The method signature makes you to pass at least 2 conditions, otherwise it would be nonsense.
    *
@@ -650,6 +668,24 @@ public abstract class Condition {
   @Nonnull
   public static Condition or(String name, Condition condition1, Condition condition2, Condition... conditions) {
     return new Or(name, merge(condition1, condition2, conditions));
+  }
+
+  /**
+   * Synonym for {@link #or(String, Condition, Condition, Condition...)}. Useful for better readability.
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition anyOf(String name, Condition condition1, Condition condition2, Condition... conditions) {
+    return or(name, condition1, condition2, conditions);
+  }
+
+  /**
+   * Synonym for {@link #or(String, Condition, Condition, Condition...)} with "any of" name. Useful for better readability.
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static Condition anyOf(Condition condition1, Condition condition2, Condition... conditions) {
+    return or("any of", condition1, condition2, conditions);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -421,7 +421,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement setSelected(boolean selected);
 
   /**
-   * Checks that given element meets all given conditions.<p>
+   * Sequentially checks that given element meets all given conditions.<p>
    *
    * IMPORTANT: If element does not match then conditions immediately, waits up to
    * 4 seconds until element meets the conditions. It's extremely useful for dynamic content.<p>
@@ -491,7 +491,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement shouldBe(Condition condition, Duration timeout);
 
   /**
-   * Checks that given element does not meet given conditions.<p>
+   * Sequentially checks that given element does not meet given conditions.<p>
    *
    * IMPORTANT: If element does match the conditions, waits up to
    * 4 seconds until element does not meet the conditions. It's extremely useful for dynamic content.<p>

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -8,7 +8,9 @@ import org.openqa.selenium.WebElement;
 
 import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.Condition.allOf;
 import static com.codeborne.selenide.Condition.and;
+import static com.codeborne.selenide.Condition.anyOf;
 import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.attributeMatching;
 import static com.codeborne.selenide.Condition.be;
@@ -278,6 +280,56 @@ final class ConditionTest {
   }
 
   @Test
+  void elementAllOfCondition() {
+    WebElement element = mockElement(true, "text");
+    assertThat(allOf("selected with text", be(selected), have(text("text"))).check(driver, element).verdict()).isEqualTo(ACCEPT);
+    assertThat(allOf("selected with text", not(be(selected)), have(text("text"))).check(driver, element).verdict()).isEqualTo(REJECT);
+    assertThat(allOf("selected with text", be(selected), have(text("incorrect"))).check(driver, element).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void elementAllOfConditionActualValue() {
+    WebElement element = mockElement(false, "text");
+    Condition condition = allOf("selected with text", be(selected), have(text("text")));
+    assertThat(condition.check(driver, element).actualValue()).isEqualTo("not selected");
+    assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void elementAllOfConditionToString() {
+    WebElement element = mockElement(false, "text");
+    Condition condition = allOf("selected with text", be(selected), have(text("text")));
+    assertThat(condition).hasToString("selected with text: be selected and have text \"text\"");
+    assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
+    assertThat(condition).hasToString("selected with text: be selected and have text \"text\"");
+  }
+
+  @Test
+  void elementAllOfWithoutNameCondition() {
+    WebElement element = mockElement(true, "text");
+    assertThat(allOf(be(selected), have(text("text"))).check(driver, element).verdict()).isEqualTo(ACCEPT);
+    assertThat(allOf(not(be(selected)), have(text("text"))).check(driver, element).verdict()).isEqualTo(REJECT);
+    assertThat(allOf(be(selected), have(text("incorrect"))).check(driver, element).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void elementAllOfWithoutNameConditionActualValue() {
+    WebElement element = mockElement(false, "text");
+    Condition condition = allOf(be(selected), have(text("text")));
+    assertThat(condition.check(driver, element).actualValue()).isEqualTo("not selected");
+    assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void elementAllOfWithoutNameConditionToString() {
+    WebElement element = mockElement(false, "text");
+    Condition condition = allOf(be(selected), have(text("text")));
+    assertThat(condition).hasToString("all of: be selected and have text \"text\"");
+    assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
+    assertThat(condition).hasToString("all of: be selected and have text \"text\"");
+  }
+
+  @Test
   void elementOrCondition() {
     WebElement element = mockElement(false, "text");
     when(element.isDisplayed()).thenReturn(true);
@@ -298,6 +350,54 @@ final class ConditionTest {
     WebElement element = mockElement(false, "text");
     Condition condition = or("selected with text", be(selected), have(text("text")));
     assertThat(condition).hasToString("selected with text: be selected or have text \"text\"");
+    assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void elementAnyOfCondition() {
+    WebElement element = mockElement(false, "text");
+    when(element.isDisplayed()).thenReturn(true);
+    assertThat(anyOf("Visible, not Selected", visible, checked).check(driver, element).verdict()).isEqualTo(ACCEPT);
+    assertThat(anyOf("Selected with text", checked, text("incorrect")).check(driver, element).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void elementAnyOfConditionActualValue() {
+    WebElement element = mockElement(false, "some text");
+    Condition condition = anyOf("selected with text", be(selected), have(text("some text")));
+    assertThat(condition.check(driver, element).actualValue()).isEqualTo("text=\"some text\"");
+    assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void elementAnyOfConditionToString() {
+    WebElement element = mockElement(false, "text");
+    Condition condition = anyOf("selected with text", be(selected), have(text("text")));
+    assertThat(condition).hasToString("selected with text: be selected or have text \"text\"");
+    assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void elementAnyOfWithoutNameCondition() {
+    WebElement element = mockElement(false, "text");
+    when(element.isDisplayed()).thenReturn(true);
+    assertThat(anyOf(visible, checked).check(driver, element).verdict()).isEqualTo(ACCEPT);
+    assertThat(anyOf(checked, text("incorrect")).check(driver, element).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void elementAnyOfWithoutNameConditionActualValue() {
+    WebElement element = mockElement(false, "some text");
+    Condition condition = anyOf(be(selected), have(text("some text")));
+    assertThat(condition.check(driver, element).actualValue()).isEqualTo("text=\"some text\"");
+    assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void elementAnyOfWithoutNameConditionToString() {
+    WebElement element = mockElement(false, "text");
+    Condition condition = anyOf(be(selected), have(text("text")));
+    assertThat(condition).hasToString("any of: be selected or have text \"text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
   }
 


### PR DESCRIPTION
From issue #2130

## Proposed changes
- Fixed description of `should` and `shouldNot` SelenideElement methods
- Added `anyOf` and `allOf` Condition methods

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works (I think that tests for aliases are not needed)
- [x] I have added necessary documentation (if appropriate)