### PR TITLE
#2475 remove hub url condition

### DIFF
--- a/modules/selenoid/src/main/java/org/selenide/selenoid/SelenoidClient.java
+++ b/modules/selenoid/src/main/java/org/selenide/selenoid/SelenoidClient.java
@@ -34,9 +34,6 @@ public class SelenoidClient {
   private final String sessionId;
 
   public SelenoidClient(String hubUrl, String sessionId) {
-    if (!hubUrl.endsWith("/wd/hub")) {
-      throw new IllegalArgumentException("Expect hub url to end with /wd/hub, but received: " + hubUrl);
-    }
     this.baseUrl = hubUrl.replace("/wd/hub", "");
     this.sessionId = sessionId;
   }

--- a/modules/selenoid/src/test/java/org/selenide/selenoid/SelenoidClientTest.java
+++ b/modules/selenoid/src/test/java/org/selenide/selenoid/SelenoidClientTest.java
@@ -6,20 +6,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SelenoidClientTest {
   @Test
   void extractsSelenoidBaseUrlFromHubUrl() {
     SelenoidClient client = new SelenoidClient("http://localhost:4444/wd/hub", "sid-01");
     assertThat(client.baseUrl).isEqualTo("http://localhost:4444");
-  }
-
-  @Test
-  void hubsUrlShouldEndWithWdHub() {
-    assertThatThrownBy(() -> new SelenoidClient("http://localhost:4444", "sid-01"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Expect hub url to end with /wd/hub, but received: http://localhost:4444");
   }
 
   @Test


### PR DESCRIPTION
## Proposed changes
Delete hubUrl checking. This condition is not always met on the selenoid side.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
