### PR TITLE
#2420 fix method $.type(Keys.*)

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumType.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumType.java
@@ -6,9 +6,11 @@ import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.appium.WebdriverUnwrapper.isMobile;
 
+@ParametersAreNonnullByDefault
 public class AppiumType extends Type {
   public AppiumType() {
     super(new AppiumClear());

--- a/src/main/java/com/codeborne/selenide/TypeOptions.java
+++ b/src/main/java/com/codeborne/selenide/TypeOptions.java
@@ -5,17 +5,17 @@ import java.time.Duration;
 public class TypeOptions {
   private static final Duration DEFAULT_DELAY_WHILE_TYPING = Duration.ofMillis(200);
 
-  private final String charSequence;
+  private final CharSequence charSequence;
   private final boolean shouldClearFieldBeforeTyping;
   private final Duration timeDelayWhileTyping;
 
-  protected TypeOptions(String charSequence, Duration timeDelayWhileTyping, boolean shouldClearFieldBeforeTyping) {
+  protected TypeOptions(CharSequence charSequence, Duration timeDelayWhileTyping, boolean shouldClearFieldBeforeTyping) {
     this.charSequence = charSequence;
     this.timeDelayWhileTyping = timeDelayWhileTyping;
     this.shouldClearFieldBeforeTyping = shouldClearFieldBeforeTyping;
   }
 
-  public static TypeOptions text(String textToType) {
+  public static TypeOptions text(CharSequence textToType) {
     return new TypeOptions(textToType, DEFAULT_DELAY_WHILE_TYPING, true);
   }
 
@@ -27,8 +27,8 @@ public class TypeOptions {
     return new TypeOptions(charSequence, timeDelayWhileTyping, shouldClearFieldBeforeTyping);
   }
 
-  public String textToType() {
-    return String.valueOf(this.charSequence);
+  public CharSequence textToType() {
+    return this.charSequence;
   }
 
   public boolean shouldClearFieldBeforeTyping() {

--- a/src/main/java/com/codeborne/selenide/commands/Type.java
+++ b/src/main/java/com/codeborne/selenide/commands/Type.java
@@ -55,15 +55,16 @@ public class Type implements Command<SelenideElement> {
   }
 
   private void typeIntoField(WebElement element, TypeOptions typeOptions) {
-    for (char character : typeOptions.textToType().toCharArray()) {
-      element.sendKeys(String.valueOf(character));
+    for (int i = 0; i < typeOptions.textToType().length(); i++) {
+      CharSequence character = typeOptions.textToType().subSequence(i, i + 1);
+      element.sendKeys(character);
       sleepAtLeast(typeOptions.timeDelay().toMillis());
     }
   }
 
   private void clearField(SelenideElement proxy, WebElementSource locator, TypeOptions typeOptions) {
     if (typeOptions.shouldClearFieldBeforeTyping()) {
-      if (!typeOptions.textToType().isEmpty()) {
+      if (typeOptions.textToType().length() > 0) {
         clear.clear(locator.driver(), proxy);
       } else {
         clear.clearAndTrigger(locator.driver(), proxy);


### PR DESCRIPTION
Don't cast parameter of `$.type()` to String - instead, it's declared as CharSequence.

