### PR TITLE
remove deprecated methods Condition.apply() and Condition.actualValue()

### DIFF
--- a/src/main/java/com/codeborne/selenide/WebElementCondition.java
+++ b/src/main/java/com/codeborne/selenide/WebElementCondition.java
@@ -6,10 +6,6 @@ import org.openqa.selenium.WebElement;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
-import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
 
 public abstract class WebElementCondition {
   protected final String name;
@@ -25,18 +21,6 @@ public abstract class WebElementCondition {
   }
 
   /**
-   * Check if given element matches this condition.
-   *
-   * @param element given WebElement
-   * @return true if element matches condition
-   * @deprecated replace by {@link #check(Driver, WebElement)}
-   */
-  @Deprecated
-  public boolean apply(Driver driver, WebElement element) {
-    throw new UnsupportedOperationException("Method 'apply' is deprecated. Please implement 'check' method.");
-  }
-
-  /**
    * Check if given element matches this condition
    *
    * @param driver  selenide driver
@@ -48,26 +32,7 @@ public abstract class WebElementCondition {
    */
   @Nonnull
   @CheckReturnValue
-  public CheckResult check(Driver driver, WebElement element) {
-    boolean result = apply(driver, element);
-    return new CheckResult(result ? ACCEPT : REJECT, null);
-  }
-
-  /**
-   * If element didn't match the condition, returns the actual value of element.
-   * Used in error reporting.
-   * Optional. Makes sense only if you need to add some additional important info to error message.
-   *
-   * @param driver  given driver
-   * @param element given WebElement
-   * @return any string that needs to be appended to error message.
-   * @deprecated not needed anymore since the actual value is returned by method {@link #check(Driver, WebElement)}
-   */
-  @Nullable
-  @Deprecated
-  public String actualValue(Driver driver, WebElement element) {
-    return null;
-  }
+  public abstract CheckResult check(Driver driver, WebElement element);
 
   @Nonnull
   @CheckReturnValue
@@ -81,7 +46,7 @@ public abstract class WebElementCondition {
   @Nonnull
   @CheckReturnValue
   public WebElementCondition because(String message) {
-    return new ExplainedCondition(this, message);
+    return new ExplainedCondition<>(this, message);
   }
 
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/ex/SelenideErrorFormatter.java
+++ b/src/main/java/com/codeborne/selenide/ex/SelenideErrorFormatter.java
@@ -14,7 +14,6 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import static com.codeborne.selenide.ex.Strings.join;
-import static org.apache.commons.lang3.StringUtils.substring;
 
 @ParametersAreNonnullByDefault
 public class SelenideErrorFormatter implements ErrorFormatter {
@@ -43,27 +42,7 @@ public class SelenideErrorFormatter implements ErrorFormatter {
       return String.format("Actual value: %s", lastCheckResult.actualValue());
     }
 
-    // Deprecated branch for custom condition (not migrated to CheckResult):
-    String actualValue = extractActualValue(condition, driver, element);
-    if (actualValue != null) {
-      return String.format("Actual value: %s", actualValue);
-    }
     return "";
-  }
-
-  @Nullable
-  @CheckReturnValue
-  protected String extractActualValue(WebElementCondition condition, Driver driver, @Nullable WebElement element) {
-    if (element != null) {
-      try {
-        return condition.actualValue(driver, element);
-      }
-      catch (RuntimeException failedToGetValue) {
-        String failedActualValue = failedToGetValue.getClass().getSimpleName() + ": " + failedToGetValue.getMessage();
-        return substring(failedActualValue, 0, 50);
-      }
-    }
-    return null;
   }
 
   @CheckReturnValue


### PR DESCRIPTION
Instead of these 2 methods, one should implement method `check(Driver driver, WebElement element)` which returns CheckResult which contains the actual value.

### Before Selenide 7.0.0

```java
public class EnabledAndVisible extends Condition {
  public EnabledAndVisible() {
    super("enabled and visible");
  }

  public boolean apply(Driver driver, WebElement element) {
    return element.isEnabled() && element.isDisplayed();
  }

  public String actualValue(Driver driver, WebElement element) {
    return String.format("enabled: %s, visible: %s", element.isEnabled(), element.isDisplayed());
  }
}
```

### Since Selenide 7.0.0

```java
public class EnabledAndVisible extends WebElementCondition {
  public EnabledAndVisible() {
    super("enabled and visible");
  }

  @Nonnull
  @Override
  public CheckResult check(Driver driver, WebElement element) {
    boolean enabled = element.isEnabled();
    boolean displayed = element.isDisplayed();
    return new CheckResult(enabled && displayed,
      String.format("enabled: %s, visible: %s", enabled, displayed));
  }
}
```

### Motivation

The latter design is better because 
1. the error message will reflect the actual value at the moment of last check, not at the moment of error message generation. Very unlikely, but sometimes they may differ.
2. it calls `isEnabled()` and `isDisplayed()` only once, not twice.