### PR TITLE
fix "toString()" method for page object fields

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideWait.java
+++ b/src/main/java/com/codeborne/selenide/SelenideWait.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
 @ParametersAreNonnullByDefault
-public class SelenideWait extends FluentWait<WebDriver> {
+public final class SelenideWait extends FluentWait<WebDriver> {
   public SelenideWait(WebDriver input, long timeout, long pollingInterval) {
     super(input);
     withTimeout(Duration.of(timeout, ChronoUnit.MILLIS));

--- a/src/main/java/com/codeborne/selenide/impl/ElementsContainerCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementsContainerCollection.java
@@ -61,4 +61,9 @@ public class ElementsContainerCollection extends AbstractList<Container> {
       throw new ElementNotFound(driver, NONE, collection.getSearchCriteria(), exist, e);
     }
   }
+
+  @Override
+  public String toString() {
+    return collection.description();
+  }
 }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementDescriber.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementDescriber.java
@@ -65,6 +65,8 @@ public class SelenideElementDescriber implements ElementDescriber {
   public String selector(By selector) {
     return selector.toString()
       .replace("By.selector: ", "")
-      .replace("By.cssSelector: ", "");
+      .replace("By.cssSelector: ", "")
+      .replace("By.tagName: ", "")
+      .replace("By.id: ", "#");
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/BySelectorCollectionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/BySelectorCollectionTest.java
@@ -20,6 +20,6 @@ final class BySelectorCollectionTest {
   @Test
   void constructorWithParent() {
     BySelectorCollection bySelectorCollection = new BySelectorCollection(driver, webElement, By.name("query"));
-    assertThat(bySelectorCollection.description()).isEqualTo("By.tagName: table[3]/By.name: query");
+    assertThat(bySelectorCollection.description()).isEqualTo("table[3]/By.name: query");
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/ElementFinderTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ElementFinderTest.java
@@ -14,13 +14,13 @@ final class ElementFinderTest {
   void toStringForFinderByCssSelectors() {
     ElementFinder parent = new ElementFinder(driver, null, By.tagName("table"), 0);
     assertThat(new ElementFinder(driver, null, By.id("app"), 0))
-      .hasToString("{By.id: app}");
+      .hasToString("{#app}");
     assertThat(new ElementFinder(driver, null, By.id("app"), 3))
-      .hasToString("{By.id: app[3]}");
+      .hasToString("{#app[3]}");
     assertThat(new ElementFinder(driver, parent, By.id("app"), 0))
-      .hasToString("{By.tagName: table/By.id: app}");
+      .hasToString("{table/#app}");
     assertThat(new ElementFinder(driver, parent, By.id("app"), 3))
-      .hasToString("{By.tagName: table/By.id: app[3]}");
+      .hasToString("{table/#app[3]}");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementDescriberTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementDescriberTest.java
@@ -27,18 +27,28 @@ final class SelenideElementDescriberTest {
 
   @Test
   void selectorIsReportedAsIs() {
-    assertThat(describe.selector(By.id("firstName"))).isEqualTo("By.id: firstName");
     assertThat(describe.selector(By.className("bootstrap-active"))).isEqualTo("By.className: bootstrap-active");
     assertThat(describe.selector(By.name("firstName"))).isEqualTo("By.name: firstName");
     assertThat(describe.selector(By.linkText("tere"))).isEqualTo("By.linkText: tere");
     assertThat(describe.selector(By.partialLinkText("tere"))).isEqualTo("By.partialLinkText: tere");
-    assertThat(describe.selector(By.tagName("tere"))).isEqualTo("By.tagName: tere");
     assertThat(describe.selector(By.xpath("tere"))).isEqualTo("By.xpath: tere");
   }
 
   @Test
   void cssSelectorIsShortened() {
     assertThat(describe.selector(By.cssSelector("#firstName"))).isEqualTo("#firstName");
+  }
+
+  @Test
+  void byTagNameSelectorIsShortened() {
+    assertThat(describe.selector(By.tagName("div"))).isEqualTo("div");
+    assertThat(describe.selector(By.tagName("h1"))).isEqualTo("h1");
+    assertThat(describe.selector(By.tagName("tere"))).isEqualTo("tere");
+  }
+
+  @Test
+  void byIdSelectorIsShortened() {
+    assertThat(describe.selector(By.id("firstName"))).isEqualTo("#firstName");
   }
 
   @Test

--- a/statics/src/test/java/integration/RadioTest.java
+++ b/statics/src/test/java/integration/RadioTest.java
@@ -55,7 +55,7 @@ final class RadioTest extends IntegrationTest {
   void selenideElement_selectRadio_elementNotFound() {
     assertThatThrownBy(() -> $(By.id("unknownId")).selectRadio("margarita"))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageStartingWith(String.format("Element not found {By.id: unknownId}%nExpected: value=\"margarita\""));
+      .hasMessageStartingWith(String.format("Element not found {#unknownId}%nExpected: value=\"margarita\""));
   }
 
   @Test

--- a/statics/src/test/java/integration/errormessages/MissingElementTest.java
+++ b/statics/src/test/java/integration/errormessages/MissingElementTest.java
@@ -109,7 +109,7 @@ final class MissingElementTest extends IntegrationTest {
       $(element(By.tagName("h2"))).shouldHave(text("expected text"))
     )
       .isInstanceOf(ElementShould.class)
-      .hasMessageMatching(String.format("Element should have text \"expected text\" \\{By.tagName: h2}%n" +
+      .hasMessageMatching(String.format("Element should have text \"expected text\" \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
         "Actual value: text=\"Dropdown list\"%n" +
         "Screenshot: %s%s%n" +
@@ -140,7 +140,7 @@ final class MissingElementTest extends IntegrationTest {
       $(pageObject.header1).shouldHave(text("expected text"))
     )
       .isInstanceOf(ElementShould.class)
-      .hasMessageMatching(String.format("Element should have text \"expected text\" \\{By.tagName: h2}%n" +
+      .hasMessageMatching(String.format("Element should have text \"expected text\" \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
         "Actual value: text=\"Dropdown list\"%n" +
         "Screenshot: %s%s%n" +
@@ -155,7 +155,7 @@ final class MissingElementTest extends IntegrationTest {
       $(pageObject.header2).shouldHave(text("expected text"))
     )
       .isInstanceOf(ElementShould.class)
-      .hasMessageMatching(String.format("Element should have text \"expected text\" \\{By.tagName: h2}%n" +
+      .hasMessageMatching(String.format("Element should have text \"expected text\" \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
         "Actual value: text=\"Dropdown list\"%n" +
         "Screenshot: %s%s%n" +
@@ -168,7 +168,7 @@ final class MissingElementTest extends IntegrationTest {
     assertThatThrownBy(() ->
       $(pageObject.categoryDropdown).selectOption("SomeOption")
     ).isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("Element not found {By.id: invalid_id}")
+      .hasMessageContaining("Element not found {#invalid_id}")
       .hasMessageContaining("Expected: exist");
   }
 
@@ -178,7 +178,7 @@ final class MissingElementTest extends IntegrationTest {
     assertThatThrownBy(() ->
       $(pageObject.categoryDropdown).click()
     ).isInstanceOf(ElementNotFound.class)
-      .hasMessageMatching(String.format("Element not found \\{By.id: invalid_id}%n" +
+      .hasMessageMatching(String.format("Element not found \\{#invalid_id}%n" +
         "Expected: clickable: interactable and enabled%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +

--- a/statics/src/test/java/integration/pageobjects/FieldOfGenericTypeTest.java
+++ b/statics/src/test/java/integration/pageobjects/FieldOfGenericTypeTest.java
@@ -54,6 +54,7 @@ public class FieldOfGenericTypeTest extends IntegrationTest {
     YetAnotherPage page = page(YetAnotherPage.class);
     assertThat(page.body).isNotNull();
     assertThat(page.body.selects).hasSize(6);
+    assertThat(page.body.selects).hasToString("body/select");
 
     assertThatThrownBy(() -> page.body.selects.get(0))
       .isInstanceOf(RuntimeException.class)

--- a/statics/src/test/java/integration/pageobjects/LazyPageObjectTest.java
+++ b/statics/src/test/java/integration/pageobjects/LazyPageObjectTest.java
@@ -59,7 +59,7 @@ public class LazyPageObjectTest extends IntegrationTest {
 
     assertThatThrownBy(thisLineShouldNotFail::size)
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageStartingWith("Element not found {By.className: wrong-content/By.tagName: form}")
+      .hasMessageStartingWith("Element not found {By.className: wrong-content/form}")
       .hasMessageContaining("Timeout: 0 ms.")
       .cause()
       .isInstanceOf(NoSuchElementException.class);

--- a/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
+++ b/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
@@ -36,7 +36,7 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
     )
       .isInstanceOf(ElementShould.class)
       .hasMessageStartingWith("""
-          Element "Tiny header" should have text "expected text" {By.tagName: h6}
+          Element "Tiny header" should have text "expected text" {h6}
           """.trim()
       );
   }
@@ -48,7 +48,7 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
     )
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageStartingWith("""
-          Element "Large header" should not have text "Page with selects" {By.tagName: h1}
+          Element "Large header" should not have text "Page with selects" {h1}
           """.trim()
       );
   }
@@ -60,7 +60,7 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
     )
       .isInstanceOf(ListSizeMismatch.class)
       .hasMessageStartingWith("""
-          List size mismatch: expected: = 666, actual: 4, collection: Middle headers {By.tagName: h2}
+          List size mismatch: expected: = 666, actual: 4, collection: Middle headers {h2}
           """.trim()
       );
   }


### PR DESCRIPTION
Before this change, method `page(YetAnotherPage.class).body.selects.toString()` tries to initialise the page and fetch all its web elements. Now it just prints our the locator (without fetching web elements).

Also, this commit shortens toString for selectors `By.tagName` and `By.id`.
Instead of `By.tagName: table[3]/By.id: login`, users will now see a shorter form `table[3]/#login`.
