### PR TITLE
#2562 export netty-codec-http dependency at "api" level

### DIFF
--- a/modules/proxy/build.gradle
+++ b/modules/proxy/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   }
   implementation("xyz.rogfam:littleproxy:${littleProxyVersion}")
   implementation("io.netty:netty-all:$nettyVersion") {because 'used by browserup-proxy'}
+  api("io.netty:netty-codec-http:$nettyVersion") {because 'allows Selenide users to add request/response interceptors'}
 
   testImplementation project(':statics')
   testImplementation project(':statics').sourceSets.test.output


### PR DESCRIPTION
It allows Selenide users to add request/response interceptors to Selenide proxy. Otherwise, class `io.netty.handler.codec.http.HttpMessage` is not visible from users' tests.


fix for #2562 

@mr-alexov 