### PR TITLE
#2398 throw a clear error message when user calls `getProxyServer()`

### DIFF
--- a/modules/selenoid/src/main/java/org/selenide/selenoid/DownloadFileInSelenoid.java
+++ b/modules/selenoid/src/main/java/org/selenide/selenoid/DownloadFileInSelenoid.java
@@ -28,9 +28,10 @@ public class DownloadFileInSelenoid extends com.codeborne.selenide.impl.Download
   }
 
   @Nullable
+  @Override
   protected DownloadsFolder getDownloadsFolder(Driver driver) {
-    return isLocalBrowser(driver) ? 
-      super.getDownloadsFolder(driver) : 
+    return isLocalBrowser(driver) ?
+      super.getDownloadsFolder(driver) :
       new SelenoidDownloadsFolder(driver);
   }
 

--- a/src/main/java/com/codeborne/selenide/Driver.java
+++ b/src/main/java/com/codeborne/selenide/Driver.java
@@ -32,8 +32,8 @@ public interface Driver {
   @Nonnull
   WebDriver getWebDriver();
 
+  @Nonnull
   @CheckReturnValue
-  @Nullable
   SelenideProxyServer getProxy();
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -200,7 +200,7 @@ public class SelenideDriver {
   }
 
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   public SelenideProxyServer getProxy() {
     return driver().getProxy();
   }

--- a/src/main/java/com/codeborne/selenide/drivercommands/CloseDriverCommand.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/CloseDriverCommand.java
@@ -21,11 +21,10 @@ public class CloseDriverCommand {
 
   public void close(WebDriverInstance wd) {
     WebDriver webDriver = wd.webDriver();
-    SelenideProxyServer proxy = wd.proxy();
     DownloadsFolder downloadsFolder = wd.downloadsFolder();
     long threadId = Thread.currentThread().getId();
     if (wd.config().holdBrowserOpen()) {
-      log.info("Hold browser and proxy open: {} -> {}, {}", threadId, webDriver, proxy);
+      log.info("Hold browser open: {} -> {}", threadId, webDriver);
       return;
     }
 
@@ -40,8 +39,9 @@ public class CloseDriverCommand {
       log.info("Closed webdriver {} in {} ms", threadId, currentTimeMillis() - start);
     }
 
-    if (proxy != null) {
+    if (wd.config().proxyEnabled()) {
       long start = currentTimeMillis();
+      SelenideProxyServer proxy = wd.proxy();
       log.info("Close proxy server: {} -> {}...", threadId, proxy);
       proxy.shutdown();
       log.info("Closed proxy server {} in {} ms", threadId, currentTimeMillis() - start);

--- a/src/main/java/com/codeborne/selenide/drivercommands/LazyDriver.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/LazyDriver.java
@@ -93,8 +93,8 @@ public class LazyDriver implements Driver {
     return checkDriverIsStarted().webDriver();
   }
 
+  @Nonnull
   @Override
-  @Nullable
   public SelenideProxyServer getProxy() {
     return checkDriverIsStarted().proxy();
   }

--- a/src/main/java/com/codeborne/selenide/drivercommands/LazyDriver.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/LazyDriver.java
@@ -90,20 +90,25 @@ public class LazyDriver implements Driver {
   @Override
   @Nonnull
   public WebDriver getWebDriver() {
-    if (closed) {
-      throw new IllegalStateException("Webdriver has been closed. You need to call open(url) to open a browser again.");
-    }
-    if (wd == null || wd.webDriver() == null) {
-      throw new IllegalStateException("No webdriver is bound to current thread: " + currentThread().getId() +
-        ". You need to call open(url) first.");
-    }
-    return wd.webDriver();
+    return checkDriverIsStarted().webDriver();
   }
 
   @Override
   @Nullable
   public SelenideProxyServer getProxy() {
-    return wd == null ? null : wd.proxy();
+    return checkDriverIsStarted().proxy();
+  }
+
+  @Nonnull
+  private WebDriverInstance checkDriverIsStarted() {
+    if (closed) {
+      throw new IllegalStateException("Webdriver has been closed. You need to call open(url) to open a browser again.");
+    }
+    if (wd == null || wd.webDriver() == null) {
+      throw new IllegalStateException("No webdriver is bound to current thread: " + currentThread().getId() +
+                                      ". You need to call open(url) first.");
+    }
+    return wd;
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/drivercommands/Navigator.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/Navigator.java
@@ -70,7 +70,7 @@ public class Navigator {
       try {
         WebDriver webDriver = driver.getAndCheckWebDriver();
         String url = applyBasicAuthIfNeeded(driver.config(), absoluteUrl, webDriver, authenticationType, credentials);
-        beforeNavigateTo(driver.config(), driver.getProxy(), authenticationType, credentials);
+        beforeNavigateTo(driver, authenticationType, credentials);
         webDriver.navigate().to(url);
       }
       catch (WebDriverException e) {
@@ -96,20 +96,12 @@ public class Navigator {
     }
   }
 
-  private void checkThatProxyIsStarted(@Nullable SelenideProxyServer selenideProxy) {
-    if (selenideProxy == null) {
-      throw new IllegalStateException("config.proxyEnabled == true but proxy server is not created. " +
-        "You need to call `setWebDriver(webDriver, selenideProxy)` instead of `setWebDriver(webDriver)` if you need to use proxy.");
-    }
-    if (!selenideProxy.isStarted()) {
-      throw new IllegalStateException("config.proxyEnabled == true but proxy server is not started.");
-    }
-  }
-
-  private void beforeNavigateTo(Config config, @Nullable SelenideProxyServer selenideProxy,
-                                @Nullable AuthenticationType authenticationType, @Nullable Credentials credentials) {
+  private void beforeNavigateTo(SelenideDriver driver,
+                                @Nullable AuthenticationType authenticationType,
+                                @Nullable Credentials credentials) {
+    Config config = driver.config();
     if (config.proxyEnabled()) {
-      checkThatProxyIsStarted(selenideProxy);
+      SelenideProxyServer selenideProxy = driver.getProxy();
       beforeNavigateToWithProxy(selenideProxy, authenticationType, credentials);
     }
     else {

--- a/src/main/java/com/codeborne/selenide/drivercommands/WebDriverWrapper.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/WebDriverWrapper.java
@@ -65,7 +65,7 @@ public class WebDriverWrapper implements Driver {
 
   @Override
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   public SelenideProxyServer getProxy() {
     return wd.proxy();
   }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
@@ -58,9 +58,6 @@ public class DownloadFileWithProxyServer {
     }
 
     SelenideProxyServer proxyServer = driver.getProxy();
-    if (proxyServer == null) {
-      throw new IllegalStateException("Cannot download file: proxy server is not started");
-    }
 
     FileDownloadFilter filter = proxyServer.responseFilter("download");
     if (filter == null) {

--- a/src/main/java/com/codeborne/selenide/impl/WebDriverInstance.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverInstance.java
@@ -7,6 +7,8 @@ import com.codeborne.selenide.proxy.SelenideProxyServer;
 import com.github.bsideup.jabel.Desugar;
 import org.openqa.selenium.WebDriver;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -29,6 +31,22 @@ public record WebDriverInstance(
   public WebDriverInstance {
     requireNonNull(config, "config must not be null");
     requireNonNull(webDriver, "webDriver must not be null");
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public SelenideProxyServer proxy() {
+    if (!config.proxyEnabled()) {
+      throw new IllegalStateException("Proxy server is not enabled. You need to set proxyEnabled=true before opening a browser.");
+    }
+    if (proxy == null) {
+      throw new IllegalStateException("config.proxyEnabled == true but proxy server is not created.");
+    }
+    if (!proxy.isStarted()) {
+      throw new IllegalStateException("config.proxyEnabled == true but proxy server is not started.");
+    }
+    return proxy;
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/DriverStub.java
+++ b/src/test/java/com/codeborne/selenide/DriverStub.java
@@ -103,7 +103,15 @@ public class DriverStub implements Driver {
   }
 
   @Override
+  @Nonnull
   public SelenideProxyServer getProxy() {
+    if (!config.proxyEnabled()) {
+      throw new IllegalStateException("Proxy server is not enabled. You need to set proxyEnabled=true before opening a browser.");
+    }
+    if (proxy == null) {
+      throw new IllegalStateException("config.proxyEnabled == true but proxy server is not created.");
+    }
+
     return proxy;
   }
 

--- a/src/test/java/com/codeborne/selenide/drivercommands/LazyDriverTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/LazyDriverTest.java
@@ -109,6 +109,14 @@ final class LazyDriverTest {
   }
 
   @Test
+  void getProxy_throwsException_ifBrowserIsNotOpen() {
+    assertThatThrownBy(() -> driver.getProxy())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageStartingWith("No webdriver is bound to current thread")
+      .hasMessageEndingWith("You need to call open(url) first.");
+  }
+
+  @Test
   void getWebDriver_throwsException_ifBrowserHasBeenClosed() {
     driver.getAndCheckWebDriver();
     driver.close();

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
@@ -101,7 +101,7 @@ final class DownloadFileWithProxyServerTest {
 
     assertThatThrownBy(() -> command.download(linkWithHref, link, 3000, none(), click()))
       .isInstanceOf(IllegalStateException.class)
-      .hasMessageContaining("Cannot download file: proxy server is not started");
+      .hasMessageContaining("config.proxyEnabled == true but proxy server is not created.");
   }
 
   private void emulateServerResponseWithFiles(final File... files) {

--- a/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -132,11 +132,9 @@ public class WebDriverRunner {
 
   /**
    * Get selenide proxy. It's activated only if Configuration.proxyEnabled == true
-   *
-   * @return null if proxy server is not started
    */
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   public static SelenideProxyServer getSelenideProxy() {
     return webdriverContainer.getProxyServer();
   }

--- a/statics/src/main/java/com/codeborne/selenide/impl/StaticDriver.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/StaticDriver.java
@@ -53,7 +53,7 @@ class StaticDriver implements Driver {
 
   @Override
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   public SelenideProxyServer getProxy() {
     return WebDriverRunner.getSelenideProxy();
   }

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
@@ -34,7 +34,7 @@ public interface WebDriverContainer {
   WebDriver getWebDriver();
 
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   SelenideProxyServer getProxyServer();
 
   void setProxy(@Nullable Proxy webProxy);

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -191,8 +191,7 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
     long threadId = setWebDriver(driver);
 
     if (config.holdBrowserOpen()) {
-      log.info("Browser and proxy will stay open due to holdBrowserOpen=true: {} -> {}, {}",
-        threadId, driver.webDriver(), driver.proxy());
+      log.info("Browser will stay open due to holdBrowserOpen=true: {} -> {}", threadId, driver.webDriver());
     }
     else {
       markForAutoClose(currentThread());
@@ -208,7 +207,7 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
 
   @Override
   @CheckReturnValue
-  @Nullable
+  @Nonnull
   public SelenideProxyServer getProxyServer() {
     return currentThreadDriver().proxy();
   }

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -267,4 +267,11 @@ final class FileDownloadToFolderTest extends IntegrationTest {
     assertThat(downloadedFile).hasSize(5 * 1024 * 1024);
   }
 
+  @Test
+  public void cannotDownloadUsingProxy_ifBrowserIsOpenedWithoutProxy() {
+    assertThatThrownBy(() -> $(byText("Download me")).download(using(PROXY)))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageStartingWith("Cannot download file: proxy server is not enabled. Setup proxyEnabled");
+  }
+
 }

--- a/statics/src/test/java/integration/UnopenedBrowserTest.java
+++ b/statics/src/test/java/integration/UnopenedBrowserTest.java
@@ -82,4 +82,31 @@ final class UnopenedBrowserTest extends IntegrationTest {
       driver.quit();
     }
   }
+
+  @Test
+  void getWebDriver_throws_IllegalStateException() {
+    assertThatThrownBy(() ->
+      WebDriverRunner.getWebDriver()
+    ).isInstanceOf(IllegalStateException.class)
+      .hasMessageStartingWith("No webdriver is bound to current thread")
+      .hasMessageEndingWith("You need to call open(url) first.");
+  }
+
+  @Test
+  void getSelenideProxy_throws_IllegalStateException() {
+    assertThatThrownBy(() ->
+      WebDriverRunner.getSelenideProxy()
+    ).isInstanceOf(IllegalStateException.class)
+      .hasMessageStartingWith("No webdriver is bound to current thread")
+      .hasMessageEndingWith("You need to call open(url) first.");
+  }
+
+  @Test
+  void getBrowserDownloadsFolder_throws_IllegalStateException() {
+    assertThatThrownBy(() ->
+      WebDriverRunner.getBrowserDownloadsFolder()
+    ).isInstanceOf(IllegalStateException.class)
+      .hasMessageStartingWith("No webdriver is bound to current thread")
+      .hasMessageEndingWith("You need to call open(url) first.");
+  }
 }


### PR DESCRIPTION
... but the browser is not opened yet. User needs call `open()` first.
