### PR TITLE
#2439 do not allow creating ElementsContainer outside of page object

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
@@ -60,6 +60,9 @@ public class SelenidePageFactory implements PageObjectFactory {
   @Nonnull
   public <PageObjectClass, T extends PageObjectClass> PageObjectClass page(Driver driver, T pageObject) {
     Type[] types = pageObject.getClass().getGenericInterfaces();
+    if (pageObject instanceof ElementsContainer) {
+      throw new IllegalArgumentException("Page object should not be marked as ElementsContainer");
+    }
     initElements(driver, null, pageObject, types);
     return pageObject;
   }
@@ -227,8 +230,9 @@ public class SelenidePageFactory implements PageObjectFactory {
         return ElementFinder.wrap(SelenideElement.class, searchContext);
       }
       else {
-        logger.warn("Cannot initialize field {}", field);
-        return null;
+        String message = String.format("Cannot initialize field %s.%s: it's not bound to any page object",
+          field.getDeclaringClass().getSimpleName(), field.getName());
+        throw new IllegalArgumentException(message);
       }
     }
     if (WebElement.class.isAssignableFrom(field.getType())) {

--- a/statics/src/test/java/integration/pageobjects/ElementsContainerWithManuallyInitializedFieldsTest.java
+++ b/statics/src/test/java/integration/pageobjects/ElementsContainerWithManuallyInitializedFieldsTest.java
@@ -15,6 +15,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.Selenide.page;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class ElementsContainerWithManuallyInitializedFieldsTest extends IntegrationTest {
 
@@ -25,7 +26,7 @@ final class ElementsContainerWithManuallyInitializedFieldsTest extends Integrati
 
   @Test
   void canInitializeElementsContainerFieldsWithoutFindByAnnotation() {
-    MyPage page = page(MyPage.class);
+    MyPage page = page();
 
     page.container.getSelf().should(exist, visible);
     page.container.headerLink.shouldHave(text("Options with 'apostrophes' and \"quotes\""));
@@ -34,6 +35,13 @@ final class ElementsContainerWithManuallyInitializedFieldsTest extends Integrati
     page.container.options.first(2).shouldHave(texts("-- Select your hero --", "John Mc'Lain"));
     page.container.options.last(3).shouldHave(texts("Arnold \"Schwarzenegger\"",
       "Mickey \"Rock'n'Roll\" Rourke", "Denzel Washington"));
+  }
+
+  @Test
+  void cannotInitializeElementsContainerOutsidePageObject() {
+    assertThatThrownBy(() -> page(MyContainer.class))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Page object should not be marked as ElementsContainer");
   }
 
   private static class MyPage {

--- a/statics/src/test/java/integration/pageobjects/LazyPageObjectTest.java
+++ b/statics/src/test/java/integration/pageobjects/LazyPageObjectTest.java
@@ -27,28 +27,23 @@ public class LazyPageObjectTest extends IntegrationTest {
   }
 
   @Test
-  public void level1() {
-    MyForm subForm = page(MyForm.class);
-    subForm.h1.should(exist);
+  public void pageObject() {
+    MyPage myPage = page(MyPage.class);
+
+    // level 2
+    assertThat(myPage.myContent.forms).hasSize(1);
+
+    // level 3
+    MyForm subForm = myPage.myContent.forms.get(0);
+    subForm.h1.shouldBe(visible);
     assertThat(subForm.h11.isDisplayed()).isTrue();
     subForm.h3s.shouldHave(size(0));
     assertThat(subForm.h3ss).hasSize(0);
     assertThat(subForm.h3sss).hasSize(0);
     subForm.h2.shouldNot(exist);
     assertThat(subForm.h22.isDisplayed()).isFalse();
-  }
 
-  @Test
-  public void level2() {
-    MyContent myContent = page(MyContent.class);
-    assertThat(myContent.forms).hasSize(1);
-    myContent.forms.get(0).h1.shouldBe(visible);
-  }
-
-  @Test
-  public void level3() {
-    MyPage myPage = page(MyPage.class);
-    assertThat(myPage.myContent.forms).hasSize(1);
+    // level 1
     myPage.h1.should(exist);
     myPage.h3.shouldNot(exist);
   }


### PR DESCRIPTION
It may happen if page object itself is marked as `extends ElementsContainer`. This is just not needed.
