### PR TITLE
#2551 Use fallback if JavascriptException occurs.

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/WebElementCommunicator.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementCommunicator.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
+import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebElement;
 
@@ -20,7 +21,7 @@ public class WebElementCommunicator implements ElementCommunicator {
                                       ".replace(/[\\u200b\\u200e\\u200f]/g, '')" +
                                       ".trim())", elements);
     }
-    catch (UnsupportedCommandException javascriptNotSupported) {
+    catch (UnsupportedCommandException | JavascriptException cannotUseJs) {
       return textsOneByOne(elements);
     }
   }
@@ -41,7 +42,7 @@ public class WebElementCommunicator implements ElementCommunicator {
         elements, attributeName
       );
     }
-    catch (UnsupportedCommandException javascriptNotSupported) {
+    catch (UnsupportedCommandException | JavascriptException cannotUseJs) {
       return attributesOneByOne(elements, attributeName);
     }
   }


### PR DESCRIPTION
On webkit(safari), when you pass a list of `WebElement` to `executeJavaScript()`, you cannot get a property of any element in the list. For example, `Array.from(arguments[0])[0].innerText` will always be null.

fixes https://github.com/selenide/selenide/issues/2551

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
