### PR TITLE
#2434 show actual texts in error message

### DIFF
--- a/modules/appium/src/test/java/it/mobile/ITTest.java
+++ b/modules/appium/src/test/java/it/mobile/ITTest.java
@@ -1,8 +1,15 @@
 package it.mobile;
 
+import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.junit5.TextReportExtension;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(TextReportExtension.class)
 public abstract class ITTest {
+  @BeforeEach
+  final void resetSettings() {
+    Configuration.timeout = 10_000;
+    Configuration.pageLoadTimeout = -1;
+  }
 }

--- a/modules/appium/src/test/java/it/mobile/android/AndroidAppiumConditionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AndroidAppiumConditionsTest.java
@@ -1,6 +1,9 @@
 package it.mobile.android;
 
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.appium.SelenideAppium;
+import com.codeborne.selenide.ex.TextsMismatch;
 import io.appium.java_client.AppiumBy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,6 +11,7 @@ import org.openqa.selenium.By;
 
 import java.util.List;
 
+import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
@@ -15,6 +19,7 @@ import static com.codeborne.selenide.appium.AppiumCollectionCondition.attributes
 import static com.codeborne.selenide.appium.AppiumCondition.attribute;
 import static com.codeborne.selenide.appium.conditions.CombinedAttribute.android;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AndroidAppiumConditionsTest extends BaseApiDemosTest {
 
@@ -26,11 +31,41 @@ class AndroidAppiumConditionsTest extends BaseApiDemosTest {
 
   @Test
   void appiumCollectionConditionAttribute() {
-    List<String> expectedAttributeValues = asList("API Demos", "KeyEventText", "Linkify", "LogTextBox", "Marquee", "Unicode");
-
     $(By.xpath(".//*[@text='Text']")).click();
     $$(By.xpath("//android.widget.TextView"))
-      .shouldHave(attributes(android("text"), expectedAttributeValues));
+      .shouldHave(attributes(android("text"), asList("API Demos", "KeyEventText", "Linkify", "LogTextBox", "Marquee", "Unicode")));
+  }
+
+  @Test
+  void appiumCollectionConditionAttribute_listSizeMismatch() {
+    $(By.xpath(".//*[@text='Text']")).click();
+    ElementsCollection elements = $$(By.xpath("//android.widget.TextView"));
+    elements.shouldHave(sizeGreaterThan(0));
+
+    Configuration.timeout = 1;
+    List<String> expectedAttributes = asList("API Demos", "KeyEventText", "Linkify", "LogTextBox");
+    assertThatThrownBy(() -> elements.shouldHave(attributes(android("text"), expectedAttributes)))
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 4, actual: 6)")
+      .hasMessageContaining("Actual (6): [API Demos, KeyEventText, Linkify, LogTextBox, Marquee, Unicode]")
+      .hasMessageContaining("Expected (4): [API Demos, KeyEventText, Linkify, LogTextBox]")
+      .hasMessageContaining("Collection: By.xpath: //android.widget.TextView");
+  }
+
+  @Test
+  void appiumCollectionConditionAttribute_textsMismatch() {
+    $(By.xpath(".//*[@text='Text']")).click();
+    ElementsCollection elements = $$(By.xpath("//android.widget.TextView"));
+    elements.shouldHave(sizeGreaterThan(0));
+
+    Configuration.timeout = 1;
+    List<String> expectedAttributes = asList("API Demos", "KeyEventText", "Linkify", "LogTextBox", "WRONG", "Unicode");
+    assertThatThrownBy(() -> elements.shouldHave(attributes(android("text"), expectedAttributes)))
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("Attribute #4 mismatch (expected: \"WRONG\", actual: \"Marquee\")")
+      .hasMessageContaining("Actual (6): [API Demos, KeyEventText, Linkify, LogTextBox, Marquee, Unicode]")
+      .hasMessageContaining("Expected (6): [API Demos, KeyEventText, Linkify, LogTextBox, WRONG, Unicode]")
+      .hasMessageContaining("Collection: By.xpath: //android.widget.TextView");
   }
 
   @Test

--- a/modules/appium/src/test/java/it/mobile/android/BaseApiDemosTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/BaseApiDemosTest.java
@@ -14,7 +14,7 @@ public abstract class BaseApiDemosTest extends ITTest {
 
   @BeforeAll
   @SuppressWarnings("deprecation")
-  public static void setup() {
+  public static void setupMobileWebdriver() {
     closeWebDriver();
     WebDriverRunner.removeListener(listener);
     WebDriverRunner.addListener(listener);

--- a/modules/appium/src/test/java/it/mobile/android/driverproviders/AndroidDriverProvider.java
+++ b/modules/appium/src/test/java/it/mobile/android/driverproviders/AndroidDriverProvider.java
@@ -1,6 +1,5 @@
 package it.mobile.android.driverproviders;
 
-import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.WebDriverProvider;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.android.options.UiAutomator2Options;
@@ -26,8 +25,6 @@ public abstract class AndroidDriverProvider implements WebDriverProvider {
   @Nonnull
   @Override
   public WebDriver createDriver(@Nonnull Capabilities capabilities) {
-    Configuration.timeout = 10_000;
-    Configuration.pageLoadTimeout = -1;
     UiAutomator2Options options = getUiAutomator2Options();
     options.setApp(getApplicationUnderTest().getAbsolutePath());
     try {

--- a/modules/appium/src/test/java/it/mobile/ios/driverproviders/IosDriverProvider.java
+++ b/modules/appium/src/test/java/it/mobile/ios/driverproviders/IosDriverProvider.java
@@ -19,8 +19,6 @@ public abstract class IosDriverProvider implements WebDriverProvider {
   @Nonnull
   @Override
   public WebDriver createDriver(@Nonnull Capabilities capabilities) {
-    Configuration.timeout = 10_000;
-    Configuration.pageLoadTimeout = -1;
     Configuration.remoteConnectionTimeout = Duration.ofSeconds(10).toMillis();
     Configuration.remoteReadTimeout = Duration.ofSeconds(30).toMillis();
     HttpClientTimeouts.defaultLocalReadTimeout = Duration.ofSeconds(20);

--- a/src/main/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrder.java
+++ b/src/main/java/com/codeborne/selenide/collections/ExactTextsCaseSensitiveInAnyOrder.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
-import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.CheckResult.rejected;
 import static com.codeborne.selenide.impl.Plugins.inject;
 
 @ParametersAreNonnullByDefault
@@ -28,11 +28,11 @@ public class ExactTextsCaseSensitiveInAnyOrder extends ExactTexts {
   @Nonnull
   @Override
   public CheckResult check(Driver driver, List<WebElement> elements) {
-    if (elements.size() != expectedTexts.size()) {
-      return new CheckResult(REJECT, elements.size());
-    }
-
     List<String> actualTexts = communicator.texts(driver, elements);
+    if (actualTexts.size() != expectedTexts.size()) {
+      String message = String.format("List size mismatch (expected: %s, actual: %s)", expectedTexts.size(), actualTexts.size());
+      return rejected(message, actualTexts);
+    }
 
     for (int i = 0; i < expectedTexts.size(); i++) {
       String expectedText = expectedTexts.get(i);

--- a/src/main/java/com/codeborne/selenide/collections/TextsInAnyOrder.java
+++ b/src/main/java/com/codeborne/selenide/collections/TextsInAnyOrder.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
-import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.CheckResult.rejected;
 import static com.codeborne.selenide.impl.Plugins.inject;
 
 @ParametersAreNonnullByDefault
@@ -28,11 +28,11 @@ public class TextsInAnyOrder extends ExactTexts {
   @Nonnull
   @Override
   public CheckResult check(Driver driver, List<WebElement> elements) {
-    if (elements.size() != expectedTexts.size()) {
-      return new CheckResult(REJECT, elements.size());
-    }
-
     List<String> actualTexts = communicator.texts(driver, elements);
+    if (actualTexts.size() != expectedTexts.size()) {
+      String message = String.format("List size mismatch (expected: %s, actual: %s)", expectedTexts.size(), actualTexts.size());
+      return rejected(message, actualTexts);
+    }
 
     for (int i = 0; i < expectedTexts.size(); i++) {
       String expectedText = expectedTexts.get(i);

--- a/src/main/java/com/codeborne/selenide/ex/AttributesMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/AttributesMismatch.java
@@ -15,8 +15,8 @@ public class AttributesMismatch extends UIAssertionError {
                             List<String> expectedValues, List<String> actualValues,
                             @Nullable String explanation, long timeoutMs, @Nullable Exception cause) {
     super(driver, message +
-        lineSeparator() + "Actual: " + actualValues +
-        lineSeparator() + "Expected: " + expectedValues +
+        lineSeparator() + "Actual (" + actualValues.size() + "): " + actualValues +
+        lineSeparator() + "Expected (" + expectedValues.size() + "): " + expectedValues +
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
         lineSeparator() + "Collection: " + collection.description(),
       expectedValues, actualValues, cause, timeoutMs);

--- a/src/main/java/com/codeborne/selenide/ex/TextsMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsMismatch.java
@@ -17,8 +17,8 @@ public class TextsMismatch extends UIAssertionError {
     super(
       collection.driver(),
       message +
-        lineSeparator() + "Actual: " + actualTexts +
-        lineSeparator() + "Expected: " + expectedTexts +
+        lineSeparator() + "Actual (" + actualTexts.size() + "): " + actualTexts +
+        lineSeparator() + "Expected (" + expectedTexts.size() + "): " + expectedTexts +
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +
         lineSeparator() + "Collection: " + collection.description(),
       expectedTexts, actualTexts,

--- a/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
@@ -19,8 +19,8 @@ final class TextsMismatchTest {
     TextsMismatch error = new TextsMismatch("Texts mismatch", collection, expectedTexts, actualTexts, null, 9000, null);
 
     assertThat(error).hasMessage(String.format("Texts mismatch%n" +
-      "Actual: [Niff, Naff, Nuff]%n" +
-      "Expected: [Piff, Paff, Puff]%n" +
+      "Actual (3): [Niff, Naff, Nuff]%n" +
+      "Expected (3): [Piff, Paff, Puff]%n" +
       "Collection: .characters%n" +
       "Timeout: 9 s."));
   }
@@ -31,10 +31,22 @@ final class TextsMismatchTest {
     TextsMismatch error = new TextsMismatch("Texts mismatch", collection, expectedTexts, actualTexts, explanation, 9000, null);
 
     assertThat(error).hasMessage(String.format("Texts mismatch%n" +
-      "Actual: [Niff, Naff, Nuff]%n" +
-      "Expected: [Piff, Paff, Puff]%n" +
+      "Actual (3): [Niff, Naff, Nuff]%n" +
+      "Expected (3): [Piff, Paff, Puff]%n" +
       "Because: we expect favorite characters%n" +
       "Collection: .characters%n" +
       "Timeout: 9 s."));
   }
+
+  @Test
+  void errorMessage_withDifferentSize() {
+    TextsMismatch error = new TextsMismatch("Texts mismatch", collection, asList("Chip", "Dale"), actualTexts, null, 9000, null);
+
+    assertThat(error).hasMessage(String.format("Texts mismatch%n" +
+                                               "Actual (3): [Niff, Naff, Nuff]%n" +
+                                               "Expected (2): [Chip, Dale]%n" +
+                                               "Collection: .characters%n" +
+                                               "Timeout: 9 s."));
+  }
+
 }

--- a/src/test/java/integration/collections/AttributesTest.java
+++ b/src/test/java/integration/collections/AttributesTest.java
@@ -25,8 +25,8 @@ public class AttributesTest extends ITest {
     assertThatThrownBy(() -> $$(".element").shouldHave(attributes("data-value", "1  uno", "2  duo", "3  trio")))
       .isInstanceOf(AttributesMismatch.class)
       .hasMessageStartingWith("Attribute \"data-value\" values mismatch (#0 expected: \"1  uno\", actual: \"1 uno\")")
-      .hasMessageContaining("Actual: [1 uno, 2 duo, 3 trio]")
-      .hasMessageContaining("Expected: [1  uno, 2  duo, 3  trio]")
+      .hasMessageContaining("Actual (3): [1 uno, 2 duo, 3 trio]")
+      .hasMessageContaining("Expected (3): [1  uno, 2  duo, 3  trio]")
       .hasMessageContaining("Collection: .element")
       .hasMessageContaining("Timeout: 1 ms.");
   }
@@ -47,7 +47,7 @@ public class AttributesTest extends ITest {
     assertThatThrownBy(() -> $$(".element").shouldHave(attributes("not-existing-attribute", "1 uno", "2 duo", "3 trio")))
       .isInstanceOf(AttributesMismatch.class)
       .hasMessageStartingWith("Attribute \"not-existing-attribute\" values mismatch")
-      .hasMessageContaining("Actual: [null, null, null]")
-      .hasMessageContaining("Expected: [1 uno, 2 duo, 3 trio]");
+      .hasMessageContaining("Actual (3): [null, null, null]")
+      .hasMessageContaining("Expected (3): [1 uno, 2 duo, 3 trio]");
   }
 }

--- a/src/test/java/integration/collections/CollectionBecauseTest.java
+++ b/src/test/java/integration/collections/CollectionBecauseTest.java
@@ -29,8 +29,8 @@ final class CollectionBecauseTest extends ITest {
     })
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith("Text #0 mismatch (expected: \"foo\", actual: \"@one.io\")")
-      .hasMessageContaining("Actual: [@one.io, @two.eu, @three.com, @four.ee]")
-      .hasMessageContaining("Expected: [foo, bar, var, buzz]")
+      .hasMessageContaining("Actual (4): [@one.io, @two.eu, @three.com, @four.ee]")
+      .hasMessageContaining("Expected (4): [foo, bar, var, buzz]")
       .hasMessageContaining("Because: that's why");
   }
 
@@ -42,9 +42,12 @@ final class CollectionBecauseTest extends ITest {
           .because("that's why")
       );
     })
-      .isInstanceOf(ListSizeMismatch.class)
-      .hasMessageStartingWith("List size mismatch")
-      .hasMessageContaining("expected: = 3 (because that's why), actual: 4, collection: #dropdown-list-container option");
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 3, actual: 4)")
+      .hasMessageContaining("Actual (4): [@one.io, @two.eu, @three.com, @four.ee]")
+      .hasMessageContaining("Expected (3): [foo, bar, var, buzz]")
+      .hasMessageContaining("Because: that's why")
+      .hasMessageContaining("Collection: #dropdown-list-container option");
   }
 
   @Test
@@ -57,8 +60,8 @@ final class CollectionBecauseTest extends ITest {
     })
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith("Text #0 mismatch (expected: \"foo\", actual: \"@one.io\")")
-      .hasMessageContaining("Actual: [@one.io, @two.eu, @three.com, @four.ee]")
-      .hasMessageContaining("Expected: [foo, bar, var, buzz]")
+      .hasMessageContaining("Actual (4): [@one.io, @two.eu, @three.com, @four.ee]")
+      .hasMessageContaining("Expected (4): [foo, bar, var, buzz]")
       .hasMessageContaining("Because: that's why");
   }
 
@@ -66,13 +69,14 @@ final class CollectionBecauseTest extends ITest {
   void canExplainWhyConditionIsExpected_exactTextsSizeMismatch() {
     assertThatThrownBy(() -> {
       $$("#dropdown-list-container option").shouldHave(
-        exactTexts("foo", "bar", "var, buzz")
-          .because("that's why")
-      );
+        exactTexts("foo", "bar", "var, buzz").because("that's why"));
     })
-      .isInstanceOf(ListSizeMismatch.class)
-      .hasMessageStartingWith("List size mismatch")
-      .hasMessageContaining("expected: = 3 (because that's why), actual: 4, collection: #dropdown-list-container option");
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 3, actual: 4)")
+      .hasMessageContaining("Actual (4): [@one.io, @two.eu, @three.com, @four.ee]")
+      .hasMessageContaining("Expected (3): [foo, bar, var, buzz]")
+      .hasMessageContaining("Because: that's why")
+      .hasMessageContaining("Collection: #dropdown-list-container option");
   }
 
   @Test

--- a/src/test/java/integration/collections/CollectionWaitTest.java
+++ b/src/test/java/integration/collections/CollectionWaitTest.java
@@ -1,7 +1,6 @@
 package integration.collections;
 
 import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.ex.TextsMismatch;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,8 +71,8 @@ final class CollectionWaitTest extends ITest {
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith(
         String.format("Text #1 mismatch (expected: \"#wrong\", actual: \"Element #1\")%n" +
-                      "Actual: [Element #0, Element #1]%n" +
-                      "Expected: [Element, #wrong]%n" +
+                      "Actual (2): [Element #0, Element #1]%n" +
+                      "Expected (2): [Element, #wrong]%n" +
                       "Collection: #collection li:first(2)"))
       .hasMessageContaining("Timeout: 1 s.");
     assertTestTookMoreThan(1, SECONDS);
@@ -82,8 +81,10 @@ final class CollectionWaitTest extends ITest {
   @Test
   void firstNElements_TextsSizeMismatchErrorMessage() {
     assertThatThrownBy(() -> $$("#collection li").first(2).shouldHave(texts("Element #wrong")))
-      .isInstanceOf(ListSizeMismatch.class)
-      .hasMessageContaining("List size mismatch: expected: = 1, actual: 2, collection: #collection li:first(2)");
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 1, actual: 2)")
+      .hasMessageContaining("Actual (2): [Element #0, Element #1]")
+      .hasMessageContaining("Expected (1): [Element #wrong]");
     assertTestTookMoreThan(1, SECONDS);
   }
 
@@ -91,8 +92,9 @@ final class CollectionWaitTest extends ITest {
   void lastNElements_errorMessage() {
     assertThatThrownBy(() -> $$("#collection li").last(2).shouldHave(texts("Element", "#wrong"), Duration.ofSeconds(1)))
       .isInstanceOf(TextsMismatch.class)
-      .hasMessageContaining(String.format("Actual: [Element #18, Element #19]%n" +
-        "Expected: [Element, #wrong]%n" +
+      .hasMessageStartingWith("Text #1 mismatch (expected: \"#wrong\", actual: \"Element #19\")")
+      .hasMessageContaining(String.format("Actual (2): [Element #18, Element #19]%n" +
+        "Expected (2): [Element, #wrong]%n" +
         "Collection: #collection li:last(2)"))
         .hasMessageContaining("Timeout: 1 s.");
     assertTestTookMoreThan(1, SECONDS);
@@ -112,8 +114,9 @@ final class CollectionWaitTest extends ITest {
       $$("#collection li").last(2).shouldHave(texts("Element #88888", "Element #99999"), Duration.ofMillis(999))
     )
       .isInstanceOf(TextsMismatch.class)
-      .hasMessageContaining("Actual: [Element #18, Element #19]")
-      .hasMessageContaining("Expected: [Element #88888, Element #99999]")
+      .hasMessageContaining("Text #0 mismatch (expected: \"Element #88888\", actual: \"Element #18\")")
+      .hasMessageContaining("Actual (2): [Element #18, Element #19]")
+      .hasMessageContaining("Expected (2): [Element #88888, Element #99999]")
       .hasMessageContaining("Timeout: 999 ms.");
     assertTestTookMoreThan(999, MILLISECONDS);
   }

--- a/src/test/java/integration/collections/ExactTextsCaseSensitiveInAnyOrderTest.java
+++ b/src/test/java/integration/collections/ExactTextsCaseSensitiveInAnyOrderTest.java
@@ -1,7 +1,6 @@
 package integration.collections;
 
 import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.ex.TextsMismatch;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,8 +42,8 @@ class ExactTextsCaseSensitiveInAnyOrderTest extends ITest {
     assertThatThrownBy(() -> $$(".element").shouldHave(exactTextsCaseSensitiveInAnyOrder(expectedTexts)))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith(String.format("Text #0 not found: \"%s\"", expectedTexts.get(0)))
-      .hasMessageContaining("Actual: [One, Two, Three]")
-      .hasMessageContaining("Expected: " + expectedTexts)
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (3): " + expectedTexts)
       .hasMessageContaining("Collection: .element");
   }
 
@@ -59,8 +58,11 @@ class ExactTextsCaseSensitiveInAnyOrderTest extends ITest {
   @Test
   void checksElementsCount() {
     assertThatThrownBy(() -> $$(".element").shouldHave(exactTextsCaseSensitiveInAnyOrder("One", "Two", "Three", "Four")))
-      .isInstanceOf(ListSizeMismatch.class)
-      .hasMessageStartingWith("List size mismatch: expected: = 4, actual: 3, collection: .element");
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 4, actual: 3)")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (4): [One, Two, Three, Four]")
+      .hasMessageContaining("Collection: .element");
   }
 
   @Test

--- a/src/test/java/integration/collections/ExactTextsCaseSensitiveTest.java
+++ b/src/test/java/integration/collections/ExactTextsCaseSensitiveTest.java
@@ -1,7 +1,6 @@
 package integration.collections;
 
 import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.ex.TextsMismatch;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,8 +27,8 @@ public class ExactTextsCaseSensitiveTest extends ITest {
   void checksOrderOfTexts() {
     assertThatThrownBy(() -> $$(".element").shouldHave(exactTextsCaseSensitive("Two", "One", "Three")))
       .isInstanceOf(TextsMismatch.class)
-      .hasMessageContaining("Actual: [One, Two, Three]")
-      .hasMessageContaining("Expected: [Two, One, Three]");
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (3): [Two, One, Three]");
   }
 
   @Test
@@ -44,8 +43,8 @@ public class ExactTextsCaseSensitiveTest extends ITest {
     assertThatThrownBy(() -> $$(".element").shouldHave(exactTextsCaseSensitive("On", "Two", "Three")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith("Text #0 mismatch (expected: \"On\", actual: \"One\")")
-      .hasMessageContaining("Actual: [One, Two, Three]")
-      .hasMessageContaining("Expected: [On, Two, Three]")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (3): [On, Two, Three]")
       .hasMessageContaining("Collection: .element");
   }
 
@@ -53,15 +52,17 @@ public class ExactTextsCaseSensitiveTest extends ITest {
   void doesNotAcceptInvalidCase() {
     assertThatThrownBy(() -> $$(".element").shouldHave(exactTextsCaseSensitive("One", "two", "Three")))
       .isInstanceOf(TextsMismatch.class)
-      .hasMessageContaining("Actual: [One, Two, Three]")
-      .hasMessageContaining("Expected: [One, two, Three]");
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (3): [One, two, Three]");
   }
 
   @Test
   void checksElementsCount() {
     assertThatThrownBy(() -> $$(".element").shouldHave(exactTextsCaseSensitive("One", "Two", "Three", "Four")))
-      .isInstanceOf(ListSizeMismatch.class)
-      .hasMessageStartingWith("List size mismatch: expected: = 4, actual: 3, collection: .element");
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 4, actual: 3)")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (4): [One, Two, Three, Four]");
   }
 
   @Test

--- a/src/test/java/integration/collections/ExactTextsTest.java
+++ b/src/test/java/integration/collections/ExactTextsTest.java
@@ -2,7 +2,6 @@ package integration.collections;
 
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.ex.TextsMismatch;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,16 +37,18 @@ public class ExactTextsTest extends ITest {
     assertThatThrownBy(() -> $$(".element").shouldHave(exactTexts("On", "Tw", "Thre")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith("Text #0 mismatch (expected: \"On\", actual: \"One\")")
-      .hasMessageContaining("Actual: [One, Two, Three]")
-      .hasMessageContaining("Expected: [On, Tw, Thre]")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (3): [On, Tw, Thre]")
       .hasMessageContaining("Collection: .element");
   }
 
   @Test
   void checksElementsCount() {
     assertThatThrownBy(() -> $$(".element").shouldHave(exactTexts("One", "Two", "Three", "Four")))
-      .isInstanceOf(ListSizeMismatch.class)
-      .hasMessageStartingWith("List size mismatch: expected: = 4, actual: 3, collection: .element");
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 4, actual: 3)")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (4): [One, Two, Three, Four]");
   }
 
   @Test

--- a/src/test/java/integration/collections/TextsInAnyOrderTest.java
+++ b/src/test/java/integration/collections/TextsInAnyOrderTest.java
@@ -1,7 +1,6 @@
 package integration.collections;
 
 import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.ex.TextsMismatch;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,16 +47,19 @@ public class TextsInAnyOrderTest extends ITest {
     assertThatThrownBy(() -> $$(".element").shouldHave(textsInAnyOrder("One", "Two", "Four")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith("Text #2 not found: \"Four\"")
-      .hasMessageContaining("Actual: [One, Two, Three]")
-      .hasMessageContaining("Expected: [One, Two, Four]")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (3): [One, Two, Four]")
       .hasMessageContaining("Collection: .element");
   }
 
   @Test
   void checksElementsCount() {
     assertThatThrownBy(() -> $$(".element").shouldHave(textsInAnyOrder("One", "Two", "Three", "Four")))
-      .isInstanceOf(ListSizeMismatch.class)
-      .hasMessageStartingWith("List size mismatch: expected: = 4, actual: 3, collection: .element");
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 4, actual: 3)")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (4): [One, Two, Three, Four]")
+      .hasMessageContaining("Collection: .element");
   }
 
   @Test

--- a/src/test/java/integration/collections/TextsTest.java
+++ b/src/test/java/integration/collections/TextsTest.java
@@ -2,7 +2,6 @@ package integration.collections;
 
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.ex.ElementNotFound;
-import com.codeborne.selenide.ex.ListSizeMismatch;
 import com.codeborne.selenide.ex.TextsMismatch;
 import integration.ITest;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,8 +29,8 @@ public class TextsTest extends ITest {
   void checksOrderOfTexts() {
     assertThatThrownBy(() -> $$(".element").shouldHave(texts("Two", "One", "Three")))
       .isInstanceOf(TextsMismatch.class)
-      .hasMessageContaining("Actual: [One, Two, Three]")
-      .hasMessageContaining("Expected: [Two, One, Three]");
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (3): [Two, One, Three]");
   }
 
   @Test
@@ -53,8 +52,8 @@ public class TextsTest extends ITest {
     assertThatThrownBy(() -> $$(".element").shouldHave(texts("Three", "Two", "One")))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith("Text #0 mismatch (expected: \"Three\", actual: \"One\")")
-      .hasMessageContaining("Actual: [One, Two, Three]")
-      .hasMessageContaining("Expected: [Three, Two, One]")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (3): [Three, Two, One]")
       .hasMessageContaining("Collection: .element");
   }
 
@@ -68,8 +67,11 @@ public class TextsTest extends ITest {
   @Test
   void checksElementsCount() {
     assertThatThrownBy(() -> $$(".element").shouldHave(texts("One", "Two", "Three", "Four")))
-      .isInstanceOf(ListSizeMismatch.class)
-      .hasMessageStartingWith("List size mismatch: expected: = 4, actual: 3, collection: .element");
+      .isInstanceOf(TextsMismatch.class)
+      .hasMessageStartingWith("List size mismatch (expected: 4, actual: 3)")
+      .hasMessageContaining("Actual (3): [One, Two, Three]")
+      .hasMessageContaining("Expected (4): [One, Two, Three, Four]")
+      .hasMessageContaining("Collection: .element");
   }
 
   @Test


### PR DESCRIPTION
... even if collection size mismatched. Users find it convenient to see the actual/expected texts in case of such failures as well.

### For example:
```java
$$(".sidebar-nav .sidebar-nav-item").shouldHave(texts("One", "Two", "Three"));
```


### Looks in 6.16.0 ... 6.17.2:
```java
List size mismatch: expected: = 3, actual: 4, collection: .sidebar-nav .sidebar-nav-item
Screenshot: ...
Page source: ...
<Click to see difference>
```

### Will look since 6.18.0:
```java
List size mismatch (expected: 3, actual: 4)
Actual (4): [One, Two, Three, Four]
Expected (3): [One, Two, Three]
Collection: .sidebar-nav .sidebar-nav-item
Screenshot: ...
Page source: ...
<Click to see difference>
```