### PR TITLE
#2658 disable Chrome warning about stolen passwords

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -52,6 +52,7 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
     Map<String, Object> preferences = new HashMap<>();
     preferences.put("safebrowsing.enabled", true);
     preferences.put("credentials_enable_service", false);
+    preferences.put("profile.password_manager_enabled", false);
     preferences.put("plugins.always_open_pdf_externally", true);
     preferences.put("profile.default_content_setting_values.automatic_downloads", 1);
 

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -47,8 +47,9 @@ final class ChromeDriverFactoryTest {
     Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
 
-    assertThat(prefsMap).hasSizeGreaterThanOrEqualTo(4);
+    assertThat(prefsMap).hasSizeGreaterThanOrEqualTo(5);
     assertThat(prefsMap).containsEntry("credentials_enable_service", false);
+    assertThat(prefsMap).containsEntry("profile.password_manager_enabled", false);
     assertThat(prefsMap).containsEntry("plugins.always_open_pdf_externally", true);
     assertThat(prefsMap).containsEntry("profile.default_content_setting_values.automatic_downloads", 1);
     assertThat(prefsMap).containsEntry("download.default_directory",
@@ -91,6 +92,7 @@ final class ChromeDriverFactoryTest {
 
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(ChromeOptions.CAPABILITY, chromeOptions);
     assertThat(prefsMap).containsEntry("credentials_enable_service", false);
+    assertThat(prefsMap).containsEntry("profile.password_manager_enabled", false);
     assertThat(prefsMap).doesNotContainKey("download.default_directory");
   }
 

--- a/src/test/java/com/codeborne/selenide/webdriver/EdgeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/EdgeDriverFactoryTest.java
@@ -35,8 +35,9 @@ class EdgeDriverFactoryTest {
     assertThat(options.get("extensions")).isEqualTo(emptyList());
 
     Map<String, Object> prefs = prefs(options);
-    assertThat(prefs).hasSize(5);
+    assertThat(prefs).hasSize(6);
     assertThat(prefs.get("credentials_enable_service")).isEqualTo(false);
+    assertThat(prefs.get("profile.password_manager_enabled")).isEqualTo(false);
     assertThat(prefs.get("plugins.always_open_pdf_externally")).isEqualTo(true);
     assertThat(prefs.get("profile.default_content_setting_values.automatic_downloads")).isEqualTo(1);
     assertThat(prefs.get("safebrowsing.enabled")).isEqualTo(true);
@@ -57,8 +58,9 @@ class EdgeDriverFactoryTest {
     );
 
     Map<String, Object> prefs = prefs(options);
-    assertThat(prefs).hasSize(5);
+    assertThat(prefs).hasSize(6);
     assertThat(prefs.get("credentials_enable_service")).isEqualTo(false);
+    assertThat(prefs.get("profile.password_manager_enabled")).isEqualTo(false);
     assertThat(prefs.get("plugins.always_open_pdf_externally")).isEqualTo(true);
     assertThat(prefs.get("profile.default_content_setting_values.automatic_downloads")).isEqualTo(1);
     assertThat(prefs.get("safebrowsing.enabled")).isEqualTo(true);

--- a/statics/src/test/java/integration/ChromeProfileByFactoryTest.java
+++ b/statics/src/test/java/integration/ChromeProfileByFactoryTest.java
@@ -57,6 +57,7 @@ final class ChromeProfileByFactoryTest extends IntegrationTest {
     assertThat(log).contains("\"excludeSwitches\": [ \"enable-automation\" ]");
     assertThat(log).contains("\"extensions\": [  ]");
     assertThat(log).contains("\"credentials_enable_service\": false");
+    assertThat(log).contains("\"profile.password_manager_enabled\": false");
     assertThat(log).contains("\"download.default_directory\": \"" + downloadsFolder.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\"));
 
     String args = "\"--proxy-bypass-list=\\u003C-loopback>\", \"--no-sandbox\", \"--disable-3d-apis\"";


### PR DESCRIPTION
e.g. "Your password you just used was found in a data breach". It's not needed in tests.

See the problem description: https://github.com/selenide/selenide/discussions/2658
