### PR TITLE
downgrade WebDriverManager from 5.4.x to 5.3.x to support Java8

### DIFF
--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -16,7 +16,7 @@ sourceSets {
 dependencies {
   api('org.opentest4j:opentest4j:1.3.0')
 
-  api('io.github.bonigarcia:webdrivermanager:5.4.1') {
+  api('io.github.bonigarcia:webdrivermanager:5.3.3') {
     exclude group: 'org.apache.httpcomponents.core5'
     exclude group: 'org.apache.httpcomponents.client5'
     exclude group: 'com.github.docker-java'


### PR DESCRIPTION
Starting from 5.4.0, WDM requires Java11+. But Selenide still supports Java8.

Let's upgrade to Java11 in major release Selenide 7.0.0
