### PR TITLE
#2372 rename superclass for conditions from `Condition` to `WebElementCondition`

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumCondition.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumCondition.java
@@ -1,12 +1,12 @@
 package com.codeborne.selenide.appium;
 
-import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.appium.conditions.AttributeWithValue;
 import com.codeborne.selenide.appium.conditions.CombinedAttribute;
 
 public class AppiumCondition {
 
-  public static Condition attribute(CombinedAttribute attribute, String expectedAttributeValue) {
+  public static WebElementCondition attribute(CombinedAttribute attribute, String expectedAttributeValue) {
     return new AttributeWithValue(attribute, expectedAttributeValue);
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/conditions/AttributeWithValue.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/conditions/AttributeWithValue.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.appium.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class AttributeWithValue extends Condition {
+public class AttributeWithValue extends WebElementCondition {
   private final CombinedAttribute attribute;
   protected final String expectedAttributeValue;
 

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -16,7 +16,6 @@ import com.codeborne.selenide.conditions.ExactOwnTextCaseSensitive;
 import com.codeborne.selenide.conditions.ExactText;
 import com.codeborne.selenide.conditions.ExactTextCaseSensitive;
 import com.codeborne.selenide.conditions.Exist;
-import com.codeborne.selenide.conditions.ExplainedCondition;
 import com.codeborne.selenide.conditions.Focused;
 import com.codeborne.selenide.conditions.Hidden;
 import com.codeborne.selenide.conditions.Href;
@@ -26,7 +25,6 @@ import com.codeborne.selenide.conditions.IsImageLoaded;
 import com.codeborne.selenide.conditions.MatchAttributeWithValue;
 import com.codeborne.selenide.conditions.MatchText;
 import com.codeborne.selenide.conditions.NamedCondition;
-import com.codeborne.selenide.conditions.Not;
 import com.codeborne.selenide.conditions.Or;
 import com.codeborne.selenide.conditions.OwnText;
 import com.codeborne.selenide.conditions.OwnTextCaseSensitive;
@@ -49,28 +47,26 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.function.Predicate;
 
-import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
-import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 import static com.codeborne.selenide.conditions.ConditionHelpers.merge;
 
 /**
  * Conditions to match web elements: checks for visibility, text etc.
  */
 @ParametersAreNonnullByDefault
-public abstract class Condition {
+public final class Condition {
   /**
    * Checks if element is visible
    *
    * <p>Sample: {@code $("input").shouldBe(visible);}</p>
    */
-  public static final Condition visible = new Visible();
+  public static final WebElementCondition visible = new Visible();
 
   /**
    * Check if element exist. It can be visible or hidden.
    *
    * <p>Sample: {@code $("input").should(exist);}</p>
    */
-  public static final Condition exist = new Exist();
+  public static final WebElementCondition exist = new Exist();
 
   /**
    * Checks that element is not visible or does not exist.
@@ -79,14 +75,14 @@ public abstract class Condition {
    *
    * <p>Sample: {@code $("input").shouldBe(hidden);}</p>
    */
-  public static final Condition hidden = new Hidden();
+  public static final WebElementCondition hidden = new Hidden();
 
   /**
    * Synonym for {@link #visible} - may be used for better readability
    *
    * <p>Sample: {@code $("#logoutLink").should(appear);}</p>
    */
-  public static final Condition appear = be(visible);
+  public static final WebElementCondition appear = be(visible);
 
   /**
    * Synonym for {@link #visible} - may be used for better readability
@@ -95,14 +91,14 @@ public abstract class Condition {
    * @deprecated use {@link #visible} or {@link #appear}
    */
   @Deprecated
-  public static final Condition appears = be(visible);
+  public static final WebElementCondition appears = be(visible);
 
   /**
    * Synonym for {@link #hidden} - may be used for better readability:
    *
    * <p>{@code $("#loginLink").should(disappear);}</p>
    */
-  public static final Condition disappear = be(hidden);
+  public static final WebElementCondition disappear = be(hidden);
 
   /**
    * Check if element is interactable:
@@ -121,7 +117,7 @@ public abstract class Condition {
    * <br/>
    * @since 6.5.0
    */
-  public static final Condition interactable = new Interactable();
+  public static final WebElementCondition interactable = new Interactable();
 
   /**
    * <p>
@@ -132,7 +128,7 @@ public abstract class Condition {
    * <p>{@code $("input").shouldBe(readonly);}</p>
    * <br>
    */
-  public static final Condition readonly = new Readonly();
+  public static final WebElementCondition readonly = new Readonly();
 
   /**
    * Check if element is "editable":
@@ -146,7 +142,7 @@ public abstract class Condition {
    * <br>
    * @since 6.5.0
    */
-  public static final Condition editable = new Editable();
+  public static final WebElementCondition editable = new Editable();
 
   /**
    * Check if element has given attribute (with any value)
@@ -154,11 +150,10 @@ public abstract class Condition {
    * <p>Sample: {@code $("#mydiv").shouldHave(attribute("fileId"));}</p>
    *
    * @param attributeName name of attribute, not null
-   * @return true iff attribute exists
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition attribute(String attributeName) {
+  public static WebElementCondition attribute(String attributeName) {
     return new Attribute(attributeName);
   }
 
@@ -170,7 +165,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition attribute(String attributeName, String expectedAttributeValue) {
+  public static WebElementCondition attribute(String attributeName, String expectedAttributeValue) {
     return new AttributeWithValue(attributeName, expectedAttributeValue);
   }
 
@@ -184,7 +179,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition attributeMatching(String attributeName, String attributeRegex) {
+  public static WebElementCondition attributeMatching(String attributeName, String attributeRegex) {
     return new MatchAttributeWithValue(attributeName, attributeRegex);
   }
 
@@ -198,7 +193,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition href(String href) {
+  public static WebElementCondition href(String href) {
     return new Href(href);
   }
 
@@ -212,7 +207,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition value(String expectedValue) {
+  public static WebElementCondition value(String expectedValue) {
     return new Value(expectedValue);
   }
 
@@ -227,7 +222,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition partialValue(String expectedValue) {
+  public static WebElementCondition partialValue(String expectedValue) {
     return new PartialValue(expectedValue);
   }
 
@@ -242,7 +237,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition pseudo(String pseudoElementName, String propertyName, String expectedValue) {
+  public static WebElementCondition pseudo(String pseudoElementName, String propertyName, String expectedValue) {
     return new PseudoElementPropertyWithValue(pseudoElementName, propertyName, expectedValue);
   }
 
@@ -255,7 +250,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition pseudo(String pseudoElementName, String expectedValue) {
+  public static WebElementCondition pseudo(String pseudoElementName, String expectedValue) {
     return new PseudoElementPropertyWithValue(pseudoElementName, "content", expectedValue);
   }
 
@@ -266,7 +261,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition exactValue(String value) {
+  public static WebElementCondition exactValue(String value) {
     return attribute("value", value);
   }
 
@@ -278,7 +273,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition name(String name) {
+  public static WebElementCondition name(String name) {
     return attribute("name", name);
   }
 
@@ -290,7 +285,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition type(String type) {
+  public static WebElementCondition type(String type) {
     return attribute("type", type);
   }
 
@@ -301,7 +296,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition id(String id) {
+  public static WebElementCondition id(String id) {
     return attribute("id", id);
   }
 
@@ -312,7 +307,7 @@ public abstract class Condition {
    * 2) For other elements, check that text is empty
    * <p>Sample: {@code $("h2").shouldBe(empty)}</p>
    */
-  public static final Condition empty = and("empty", exactValue(""), exactText(""));
+  public static final WebElementCondition empty = and("empty", exactValue(""), exactText(""));
 
   /**
    * Assert that given element's text matches given regular expression
@@ -323,33 +318,33 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition matchText(String regex) {
+  public static WebElementCondition matchText(String regex) {
     return new MatchText(regex);
   }
 
   /**
    * Assert that given element's text CONTAINS given text
    *
-   * <p>Sample: <code>$("h1").shouldHave(partialText("ello Joh"))</code></p>
+   * <p>Sample: {@code $("h1").shouldHave(partialText("ello Joh"))}</p>
    *
    * @since 6.7.0
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition partialText(String expectedText) {
+  public static WebElementCondition partialText(String expectedText) {
     return new PartialText(expectedText);
   }
 
   /**
    * Assert that given element's text CONTAINS given text (case-sensitive)
    *
-   * <p>Sample: <code>$("h1").should(partialTextCaseSensitive("ELLO jOH"))</code></p>
+   * <p>Sample: {@code $("h1").should(partialTextCaseSensitive("ELLO jOH"))}</p>
    *
    * @since 6.7.0
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition partialTextCaseSensitive(String expectedText) {
+  public static WebElementCondition partialTextCaseSensitive(String expectedText) {
     return new PartialTextCaseSensitive(expectedText);
   }
 
@@ -369,12 +364,12 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition text(String text) {
+  public static WebElementCondition text(String text) {
     return new Text(text);
   }
 
   /**
-   * Checks on a element that exactly given text is selected (=marked with mouse/keyboard)
+   * Checks on {@code <a>} element that exactly given text is selected (=marked with mouse/keyboard)
    *
    * <p>Sample: {@code $("input").shouldHave(selectedText("Text"))}</p>
    *
@@ -384,7 +379,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition selectedText(String expectedText) {
+  public static WebElementCondition selectedText(String expectedText) {
     return new SelectedText(expectedText);
   }
 
@@ -399,7 +394,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition textCaseSensitive(String text) {
+  public static WebElementCondition textCaseSensitive(String text) {
     return new CaseSensitiveText(text);
   }
 
@@ -414,7 +409,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition exactText(String text) {
+  public static WebElementCondition exactText(String text) {
     return new ExactText(text);
   }
 
@@ -429,7 +424,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition innerText(String text) {
+  public static WebElementCondition innerText(String text) {
     return new InnerText(text);
   }
 
@@ -444,7 +439,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition ownText(String text) {
+  public static WebElementCondition ownText(String text) {
     return new OwnText(text);
   }
 
@@ -460,7 +455,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition ownTextCaseSensitive(String text) {
+  public static WebElementCondition ownTextCaseSensitive(String text) {
     return new OwnTextCaseSensitive(text);
   }
 
@@ -475,7 +470,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition exactOwnText(String text) {
+  public static WebElementCondition exactOwnText(String text) {
     return new ExactOwnText(text);
   }
 
@@ -491,7 +486,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition exactOwnTextCaseSensitive(String text) {
+  public static WebElementCondition exactOwnTextCaseSensitive(String text) {
     return new ExactOwnTextCaseSensitive(text);
   }
 
@@ -505,7 +500,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition exactTextCaseSensitive(String text) {
+  public static WebElementCondition exactTextCaseSensitive(String text) {
     return new ExactTextCaseSensitive(text);
   }
 
@@ -516,7 +511,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition tagName(String cssClass) {
+  public static WebElementCondition tagName(String cssClass) {
     return new TagName(cssClass);
   }
 
@@ -526,7 +521,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition cssClass(String cssClass) {
+  public static WebElementCondition cssClass(String cssClass) {
     return new CssClass(cssClass);
   }
 
@@ -551,7 +546,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition cssValue(String propertyName, @Nullable String expectedValue) {
+  public static WebElementCondition cssValue(String propertyName, @Nullable String expectedValue) {
     return new CssValue(propertyName, expectedValue);
   }
 
@@ -565,47 +560,47 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition match(String description, Predicate<WebElement> predicate) {
+  public static WebElementCondition match(String description, Predicate<WebElement> predicate) {
     return new CustomMatch(description, predicate);
   }
 
   /**
    * Check if image is loaded.
    */
-  public static final Condition image = new IsImageLoaded();
+  public static final WebElementCondition image = new IsImageLoaded();
 
   /**
    * Check if browser focus is currently in given element.
    */
-  public static final Condition focused = new Focused();
+  public static final WebElementCondition focused = new Focused();
 
   /**
    * Checks that element is not disabled
    *
    * @see WebElement#isEnabled()
    */
-  public static final Condition enabled = new Enabled();
+  public static final WebElementCondition enabled = new Enabled();
 
   /**
    * Checks that element is disabled
    *
    * @see WebElement#isEnabled()
    */
-  public static final Condition disabled = new Disabled();
+  public static final WebElementCondition disabled = new Disabled();
 
   /**
    * Checks that element is selected (inputs like drop-downs etc.)
    *
    * @see WebElement#isSelected()
    */
-  public static final Condition selected = new Selected();
+  public static final WebElementCondition selected = new Selected();
 
   /**
    * Checks that checkbox is checked
    *
    * @see WebElement#isSelected()
    */
-  public static final Condition checked = new Checked();
+  public static final WebElementCondition checked = new Checked();
 
   /**
    * Negate given condition.
@@ -616,7 +611,7 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition not(final Condition condition) {
+  public static WebElementCondition not(WebElementCondition condition) {
     return condition.negate();
   }
 
@@ -632,25 +627,30 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition and(String name, Condition condition1, Condition condition2, Condition... conditions) {
+  public static WebElementCondition and(String name, WebElementCondition condition1, WebElementCondition condition2,
+                                        WebElementCondition... conditions) {
     return new And(name, merge(condition1, condition2, conditions));
   }
 
   /**
-   * Synonym for {@link #and(String, Condition, Condition, Condition...)}. Useful for better readability.
+   * Synonym for {@link #and(String, WebElementCondition, WebElementCondition, WebElementCondition...)}.
+   * Useful for better readability.
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition allOf(String name, Condition condition1, Condition condition2, Condition... conditions) {
+  public static WebElementCondition allOf(String name, WebElementCondition condition1, WebElementCondition condition2,
+                                          WebElementCondition... conditions) {
     return and(name, condition1, condition2, conditions);
   }
 
   /**
-   * Synonym for {@link #and(String, Condition, Condition, Condition...)} with "all of" name. Useful for better readability.
+   * Synonym for {@link #and(String, WebElementCondition, WebElementCondition, WebElementCondition...)}
+   * with "all of" name. Useful for better readability.
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition allOf(Condition condition1, Condition condition2, Condition... conditions) {
+  public static WebElementCondition allOf(WebElementCondition condition1, WebElementCondition condition2,
+                                          WebElementCondition... conditions) {
     return and("all of", condition1, condition2, conditions);
   }
 
@@ -666,25 +666,30 @@ public abstract class Condition {
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition or(String name, Condition condition1, Condition condition2, Condition... conditions) {
+  public static WebElementCondition or(String name, WebElementCondition condition1, WebElementCondition condition2,
+                                       WebElementCondition... conditions) {
     return new Or(name, merge(condition1, condition2, conditions));
   }
 
   /**
-   * Synonym for {@link #or(String, Condition, Condition, Condition...)}. Useful for better readability.
+   * Synonym for {@link #or(String, WebElementCondition, WebElementCondition, WebElementCondition...)}.
+   * Useful for better readability.
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition anyOf(String name, Condition condition1, Condition condition2, Condition... conditions) {
+  public static WebElementCondition anyOf(String name, WebElementCondition condition1, WebElementCondition condition2,
+                                          WebElementCondition... conditions) {
     return or(name, condition1, condition2, conditions);
   }
 
   /**
-   * Synonym for {@link #or(String, Condition, Condition, Condition...)} with "any of" name. Useful for better readability.
+   * Synonym for {@link #or(String, WebElementCondition, WebElementCondition, WebElementCondition...)}
+   * with "any of" name. Useful for better readability.
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition anyOf(Condition condition1, Condition condition2, Condition... conditions) {
+  public static WebElementCondition anyOf(WebElementCondition condition1, WebElementCondition condition2,
+                                          WebElementCondition... conditions) {
     return or("any of", condition1, condition2, conditions);
   }
 
@@ -693,11 +698,11 @@ public abstract class Condition {
    * Example element.should(be(visible),have(text("abc"))
    *
    * @param delegate next condition to wrap
-   * @return Condition
+   * @return WebElementCondition
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition be(Condition delegate) {
+  public static WebElementCondition be(WebElementCondition delegate) {
     return wrap("be", delegate);
   }
 
@@ -706,106 +711,15 @@ public abstract class Condition {
    * Example element.should(be(visible),have(text("abc"))
    *
    * @param delegate next condition to wrap
-   * @return Condition
+   * @return WebElementCondition
    */
   @CheckReturnValue
   @Nonnull
-  public static Condition have(Condition delegate) {
+  public static WebElementCondition have(WebElementCondition delegate) {
     return wrap("have", delegate);
   }
 
-  private static Condition wrap(String prefix, Condition delegate) {
+  private static WebElementCondition wrap(String prefix, WebElementCondition delegate) {
     return new NamedCondition(prefix, delegate);
   }
-
-  private final String name;
-  private final boolean missingElementSatisfiesCondition;
-
-  public Condition(String name) {
-    this(name, false);
-  }
-
-  public Condition(String name, boolean missingElementSatisfiesCondition) {
-    this.name = name;
-    this.missingElementSatisfiesCondition = missingElementSatisfiesCondition;
-  }
-
-  /**
-   * Check if given element matches this condition.
-   *
-   * @param element given WebElement
-   * @return true if element matches condition
-   * @deprecated replace by {@link #check(Driver, WebElement)}
-   */
-  @Deprecated
-  public boolean apply(Driver driver, WebElement element) {
-    throw new UnsupportedOperationException("Method 'apply' is deprecated. Please implement 'check' method.");
-  }
-
-  /**
-   * Check if given element matches this condition
-   *
-   * @param driver  selenide driver
-   * @param element given WebElement
-   * @return {@link CheckResult.Verdict#ACCEPT} if element matches condition, or
-   *         {@link CheckResult.Verdict#REJECT} if element doesn't match (and we should keep trying until timeout).
-   *
-   * @since 6.0.0
-   */
-  @Nonnull
-  @CheckReturnValue
-  public CheckResult check(Driver driver, WebElement element) {
-    boolean result = apply(driver, element);
-    return new CheckResult(result ? ACCEPT : REJECT, null);
-  }
-
-  /**
-   * If element didn't match the condition, returns the actual value of element.
-   * Used in error reporting.
-   * Optional. Makes sense only if you need to add some additional important info to error message.
-   *
-   * @param driver  given driver
-   * @param element given WebElement
-   * @return any string that needs to be appended to error message.
-   * @deprecated not needed anymore since the actual value is returned by method {@link #check(Driver, WebElement)}
-   */
-  @Nullable
-  @Deprecated
-  public String actualValue(Driver driver, WebElement element) {
-    return null;
-  }
-
-  @Nonnull
-  @CheckReturnValue
-  public Condition negate() {
-    return new Not(this, missingElementSatisfiesCondition);
-  }
-
-  /**
-   * Should be used for explaining the reason of condition
-   */
-  @Nonnull
-  @CheckReturnValue
-  public Condition because(String message) {
-    return new ExplainedCondition(this, message);
-  }
-
-  @Nonnull
-  @CheckReturnValue
-  @Override
-  public String toString() {
-    return name;
-  }
-
-  @Nonnull
-  @CheckReturnValue
-  public String getName() {
-    return name;
-  }
-
-  @CheckReturnValue
-  public boolean missingElementSatisfiesCondition() {
-    return missingElementSatisfiesCondition;
-  }
-
 }

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -220,7 +220,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    */
   @CheckReturnValue
   @Nonnull
-  public ElementsCollection filter(Condition condition) {
+  public ElementsCollection filter(WebElementCondition condition) {
     return new ElementsCollection(new FilteringCollection(collection, condition));
   }
 
@@ -229,12 +229,12 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    *
    * @param condition condition
    * @return ElementsCollection
-   * @see #filter(Condition)
+   * @see #filter(WebElementCondition)
    * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
    */
   @CheckReturnValue
   @Nonnull
-  public ElementsCollection filterBy(Condition condition) {
+  public ElementsCollection filterBy(WebElementCondition condition) {
     return filter(condition);
   }
 
@@ -247,7 +247,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    */
   @CheckReturnValue
   @Nonnull
-  public ElementsCollection exclude(Condition condition) {
+  public ElementsCollection exclude(WebElementCondition condition) {
     return new ElementsCollection(new FilteringCollection(collection, not(condition)));
   }
 
@@ -256,12 +256,12 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    *
    * @param condition condition
    * @return ElementsCollection
-   * @see #exclude(Condition)
+   * @see #exclude(WebElementCondition)
    * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
    */
   @CheckReturnValue
   @Nonnull
-  public ElementsCollection excludeWith(Condition condition) {
+  public ElementsCollection excludeWith(WebElementCondition condition) {
     return exclude(condition);
   }
 
@@ -274,7 +274,7 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    */
   @CheckReturnValue
   @Nonnull
-  public SelenideElement find(Condition condition) {
+  public SelenideElement find(WebElementCondition condition) {
     return CollectionElementByCondition.wrap(collection, condition);
   }
 
@@ -283,12 +283,12 @@ public class ElementsCollection extends AbstractList<SelenideElement> {
    *
    * @param condition condition
    * @return SelenideElement
-   * @see #find(Condition)
+   * @see #find(WebElementCondition)
    * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
    */
   @CheckReturnValue
   @Nonnull
-  public SelenideElement findBy(Condition condition) {
+  public SelenideElement findBy(WebElementCondition condition) {
     return find(condition);
   }
 

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -25,7 +25,7 @@ import java.time.Duration;
 
 /**
  * Wrapper around {@link WebElement} with additional methods like
- * {@link #shouldBe(Condition...)} and {@link #shouldHave(Condition...)}
+ * {@link #shouldBe(WebElementCondition...)} and {@link #shouldHave(WebElementCondition...)}
  */
 @ParametersAreNonnullByDefault
 public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, Locatable, TakesScreenshot {
@@ -415,7 +415,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see <a href="https://github.com/selenide/selenide/wiki/do-not-use-getters-in-tests">NOT RECOMMENDED</a>
    */
   @CheckReturnValue
-  boolean is(Condition condition);
+  boolean is(WebElementCondition condition);
 
   /**
    * immediately returns true if element matches given condition
@@ -427,7 +427,7 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see <a href="https://github.com/selenide/selenide/wiki/do-not-use-getters-in-tests">NOT RECOMMENDED</a>
    */
   @CheckReturnValue
-  boolean has(Condition condition);
+  boolean has(WebElementCondition condition);
 
   /**
    * Set checkbox state to CHECKED or UNCHECKED.
@@ -458,56 +458,56 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement should(Condition... condition);
+  SelenideElement should(WebElementCondition... condition);
 
   /**
    * Wait until given element meets given condition (with given timeout)
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement should(Condition condition, Duration timeout);
+  SelenideElement should(WebElementCondition condition, Duration timeout);
 
   /**
-   * Synonym for {@link #should(com.codeborne.selenide.Condition...)}. Useful for better readability.<p>
+   * Synonym for {@link #should(WebElementCondition...)}. Useful for better readability.<p>
    *
    * For example: {@code
    * $("#errorMessage").shouldHave(text("Hello"), text("World"));
    * }
    *
-   * @see SelenideElement#should(com.codeborne.selenide.Condition...)
+   * @see SelenideElement#should(WebElementCondition...)
    * @see com.codeborne.selenide.commands.ShouldHave
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldHave(Condition... condition);
+  SelenideElement shouldHave(WebElementCondition... condition);
 
   /**
    * Wait until given element meets given condition (with given timeout)
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldHave(Condition condition, Duration timeout);
+  SelenideElement shouldHave(WebElementCondition condition, Duration timeout);
 
   /**
-   * Synonym for {@link #should(com.codeborne.selenide.Condition...)}. Useful for better readability.<p>
+   * Synonym for {@link #should(WebElementCondition...)}. Useful for better readability.<p>
    *
    * For example: {@code
    * $("#errorMessage").shouldBe(visible, enabled);
    * }
    *
-   * @see SelenideElement#should(com.codeborne.selenide.Condition...)
+   * @see SelenideElement#should(WebElementCondition...)
    * @see com.codeborne.selenide.commands.ShouldBe
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldBe(Condition... condition);
+  SelenideElement shouldBe(WebElementCondition... condition);
 
   /**
    * Wait until given element meets given condition (with given timeout)
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldBe(Condition condition, Duration timeout);
+  SelenideElement shouldBe(WebElementCondition condition, Duration timeout);
 
   /**
    * Sequentially checks that given element does not meet given conditions.<p>
@@ -526,56 +526,56 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldNot(Condition... condition);
+  SelenideElement shouldNot(WebElementCondition... condition);
 
   /**
    * Wait until given element meets given condition (with given timeout)
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldNot(Condition condition, Duration timeout);
+  SelenideElement shouldNot(WebElementCondition condition, Duration timeout);
 
   /**
-   * Synonym for {@link #shouldNot(com.codeborne.selenide.Condition...)}. Useful for better readability.<p>
+   * Synonym for {@link #shouldNot(WebElementCondition...)}. Useful for better readability.<p>
    *
    * For example: {@code
    * $("#errorMessage").shouldNotHave(text("Exception"), text("Error"));
    * }
    *
-   * @see SelenideElement#shouldNot(com.codeborne.selenide.Condition...)
+   * @see SelenideElement#shouldNot(WebElementCondition...)
    * @see com.codeborne.selenide.commands.ShouldNotHave
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldNotHave(Condition... condition);
+  SelenideElement shouldNotHave(WebElementCondition... condition);
 
   /**
    * Wait until given element does NOT meet given condition (with given timeout)
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldNotHave(Condition condition, Duration timeout);
+  SelenideElement shouldNotHave(WebElementCondition condition, Duration timeout);
 
   /**
-   * Synonym for {@link #shouldNot(com.codeborne.selenide.Condition...)}. Useful for better readability.<p>
+   * Synonym for {@link #shouldNot(WebElementCondition...)}. Useful for better readability.<p>
    *
    * For example: {@code
    * $("#errorMessage").shouldNotBe(visible, enabled);
    * }
    *
-   * @see SelenideElement#shouldNot(com.codeborne.selenide.Condition...)
+   * @see SelenideElement#shouldNot(WebElementCondition...)
    * @see com.codeborne.selenide.commands.ShouldNotBe
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldNotBe(Condition... condition);
+  SelenideElement shouldNotBe(WebElementCondition... condition);
 
   /**
    * Wait until given element does NOT meet given condition (with given timeout)
    */
   @Nonnull
   @CanIgnoreReturnValue
-  SelenideElement shouldNotBe(Condition condition, Duration timeout);
+  SelenideElement shouldNotBe(WebElementCondition condition, Duration timeout);
 
   /**
    * Short description of WebElement, usually a selector.

--- a/src/main/java/com/codeborne/selenide/WebElementCondition.java
+++ b/src/main/java/com/codeborne/selenide/WebElementCondition.java
@@ -1,0 +1,104 @@
+package com.codeborne.selenide;
+
+import com.codeborne.selenide.conditions.ExplainedCondition;
+import com.codeborne.selenide.conditions.Not;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+
+public abstract class WebElementCondition {
+  protected final String name;
+  protected final boolean missingElementSatisfiesCondition;
+
+  protected WebElementCondition(String name) {
+    this(name, false);
+  }
+
+  protected WebElementCondition(String name, boolean missingElementSatisfiesCondition) {
+    this.name = name;
+    this.missingElementSatisfiesCondition = missingElementSatisfiesCondition;
+  }
+
+  /**
+   * Check if given element matches this condition.
+   *
+   * @param element given WebElement
+   * @return true if element matches condition
+   * @deprecated replace by {@link #check(Driver, WebElement)}
+   */
+  @Deprecated
+  public boolean apply(Driver driver, WebElement element) {
+    throw new UnsupportedOperationException("Method 'apply' is deprecated. Please implement 'check' method.");
+  }
+
+  /**
+   * Check if given element matches this condition
+   *
+   * @param driver  selenide driver
+   * @param element given WebElement
+   * @return {@link CheckResult.Verdict#ACCEPT} if element matches condition, or
+   *         {@link CheckResult.Verdict#REJECT} if element doesn't match (and we should keep trying until timeout).
+   *
+   * @since 6.0.0
+   */
+  @Nonnull
+  @CheckReturnValue
+  public CheckResult check(Driver driver, WebElement element) {
+    boolean result = apply(driver, element);
+    return new CheckResult(result ? ACCEPT : REJECT, null);
+  }
+
+  /**
+   * If element didn't match the condition, returns the actual value of element.
+   * Used in error reporting.
+   * Optional. Makes sense only if you need to add some additional important info to error message.
+   *
+   * @param driver  given driver
+   * @param element given WebElement
+   * @return any string that needs to be appended to error message.
+   * @deprecated not needed anymore since the actual value is returned by method {@link #check(Driver, WebElement)}
+   */
+  @Nullable
+  @Deprecated
+  public String actualValue(Driver driver, WebElement element) {
+    return null;
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  public WebElementCondition negate() {
+    return new Not(this, missingElementSatisfiesCondition);
+  }
+
+  /**
+   * Should be used for explaining the reason of condition
+   */
+  @Nonnull
+  @CheckReturnValue
+  public WebElementCondition because(String message) {
+    return new ExplainedCondition(this, message);
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  public String getName() {
+    return name;
+  }
+
+  @CheckReturnValue
+  public boolean missingElementSatisfiesCondition() {
+    return missingElementSatisfiesCondition;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/Matches.java
+++ b/src/main/java/com/codeborne/selenide/commands/Matches.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.impl.Cleanup;
 import com.codeborne.selenide.impl.WebElementSource;
@@ -21,7 +21,7 @@ public class Matches implements Command<Boolean> {
   @Override
   @CheckReturnValue
   public Boolean execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
-    Condition condition = firstOf(args);
+    WebElementCondition condition = firstOf(args);
     WebElement element = getElementOrNull(locator);
     if (element != null) {
       return condition.check(locator.driver(), element).verdict() == ACCEPT;

--- a/src/main/java/com/codeborne/selenide/commands/Should.java
+++ b/src/main/java/com/codeborne/selenide/commands/Should.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.WebElementSource;
 
 import javax.annotation.Nonnull;
@@ -26,7 +26,7 @@ public class Should implements Command<SelenideElement> {
   @Override
   @Nonnull
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
-    for (Condition condition : argsToConditions(args)) {
+    for (WebElementCondition condition : argsToConditions(args)) {
       locator.checkCondition(prefix, condition, false);
     }
     return proxy;

--- a/src/main/java/com/codeborne/selenide/commands/ShouldNot.java
+++ b/src/main/java/com/codeborne/selenide/commands/ShouldNot.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.Command;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.WebElementSource;
 
 import javax.annotation.Nonnull;
@@ -26,7 +26,7 @@ public class ShouldNot implements Command<SelenideElement> {
   @Override
   @Nonnull
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
-    for (Condition condition : argsToConditions(args)) {
+    for (WebElementCondition condition : argsToConditions(args)) {
       locator.checkCondition(prefix, condition, true);
     }
     return proxy;

--- a/src/main/java/com/codeborne/selenide/commands/Util.java
+++ b/src/main/java/com/codeborne/selenide/commands/Util.java
@@ -1,6 +1,6 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.WebElementCondition;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -31,14 +31,14 @@ public class Util {
 
   @CheckReturnValue
   @Nonnull
-  public static List<Condition> argsToConditions(@Nullable Object[] args) {
+  public static List<WebElementCondition> argsToConditions(@Nullable Object[] args) {
     if (args == null) return emptyList();
 
-    List<Condition> conditions = new ArrayList<>(args.length);
+    List<WebElementCondition> conditions = new ArrayList<>(args.length);
     for (Object arg : args) {
-      if (arg instanceof Condition conditionArgument)
+      if (arg instanceof WebElementCondition conditionArgument)
         conditions.add(conditionArgument);
-      else if (arg instanceof Condition[] conditionsArray)
+      else if (arg instanceof WebElementCondition[] conditionsArray)
         conditions.addAll(asList(conditionsArray));
       else if (!(arg instanceof String || arg instanceof Long || arg instanceof Duration))
         throw new IllegalArgumentException("Unknown parameter: " + arg);

--- a/src/main/java/com/codeborne/selenide/conditions/And.java
+++ b/src/main/java/com/codeborne/selenide/conditions/And.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -15,8 +15,8 @@ import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 import static java.util.stream.Collectors.joining;
 
 @ParametersAreNonnullByDefault
-public class And extends Condition {
-  private final List<? extends Condition> conditions;
+public class And extends WebElementCondition {
+  private final List<? extends WebElementCondition> conditions;
 
   /**
    * Ctor.
@@ -25,12 +25,12 @@ public class And extends Condition {
    * @param conditions conditions list
    * @throws IllegalArgumentException if {@code conditions} is empty
    */
-  public And(String name, List<? extends Condition> conditions) {
-    super(name, checkedConditionsListCtorArg(conditions).stream().allMatch(Condition::missingElementSatisfiesCondition));
+  public And(String name, List<? extends WebElementCondition> conditions) {
+    super(name, checkedConditionsListCtorArg(conditions).stream().allMatch(WebElementCondition::missingElementSatisfiesCondition));
     this.conditions = conditions;
   }
 
-  private static List<? extends Condition> checkedConditionsListCtorArg(List<? extends Condition> conditions) {
+  private static List<? extends WebElementCondition> checkedConditionsListCtorArg(List<? extends WebElementCondition> conditions) {
     if (conditions.isEmpty()) {
       throw new IllegalArgumentException("conditions list is empty");
     }
@@ -39,8 +39,10 @@ public class And extends Condition {
 
   @Nonnull
   @Override
-  public Condition negate() {
-    return new Not(this, conditions.stream().map(Condition::negate).allMatch(Condition::missingElementSatisfiesCondition));
+  public WebElementCondition negate() {
+    return new Not(this,
+      conditions.stream().map(WebElementCondition::negate).allMatch(WebElementCondition::missingElementSatisfiesCondition)
+    );
   }
 
   @Nonnull
@@ -49,7 +51,7 @@ public class And extends Condition {
   public CheckResult check(Driver driver, WebElement element) {
     List<CheckResult> results = new ArrayList<>();
 
-    for (Condition c : conditions) {
+    for (WebElementCondition c : conditions) {
       CheckResult checkResult = c.check(driver, element);
       if (checkResult.verdict() != ACCEPT) {
         return checkResult;
@@ -67,6 +69,6 @@ public class And extends Condition {
   @CheckReturnValue
   @Override
   public String toString() {
-    return getName() + ": " + conditions.stream().map(Condition::toString).collect(joining(" and "));
+    return getName() + ": " + conditions.stream().map(WebElementCondition::toString).collect(joining(" and "));
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/Attribute.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Attribute.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class Attribute extends Condition {
+public class Attribute extends WebElementCondition {
   private final String attributeName;
 
   public Attribute(String attributeName) {

--- a/src/main/java/com/codeborne/selenide/conditions/AttributeWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/AttributeWithValue.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class AttributeWithValue extends Condition {
+public class AttributeWithValue extends WebElementCondition {
   private final String attributeName;
   protected final String expectedAttributeValue;
 

--- a/src/main/java/com/codeborne/selenide/conditions/Checked.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Checked.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class Checked extends Condition {
+public class Checked extends WebElementCondition {
 
   public Checked() {
     super("checked");

--- a/src/main/java/com/codeborne/selenide/conditions/CssClass.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CssClass.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class CssClass extends Condition {
+public class CssClass extends WebElementCondition {
   private final String expectedCssClass;
 
   public CssClass(String expectedCssClass) {

--- a/src/main/java/com/codeborne/selenide/conditions/CssValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CssValue.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -13,7 +13,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 
 @ParametersAreNonnullByDefault
-public class CssValue extends Condition {
+public class CssValue extends WebElementCondition {
   private final String propertyName;
   private final String expectedValue;
 

--- a/src/main/java/com/codeborne/selenide/conditions/CustomMatch.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CustomMatch.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -11,7 +11,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.function.Predicate;
 
 @ParametersAreNonnullByDefault
-public class CustomMatch extends Condition {
+public class CustomMatch extends WebElementCondition {
   protected final Predicate<WebElement> predicate;
 
   public CustomMatch(String description, Predicate<WebElement> predicate) {

--- a/src/main/java/com/codeborne/selenide/conditions/Disabled.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Disabled.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class Disabled extends Condition {
+public class Disabled extends WebElementCondition {
 
   public Disabled() {
     super("disabled");

--- a/src/main/java/com/codeborne/selenide/conditions/Enabled.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Enabled.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class Enabled extends Condition {
+public class Enabled extends WebElementCondition {
 
   public Enabled() {
     super("enabled");

--- a/src/main/java/com/codeborne/selenide/conditions/Exist.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Exist.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
@@ -13,7 +13,7 @@ import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 
 @ParametersAreNonnullByDefault
-public class Exist extends Condition {
+public class Exist extends WebElementCondition {
   public Exist() {
     super("exist");
   }
@@ -32,7 +32,7 @@ public class Exist extends Condition {
 
   @Nonnull
   @Override
-  public Condition negate() {
+  public WebElementCondition negate() {
     return new Not(this, true);
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/ExplainedCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/ExplainedCondition.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -10,11 +10,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class ExplainedCondition extends Condition {
-  private final Condition delegate;
+public class ExplainedCondition<T extends WebElementCondition> extends WebElementCondition {
+  private final T delegate;
   private final String message;
 
-  public ExplainedCondition(Condition delegate, String message) {
+  public ExplainedCondition(T delegate, String message) {
     super(delegate.getName(), delegate.missingElementSatisfiesCondition());
     this.delegate = delegate;
     this.message = message;
@@ -30,7 +30,7 @@ public class ExplainedCondition extends Condition {
   @Nonnull
   @CheckReturnValue
   @Override
-  public Condition negate() {
+  public WebElementCondition negate() {
     return delegate.negate().because(message);
   }
 

--- a/src/main/java/com/codeborne/selenide/conditions/Focused.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Focused.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.ElementDescriber;
 import org.openqa.selenium.WebElement;
 
@@ -12,7 +12,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static com.codeborne.selenide.impl.Plugins.inject;
 
 @ParametersAreNonnullByDefault
-public class Focused extends Condition {
+public class Focused extends WebElementCondition {
   private final ElementDescriber describe = inject(ElementDescriber.class);
 
   public Focused() {

--- a/src/main/java/com/codeborne/selenide/conditions/Hidden.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Hidden.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
@@ -12,7 +12,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 
 @ParametersAreNonnullByDefault
-public class Hidden extends Condition {
+public class Hidden extends WebElementCondition {
   public Hidden() {
     super("hidden", true);
   }
@@ -31,7 +31,7 @@ public class Hidden extends Condition {
 
   @Nonnull
   @Override
-  public Condition negate() {
+  public WebElementCondition negate() {
     return new Not(this, false);
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/IsImageLoaded.java
+++ b/src/main/java/com/codeborne/selenide/conditions/IsImageLoaded.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.JavaScript;
 import org.openqa.selenium.WebElement;
 
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class IsImageLoaded extends Condition {
+public class IsImageLoaded extends WebElementCondition {
   private static final JavaScript js = new JavaScript("is-image.js");
 
   public IsImageLoaded() {

--- a/src/main/java/com/codeborne/selenide/conditions/MatchAttributeWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/MatchAttributeWithValue.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -11,7 +11,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.regex.Pattern;
 
 @ParametersAreNonnullByDefault
-public class MatchAttributeWithValue extends Condition {
+public class MatchAttributeWithValue extends WebElementCondition {
   private final String attributeName;
   private final Pattern attributeRegex;
 

--- a/src/main/java/com/codeborne/selenide/conditions/NamedCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/NamedCondition.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -10,11 +10,11 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class NamedCondition extends Condition {
+public class NamedCondition extends WebElementCondition {
   private final String prefix;
-  private final Condition delegate;
+  private final WebElementCondition delegate;
 
-  public NamedCondition(String prefix, Condition delegate) {
+  public NamedCondition(String prefix, WebElementCondition delegate) {
     super(delegate.getName(), delegate.missingElementSatisfiesCondition());
     this.prefix = prefix;
     this.delegate = delegate;
@@ -30,7 +30,7 @@ public class NamedCondition extends Condition {
   @Nonnull
   @CheckReturnValue
   @Override
-  public Condition negate() {
+  public WebElementCondition negate() {
     return delegate.negate();
   }
 

--- a/src/main/java/com/codeborne/selenide/conditions/Not.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Not.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -13,10 +13,10 @@ import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 
 @ParametersAreNonnullByDefault
-public class Not extends Condition {
-  private final Condition condition;
+public class Not extends WebElementCondition {
+  private final WebElementCondition condition;
 
-  public Not(Condition originalCondition, boolean absentElementMatchesCondition) {
+  public Not(WebElementCondition originalCondition, boolean absentElementMatchesCondition) {
     super("not " + originalCondition.getName(), absentElementMatchesCondition);
     this.condition = originalCondition;
   }

--- a/src/main/java/com/codeborne/selenide/conditions/Or.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Or.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -16,9 +16,9 @@ import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 import static java.util.stream.Collectors.joining;
 
 @ParametersAreNonnullByDefault
-public class Or extends Condition {
+public class Or extends WebElementCondition {
 
-  private final List<? extends Condition> conditions;
+  private final List<? extends WebElementCondition> conditions;
 
   /**
    * Ctor.
@@ -27,12 +27,12 @@ public class Or extends Condition {
    * @param conditions conditions list
    * @throws IllegalArgumentException if {@code conditions} is empty
    */
-  public Or(String name, List<? extends Condition> conditions) {
-    super(name, checkedConditionsListCtorArg(conditions).stream().anyMatch(Condition::missingElementSatisfiesCondition));
+  public Or(String name, List<? extends WebElementCondition> conditions) {
+    super(name, checkedConditionsListCtorArg(conditions).stream().anyMatch(WebElementCondition::missingElementSatisfiesCondition));
     this.conditions = conditions;
   }
 
-  private static List<? extends Condition> checkedConditionsListCtorArg(List<? extends Condition> conditions) {
+  private static List<? extends WebElementCondition> checkedConditionsListCtorArg(List<? extends WebElementCondition> conditions) {
     if (conditions.isEmpty()) {
       throw new IllegalArgumentException("conditions list is empty");
     }
@@ -42,8 +42,10 @@ public class Or extends Condition {
   @Nonnull
   @CheckReturnValue
   @Override
-  public Condition negate() {
-    return new Not(this, conditions.stream().map(Condition::negate).anyMatch(Condition::missingElementSatisfiesCondition));
+  public WebElementCondition negate() {
+    return new Not(this,
+      conditions.stream().map(WebElementCondition::negate).anyMatch(WebElementCondition::missingElementSatisfiesCondition)
+    );
   }
 
   @Nonnull
@@ -51,7 +53,7 @@ public class Or extends Condition {
   @Override
   public CheckResult check(Driver driver, WebElement element) {
     List<CheckResult> results = new ArrayList<>();
-    for (Condition c : conditions) {
+    for (WebElementCondition c : conditions) {
       CheckResult check = c.check(driver, element);
       if (check.verdict() == ACCEPT) {
         return check;
@@ -69,6 +71,6 @@ public class Or extends Condition {
   @CheckReturnValue
   @Override
   public String toString() {
-    return getName() + ": " + conditions.stream().map(Condition::toString).collect(joining(" or "));
+    return getName() + ": " + conditions.stream().map(WebElementCondition::toString).collect(joining(" or "));
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/PartialValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PartialValue.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
@@ -13,7 +13,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @ParametersAreNonnullByDefault
-public class PartialValue extends Condition {
+public class PartialValue extends WebElementCondition {
   private final String expectedValue;
 
   public PartialValue(String expectedValue) {

--- a/src/main/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/PseudoElementPropertyWithValue.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -13,7 +13,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.defaultString;
 
 @ParametersAreNonnullByDefault
-public class PseudoElementPropertyWithValue extends Condition {
+public class PseudoElementPropertyWithValue extends WebElementCondition {
 
   static final String JS_CODE = "return window.getComputedStyle(arguments[0], arguments[1])" +
     ".getPropertyValue(arguments[2]);";

--- a/src/main/java/com/codeborne/selenide/conditions/Selected.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Selected.java
@@ -1,15 +1,15 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class Selected extends Condition {
+public class Selected extends WebElementCondition {
 
   public Selected() {
     super("selected");

--- a/src/main/java/com/codeborne/selenide/conditions/TagName.java
+++ b/src/main/java/com/codeborne/selenide/conditions/TagName.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -11,7 +11,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Objects;
 
 @ParametersAreNonnullByDefault
-public class TagName extends Condition {
+public class TagName extends WebElementCondition {
   private final String expectedTagName;
 
   public TagName(String expectedTagName) {

--- a/src/main/java/com/codeborne/selenide/conditions/TextCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/TextCondition.java
@@ -1,9 +1,9 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.TextCheck;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public abstract class TextCondition extends Condition {
+public abstract class TextCondition extends WebElementCondition {
   private final String expectedText;
 
   protected TextCondition(String name, String expectedText) {

--- a/src/main/java/com/codeborne/selenide/conditions/Value.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Value.java
@@ -1,9 +1,9 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.TextCheck;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.Html;
 import org.openqa.selenium.WebElement;
 
@@ -12,7 +12,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class Value extends Condition {
+public class Value extends WebElementCondition {
   private final String expectedValue;
 
   public Value(String expectedValue) {

--- a/src/main/java/com/codeborne/selenide/conditions/Visible.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Visible.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class Visible extends Condition {
+public class Visible extends WebElementCondition {
   public Visible() {
     super("visible");
   }
@@ -25,7 +25,7 @@ public class Visible extends Condition {
   @Override
   @CheckReturnValue
   @Nonnull
-  public Condition negate() {
+  public WebElementCondition negate() {
     return new Not(this, true);
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/datetime/TemporalCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/datetime/TemporalCondition.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions.datetime;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -13,7 +13,7 @@ import java.time.temporal.TemporalAccessor;
 import static java.util.Objects.requireNonNull;
 
 @ParametersAreNonnullByDefault
-public abstract class TemporalCondition<T extends TemporalAccessor> extends Condition {
+public abstract class TemporalCondition<T extends TemporalAccessor> extends WebElementCondition {
   private final TemporalFormatCondition<T> formatCondition;
 
   protected TemporalCondition(String name, TemporalFormatCondition<T> format) {

--- a/src/main/java/com/codeborne/selenide/conditions/datetime/TemporalFormatCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/datetime/TemporalFormatCondition.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions.datetime;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -17,7 +17,7 @@ import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 
 @ParametersAreNonnullByDefault
-public abstract class TemporalFormatCondition<T extends TemporalAccessor> extends Condition {
+public abstract class TemporalFormatCondition<T extends TemporalAccessor> extends WebElementCondition {
   private final String pattern;
   private final DateTimeFormatter format;
 

--- a/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
@@ -1,7 +1,7 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.CollectionSource;
 import org.openqa.selenium.By;
@@ -12,16 +12,16 @@ import java.util.List;
 
 @ParametersAreNonnullByDefault
 public class ElementNotFound extends UIAssertionError {
-  public ElementNotFound(Driver driver, Alias alias, By searchCriteria, Condition expectedCondition) {
+  public ElementNotFound(Driver driver, Alias alias, By searchCriteria, WebElementCondition expectedCondition) {
     this(driver, alias, searchCriteria.toString(), expectedCondition, null);
   }
 
-  public ElementNotFound(Driver driver, Alias alias, String searchCriteria, Condition expectedCondition) {
+  public ElementNotFound(Driver driver, Alias alias, String searchCriteria, WebElementCondition expectedCondition) {
     super(driver, String.format("Element%s not found {%s}" +
       "%nExpected: %s", alias.appendable(), searchCriteria, expectedCondition));
   }
 
-  public ElementNotFound(Driver driver, Alias alias, String searchCriteria, Condition expectedCondition,
+  public ElementNotFound(Driver driver, Alias alias, String searchCriteria, WebElementCondition expectedCondition,
                          @Nullable Throwable cause) {
     super(driver, String.format("Element%s not found {%s}" +
       "%nExpected: %s", alias.appendable(), searchCriteria, expectedCondition), cause);

--- a/src/main/java/com/codeborne/selenide/ex/ElementShould.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShould.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.ElementDescriber;
 import org.openqa.selenium.WebElement;
@@ -18,7 +18,7 @@ public class ElementShould extends UIAssertionError {
   private static final ElementDescriber describe = inject(ElementDescriber.class);
 
   public ElementShould(Driver driver, Alias alias, String searchCriteria, String prefix,
-                       Condition expectedCondition, @Nullable CheckResult lastCheckResult,
+                       WebElementCondition expectedCondition, @Nullable CheckResult lastCheckResult,
                        WebElement element, @Nullable Throwable cause) {
     super(
       driver,

--- a/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.ElementDescriber;
 import org.openqa.selenium.WebElement;
@@ -18,7 +18,7 @@ public class ElementShouldNot extends UIAssertionError {
   private static final ElementDescriber describe = inject(ElementDescriber.class);
 
   public ElementShouldNot(Driver driver, Alias alias, String searchCriteria, String prefix,
-                          Condition expectedCondition, @Nullable CheckResult lastCheckResult,
+                          WebElementCondition expectedCondition, @Nullable CheckResult lastCheckResult,
                           WebElement element, @Nullable Throwable cause) {
     super(
       driver,

--- a/src/main/java/com/codeborne/selenide/ex/ErrorFormatter.java
+++ b/src/main/java/com/codeborne/selenide/ex/ErrorFormatter.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.Screenshot;
 import org.openqa.selenium.WebElement;
 
@@ -23,7 +23,7 @@ public interface ErrorFormatter {
 
   @CheckReturnValue
   @Nonnull
-  String actualValue(Condition condition, Driver driver,
+  String actualValue(WebElementCondition condition, Driver driver,
                      @Nullable WebElement element,
                      @Nullable CheckResult lastCheckResult);
 }

--- a/src/main/java/com/codeborne/selenide/ex/SelenideErrorFormatter.java
+++ b/src/main/java/com/codeborne/selenide/ex/SelenideErrorFormatter.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.Cleanup;
 import com.codeborne.selenide.impl.DurationFormat;
 import com.codeborne.selenide.impl.Screenshot;
@@ -36,7 +36,7 @@ public class SelenideErrorFormatter implements ErrorFormatter {
   @CheckReturnValue
   @Nonnull
   @Override
-  public String actualValue(Condition condition, Driver driver,
+  public String actualValue(WebElementCondition condition, Driver driver,
                             @Nullable WebElement element,
                             @Nullable CheckResult lastCheckResult) {
     if (lastCheckResult != null && lastCheckResult.actualValue() != null) {
@@ -53,7 +53,7 @@ public class SelenideErrorFormatter implements ErrorFormatter {
 
   @Nullable
   @CheckReturnValue
-  protected String extractActualValue(Condition condition, Driver driver, @Nullable WebElement element) {
+  protected String extractActualValue(WebElementCondition condition, Driver driver, @Nullable WebElement element) {
     if (element != null) {
       try {
         return condition.actualValue(driver, element);

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.openqa.selenium.WebElement;
 
@@ -56,7 +56,7 @@ public class CollectionElement extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
+  public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     if (collection.getElements().isEmpty()) {
       return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, cause);
     }

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
@@ -19,16 +19,16 @@ public class CollectionElementByCondition extends WebElementSource {
 
   @CheckReturnValue
   @Nonnull
-  public static SelenideElement wrap(CollectionSource collection, Condition condition) {
+  public static SelenideElement wrap(CollectionSource collection, WebElementCondition condition) {
     return (SelenideElement) Proxy.newProxyInstance(
       collection.getClass().getClassLoader(), new Class<?>[]{SelenideElement.class},
       new SelenideElementProxy<>(new CollectionElementByCondition(collection, condition)));
   }
 
   private final CollectionSource collection;
-  private final Condition condition;
+  private final WebElementCondition condition;
 
-  CollectionElementByCondition(CollectionSource collection, Condition condition) {
+  CollectionElementByCondition(CollectionSource collection, WebElementCondition condition) {
     this.collection = collection;
     this.condition = condition;
   }

--- a/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -134,7 +134,7 @@ public class ElementFinder extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
+  public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     if (parent != null) {
       parent.checkCondition("", exist, false);
     }

--- a/src/main/java/com/codeborne/selenide/impl/FilteringCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/FilteringCollection.java
@@ -1,7 +1,7 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
@@ -16,10 +16,10 @@ import static java.util.stream.Collectors.toList;
 @ParametersAreNonnullByDefault
 public class FilteringCollection implements CollectionSource {
   private final CollectionSource originalCollection;
-  private final Condition filter;
+  private final WebElementCondition filter;
   private Alias alias = NONE;
 
-  public FilteringCollection(CollectionSource originalCollection, Condition filter) {
+  public FilteringCollection(CollectionSource originalCollection, WebElementCondition filter) {
     this.originalCollection = originalCollection;
     this.filter = filter;
   }

--- a/src/main/java/com/codeborne/selenide/impl/JSElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/JSElementFinder.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -61,7 +61,7 @@ public class JSElementFinder extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
+  public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     parent.checkCondition("", exist, false);
     return super.createElementNotFoundError(condition, cause);
   }

--- a/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.openqa.selenium.WebElement;
 
@@ -56,7 +56,7 @@ public class LastCollectionElement extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
+  public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     if (collection.getElements().isEmpty()) {
       return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, cause);
     }

--- a/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.openqa.selenium.WebElement;
 
@@ -92,7 +92,7 @@ public class LazyWebElementSnapshot extends WebElementSource {
 
   @Nonnull
   @Override
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
+  public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     return delegate.createElementNotFoundError(condition, cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -1,10 +1,10 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.conditions.And;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.ElementShould;
 import com.codeborne.selenide.ex.ElementShouldNot;
@@ -84,7 +84,7 @@ public abstract class WebElementSource {
 
   @CheckReturnValue
   @Nonnull
-  public ElementNotFound createElementNotFoundError(Condition condition, Throwable cause) {
+  public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     if (cause instanceof UIAssertionError) {
       throw new IllegalArgumentException("Unexpected UIAssertionError as a cause of ElementNotFound: " + cause, cause);
     }
@@ -100,14 +100,14 @@ public abstract class WebElementSource {
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void checkCondition(String prefix, Condition condition, boolean invert) {
+  public void checkCondition(String prefix, WebElementCondition condition, boolean invert) {
     checkConditionAndReturnElement(prefix, condition, invert);
   }
 
   @Nullable
   @CheckReturnValue
-  private WebElement checkConditionAndReturnElement(String prefix, Condition condition, boolean invert) {
-    Condition check = invert ? not(condition) : condition;
+  private WebElement checkConditionAndReturnElement(String prefix, WebElementCondition condition, boolean invert) {
+    WebElementCondition check = invert ? not(condition) : condition;
 
     Throwable lastError = null;
     WebElement element = null;
@@ -127,7 +127,7 @@ public abstract class WebElementSource {
     return handleError(prefix, condition, invert, check, lastError, element, checkResult);
   }
 
-  private WebElement handleError(String prefix, Condition condition, boolean invert, Condition check,
+  private WebElement handleError(String prefix, WebElementCondition condition, boolean invert, WebElementCondition check,
                                  @Nullable Throwable lastError, @Nullable WebElement element, @Nullable CheckResult checkResult) {
     if (lastError != null && Cleanup.of.isInvalidSelectorError(lastError)) {
       throw Cleanup.of.wrapInvalidSelectorException(lastError);

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -116,7 +116,7 @@ final class ConditionTest {
 
   @Test
   void elementHasAttributeWithGivenValue() {
-    Condition condition = attribute("name", "selenide");
+    WebElementCondition condition = attribute("name", "selenide");
     assertThat(condition.check(driver, elementWithAttribute("name", "selenide")).verdict()).isEqualTo(ACCEPT);
     assertThat(condition.check(driver, elementWithAttribute("name", "selenide is great")).verdict()).isEqualTo(REJECT);
     assertThat(condition.check(driver, elementWithAttribute("id", "id2")).verdict()).isEqualTo(REJECT);
@@ -124,7 +124,7 @@ final class ConditionTest {
 
   @Test
   void matchingAttributeWithRegex() {
-    Condition condition = attributeMatching("name", "selenide.*");
+    WebElementCondition condition = attributeMatching("name", "selenide.*");
     assertThat(condition.check(driver, elementWithAttribute("name", "selenide")).verdict()).isEqualTo(ACCEPT);
     assertThat(condition.check(driver, elementWithAttribute("name", "selenide is great")).verdict()).isEqualTo(ACCEPT);
     assertThat(condition.check(driver, elementWithAttribute("id", "selenide")).verdict()).isEqualTo(REJECT);
@@ -265,7 +265,7 @@ final class ConditionTest {
   @Test
   void elementAndConditionActualValue() {
     WebElement element = mockElement(false, "text");
-    Condition condition = and("selected with text", be(selected), have(text("text")));
+    WebElementCondition condition = and("selected with text", be(selected), have(text("text")));
     assertThat(condition.check(driver, element).actualValue()).isEqualTo("not selected");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
   }
@@ -273,7 +273,7 @@ final class ConditionTest {
   @Test
   void elementAndConditionToString() {
     WebElement element = mockElement(false, "text");
-    Condition condition = and("selected with text", be(selected), have(text("text")));
+    WebElementCondition condition = and("selected with text", be(selected), have(text("text")));
     assertThat(condition).hasToString("selected with text: be selected and have text \"text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
     assertThat(condition).hasToString("selected with text: be selected and have text \"text\"");
@@ -290,7 +290,7 @@ final class ConditionTest {
   @Test
   void elementAllOfConditionActualValue() {
     WebElement element = mockElement(false, "text");
-    Condition condition = allOf("selected with text", be(selected), have(text("text")));
+    WebElementCondition condition = allOf("selected with text", be(selected), have(text("text")));
     assertThat(condition.check(driver, element).actualValue()).isEqualTo("not selected");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
   }
@@ -298,7 +298,7 @@ final class ConditionTest {
   @Test
   void elementAllOfConditionToString() {
     WebElement element = mockElement(false, "text");
-    Condition condition = allOf("selected with text", be(selected), have(text("text")));
+    WebElementCondition condition = allOf("selected with text", be(selected), have(text("text")));
     assertThat(condition).hasToString("selected with text: be selected and have text \"text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
     assertThat(condition).hasToString("selected with text: be selected and have text \"text\"");
@@ -315,7 +315,7 @@ final class ConditionTest {
   @Test
   void elementAllOfWithoutNameConditionActualValue() {
     WebElement element = mockElement(false, "text");
-    Condition condition = allOf(be(selected), have(text("text")));
+    WebElementCondition condition = allOf(be(selected), have(text("text")));
     assertThat(condition.check(driver, element).actualValue()).isEqualTo("not selected");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
   }
@@ -323,7 +323,7 @@ final class ConditionTest {
   @Test
   void elementAllOfWithoutNameConditionToString() {
     WebElement element = mockElement(false, "text");
-    Condition condition = allOf(be(selected), have(text("text")));
+    WebElementCondition condition = allOf(be(selected), have(text("text")));
     assertThat(condition).hasToString("all of: be selected and have text \"text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(REJECT);
     assertThat(condition).hasToString("all of: be selected and have text \"text\"");
@@ -340,7 +340,7 @@ final class ConditionTest {
   @Test
   void elementOrConditionActualValue() {
     WebElement element = mockElement(false, "some text");
-    Condition condition = or("selected with text", be(selected), have(text("some text")));
+    WebElementCondition condition = or("selected with text", be(selected), have(text("some text")));
     assertThat(condition.check(driver, element).actualValue()).isEqualTo("text=\"some text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
   }
@@ -348,7 +348,7 @@ final class ConditionTest {
   @Test
   void elementOrConditionToString() {
     WebElement element = mockElement(false, "text");
-    Condition condition = or("selected with text", be(selected), have(text("text")));
+    WebElementCondition condition = or("selected with text", be(selected), have(text("text")));
     assertThat(condition).hasToString("selected with text: be selected or have text \"text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
   }
@@ -364,7 +364,7 @@ final class ConditionTest {
   @Test
   void elementAnyOfConditionActualValue() {
     WebElement element = mockElement(false, "some text");
-    Condition condition = anyOf("selected with text", be(selected), have(text("some text")));
+    WebElementCondition condition = anyOf("selected with text", be(selected), have(text("some text")));
     assertThat(condition.check(driver, element).actualValue()).isEqualTo("text=\"some text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
   }
@@ -372,7 +372,7 @@ final class ConditionTest {
   @Test
   void elementAnyOfConditionToString() {
     WebElement element = mockElement(false, "text");
-    Condition condition = anyOf("selected with text", be(selected), have(text("text")));
+    WebElementCondition condition = anyOf("selected with text", be(selected), have(text("text")));
     assertThat(condition).hasToString("selected with text: be selected or have text \"text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
   }
@@ -388,7 +388,7 @@ final class ConditionTest {
   @Test
   void elementAnyOfWithoutNameConditionActualValue() {
     WebElement element = mockElement(false, "some text");
-    Condition condition = anyOf(be(selected), have(text("some text")));
+    WebElementCondition condition = anyOf(be(selected), have(text("some text")));
     assertThat(condition.check(driver, element).actualValue()).isEqualTo("text=\"some text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
   }
@@ -396,32 +396,32 @@ final class ConditionTest {
   @Test
   void elementAnyOfWithoutNameConditionToString() {
     WebElement element = mockElement(false, "text");
-    Condition condition = anyOf(be(selected), have(text("text")));
+    WebElementCondition condition = anyOf(be(selected), have(text("text")));
     assertThat(condition).hasToString("any of: be selected or have text \"text\"");
     assertThat(condition.check(driver, element).verdict()).isEqualTo(ACCEPT);
   }
 
   @Test
   void conditionBe() {
-    Condition condition = be(visible);
+    WebElementCondition condition = be(visible);
     assertThat(condition).hasToString("be visible");
   }
 
   @Test
   void conditionHave() {
-    Condition condition = have(attribute("name"));
+    WebElementCondition condition = have(attribute("name"));
     assertThat(condition).hasToString("have attribute name");
   }
 
   @Test
   void conditionMissingElementSatisfiesCondition() {
-    Condition condition = attribute("name");
+    WebElementCondition condition = attribute("name");
     assertThat(condition.missingElementSatisfiesCondition()).isFalse();
   }
 
   @Test
   void conditionToString() {
-    Condition condition = attribute("name").because("it's awesome");
+    WebElementCondition condition = attribute("name").because("it's awesome");
     assertThat(condition).hasToString("attribute name (because it's awesome)");
   }
 

--- a/src/test/java/com/codeborne/selenide/commands/DragAndDropToTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/DragAndDropToTest.java
@@ -1,6 +1,6 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.DragAndDropOptions;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
@@ -44,7 +44,7 @@ class DragAndDropToTest {
     when(locator.driver()).thenReturn(driver);
     when(locator.getWebElement()).thenReturn(locatorWebElement);
     when(targetSelenideElement.getWrappedElement()).thenReturn(targetWebElement);
-    doNothing().when(locator).checkCondition(anyString(), any(Condition.class), anyBoolean());
+    doNothing().when(locator).checkCondition(anyString(), any(WebElementCondition.class), anyBoolean());
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/commands/ShouldHaveCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/ShouldHaveCommandTest.java
@@ -1,7 +1,7 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,8 +27,8 @@ final class ShouldHaveCommandTest {
 
   @Test
   void checksEveryConditionFromGivenParameters() {
-    Condition condition1 = text("aaa");
-    Condition condition2 = attribute("readonly");
+    WebElementCondition condition1 = text("aaa");
+    WebElementCondition condition2 = attribute("readonly");
     SelenideElement returnedElement = shouldHaveCommand.execute(proxy, locator, new Object[]{condition1, condition2});
     assertThat(returnedElement).isEqualTo(proxy);
     verify(locator).checkCondition("have ", condition1, false);

--- a/src/test/java/com/codeborne/selenide/commands/UtilCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/UtilCommandTest.java
@@ -1,6 +1,6 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.WebElementCondition;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -20,23 +20,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 final class UtilCommandTest {
   @Test
   void extractsConditionsFromGivenArguments() {
-    List<Condition> conditions = argsToConditions(new Object[]{enabled, visible});
+    List<WebElementCondition> conditions = argsToConditions(new Object[]{enabled, visible});
     assertThat(conditions).isEqualTo(asList(enabled, visible));
   }
 
   @Test
   void supportsArraysOfConditions() {
-    List<Condition> conditions = argsToConditions(new Object[]{
+    List<WebElementCondition> conditions = argsToConditions(new Object[]{
       enabled,
-      new Condition[]{appear, exist},
-      new Condition[]{disabled, enabled, readonly}
+      new WebElementCondition[]{appear, exist},
+      new WebElementCondition[]{disabled, enabled, readonly}
     });
     assertThat(conditions).isEqualTo(asList(enabled, appear, exist, disabled, enabled, readonly));
   }
 
   @Test
   void ignores_String_Long_Duration_arguments() {
-    List<Condition> conditions = argsToConditions(new Object[]{42L, "Some text", exist, Duration.ofSeconds(3), visible});
+    List<WebElementCondition> conditions = argsToConditions(new Object[]{42L, "Some text", exist, Duration.ofSeconds(3), visible});
     assertThat(conditions).isEqualTo(asList(exist, visible));
   }
 

--- a/src/test/java/com/codeborne/selenide/conditions/AndTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/AndTest.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
@@ -173,7 +173,7 @@ final class AndTest {
   }
 
   @ParametersAreNonnullByDefault
-  private static class SimpleCondition extends Condition {
+  private static class SimpleCondition extends WebElementCondition {
     private final boolean applyResult;
 
     SimpleCondition(boolean applyResult) {
@@ -195,7 +195,7 @@ final class AndTest {
     @Nonnull
     @CheckReturnValue
     @Override
-    public Condition negate() {
+    public WebElementCondition negate() {
       return new Not(this, !this.missingElementSatisfiesCondition());
     }
 

--- a/src/test/java/com/codeborne/selenide/conditions/ExplainedConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/ExplainedConditionTest.java
@@ -1,14 +1,14 @@
 package com.codeborne.selenide.conditions;
 
-import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.WebElementCondition;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class ExplainedConditionTest {
-  private final Condition visible = new Visible().because("I see it");
-  private final Condition hidden = new Hidden().because("I don't see it");
-  private final Condition text = new Text("blah").because("I typed it");
+  private final WebElementCondition visible = new Visible().because("I see it");
+  private final WebElementCondition hidden = new Hidden().because("I don't see it");
+  private final WebElementCondition text = new Text("blah").because("I typed it");
 
   @Test
   void negate() {

--- a/src/test/java/com/codeborne/selenide/conditions/NotTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/NotTest.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,8 +20,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class NotTest {
-  Condition originalCondition = mock();
-  Not notCondition;
+  private final WebElementCondition originalCondition = mock();
+  private Not notCondition;
 
   @BeforeEach
   void commonMockCalls() {

--- a/src/test/java/com/codeborne/selenide/conditions/OrTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/OrTest.java
@@ -1,8 +1,8 @@
 package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
@@ -171,7 +171,7 @@ final class OrTest {
   }
 
   @ParametersAreNonnullByDefault
-  private static class SimpleCondition extends Condition {
+  private static class SimpleCondition extends WebElementCondition {
     private final boolean applyResult;
 
     SimpleCondition(boolean applyResult) {
@@ -193,7 +193,7 @@ final class OrTest {
     @Nonnull
     @CheckReturnValue
     @Override
-    public Condition negate() {
+    public WebElementCondition negate() {
       return new Not(this, !this.missingElementSatisfiesCondition());
     }
 

--- a/src/test/java/com/codeborne/selenide/impl/ArgumentsTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ArgumentsTest.java
@@ -1,6 +1,6 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.WebElementCondition;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.ClickOptions.usingJavaScript;
@@ -14,7 +14,7 @@ class ArgumentsTest {
   void extractsArgumentOfGivenType() {
     Arguments arguments = new Arguments(visible, "this", 42, "that");
     assertThat(arguments.ofType(String.class)).contains("this");
-    assertThat(arguments.ofType(Condition.class)).contains(visible);
+    assertThat(arguments.ofType(WebElementCondition.class)).contains(visible);
     assertThat(arguments.ofType(Boolean.class)).isEmpty();
   }
 

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
@@ -1,9 +1,9 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchElementException;
@@ -90,7 +90,7 @@ final class CollectionElementByConditionTest {
     when(collection.getElements()).thenReturn(singletonList(mock()));
     CollectionElementByCondition collectionElement = new CollectionElementByCondition(collection, visible);
 
-    Condition mockedCollection = mock();
+    WebElementCondition mockedCollection = mock();
     when(mockedCollection.toString()).thenReturn("Reason description");
     ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(mockedCollection, new Error("Error message"));
 

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
@@ -1,9 +1,9 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
@@ -66,7 +66,7 @@ final class CollectionElementTest {
     when(collection.description()).thenReturn("Collection description");
     CollectionElement collectionElement = new CollectionElement(collection, 33);
 
-    Condition mockedCollection = mock();
+    WebElementCondition mockedCollection = mock();
     ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(mockedCollection, new Error("Error message"));
 
     assertThat(elementNotFoundError)
@@ -84,7 +84,7 @@ final class CollectionElementTest {
     when(collection.getElements()).thenReturn(singletonList(mock()));
     CollectionElement collectionElement = new CollectionElement(collection, 1);
 
-    Condition mockedCollection = mock();
+    WebElementCondition mockedCollection = mock();
     when(mockedCollection.toString()).thenReturn("Reason description");
     ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(mockedCollection, new Error("Error message"));
 

--- a/src/test/java/integration/ConditionsTest.java
+++ b/src/test/java/integration/ConditionsTest.java
@@ -1,6 +1,6 @@
 package integration;
 
-import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.ElementShould;
 import com.codeborne.selenide.ex.ElementShouldNot;
@@ -130,13 +130,13 @@ final class ConditionsTest extends ITest {
 
   @Test
   void userCanUseOrCondition() {
-    Condition one_of_conditions = or("baskerville", partialText("Basker"), partialText("Walle"));
+    WebElementCondition one_of_conditions = or("baskerville", partialText("Basker"), partialText("Walle"));
     $("#baskerville").shouldBe(one_of_conditions);
 
-    Condition all_of_conditions = or("baskerville", partialText("Basker"), partialText("rville"));
+    WebElementCondition all_of_conditions = or("baskerville", partialText("Basker"), partialText("rville"));
     $("#baskerville").shouldBe(all_of_conditions);
 
-    Condition none_of_conditions = or("baskerville", partialText("pasker"), partialText("wille"));
+    WebElementCondition none_of_conditions = or("baskerville", partialText("pasker"), partialText("wille"));
     $("#baskerville").shouldNotBe(none_of_conditions);
 
     $("#baskerville").shouldHave(anyOf(partialText("Basker"), partialText("Walle")));

--- a/src/test/java/integration/Coordinates.java
+++ b/src/test/java/integration/Coordinates.java
@@ -1,8 +1,8 @@
 package integration;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nonnull;
@@ -15,7 +15,7 @@ import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 import static java.lang.Integer.parseInt;
 
 @ParametersAreNonnullByDefault
-class Coordinates extends Condition {
+class Coordinates extends WebElementCondition {
   private static final Pattern regex = Pattern.compile("\\((\\d+), (\\d+)\\)");
   private final int expectedX;
   private final int expectedY;
@@ -46,7 +46,7 @@ class Coordinates extends Condition {
     return new CheckResult(ACCEPT, text);
   }
 
-  public static Condition coordinates(int expectedX, int expectedY) {
+  public static WebElementCondition coordinates(int expectedX, int expectedY) {
     return new Coordinates(expectedX, expectedY);
   }
 }

--- a/src/test/java/integration/TabsTest.java
+++ b/src/test/java/integration/TabsTest.java
@@ -1,6 +1,5 @@
 package integration;
 
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ex.WindowNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,7 +94,7 @@ final class TabsTest extends ITest {
     $(byText("Page3: jquery")).click();
 
     $("h1").shouldHave(text("Tabs"));
-    Condition oneOfTitles = or("one of titles", text("Tabs"), text("Page with alerts"), text("File uploads"), text("Page with JQuery"));
+    var oneOfTitles = or("one of titles", text("Tabs"), text("Page with alerts"), text("File uploads"), text("Page with JQuery"));
 
     switchTo().window(1);
     $("h1").shouldHave(oneOfTitles);

--- a/src/test/java/integration/customconditions/ChildElementTest.java
+++ b/src/test/java/integration/customconditions/ChildElementTest.java
@@ -1,8 +1,8 @@
 package integration.customconditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.ElementShould;
 import integration.ITest;
@@ -65,8 +65,8 @@ final class ChildElementTest extends ITest {
       .hasMessageContaining("Expected: child td with attribute class=\"first_row\"");
   }
 
-  public static Condition child(final String childCssSelector, final Condition condition) {
-    return new Condition("child " + childCssSelector + " with " + condition.getName()) {
+  public static WebElementCondition child(String childCssSelector, WebElementCondition condition) {
+    return new WebElementCondition("child " + childCssSelector + " with " + condition.getName()) {
       @Nonnull
       @Override
       public CheckResult check(Driver driver, WebElement element) {

--- a/src/test/java/integration/customconditions/MoveAroundTest.java
+++ b/src/test/java/integration/customconditions/MoveAroundTest.java
@@ -1,8 +1,8 @@
 package integration.customconditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementShould;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,8 +39,8 @@ final class MoveAroundTest extends ITest {
       .hasMessageContaining("Actual value: Location: (");
   }
 
-  public static Condition moveAround(int movePeriodMs) {
-    return new Condition("moveAround") {
+  public static WebElementCondition moveAround(int movePeriodMs) {
+    return new WebElementCondition("moveAround") {
       @Nonnull
       @Override
       public CheckResult check(Driver driver, WebElement element) {

--- a/src/test/java/integration/customconditions/TextOfLengthTest.java
+++ b/src/test/java/integration/customconditions/TextOfLengthTest.java
@@ -1,8 +1,8 @@
 package integration.customconditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementShould;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,8 +35,8 @@ final class TextOfLengthTest extends ITest {
       .hasMessageContaining("Actual value: length(\"Page with moving elements\") = 25");
   }
 
-  public static Condition textOfLength(int expectedLength) {
-    return new Condition("text of length " + expectedLength) {
+  public static WebElementCondition textOfLength(int expectedLength) {
+    return new WebElementCondition("text of length " + expectedLength) {
       @Nonnull
       @Override
       public CheckResult check(Driver driver, WebElement webElement) {

--- a/src/test/java/integration/customconditions/ValueInAttributeTest.java
+++ b/src/test/java/integration/customconditions/ValueInAttributeTest.java
@@ -1,8 +1,8 @@
 package integration.customconditions;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.ex.ElementShould;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,8 +35,8 @@ final class ValueInAttributeTest extends ITest {
       .hasMessageContaining("Actual value: https://google.com/");
   }
 
-  private static Condition valueInAttribute(String attributeName, String value) {
-    return new Condition(String.format("value '%s' in attribute '%s'", value, attributeName)) {
+  private static WebElementCondition valueInAttribute(String attributeName, String value) {
+    return new WebElementCondition(String.format("value '%s' in attribute '%s'", value, attributeName)) {
       @Override
       @Nonnull
       public CheckResult check(Driver driver, WebElement element) {


### PR DESCRIPTION

* this removes cross-dependency between parent class `Condition` and its subclasses.
* this in turn fixes the static initialisation deadlock (described in #2372)
* widely used constants like `visible`, `enabled` stay in class `Condition`
