### PR TITLE
Remove deprecated selected value

### DIFF
--- a/modules/appium/README.md
+++ b/modules/appium/README.md
@@ -75,14 +75,16 @@ SelenideAppium.openIOSDeepLink("mydemoapprn://product-details/1");
    $(AppiumBy.xpath(".//*[@text='People Names']")).click(longPress());
    $(AppiumBy.xpath(".//*[@text='People Names']")).click(longPressFor(ofSeconds(5)));
    $(AppiumBy.xpath(".//*[@text='People Names']")).tap(longPressFor(ofSeconds(4)));
-
-  //drag and drop
-   SelenideElement from = $(By.id("io.appium.android.apis:id/drag_dot_1")).shouldBe(visible);
-   SelenideElement to = $(By.id("io.appium.android.apis:id/drag_dot_2")).shouldBe(visible);
-   from.dragAndDropTo(to);
 ```
 
-4. Don't worry about casts
+4. Drag and drop
+```java
+  SelenideElement source = $(By.id("io.appium.android.apis:id/drag_dot_1")).shouldBe(visible);
+  SelenideElement target = $(By.id("io.appium.android.apis:id/drag_dot_2")).shouldBe(visible);
+  source.dragAndDrop(to(target));
+```
+
+5. Don't worry about casts
 ```java
 AndroidDriver androidDriver = AppiumDriverRunner.getAndroidDriver();
 IOSDriver iosDriver = AppiumDriverRunner.getIosDriver();
@@ -90,7 +92,7 @@ boolean isAndroid = AppiumDriverRunner.isAndroidDriver();
 boolean isIos = AppiumDriverRunner.isIosDriver();
 ```
 
-5. Rich Assertions
+6. Rich Assertions
 
 In Appium, it is common that we want to extract values from different attributes.
 
@@ -125,7 +127,7 @@ $$(AppiumBy.xpath("//android.widget.TextView"))
       .shouldHave(AppiumCollectionCondition.attributes(combinedAttribute, expectedList));
 ```
 
-6. We handle the scrolling for you
+7. We handle the scrolling for you
 
 ```java
 $(By.xpath(".//*[@text='Tabs']")).scrollTo().click(); //scroll max of 30 times in downward direction to find element
@@ -135,7 +137,7 @@ $(By.xpath(".//*[@text='Animation']")).scroll(up(0.15f, 0.60f)); //scroll max of
 $(By.xpath(".//*[@text='Animation']")).scroll(down(0.15f, 0.60f)); //scroll max of 30 times in downward direction with custom swiping height relative to device height
 ```
 
-7. We got covered you to the left and right
+8. We got covered you to the left and right
 
 ```java
 $(By.xpath(".//*[@text='Tabs']")).swipeTo().click(); //swipe max of 30 times in right direction to find element
@@ -143,7 +145,7 @@ $(By.xpath(".//*[@text='Tabs']")).swipe(left()).click(); //swipe max of 30 times
 $(By.xpath(".//*[@text='Tabs']")).swipe(left(10)).click(); //swipe max of 10 times in left direction to find element
 ```
 
-8. Not able to use page factory for dynamic elements? We got you covered with CombinedBy for writing dynamic locators for both android and ios platforms
+9. Not able to use page factory for dynamic elements? We got you covered with CombinedBy for writing dynamic locators for both android and ios platforms
 
 ```java
 int index = 1;

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumDragAndDrop.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumDragAndDrop.java
@@ -2,7 +2,7 @@ package com.codeborne.selenide.appium.commands;
 
 import com.codeborne.selenide.DragAndDropOptions;
 import com.codeborne.selenide.SelenideElement;
-import com.codeborne.selenide.commands.DragAndDropTo;
+import com.codeborne.selenide.commands.DragAndDrop;
 import com.codeborne.selenide.impl.WebElementSource;
 import io.appium.java_client.AppiumDriver;
 import org.openqa.selenium.Point;
@@ -26,8 +26,8 @@ import static java.time.Duration.ofMillis;
 import static java.util.Collections.singletonList;
 
 @ParametersAreNonnullByDefault
-public class AppiumDragAndDropTo extends DragAndDropTo {
-  private static final Logger log = LoggerFactory.getLogger(AppiumDragAndDropTo.class);
+public class AppiumDragAndDrop extends DragAndDrop {
+  private static final Logger log = LoggerFactory.getLogger(AppiumDragAndDrop.class);
 
   @Override
   @Nonnull

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/SelenideAppiumCommands.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/SelenideAppiumCommands.java
@@ -7,8 +7,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class SelenideAppiumCommands extends Commands {
   public SelenideAppiumCommands() {
-    add("dragAndDropTo", new AppiumDragAndDropTo());
-    add("dragAndDrop", new AppiumDragAndDropTo());
+    add("dragAndDrop", new AppiumDragAndDrop());
     add("click", new AppiumClick());
     add("doubleClick", new AppiumDoubleClick());
     add("clear", new AppiumClear());

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1098,14 +1098,6 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   String getSelectedOptionValue();
 
   /**
-   * @deprecated Use {@link #getSelectedOptionValue()} instead
-   */
-  @Deprecated
-  @CheckReturnValue
-  @Nullable
-  String getSelectedValue();
-
-  /**
    * Get text of selected option in select field
    * <p>
    *
@@ -1123,14 +1115,6 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   @CheckReturnValue
   @Nullable
   String getSelectedOptionText();
-
-  /**
-   * @deprecated Use {@link #getSelectedOptionText()} instead
-   */
-  @Deprecated
-  @CheckReturnValue
-  @Nullable
-  String getSelectedText();
 
   /**
    * Ask browser to scroll to this element

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.commands.DragAndDrop;
 import com.codeborne.selenide.commands.GetSelectedOptionText;
 import com.codeborne.selenide.commands.GetSelectedOptionValue;
 import com.codeborne.selenide.files.FileFilter;
@@ -1411,28 +1412,28 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * <br>
    * using a CSS selector defining the target element:
    * <br>
-   * {@code $("#element").dragAndDropTo(to("#target")) }
+   * {@code $("#element").dragAndDrop(to("#target")) }
    * <br>
    * using a SelenideElement defining the target element:
    * <br>
-   * {@code $("#element").dragAndDropTo(to($("#target"))) }
+   * {@code $("#element").dragAndDrop(to($("#target"))) }
    * <br>
    * <br>
    * define which way it will be executed:
    * <br>
    * using {@code JavaScript } (by default):
    * <br>
-   * {@code $("#element").dragAndDropTo(to("#target").usingJS()) }
+   * {@code $("#element").dragAndDrop(to("#target").usingJS()) }
    * <br>
    * using {@code Actions }:
    * <br>
-   * {@code $("#element").dragAndDropTo(to("#target").usingSeleniumActions()) }
+   * {@code $("#element").dragAndDrop(to("#target").usingSeleniumActions()) }
    * <br>
   / *
    * @param options drag and drop options to define target and which way it will be executed
    *
    * @return this element
-   * @see com.codeborne.selenide.commands.DragAndDropTo
+   * @see DragAndDrop
    */
   @Nonnull
   @CanIgnoreReturnValue

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -126,9 +126,7 @@ public class Commands {
     add("getOptions", new GetOptions());
     add("getSelectedOption", new GetSelectedOption());
     add("getSelectedOptions", new GetSelectedOptions());
-    add("getSelectedText", new GetSelectedOptionText());
     add("getSelectedOptionText", new GetSelectedOptionText());
-    add("getSelectedValue", new GetSelectedOptionValue());
     add("getSelectedOptionValue", new GetSelectedOptionValue());
     add("selectOption", new SelectOptionByTextOrIndex());
     add("selectOptionContainingText", new SelectOptionContainingText());

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -56,8 +56,7 @@ public class Commands {
   }
 
   private void addActionsCommands() {
-    add("dragAndDropTo", new DragAndDropTo());
-    add("dragAndDrop", new DragAndDropTo());
+    add("dragAndDrop", new DragAndDrop());
     add("hover", new Hover());
     add("scrollTo", new ScrollTo());
     add("scrollIntoView", new ScrollIntoView());

--- a/src/main/java/com/codeborne/selenide/commands/DragAndDrop.java
+++ b/src/main/java/com/codeborne/selenide/commands/DragAndDrop.java
@@ -20,7 +20,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.DragAndDropOptions.DragAndDropMethod.JS;
 
 @ParametersAreNonnullByDefault
-public class DragAndDropTo implements Command<SelenideElement> {
+public class DragAndDrop implements Command<SelenideElement> {
   private static final JavaScript js = new JavaScript("drag_and_drop_script.js");
 
   @Override

--- a/src/test/java/com/codeborne/selenide/commands/DragAndDropTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/DragAndDropTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class DragAndDropToTest {
+class DragAndDropTest {
 
   private final JSWebDriver webDriver = mock();
   private final DriverStub driver = new DriverStub(webDriver);
@@ -36,7 +36,7 @@ class DragAndDropToTest {
   private final WebElement locatorWebElement = mock();
   private final SelenideElement targetSelenideElement = mock();
   private final WebElement targetWebElement = mock();
-  private final DragAndDropTo command = new DragAndDropTo();
+  private final DragAndDrop command = new DragAndDrop();
   private final FileContent jsSource = new FileContent("drag_and_drop_script.js");
 
   @BeforeEach

--- a/statics/src/test/java/integration/SelectsTest.java
+++ b/statics/src/test/java/integration/SelectsTest.java
@@ -189,7 +189,7 @@ final class SelectsTest extends IntegrationTest {
   }
 
   @Test
-  void getSelectedText_cannotBeNull() {
+  void getSelectedOptionText_cannotBeNull() {
     SelenideElement select = $("select#gender");
     assertThat(select.getSelectedOptionText()).isEqualTo("");
 


### PR DESCRIPTION
This PR removed few deprecated Selenide methods:

1. `$.getSelectedValue()` was replaced by `$.getSelectedOptionValue()`
2. `$.getSelectedText()` was replaced by `$.getSelectedOptionText()`