### PR TITLE
Appium Scroll: added ability to set top and bottom point coordinates …

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumScrollOptions.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumScrollOptions.java
@@ -5,10 +5,20 @@ public class AppiumScrollOptions {
   private final ScrollDirection scrollDirection;
   private final int maxSwipeCounts;
   private static final int DEFAULT_MAX_SWIPE_COUNTS = 30;
+  private final float topPointHeightPercent;
+  private static final float DEFAULT_TOP_POINT_HEIGHT_PERCENT = 0.25f;
+  private final float bottomPointHeightPercent;
+  private static final float DEFAULT_BOTTOM_POINT_HEIGHT_PERCENT = 0.5f;
 
   private AppiumScrollOptions(ScrollDirection scrollDirection, int maxSwipeCounts) {
+    this(scrollDirection, maxSwipeCounts, DEFAULT_TOP_POINT_HEIGHT_PERCENT, DEFAULT_BOTTOM_POINT_HEIGHT_PERCENT);
+  }
+
+  private AppiumScrollOptions(ScrollDirection scrollDirection, int maxSwipeCounts, float topPointHeightPercent, float bottomPointHeightPercent) {
     this.scrollDirection = scrollDirection;
     this.maxSwipeCounts = maxSwipeCounts;
+    this.topPointHeightPercent = topPointHeightPercent;
+    this.bottomPointHeightPercent = bottomPointHeightPercent;
   }
 
   public static AppiumScrollOptions with(ScrollDirection scrollDirection, int maxSwipeCounts) {
@@ -31,6 +41,14 @@ public class AppiumScrollOptions {
     return new AppiumScrollOptions(ScrollDirection.UP, maxSwipeCounts);
   }
 
+  public static AppiumScrollOptions up(float top, float bottom) {
+    return new AppiumScrollOptions(ScrollDirection.UP, DEFAULT_MAX_SWIPE_COUNTS, top, bottom);
+  }
+
+  public static AppiumScrollOptions down(float top, float bottom) {
+    return new AppiumScrollOptions(ScrollDirection.DOWN, DEFAULT_MAX_SWIPE_COUNTS, top, bottom);
+  }
+
   public int getMaxSwipeCounts() {
     return maxSwipeCounts;
   }
@@ -39,4 +57,11 @@ public class AppiumScrollOptions {
     return scrollDirection;
   }
 
+  public float getTopPointHeightPercent() {
+    return topPointHeightPercent;
+  }
+
+  public float getBottomPointHeightPercent() {
+    return bottomPointHeightPercent;
+  }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumScrollOptions.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumScrollOptions.java
@@ -14,7 +14,8 @@ public class AppiumScrollOptions {
     this(scrollDirection, maxSwipeCounts, DEFAULT_TOP_POINT_HEIGHT_PERCENT, DEFAULT_BOTTOM_POINT_HEIGHT_PERCENT);
   }
 
-  private AppiumScrollOptions(ScrollDirection scrollDirection, int maxSwipeCounts, float topPointHeightPercent, float bottomPointHeightPercent) {
+  private AppiumScrollOptions(ScrollDirection scrollDirection, int maxSwipeCounts,
+                              float topPointHeightPercent, float bottomPointHeightPercent) {
     this.scrollDirection = scrollDirection;
     this.maxSwipeCounts = maxSwipeCounts;
     this.topPointHeightPercent = topPointHeightPercent;

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
@@ -72,7 +72,8 @@ public class AppiumScrollTo implements Command<SelenideElement> {
 
     while (isElementNotDisplayed(locator)
            && isLessThanMaxSwipeCount(currentSwipeCount, scrollOptions.getMaxSwipeCounts())) {
-      performScroll(appiumDriver, scrollOptions.getScrollDirection(), scrollOptions.getTopPointHeightPercent(), scrollOptions.getBottomPointHeightPercent());
+      performScroll(appiumDriver, scrollOptions.getScrollDirection(), scrollOptions.getTopPointHeightPercent(),
+                    scrollOptions.getBottomPointHeightPercent());
       currentSwipeCount++;
     }
   }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumScrollTo.java
@@ -72,7 +72,7 @@ public class AppiumScrollTo implements Command<SelenideElement> {
 
     while (isElementNotDisplayed(locator)
            && isLessThanMaxSwipeCount(currentSwipeCount, scrollOptions.getMaxSwipeCounts())) {
-      performScroll(appiumDriver, scrollOptions.getScrollDirection());
+      performScroll(appiumDriver, scrollOptions.getScrollDirection(), scrollOptions.getTopPointHeightPercent(), scrollOptions.getBottomPointHeightPercent());
       currentSwipeCount++;
     }
   }
@@ -93,21 +93,21 @@ public class AppiumScrollTo implements Command<SelenideElement> {
     return appiumDriver.manage().window().getSize();
   }
 
-  private void performScroll(AppiumDriver appiumDriver, ScrollDirection scrollDirection) {
+  private void performScroll(AppiumDriver appiumDriver, ScrollDirection scrollDirection, float top, float bottom) {
     Dimension size = getMobileDeviceSize(appiumDriver);
-    AppiumScrollCoordinates scrollCoordinates = getScrollCoordinates(scrollDirection, size);
+    AppiumScrollCoordinates scrollCoordinates = getScrollCoordinates(scrollDirection, size, top, bottom);
     PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
     Sequence sequenceToPerformScroll = getSequenceToPerformScroll(finger, scrollCoordinates);
     appiumDriver.perform(singletonList(sequenceToPerformScroll));
   }
 
-  private AppiumScrollCoordinates getScrollCoordinates(ScrollDirection scrollDirection, Dimension size) {
+  private AppiumScrollCoordinates getScrollCoordinates(ScrollDirection scrollDirection, Dimension size, float top, float bottom) {
     if (scrollDirection == ScrollDirection.UP) {
-      return new AppiumScrollCoordinates(size.getWidth() / 2, (int) (size.getHeight() * 0.25),
-                                         size.getWidth() / 2, size.getHeight() / 2);
+      return new AppiumScrollCoordinates(size.getWidth() / 2, (int) (size.getHeight() * top),
+                                         size.getWidth() / 2, (int) (size.getHeight() * bottom));
     } else {
-      return new AppiumScrollCoordinates(size.getWidth() / 2, size.getHeight() / 2,
-                                         size.getWidth() / 2, (int) (size.getHeight() * 0.25));
+      return new AppiumScrollCoordinates(size.getWidth() / 2, (int) (size.getHeight() * bottom),
+                                         size.getWidth() / 2, (int) (size.getHeight() * top));
     }
   }
 


### PR DESCRIPTION
…for scroll

## Proposed changes
**As Is**: coordinates for scroll in Appium are hardcoded (from center of screen to 0.25 of height). I have a some kind of bottomsheet, wich can be expanded by swipe from bottom to top. But start point of swipe should be below then center of the screen. I cannot do that.
**To Be**: user can set start and end points of scroll in percent of screen height.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew :appium test` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
