### PR TITLE
bump TestNG 7.4.0 to 7.8.0

### DIFF
--- a/modules/testng/build.gradle
+++ b/modules/testng/build.gradle
@@ -1,6 +1,6 @@
 ext {
   artifactId = 'selenide-testng'
-  testngVersion = '7.4.0'
+  testngVersion = '7.8.0'
 }
 
 dependencies {


### PR DESCRIPTION
finally, we can upgrade TestNG because we now we run on Java 11.
