### PR TITLE
#2612 don't set page load timeout in mobile tests

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumNavigator.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumNavigator.java
@@ -15,7 +15,7 @@ public class AppiumNavigator {
 
   public void launchApp(Supplier<Runnable> driverSupplier) {
     Configuration.browserSize = null;
-    Configuration.pageLoadTimeout = 0;
+    Configuration.pageLoadTimeout = -1;
     SelenideLogger.run("launch app", "", driverSupplier.get());
   }
 


### PR DESCRIPTION
it was a bug that we set "pageLoadTimeout" to 0. It caused the endless messages "NotImplementedError: Not implemented yet for pageLoad" in logs, and maybe even app crash (not proven).

when "pageLoadTimeout" is -1, then Selenide doesn't even try to set it.

