### PR TITLE
restore support for "self" field in Container

### DIFF
--- a/src/main/java/com/codeborne/selenide/Container.java
+++ b/src/main/java/com/codeborne/selenide/Container.java
@@ -1,9 +1,20 @@
 package com.codeborne.selenide;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Marker interface for declaring page objects fields that contain other elements
  *
  * @since 6.19.0
  */
 public interface Container {
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.FIELD)
+  @interface Self {
+  }
+
 }

--- a/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
@@ -214,6 +214,10 @@ public class SelenidePageFactory implements PageObjectFactory {
                          Driver driver, @Nullable WebElementSource searchContext,
                          Field field, By selector, Type[] genericTypes) {
     String alias = alias(field);
+
+    if (field.isAnnotationPresent(Container.Self.class)) {
+      return injectSelf(searchContext, field);
+    }
     if (WebElement.class.isAssignableFrom(field.getType())) {
       return decorateWebElement(driver, searchContext, selector, field, alias);
     }
@@ -231,6 +235,19 @@ public class SelenidePageFactory implements PageObjectFactory {
     }
 
     return defaultFieldDecorator(driver, searchContext).decorate(loader, field);
+  }
+
+  @Nonnull
+  @CheckReturnValue
+  private SelenideElement injectSelf(@Nullable WebElementSource searchContext, Field field) {
+    if (searchContext != null) {
+      return ElementFinder.wrap(SelenideElement.class, searchContext);
+    }
+    else {
+      String message = String.format("Cannot initialize field %s.%s: it's not bound to any page object",
+        field.getDeclaringClass().getSimpleName(), field.getName());
+      throw new IllegalArgumentException(message);
+    }
   }
 
   private List<WebElement> createWebElementsList(ClassLoader loader, Driver driver, @Nullable WebElementSource searchContext,

--- a/statics/src/test/java/integration/pageobjects/ElementsContainerWithManuallyInitializedFieldsTest.java
+++ b/statics/src/test/java/integration/pageobjects/ElementsContainerWithManuallyInitializedFieldsTest.java
@@ -14,6 +14,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.Selenide.page;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class ElementsContainerWithManuallyInitializedFieldsTest extends IntegrationTest {
 
@@ -34,6 +35,13 @@ final class ElementsContainerWithManuallyInitializedFieldsTest extends Integrati
       "Mickey \"Rock'n'Roll\" Rourke", "Denzel Washington"));
   }
 
+  @Test
+  void cannotInitializeElementsContainerOutsidePageObject() {
+    assertThatThrownBy(() -> page(InvalidContainer.class))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Cannot initialize field InvalidContainer.self: it's not bound to any page object");
+  }
+
   private static class MyPage {
     @FindBy(css = "#apostrophes-and-quotes")
     MyContainer container;
@@ -42,5 +50,13 @@ final class ElementsContainerWithManuallyInitializedFieldsTest extends Integrati
   private static class MyContainer implements Container {
     SelenideElement headerLink = $("h2>a");
     ElementsCollection options = $$("#hero>option");
+  }
+
+  private static class InvalidContainer implements Container {
+    @Self
+    SelenideElement self;
+
+    @FindBy(css = "h2 a")
+    SelenideElement headerLink;
   }
 }

--- a/statics/src/test/java/integration/pageobjects/PageObjectTest.java
+++ b/statics/src/test/java/integration/pageobjects/PageObjectTest.java
@@ -115,6 +115,7 @@ final class PageObjectTest extends IntegrationTest {
 
   @Test
   void canComposePageFromReusableBlocks() {
+    pageWithSelects.status.self.shouldBe(visible);
     pageWithSelects.status.name.shouldHave(text("Bob Smith"), visible);
     pageWithSelects.status.lastLogin.shouldHave(text("01.01.1970"));
   }
@@ -197,6 +198,9 @@ final class PageObjectTest extends IntegrationTest {
   }
 
   static class StatusBlock implements Container {
+    @Self
+    SelenideElement self;
+
     @FindBy(className = "name")
     SelenideElement name;
 


### PR DESCRIPTION
Now you need to declare your own field of type `SelenideElement` and annotate it with `@Self`:

```java
  static class StatusBlock implements Container {
    @Self
    SelenideElement self;

    @FindBy(className = "name")
    SelenideElement name;
}
```