### PR TITLE
Add getSearchLocator command

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1257,6 +1257,16 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   String getSearchCriteria();
 
   /**
+   * Return locator of criteria by which this element is located
+   *
+   * @return e.g. "//div[data-test-id='sample']"
+   * @see com.codeborne.selenide.commands.GetSearchLocator
+   */
+  @CheckReturnValue
+  @Nonnull
+  String getSearchLocator();
+
+  /**
    * @return the original Selenium {@link WebElement} wrapped by this object
    * @throws org.openqa.selenium.NoSuchElementException if element does not exist (without waiting for the element)
    * @see com.codeborne.selenide.commands.ToWebElement

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -51,6 +51,7 @@ public class Commands {
     add("screenshot", new TakeScreenshot());
     add("screenshotAsImage", new TakeScreenshotAsImage());
     add("getSearchCriteria", new GetSearchCriteria());
+    add("getSearchLocator", new GetSearchLocator());
     add("execute", new Execute<>());
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/GetOptions.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetOptions.java
@@ -58,6 +58,13 @@ public class GetOptions implements Command<ElementsCollection> {
     }
 
     @Override
+    @CheckReturnValue
+    @Nonnull
+    public String getSearchLocator() {
+      return selectElement.getSearchLocator();
+    }
+
+    @Override
     public String toString() {
       return selectElement + " options";
     }

--- a/src/main/java/com/codeborne/selenide/commands/GetSearchLocator.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSearchLocator.java
@@ -1,0 +1,20 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class GetSearchLocator implements Command<String> {
+  @Override
+  @Nonnull
+  @CheckReturnValue
+  public String execute(SelenideElement proxy, WebElementSource locator, @Nullable Object[] args) {
+    return locator.getSearchLocator();
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/GetSelectedOptions.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetSelectedOptions.java
@@ -58,6 +58,13 @@ public class GetSelectedOptions implements Command<ElementsCollection> {
     }
 
     @Override
+    @CheckReturnValue
+    @Nonnull
+    public String getSearchLocator() {
+      return selectElement.getSearchLocator();
+    }
+
+    @Override
     public String toString() {
       return selectElement + " selected options";
     }

--- a/src/main/java/com/codeborne/selenide/impl/BySelectorCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/BySelectorCollection.java
@@ -55,6 +55,13 @@ public class BySelectorCollection implements CollectionSource {
       parent.getSearchCriteria() + "/" + describe.selector(selector);
   }
 
+  @Nonnull
+  @CheckReturnValue
+  @Override
+  public String getSearchLocator() {
+    return describe.locator(selector);
+  }
+
   @Override
   public String toString() {
     return parent == null ? '[' + describe.selector(selector) + ']' :

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
@@ -56,6 +56,13 @@ public class CollectionElement extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
+  public String getSearchLocator() {
+    return collection.getSearchLocator();
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
   public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     if (collection.getElements().isEmpty()) {
       return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, cause);

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
@@ -61,4 +61,11 @@ public class CollectionElementByCondition extends WebElementSource {
   public String getSearchCriteria() {
     return collection.description() + ".findBy(" + condition + ")";
   }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public String getSearchLocator() {
+    return collection.getSearchLocator();
+  }
 }

--- a/src/main/java/com/codeborne/selenide/impl/CollectionSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionSnapshot.java
@@ -45,6 +45,13 @@ public class CollectionSnapshot implements CollectionSource {
   }
 
   @Override
+  @CheckReturnValue
+  @Nonnull
+  public String getSearchLocator() {
+    return originalCollection.getSearchLocator();
+  }
+
+  @Override
   public String toString() {
     return getSearchCriteria();
   }

--- a/src/main/java/com/codeborne/selenide/impl/CollectionSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionSource.java
@@ -30,14 +30,24 @@ public interface CollectionSource {
 
   @CheckReturnValue
   @Nonnull
+  String getSearchLocator();
+
+  @CheckReturnValue
+  @Nonnull
   default String description() {
-    return getAlias().get(() -> getSearchCriteria());
+    return getAlias().get(this::getSearchCriteria);
   }
 
   @CheckReturnValue
   @Nonnull
   default String shortDescription() {
-    return getAlias().getOrElse(() -> getSearchCriteria());
+    return getAlias().getOrElse(this::getSearchCriteria);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  default String locator() {
+    return getAlias().get(this::getSearchLocator);
   }
 
   @CheckReturnValue

--- a/src/main/java/com/codeborne/selenide/impl/ElementDescriber.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementDescriber.java
@@ -27,6 +27,19 @@ public interface ElementDescriber {
   String selector(By selector);
 
   /**
+   * Returns locator value of element selector
+   *
+   * @param selector An element selector
+   * @return A locator of element selector
+   */
+  @CheckReturnValue
+  @Nonnull
+  default String locator(By selector) {
+    final By.Remotable.Parameters remoteParameters = ((By.Remotable) selector).getRemoteParameters();
+    return String.valueOf(remoteParameters.value());
+  }
+
+  /**
    * Outputs string presentation of the element's collection
    *
    * @param elements elements of string

--- a/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
@@ -151,6 +151,13 @@ public class ElementFinder extends WebElementSource {
       parent.getSearchCriteria() + "/" + elementCriteria();
   }
 
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public String getSearchLocator() {
+    return describe.locator(criteria);
+  }
+
   @Nonnull
   private String elementCriteria() {
     return index == 0 ?

--- a/src/main/java/com/codeborne/selenide/impl/FilteringCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/FilteringCollection.java
@@ -52,6 +52,13 @@ public class FilteringCollection implements CollectionSource {
   }
 
   @Override
+  @CheckReturnValue
+  @Nonnull
+  public String getSearchLocator() {
+    return originalCollection.getSearchLocator();
+  }
+
+  @Override
   public String toString() {
     return originalCollection + ".filter(" + filter + ')';
   }

--- a/src/main/java/com/codeborne/selenide/impl/HeadOfCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/HeadOfCollection.java
@@ -54,6 +54,13 @@ public class HeadOfCollection implements CollectionSource {
   }
 
   @Override
+  @CheckReturnValue
+  @Nonnull
+  public String getSearchLocator() {
+    return originalCollection.getSearchLocator();
+  }
+
+  @Override
   public String toString() {
     return originalCollection + ":first(" + size + ')';
   }

--- a/src/main/java/com/codeborne/selenide/impl/JSElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/JSElementFinder.java
@@ -76,6 +76,13 @@ public class JSElementFinder extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
+  public String getSearchLocator() {
+    return locator();
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
   public String toString() {
     return "{" + description() + '}';
   }

--- a/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
@@ -56,6 +56,13 @@ public class LastCollectionElement extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
+  public String getSearchLocator() {
+    return collection.getSearchLocator();
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
   public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     if (collection.getElements().isEmpty()) {
       return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, cause);

--- a/src/main/java/com/codeborne/selenide/impl/LazyCollectionSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyCollectionSnapshot.java
@@ -40,6 +40,12 @@ public class LazyCollectionSnapshot implements CollectionSource {
     return delegate.getSearchCriteria();
   }
 
+  @Nonnull
+  @Override
+  public String getSearchLocator() {
+    return delegate.getSearchLocator();
+  }
+
   @Override
   public String toString() {
     return delegate.toString();

--- a/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/LazyWebElementSnapshot.java
@@ -55,6 +55,12 @@ public class LazyWebElementSnapshot extends WebElementSource {
     return delegate.getSearchCriteria();
   }
 
+  @Nonnull
+  @Override
+  public String getSearchLocator() {
+    return delegate.getSearchLocator();
+  }
+
   @Override
   public void setAlias(String alias) {
     delegate.setAlias(alias);

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -37,6 +37,7 @@ class SelenideElementProxy<T extends SelenideElement> implements InvocationHandl
     "toWebElement",
     "toString",
     "getSearchCriteria",
+    "getSearchLocator",
     "$",
     "$x",
     "find",

--- a/src/main/java/com/codeborne/selenide/impl/TailOfCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/TailOfCollection.java
@@ -52,6 +52,13 @@ public class TailOfCollection implements CollectionSource {
   }
 
   @Override
+  @CheckReturnValue
+  @Nonnull
+  public String getSearchLocator() {
+    return originalCollection.getSearchLocator();
+  }
+
+  @Override
   public String toString() {
     return originalCollection + ":last(" + size + ')';
   }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -47,6 +47,10 @@ public abstract class WebElementSource {
   @Nonnull
   public abstract String getSearchCriteria();
 
+  @CheckReturnValue
+  @Nonnull
+  public abstract String getSearchLocator();
+
   public void setAlias(String alias) {
     this.alias = new Alias(alias);
   }
@@ -61,6 +65,12 @@ public abstract class WebElementSource {
   @Nonnull
   public String description() {
     return alias.getOrElse(this::getSearchCriteria);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  public String locator() {
+    return alias.getOrElse(this::getSearchLocator);
   }
 
   @Override
@@ -97,6 +107,13 @@ public abstract class WebElementSource {
     if (arg instanceof By by) return by;
     if (arg instanceof String cssSelector) return By.cssSelector(cssSelector);
     throw new IllegalArgumentException("Unsupported selector type: " + arg);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  public static String getLocator(Object arg) {
+    final By.Remotable.Parameters remoteParameters = ((By.Remotable) arg).getRemoteParameters();
+    return String.valueOf(remoteParameters.value());
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/src/main/java/com/codeborne/selenide/impl/WebElementWrapper.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementWrapper.java
@@ -64,6 +64,13 @@ public class WebElementWrapper extends WebElementSource {
   @Override
   @CheckReturnValue
   @Nonnull
+  public String getSearchLocator() {
+    return locator();
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
   public String toString() {
     return getAlias().getOrElse(() -> describe.fully(driver(), delegate));
   }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementsCollectionWrapper.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementsCollectionWrapper.java
@@ -45,6 +45,13 @@ public class WebElementsCollectionWrapper implements CollectionSource {
   }
 
   @Override
+  @CheckReturnValue
+  @Nonnull
+  public String getSearchLocator() {
+    return locator();
+  }
+
+  @Override
   public String toString() {
     return getSearchCriteria();
   }
@@ -53,7 +60,7 @@ public class WebElementsCollectionWrapper implements CollectionSource {
   @CheckReturnValue
   @Nonnull
   public String description() {
-    return alias.getOrElse(() -> getSearchCriteria());
+    return alias.getOrElse(this::getSearchCriteria);
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/commands/GetSearchLocatorCommandTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/GetSearchLocatorCommandTest.java
@@ -1,0 +1,22 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class GetSearchLocatorCommandTest {
+  private final SelenideElement proxy = mock();
+  private final WebElementSource locator = mock();
+  private final GetSearchLocator getSearchLocatorCommand = new GetSearchLocator();
+
+  @Test
+  void returnsSearchCriteria() {
+    when(locator.getSearchLocator()).thenReturn("//div[id='sample']");
+    assertThat(getSearchLocatorCommand.execute(proxy, locator, null))
+      .isEqualTo("//div[id='sample']");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
@@ -49,6 +49,16 @@ final class CollectionElementTest {
   }
 
   @Test
+  void getSearchLocator() {
+    String collectionLocator = "Collection locator";
+    CollectionSource collection = mock();
+    when(collection.getSearchLocator()).thenReturn(collectionLocator);
+    CollectionElement collectionElement = new CollectionElement(collection, 1);
+    assertThat(collectionElement.getSearchLocator())
+      .isEqualTo(collectionLocator);
+  }
+
+  @Test
   void testToString() {
     CollectionSource collection = mock();
     String collectionDescription = "Collection description";


### PR DESCRIPTION
## Proposed changes
`$x("//div[id='sample']").getSearchLocator()` execution will return `//div[id='sample']` string.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
