### PR TITLE
upgrade Jetty from 9.x to 11.x

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,14 +3,13 @@ ext {
   seleniumVersion = project.properties['seleniumVersionNightlyBuild'] ?: seleniumVersionStable
   httpClientVersion = '5.3.1'
   junitVersion = '5.10.1'
-  jettyVersion = '9.4.53.v20231009'
+  jettyVersion = '11.0.19'
   nettyVersion = '4.1.106.Final'
   assertjVersion = '3.25.2'
   mockitoVersion = '5.10.0'
   slf4jVersion = '2.0.11'
   browserupProxyVersion = '2.2.15'
   littleProxyVersion = '2.1.1'
-  commonsFileuploadVersion = '1.5.0.redhat-00001'
   jabelVersion = '1.0.0'
   byteBuddyVersion = '1.14.9'
   archunitVersion = '1.2.1'
@@ -47,7 +46,6 @@ subprojects {
     testImplementation("io.netty:netty-all:$nettyVersion")
     testImplementation("io.netty:netty-codec:$nettyVersion")
     testImplementation("org.eclipse.jetty:jetty-servlet:${jettyVersion}")
-    testImplementation("commons-fileupload:commons-fileupload:${commonsFileuploadVersion}")
     testImplementation("org.apache.commons:commons-text:1.11.0")
     testImplementation("com.tngtech.archunit:archunit-junit5:${archunitVersion}")
     api("org.slf4j:slf4j-api:$slf4jVersion")

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -25,9 +25,6 @@ subprojects {
         snapshotsOnly()
       }
     }
-    maven {
-      url "https://maven.repository.redhat.com/ga/"
-    }
   }
 
   dependencies {

--- a/modules/grid/src/test/java/integration/FileUploadToGridTest.java
+++ b/modules/grid/src/test/java/integration/FileUploadToGridTest.java
@@ -39,11 +39,11 @@ final class FileUploadToGridTest extends AbstractGridTest {
 
     assertThat(server.getUploadedFiles()).hasSize(2);
 
-    assertThat(server.getUploadedFiles().get(0).getName()).endsWith("hello_grid_world.txt");
-    assertThat(server.getUploadedFiles().get(1).getName()).endsWith("goodbye_grid_world.txt");
+    assertThat(server.getUploadedFiles().get(0).name()).endsWith("hello_grid_world.txt");
+    assertThat(server.getUploadedFiles().get(1).name()).endsWith("goodbye_grid_world.txt");
 
-    assertThat(server.getUploadedFiles().get(0).getString()).contains("Hello, Selenium Grid!");
-    assertThat(server.getUploadedFiles().get(1).getString()).contains("Goodbye, Selenium Grid!");
+    assertThat(server.getUploadedFiles().get(0).content()).contains("Hello, Selenium Grid!");
+    assertThat(server.getUploadedFiles().get(1).content()).contains("Goodbye, Selenium Grid!");
   }
 
   @Test
@@ -55,11 +55,11 @@ final class FileUploadToGridTest extends AbstractGridTest {
     $("h3").shouldHave(text("Uploaded 3 files").because("Actual files: " + server.getUploadedFiles()));
 
     assertThat(server.getUploadedFiles())
-      .extracting(f -> f.getName())
+      .extracting(f -> f.name())
       .containsExactlyInAnyOrder("файл.txt", "hello_grid_world.txt", "goodbye_grid_world.txt");
 
     assertThat(server.getUploadedFiles())
-      .extracting(f -> f.getString("UTF-8").trim())
+      .extracting(f -> f.content().trim())
       .containsExactlyInAnyOrder("коромысло", "Hello, Selenium Grid!", "Goodbye, Selenium Grid!");
   }
 }

--- a/src/test/java/integration/FileUploadTest.java
+++ b/src/test/java/integration/FileUploadTest.java
@@ -37,9 +37,9 @@ final class FileUploadTest extends ITest {
     assertThat(f2.getName()).isEqualTo("firebug-1.11.4.xpi");
 
     assertThat(server.getUploadedFiles()).hasSize(2);
-    assertThat(server.getUploadedFiles().get(0).getName()).endsWith("hello_world.txt");
-    assertThat(server.getUploadedFiles().get(1).getName()).endsWith("firebug-1.11.4.xpi");
-    assertThat(server.getUploadedFiles().get(0).getString()).isEqualTo("Hello, WinRar!");
+    assertThat(server.getUploadedFiles().get(0).name()).endsWith("hello_world.txt");
+    assertThat(server.getUploadedFiles().get(1).name()).endsWith("firebug-1.11.4.xpi");
+    assertThat(server.getUploadedFiles().get(0).content()).isEqualTo("Hello, WinRar!");
   }
 
   @Test
@@ -49,7 +49,7 @@ final class FileUploadTest extends ITest {
     $("h3").shouldHave(text("Uploaded 1 files"));
     assertThat(file).exists();
     assertThat(file.getPath()).endsWith("hello_world.txt");
-    assertThat(server.getUploadedFiles().get(0).getName()).endsWith("hello_world.txt");
+    assertThat(server.getUploadedFiles().get(0).name()).endsWith("hello_world.txt");
   }
 
   @Test
@@ -69,15 +69,15 @@ final class FileUploadTest extends ITest {
     $("h3").shouldHave(text("Uploaded 9 files"));
     assertThat(server.getUploadedFiles()).hasSize(9);
 
-    assertThat(server.getUploadedFiles().get(0).getName()).endsWith("hello_world.txt");
-    assertThat(server.getUploadedFiles().get(1).getName()).endsWith("jquery.min.js");
-    assertThat(server.getUploadedFiles().get(2).getName()).endsWith("jquery-ui.min.css");
-    assertThat(server.getUploadedFiles().get(3).getName()).endsWith("long_ajax_request.html");
-    assertThat(server.getUploadedFiles().get(8).getName()).endsWith("selenide-logo-big.png");
+    assertThat(server.getUploadedFiles().get(0).name()).endsWith("hello_world.txt");
+    assertThat(server.getUploadedFiles().get(1).name()).endsWith("jquery.min.js");
+    assertThat(server.getUploadedFiles().get(2).name()).endsWith("jquery-ui.min.css");
+    assertThat(server.getUploadedFiles().get(3).name()).endsWith("long_ajax_request.html");
+    assertThat(server.getUploadedFiles().get(8).name()).endsWith("selenide-logo-big.png");
 
-    assertThat(server.getUploadedFiles().get(0).getString()).contains("Hello, WinRar!");
-    assertThat(server.getUploadedFiles().get(1).getString()).contains("jQuery JavaScript Library");
-    assertThat(server.getUploadedFiles().get(2).getString()).contains("jQuery UI");
+    assertThat(server.getUploadedFiles().get(0).content()).contains("Hello, WinRar!");
+    assertThat(server.getUploadedFiles().get(1).content()).contains("jQuery JavaScript Library");
+    assertThat(server.getUploadedFiles().get(2).content()).contains("jQuery UI");
   }
 
   @Test
@@ -91,8 +91,8 @@ final class FileUploadTest extends ITest {
     $("h3").shouldHave(text("Uploaded 2 files"));
     assertThat(server.getUploadedFiles()).hasSize(2);
 
-    assertThat(server.getUploadedFiles().get(0).getName()).endsWith("Logger.class");
-    assertThat(server.getUploadedFiles().get(1).getName()).endsWith("LoggerFactory.class");
+    assertThat(server.getUploadedFiles().get(0).name()).endsWith("Logger.class");
+    assertThat(server.getUploadedFiles().get(1).name()).endsWith("LoggerFactory.class");
   }
 
   @Test
@@ -109,11 +109,11 @@ final class FileUploadTest extends ITest {
 
     assertThat(server.getUploadedFiles()).hasSize(2);
 
-    assertThat(server.getUploadedFiles().get(0).getName()).endsWith("hello_world.txt");
-    assertThat(server.getUploadedFiles().get(1).getName()).endsWith("jquery.min.js");
+    assertThat(server.getUploadedFiles().get(0).name()).endsWith("hello_world.txt");
+    assertThat(server.getUploadedFiles().get(1).name()).endsWith("jquery.min.js");
 
-    assertThat(server.getUploadedFiles().get(0).getString()).contains("Hello, WinRar!");
-    assertThat(server.getUploadedFiles().get(1).getString()).contains("jQuery JavaScript Library v1.8.3");
+    assertThat(server.getUploadedFiles().get(0).content()).contains("Hello, WinRar!");
+    assertThat(server.getUploadedFiles().get(1).content()).contains("jQuery JavaScript Library v1.8.3");
   }
 
   @Test
@@ -128,11 +128,11 @@ final class FileUploadTest extends ITest {
     $("h3").shouldHave(text("Uploaded 3 files").because("Actual files: " + server.getUploadedFiles()));
 
     assertThat(server.getUploadedFiles())
-      .extracting(f -> f.getName())
+      .extracting(f -> f.name())
       .containsExactlyInAnyOrder("файл-с-русским-названием.txt", "hello_world.txt", "child_frame.txt");
 
     assertThat(server.getUploadedFiles())
-      .extracting(f -> f.getString("UTF-8"))
+      .extracting(f -> f.content())
       .containsExactlyInAnyOrder("Превед медвед!", "Hello, WinRar!", "This is last frame!");
   }
 

--- a/src/test/java/integration/server/BaseHandler.java
+++ b/src/test/java/integration/server/BaseHandler.java
@@ -5,9 +5,9 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -22,8 +22,8 @@ import static integration.server.Delayer.pause;
 import static java.lang.Thread.currentThread;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
 
 public abstract class BaseHandler extends HttpServlet {
   static final String CONTENT_TYPE_PLAIN_TEXT = "text/plain";

--- a/src/test/java/integration/server/BasicAuthHandler.java
+++ b/src/test/java/integration/server/BasicAuthHandler.java
@@ -1,13 +1,13 @@
 package integration.server;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import static org.apache.hc.core5.http.HttpStatus.SC_UNAUTHORIZED;
 

--- a/src/test/java/integration/server/BearerTokenAuthenticator.java
+++ b/src/test/java/integration/server/BearerTokenAuthenticator.java
@@ -4,10 +4,10 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.security.ServerAuthException;

--- a/src/test/java/integration/server/BearerTokenHandler.java
+++ b/src/test/java/integration/server/BearerTokenHandler.java
@@ -1,15 +1,15 @@
 package integration.server;
 
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.hc.core5.http.HttpStatus.SC_UNAUTHORIZED;
 
 class BearerTokenHandler extends BaseHandler {

--- a/src/test/java/integration/server/CorsProtectedHandler.java
+++ b/src/test/java/integration/server/CorsProtectedHandler.java
@@ -4,11 +4,11 @@ import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 class CorsProtectedHandler extends BaseHandler {
   private static final Logger log = LoggerFactory.getLogger(CorsProtectedHandler.class);

--- a/src/test/java/integration/server/FileDownloadHandler.java
+++ b/src/test/java/integration/server/FileDownloadHandler.java
@@ -2,9 +2,9 @@ package integration.server;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -16,9 +16,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.lang.Long.parseLong;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 class FileDownloadHandler extends BaseHandler {
   private final Set<String> sessions;

--- a/src/test/java/integration/server/FileRenderHandler.java
+++ b/src/test/java/integration/server/FileRenderHandler.java
@@ -5,15 +5,15 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 @ParametersAreNonnullByDefault
 class FileRenderHandler extends BaseHandler {

--- a/src/test/java/integration/server/HeadersPrinterHandler.java
+++ b/src/test/java/integration/server/HeadersPrinterHandler.java
@@ -1,11 +1,11 @@
 package integration.server;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 
 import static java.util.Collections.list;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 class HeadersPrinterHandler extends BaseHandler {
   @Override

--- a/src/test/java/integration/server/SSLConnector.java
+++ b/src/test/java/integration/server/SSLConnector.java
@@ -20,12 +20,12 @@ public class SSLConnector extends ServerConnector {
 
   private static HttpConfiguration https() {
     HttpConfiguration https = new HttpConfiguration();
-    https.addCustomizer(new SecureRequestCustomizer());
+    https.addCustomizer(new SecureRequestCustomizer(false));
     return https;
   }
 
-  private static SslContextFactory createSslContextFactory() {
-    SslContextFactory sslContextFactory = new SslContextFactory.Server();
+  private static SslContextFactory.Server createSslContextFactory() {
+    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
 
     // created with "keytool -genkey -alias test.selenide.org -keyalg RSA -keystore src/test/resources/test-selenide.jks"
     sslContextFactory.setKeyStorePath(SSLConnector.class.getResource("/test-selenide.jks").toExternalForm());

--- a/src/test/java/integration/server/UploadedFile.java
+++ b/src/test/java/integration/server/UploadedFile.java
@@ -1,0 +1,23 @@
+package integration.server;
+
+import java.io.Serializable;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class UploadedFile implements Serializable {
+  private final String name;
+  private final byte[] content;
+
+  UploadedFile(String name, byte[] content) {
+    this.name = name;
+    this.content = content;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String content() {
+    return new String(content, UTF_8);
+  }
+}


### PR DESCRIPTION
this way, we can remove the ancient "commons-fileupload" dependency.

