### PR TITLE
fix: type command issue

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumType.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumType.java
@@ -1,19 +1,50 @@
 package com.codeborne.selenide.appium.commands;
 
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.TypeOptions;
+import com.codeborne.selenide.appium.AppiumDriverRunner;
 import com.codeborne.selenide.commands.Type;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import static com.codeborne.selenide.Stopwatch.sleepAtLeast;
 import static com.codeborne.selenide.appium.WebdriverUnwrapper.isMobile;
+import static java.util.Objects.requireNonNull;
 
 @ParametersAreNonnullByDefault
 public class AppiumType extends Type {
   public AppiumType() {
     super(new AppiumClear());
+  }
+
+  @Nullable
+  @Override
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object[] args) {
+    TypeOptions typeOptions = extractOptions(requireNonNull(args));
+    clearField(proxy, locator, typeOptions);
+
+    WebElement element = findElement(locator);
+    typeIntoField(locator, element, typeOptions);
+    return proxy;
+  }
+
+  private void typeIntoField(WebElementSource locator, WebElement element, TypeOptions typeOptions) {
+    Actions actions = new Actions(locator.driver().getWebDriver());
+    for (int i = 0; i < typeOptions.textToType().length(); i++) {
+      CharSequence character = typeOptions.textToType().subSequence(i, i + 1);
+      if(AppiumDriverRunner.isAndroidDriver()) {
+        actions.click(element).sendKeys(character).perform();
+      } else {
+        element.sendKeys(character);
+      }
+      sleepAtLeast(typeOptions.timeDelay().toMillis());
+    }
   }
 
   @Override

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumType.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumType.java
@@ -38,8 +38,9 @@ public class AppiumType extends Type {
     Actions actions = new Actions(locator.driver().getWebDriver());
     for (int i = 0; i < typeOptions.textToType().length(); i++) {
       CharSequence character = typeOptions.textToType().subSequence(i, i + 1);
-      if(AppiumDriverRunner.isAndroidDriver()) {
-        actions.click(element).sendKeys(character).perform();
+      if (AppiumDriverRunner.isAndroidDriver()) {
+        element.click();
+        actions.sendKeys(character).perform();
       } else {
         element.sendKeys(character);
       }

--- a/modules/appium/src/test/java/it/mobile/android/AndroidTypeTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AndroidTypeTest.java
@@ -1,0 +1,33 @@
+package it.mobile.android;
+
+import com.codeborne.selenide.appium.SelenideAppium;
+import io.appium.java_client.AppiumBy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
+import static com.codeborne.selenide.appium.SelenideAppium.$;
+
+class AndroidTypeTest extends BaseApiDemosTest {
+
+  @BeforeEach
+  void setUp() {
+    closeWebDriver();
+    SelenideAppium.launchApp();
+  }
+
+  @Test
+  void androidType() {
+    $(AppiumBy.xpath(".//*[@text='Views']")).tap();
+    $(AppiumBy.xpath(".//*[@text='TextFields']"))
+      .scrollTo()
+      .shouldBe(visible)
+      .click();
+    $(AppiumBy.id("io.appium.android.apis:id/edit"))
+      .shouldBe(visible)
+      .type("abc")
+      .shouldHave(text("abc"));
+  }
+}

--- a/modules/appium/src/test/java/it/mobile/android/AndroidTypeTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AndroidTypeTest.java
@@ -1,22 +1,13 @@
 package it.mobile.android;
 
-import com.codeborne.selenide.appium.SelenideAppium;
 import io.appium.java_client.AppiumBy;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.appium.SelenideAppium.$;
 
 class AndroidTypeTest extends BaseApiDemosTest {
-
-  @BeforeEach
-  void setUp() {
-    closeWebDriver();
-    SelenideAppium.launchApp();
-  }
 
   @Test
   void androidType() {

--- a/modules/appium/src/test/java/it/mobile/ios/IosTypeTest.java
+++ b/modules/appium/src/test/java/it/mobile/ios/IosTypeTest.java
@@ -1,0 +1,20 @@
+package it.mobile.ios;
+
+import com.codeborne.selenide.appium.AppiumSelectors;
+import com.codeborne.selenide.appium.SelenideAppium;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.*;
+import static com.codeborne.selenide.appium.SelenideAppium.$;
+
+class IosTypeTest extends BaseSwagLabsAppIosTest {
+
+  @Test
+  void iosType() {
+    SelenideAppium.openIOSDeepLink("mydemoapprn://login");
+    $(AppiumSelectors.byName("Username input field"))
+      .shouldBe(visible)
+      .type("abc")
+      .shouldHave(text("abc"));
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/Type.java
+++ b/src/main/java/com/codeborne/selenide/commands/Type.java
@@ -45,11 +45,21 @@ public class Type implements Command<SelenideElement> {
     return locator.findAndAssertElementIsEditable();
   }
 
-  private TypeOptions extractOptions(Object[] args) {
+  protected TypeOptions extractOptions(Object[] args) {
     if (args[0] instanceof TypeOptions options) {
       return options;
     } else {
       return TypeOptions.text(firstOf(args));
+    }
+  }
+
+  protected void clearField(SelenideElement proxy, WebElementSource locator, TypeOptions typeOptions) {
+    if (typeOptions.shouldClearFieldBeforeTyping()) {
+      if (typeOptions.textToType().length() > 0) {
+        clear.clear(locator.driver(), proxy);
+      } else {
+        clear.clearAndTrigger(locator.driver(), proxy);
+      }
     }
   }
 
@@ -58,16 +68,6 @@ public class Type implements Command<SelenideElement> {
       CharSequence character = typeOptions.textToType().subSequence(i, i + 1);
       element.sendKeys(character);
       sleepAtLeast(typeOptions.timeDelay().toMillis());
-    }
-  }
-
-  private void clearField(SelenideElement proxy, WebElementSource locator, TypeOptions typeOptions) {
-    if (typeOptions.shouldClearFieldBeforeTyping()) {
-      if (typeOptions.textToType().length() > 0) {
-        clear.clear(locator.driver(), proxy);
-      } else {
-        clear.clearAndTrigger(locator.driver(), proxy);
-      }
     }
   }
 }


### PR DESCRIPTION
## Proposed changes
Fixes the issue - https://github.com/selenide/selenide/issues/2459

Sendkeys work different on android and ios.
For Android we have to use actions.sendKeys and for ios we can use default sendKeys (action.sendkeys is not working in ios)
Added tests for safety

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
