### PR TITLE
Fix flaky android test

### DIFF
--- a/modules/appium/src/test/java/it/mobile/android/Login.java
+++ b/modules/appium/src/test/java/it/mobile/android/Login.java
@@ -1,7 +1,6 @@
 package it.mobile.android;
 
 import com.codeborne.selenide.SelenideElement;
-import com.codeborne.selenide.TypeOptions;
 import com.codeborne.selenide.appium.SelenideAppium;
 import com.codeborne.selenide.appium.SelenideAppiumElement;
 import io.appium.java_client.pagefactory.AndroidFindBy;
@@ -14,7 +13,6 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.page;
 import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static io.appium.java_client.AppiumBy.accessibilityId;
-import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 
 class SauceLabLoginTest extends BaseSwagLabsAndroidTest {

--- a/modules/appium/src/test/java/it/mobile/android/Login.java
+++ b/modules/appium/src/test/java/it/mobile/android/Login.java
@@ -42,17 +42,6 @@ class SauceLabLoginTest extends BaseSwagLabsAndroidTest {
       .shouldBe(visible, ofSeconds(10))
       .shouldHave(text("Provided credentials do not match any user in this service."));
   }
-
-  @Test
-  void canTypeTextSlowly() {
-    LoginPage loginPage = page();
-    loginPage.login.type(TypeOptions.text("bob@example.com").withDelay(ofMillis(10)));
-    loginPage.password.sendKeys("10203040");
-    loginPage.loginButton.click();
-
-    CheckoutPage nextPage = page();
-    nextPage.title.shouldBe(visible, ofSeconds(10));
-  }
 }
 
 class LoginPage {


### PR DESCRIPTION
## Proposed changes
AndroidTypeTest and IosTypeTest were added to test the type method and hence I removed this flaky test.

I tried several ways to fix this. But instead of typing bob@example.com it keeps typing `ob.example.com`. I think it is problem with the app. Hence removing this test.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
