### PR TITLE
Fix Appium browser when browser is Remote

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/WebdriverUnwrapper.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebdriverUnwrapper.java
@@ -1,6 +1,10 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
+import java.util.Optional;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -8,11 +12,6 @@ import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.WrapsElement;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
-
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.Optional;
 
 public class WebdriverUnwrapper {
   public static <T> boolean instanceOf(Driver driver, Class<T> klass) {
@@ -31,9 +30,7 @@ public class WebdriverUnwrapper {
     WebDriver webdriver = unwrap(driverOrElement);
 
     //noinspection unchecked
-    return webdriver != null && klass.isAssignableFrom(webdriver.getClass()) ?
-      Optional.of((T) webdriver) :
-      Optional.empty();
+    return webdriver != null && klass.isAssignableFrom(webdriver.getClass()) ? Optional.of((T) webdriver) : Optional.empty();
   }
 
   public static <T> T cast(WebElement probablyWrappedWebElement, Class<T> klass) {
@@ -55,8 +52,12 @@ public class WebdriverUnwrapper {
     if (driverOrElement instanceof WrapsDriver wrapper) {
       return unwrap(wrapper.getWrappedDriver());
     }
-    if (driverOrElement instanceof RemoteWebDriver remoteWebDriver) {
-      return new Augmenter().augment(remoteWebDriver);
+    try {
+      if (driverOrElement instanceof RemoteWebDriver remoteWebDriver) {
+        return new Augmenter().augment(remoteWebDriver);
+      }
+    } catch (IllegalStateException e) {
+      return (WebDriver) driverOrElement;
     }
     return null;
   }
@@ -64,7 +65,6 @@ public class WebdriverUnwrapper {
   @Nonnull
   @CheckReturnValue
   public static RemoteWebDriver unwrapRemoteWebDriver(WebDriver driver) {
-    return driver instanceof WrapsDriver wrapper ?
-      (RemoteWebDriver) wrapper.getWrappedDriver() : (RemoteWebDriver) driver;
+    return driver instanceof WrapsDriver wrapper ? (RemoteWebDriver) wrapper.getWrappedDriver() : (RemoteWebDriver) driver;
   }
 }


### PR DESCRIPTION
## Proposed changes
This pr fixes an issue when a mobile driver uses a remote device (io.appium.java_client.android.AndroidDriver#AndroidDriver(java.net.URL, org.openqa.selenium.Capabilities)), like BrowserStack. After the commit 98c4ee8f4eff7dd24717c34fc4b39dcbade2f288 - in a case when we use $.setValue() AppiumSetValue command we got 'Unable to create new proxy exception' https://pastebin.com/7amtjpk5 Because AndroidDriver doesn't contain an appropriate constructor. I could not be reproduced on local emulators
## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
