### PR TITLE
#2130 oneOfTexts() - like conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.3 (released ...)
+* add `oneOfTexts(Collection)`- like Conditions (#2130) -- thanks to Yury Yurchenko
+
 ## 7.0.2 (released 01.11.2023)
 * bump Selenium from 4.14.1 to 4.15.0 (#2540)
 

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -25,6 +25,10 @@ import com.codeborne.selenide.conditions.IsImageLoaded;
 import com.codeborne.selenide.conditions.MatchAttributeWithValue;
 import com.codeborne.selenide.conditions.MatchText;
 import com.codeborne.selenide.conditions.NamedCondition;
+import com.codeborne.selenide.conditions.OneOfExactTexts;
+import com.codeborne.selenide.conditions.OneOfExactTextsCaseSensitive;
+import com.codeborne.selenide.conditions.OneOfTexts;
+import com.codeborne.selenide.conditions.OneOfTextsCaseSensitive;
 import com.codeborne.selenide.conditions.Or;
 import com.codeborne.selenide.conditions.OwnText;
 import com.codeborne.selenide.conditions.OwnTextCaseSensitive;
@@ -45,6 +49,7 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Collection;
 import java.util.function.Predicate;
 
 import static com.codeborne.selenide.conditions.ConditionHelpers.merge;
@@ -311,6 +316,66 @@ public final class Condition {
   @Nonnull
   public static WebElementCondition matchText(String regex) {
     return new MatchText(regex);
+  }
+
+  /**
+   * Assert that given element's TEXT case-insensitively CONTAINS at least
+   * one of the given {@code texts}. Assertion fails if specified collection is empty.
+   *
+   * <p>NB! Ignores multiple whitespaces between words.</p>
+   * <p>NB! Nulls and blank strings are not allowed in the specified collection
+   * (because any element does contain an empty text).</p>
+   * @throws IllegalArgumentException If specified collection contains {@code null}s or blank strings.
+   * @since 7.0.3
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static WebElementCondition oneOfTexts(Collection<String> texts) {
+    return new OneOfTexts(texts);
+  }
+
+  /**
+   * Assert that given element's TEXT case-sensitively CONTAINS at least
+   * one of the given {@code texts}. Assertion fails if specified collection is empty.
+   *
+   * <p>NB! Ignores multiple whitespaces between words.</p>
+   * <p>NB! Nulls and blank strings are not allowed in the specified collection
+   * (because any element does contain an empty text).</p>
+   * @throws IllegalArgumentException If specified collection contains {@code null}s or blank strings.
+   * @since 7.0.3
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static WebElementCondition oneOfTextsCaseSensitive(Collection<String> texts) {
+    return new OneOfTextsCaseSensitive(texts);
+  }
+
+  /**
+   * Assert that given element's TEXT case-insensitively EQUALS to
+   * one of the given {@code texts}. Assertion fails if specified collection is empty.
+   *
+   * <p>NB! Ignores multiple whitespaces between words.</p>
+   * @throws IllegalArgumentException If specified collection contains {@code null} elements.
+   * @since 7.0.3
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static WebElementCondition oneOfExactTexts(Collection<String> texts) {
+    return new OneOfExactTexts(texts);
+  }
+
+  /**
+   * Assert that given element's TEXT case-sensitively EQUALS to
+   * one of the given {@code texts}. Assertion fails if specified collection is empty.
+   *
+   * <p>NB! Ignores multiple whitespaces between words.</p>
+   * @throws IllegalArgumentException If specified collection contains {@code null} elements.
+   * @since 7.0.3
+   */
+  @CheckReturnValue
+  @Nonnull
+  public static WebElementCondition oneOfExactTextsCaseSensitive(Collection<String> texts) {
+    return new OneOfExactTextsCaseSensitive(texts);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/conditions/OneOfExactTexts.java
+++ b/src/main/java/com/codeborne/selenide/conditions/OneOfExactTexts.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.impl.Html;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Collection;
+import java.util.Objects;
+
+@ParametersAreNonnullByDefault
+public class OneOfExactTexts extends TextCondition {
+  private final Collection<String> targets;
+
+  public OneOfExactTexts(Collection<String> targets) {
+    super("one of exact texts", targets.toString());
+    if (targets.stream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("The collection must not contain null");
+    }
+    this.targets = targets;
+  }
+
+  @CheckReturnValue
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    return targets.stream()
+      .anyMatch(target -> Html.text.equals(actualText, target));
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/OneOfExactTextsCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/conditions/OneOfExactTextsCaseSensitive.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.impl.Html;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Collection;
+import java.util.Objects;
+
+@ParametersAreNonnullByDefault
+public class OneOfExactTextsCaseSensitive extends TextCondition {
+  private final Collection<String> targets;
+
+  public OneOfExactTextsCaseSensitive(Collection<String> targets) {
+    super("one of exact texts case sensitive", targets.toString());
+    if (targets.stream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("The collection must not contain null");
+    }
+    this.targets = targets;
+  }
+
+  @CheckReturnValue
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    return targets.stream()
+      .anyMatch(target -> Html.text.equalsCaseSensitive(actualText, target));
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/OneOfTexts.java
+++ b/src/main/java/com/codeborne/selenide/conditions/OneOfTexts.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.impl.Html;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Collection;
+import java.util.Objects;
+
+@ParametersAreNonnullByDefault
+public class OneOfTexts extends TextCondition {
+  private final Collection<String> targets;
+
+  public OneOfTexts(Collection<String> targets) {
+    super("one of texts", targets.toString());
+    if (targets.stream().anyMatch(target -> Objects.isNull(target) || target.isBlank())) {
+      throw new IllegalArgumentException("The collection must not contain null or blank strings");
+    }
+    this.targets = targets;
+  }
+
+  @CheckReturnValue
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    return targets.stream()
+      .anyMatch(target -> Html.text.contains(actualText, target));
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/OneOfTextsCaseSensitive.java
+++ b/src/main/java/com/codeborne/selenide/conditions/OneOfTextsCaseSensitive.java
@@ -1,0 +1,28 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.impl.Html;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Collection;
+import java.util.Objects;
+
+@ParametersAreNonnullByDefault
+public class OneOfTextsCaseSensitive extends TextCondition {
+  private final Collection<String> targets;
+
+  public OneOfTextsCaseSensitive(Collection<String> targets) {
+    super("one of texts case sensitive", targets.toString());
+    if (targets.stream().anyMatch(target -> Objects.isNull(target) || target.isBlank())) {
+      throw new IllegalArgumentException("The collection must not contain null or blank strings");
+    }
+    this.targets = targets;
+  }
+
+  @CheckReturnValue
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    return targets.stream()
+      .anyMatch(target -> Html.text.containsCaseSensitive(actualText, target));
+  }
+}

--- a/src/test/java/com/codeborne/selenide/conditions/OneOfExactTextsCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/OneOfExactTextsCaseSensitiveTest.java
@@ -1,0 +1,71 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.TextCheck;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static org.assertj.core.api.Assertions.*;
+
+class OneOfExactTextsCaseSensitiveTest {
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(TextCheck.FULL_TEXT));
+  private final Collection<String> collectionWithNull = new HashSet<>(Arrays.asList("John", "Lucy", null, "Banana"));
+  private final Collection<String> collectionWithEmptyString = List.of("John", "Lucy", "", "Banana");
+  private final Collection<String> collectionWithBlankString = List.of("John", "Lucy", "   ", "Banana");
+  private final Collection<String> regularCollection = List.of(" John  ", " Lucy", "Vodka", "  Banana    ");
+  private final OneOfExactTextsCaseSensitive regularCollectionArgument = new OneOfExactTextsCaseSensitive(regularCollection);
+
+  @Test
+  void shouldNotMatchRegularCollectionDifferentCases() {
+    assertThat(regularCollectionArgument
+      .check(driver, mockElement("bAnAnA")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldMatchRegularCollectionSameCases() {
+    assertThat(regularCollectionArgument.check(driver, mockElement("Banana")).verdict()).isEqualTo(ACCEPT);
+    assertThat(regularCollectionArgument.check(driver, mockElement("Lucy")).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void shouldNotMatchRegularCollection() {
+    assertThat(regularCollectionArgument.check(driver, mockElement("Banan")).verdict()).isEqualTo(REJECT);
+    assertThat(regularCollectionArgument.check(driver, mockElement("Nice Banana")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldThrowExceptionBecauseOfNullCollectionItem() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new OneOfExactTextsCaseSensitive(collectionWithNull));
+  }
+
+  @Test
+  void shouldNotMatchEmptyCollection() {
+    assertThat(new OneOfExactTextsCaseSensitive(Collections.emptyList())
+      .check(driver, mockElement("")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfExactTextsCaseSensitive(Collections.emptyList())
+      .check(driver, mockElement("Hi")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldMatchCollectionWithEmptyStringIfElementsTextIsAlsoEmpty() {
+    assertThat(new OneOfExactTextsCaseSensitive(collectionWithEmptyString)
+      .check(driver, mockElement("")).verdict()).isEqualTo(ACCEPT);
+    assertThat(new OneOfExactTextsCaseSensitive(collectionWithBlankString)
+      .check(driver, mockElement("")).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void shouldNotMatchCollectionWithEmptyStringIfElementsTextIsNotEmptyAndDoesntMatchAnotherStrings() {
+    assertThat(new OneOfExactTextsCaseSensitive(collectionWithEmptyString)
+      .check(driver, mockElement("apple")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfExactTextsCaseSensitive(collectionWithBlankString)
+      .check(driver, mockElement("apple")).verdict()).isEqualTo(REJECT);
+  }
+
+}

--- a/src/test/java/com/codeborne/selenide/conditions/OneOfExactTextsTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/OneOfExactTextsTest.java
@@ -1,0 +1,61 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.TextCheck;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class OneOfExactTextsTest {
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(TextCheck.FULL_TEXT));
+  private final Collection<String> collectionWithNull = new HashSet<>(Arrays.asList("John", "Lucy", null, "Banana"));
+  private final Collection<String> collectionWithEmptyString = List.of("John", "Lucy", "", "Banana");
+  private final Collection<String> collectionWithBlankString = List.of("John", "Lucy", "   ", "Banana");
+  private final Collection<String> regularCollection = List.of("John", "Lucy", "Vodka", "  Banana   ");
+
+  @Test
+  void shouldMatchRegularCollectionDifferentCases() {
+    assertThat(new OneOfExactTexts(regularCollection).check(driver, mockElement("bAnAnA")).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void shouldNotMatchRegularCollection() {
+    assertThat(new OneOfExactTexts(regularCollection).check(driver, mockElement("Banan")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfExactTexts(regularCollection).check(driver, mockElement("Bananaa")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldThrowExceptionBecauseOfNullCollectionItem() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new OneOfExactTexts(collectionWithNull));
+  }
+
+  @Test
+  void shouldNotMatchEmptyCollection() {
+    assertThat(new OneOfExactTexts(Collections.emptyList()).check(driver, mockElement("")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfExactTexts(Collections.emptyList()).check(driver, mockElement("Hi")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldMatchCollectionWithEmptyStringIfElementsTextIsAlsoEmpty() {
+    assertThat(new OneOfExactTexts(collectionWithEmptyString).check(driver, mockElement("")).verdict()).isEqualTo(ACCEPT);
+    assertThat(new OneOfExactTexts(collectionWithBlankString).check(driver, mockElement("")).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void shouldNotMatchCollectionWithEmptyStringIfElementsTextIsNotEmptyAndDoesntMatchAnotherStrings() {
+    assertThat(new OneOfExactTexts(collectionWithEmptyString).check(driver, mockElement("apple")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfExactTexts(collectionWithBlankString).check(driver, mockElement("apple")).verdict()).isEqualTo(REJECT);
+  }
+}

--- a/src/test/java/com/codeborne/selenide/conditions/OneOfTextsCaseSensitiveTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/OneOfTextsCaseSensitiveTest.java
@@ -1,0 +1,70 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.TextCheck;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class OneOfTextsCaseSensitiveTest {
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(TextCheck.FULL_TEXT));
+
+  private final Collection<String> collectionWithNull = new HashSet<>(Arrays.asList("John", "Lucy", null, "Banana"));
+  private final Collection<String> collectionWithEmptyString = List.of("John", "Lucy", "", "Banana");
+  private final Collection<String> collectionWithBlankString = List.of("John", "Lucy", "   ", "Banana");
+  private final Collection<String> regularCollection = List.of("John", "Lucy", "Vod  ka", " Banana   fruit  ");
+  private final OneOfTextsCaseSensitive regularCollectionArgument = new OneOfTextsCaseSensitive(regularCollection);
+
+  @Test
+  void shouldMatchRegularCollection() {
+    assertThat(regularCollectionArgument.check(driver,
+      mockElement("My favorite fruit is BBanana fruitT of course")).verdict()).isEqualTo(ACCEPT);
+    assertThat(regularCollectionArgument.check(driver,
+      mockElement("My favorite fruit is of course bbBanana fruit")).verdict()).isEqualTo(ACCEPT);
+    assertThat(regularCollectionArgument.check(driver,
+      mockElement("Banana fruitTt My favorite fruit is of course")).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void shouldNotMatchRegularCollectionDifferentCases() {
+    assertThat(regularCollectionArgument.check(driver,
+      mockElement("My favorite fruit is bAnAnAaaaaaa of course")).verdict()).isEqualTo(REJECT);
+    assertThat(regularCollectionArgument.check(driver,
+      mockElement("My favorite fruit is of course bAnAnA")).verdict()).isEqualTo(REJECT);
+    assertThat(regularCollectionArgument.check(driver,
+      mockElement("bAnAnA My favorite fruit is of course")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldNotMatchRegularCollection() {
+    assertThat(regularCollectionArgument.check(driver,
+      mockElement("My favorite fruit is Banan of course")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldThrowExceptionBecauseOfNullCollectionItem() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new OneOfTextsCaseSensitive(collectionWithNull));
+  }
+
+  @Test
+  void shouldNotMatchEmptyCollection() {
+    assertThat(new OneOfTextsCaseSensitive(Collections.emptyList())
+      .check(driver, mockElement("")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfTextsCaseSensitive(Collections.emptyList())
+      .check(driver, mockElement("Hi")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldThrowExceptionIfCollectionContainsEmptyOrBlankString() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new OneOfTextsCaseSensitive(collectionWithEmptyString));
+    assertThatIllegalArgumentException().isThrownBy(() -> new OneOfTextsCaseSensitive(collectionWithBlankString));
+  }
+}

--- a/src/test/java/com/codeborne/selenide/conditions/OneOfTextsTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/OneOfTextsTest.java
@@ -1,0 +1,64 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.TextCheck;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.Mocks.mockElement;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class OneOfTextsTest {
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(TextCheck.FULL_TEXT));
+  private final Collection<String> collectionWithNull = new HashSet<>(Arrays.asList("John", "Lucy", null, "Banana"));
+  private final Collection<String> collectionWithEmptyString = List.of("John", "Lucy", "", "Banana");
+  private final Collection<String> collectionWithBlankString = List.of("John", "Lucy", "   ", "Banana");
+  private final Collection<String> regularCollection = List.of("John", "Lucy", "Vod  ka", "  Banana   fruit  ");
+
+  @Test
+  void shouldMatchRegularCollectionDifferentCases() {
+    assertThat(new OneOfTexts(regularCollection).check(driver,
+      mockElement("My favorite fruit is bbAnAnA fRuItt of course")).verdict()).isEqualTo(ACCEPT);
+    assertThat(new OneOfTexts(regularCollection).check(driver,
+      mockElement("My favorite is of course bbbAnAnA frUit")).verdict()).isEqualTo(ACCEPT);
+    assertThat(new OneOfTexts(regularCollection).check(driver,
+      mockElement("bAnAnA fRuiT My favorite is of course")).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void shouldNotMatchRegularCollection() {
+    assertThat(new OneOfTexts(regularCollection).check(driver,
+      mockElement("My favorite fruit is Banan fruit of course")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfTexts(regularCollection).check(driver,
+      mockElement("Banana ruit My favorite fruit is  of course")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfTexts(regularCollection).check(driver,
+      mockElement("My favorite fruit is of course Banana fruiit")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldThrowExceptionBecauseOfNullCollectionItem() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new OneOfTexts(collectionWithNull));
+  }
+
+  @Test
+  void shouldNotMatchEmptyCollection() {
+    assertThat(new OneOfTexts(Collections.emptyList()).check(driver, mockElement("")).verdict()).isEqualTo(REJECT);
+    assertThat(new OneOfTexts(Collections.emptyList()).check(driver, mockElement("Hi")).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void shouldThrowExceptionIfCollectionContainsBlankStrings() {
+    assertThatIllegalArgumentException().isThrownBy(() -> new OneOfTexts(collectionWithEmptyString));
+    assertThatIllegalArgumentException().isThrownBy(() -> new OneOfTexts(collectionWithBlankString));
+  }
+}


### PR DESCRIPTION
Hi everybody!

## Proposed changes
#2130

1. Four conditions added:
    - oneOfTexts(Collection\<String>)
    - oneOfTextsCaseSensitive(Collection\<String>)
    - oneOfExactTexts(Collection\<String>)
    - oneOfExactTextsCaseSensitive(Collection\<String>)
1. Unit tests added.

1. CHANGELOG.md is updated (but I'm not sure I did that correctly).

Feel free to ask questions and suggest corrections!

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command 
(my comment: `gradle check` fails with checkstyle errors because of LF/CRLF, but git must be fixed it while commiting/pushing)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
