### PR TITLE
Restore collection loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 7.0.1 (planned to 26.10.2023)
+* restore for loop for collections (method `$$.iterator()`)
 * #2372 Fix deadlock in static initialization of collection conditions
 
 ## 7.0.0 (released 25.10.2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.0.1 (planned to 26.10.2023)
 * restore for loop for collections (method `$$.iterator()`)
+* restore method `$$.isEmpty()`
 * #2372 Fix deadlock in static initialization of collection conditions
 
 ## 7.0.0 (released 25.10.2023)

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -382,7 +382,7 @@ public class ElementsCollection implements Iterable<SelenideElement> {
 
   /**
    * <p>
-   * return actual size of the collection, doesn't wait on collection to be loaded.
+   * return actual size of the collection, doesn't wait until collection is fully loaded.
    * </p>
    *
    * @return actual size of the collection
@@ -396,6 +396,18 @@ public class ElementsCollection implements Iterable<SelenideElement> {
     catch (IndexOutOfBoundsException outOfCollection) {
       return 0;
     }
+  }
+
+  /**
+   * <p>
+   * return actual state of the collection, doesn't wait until collection is fully loaded.
+   * </p>
+   *
+   * @return actual size of the collection
+   * @see <a href="https://github.com/selenide/selenide/wiki/do-not-use-getters-in-tests">NOT RECOMMENDED</a>
+   */
+  public boolean isEmpty() {
+    return size() == 0;
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -40,7 +41,7 @@ import static com.codeborne.selenide.logevents.ErrorsCollector.validateAssertion
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
 
 @ParametersAreNonnullByDefault
-public class ElementsCollection {
+public class ElementsCollection implements Iterable<SelenideElement> {
   private static final ElementCommunicator communicator = inject(ElementCommunicator.class);
 
   private final CollectionSource collection;
@@ -410,6 +411,23 @@ public class ElementsCollection {
   @Nonnull
   public ElementsCollection snapshot() {
     return new ElementsCollection(new CollectionSnapshot(collection));
+  }
+
+  /**
+   * Does not reload collection elements while iterating it.
+   *
+   * Not recommended: As a rule, tests should not iterate collection elements.
+   * Instead, try to write a {@link CollectionCondition} which verifies the whole collection.
+   *
+   * @see <a href="https://github.com/selenide/selenide/wiki/do-not-use-getters-in-tests">NOT RECOMMENDED</a>
+   *
+   * To make it explicit, we recommend to use method {@link #asFixedIterable()} or {@link #asDynamicIterable()} instead.
+   */
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public Iterator<SelenideElement> iterator() {
+    return asFixedIterable().iterator();
   }
 
   /**

--- a/src/test/java/integration/collections/ForLoopOverCollectionTest.java
+++ b/src/test/java/integration/collections/ForLoopOverCollectionTest.java
@@ -1,0 +1,33 @@
+package integration.collections;
+
+import com.codeborne.selenide.SelenideElement;
+import integration.ITest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.or;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+
+public class ForLoopOverCollectionTest extends ITest {
+  @BeforeEach
+  void openPage() {
+    openFile("page_with_list_of_elements.html");
+  }
+
+  @Test
+  void canIterateCollection() {
+    $$(".element").shouldHave(size(3));
+
+    /*
+     * Not recommended.
+     * Please, don't use IFs and LOOPs in your tests.
+     * It's a sign of a bad test design.
+     */
+    for (SelenideElement element : $$(".element")) {
+      element.shouldBe(visible);
+      element.shouldHave(or("", text("One"), text("Two"), text("Three")));
+    }
+  }
+}

--- a/src/test/java/integration/collections/ForLoopOverCollectionTest.java
+++ b/src/test/java/integration/collections/ForLoopOverCollectionTest.java
@@ -9,7 +9,13 @@ import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.or;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
+import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Not recommended.
+ * Please, don't use IFs and LOOPs in your tests.
+ * It's a sign of a bad test design.
+ */
 public class ForLoopOverCollectionTest extends ITest {
   @BeforeEach
   void openPage() {
@@ -20,14 +26,15 @@ public class ForLoopOverCollectionTest extends ITest {
   void canIterateCollection() {
     $$(".element").shouldHave(size(3));
 
-    /*
-     * Not recommended.
-     * Please, don't use IFs and LOOPs in your tests.
-     * It's a sign of a bad test design.
-     */
     for (SelenideElement element : $$(".element")) {
       element.shouldBe(visible);
       element.shouldHave(or("", text("One"), text("Two"), text("Three")));
     }
+  }
+
+  @Test
+  void canCheckIfCollectionIsEmpty() {
+    assertThat($$(".element").isEmpty()).isFalse();
+    assertThat($$(".none").isEmpty()).isTrue();
   }
 }


### PR DESCRIPTION
restore 2 methods:
1. `$$.iterator()`
2. `$$.isEmpty()`

I still think these tests should not be used in tests.
But they are widely used, so we had to make a compromise.