### PR TITLE
add setDriver method to WebDriverRunner

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -114,19 +114,22 @@ public class Selenide {
   }
 
   /**
-   * Replace browser with a new one, using given Config
-   * Please note that config would affect only browser startup props.
+   * If browser window was already opened before, it will be reused. Config will be ignored.
+   * Otherwise, a new browser window will be opened.
+   * Please note:
+   * config will be ignored if browser window was already opened before.
+   * that config would affect only browser startup props.
    * Such as: browser, browserCapabilities, remote, browserSize, browserVersion, startMaximized, etc.
    * Global configs will be the same (timeout, pollingInterval, baseUrl, etc.).
    * Also default WebDriverRunner setup would be applied to your browser: proxy, listeners
    */
   public static void open(String url, Config config) {
-    WebDriverRunner.replaceBrowser(config);
+    WebDriverRunner.getOrCreateNewBrowser(config);
     open(url);
   }
 
   public static void open(Config config) {
-    WebDriverRunner.replaceBrowser(config);
+    WebDriverRunner.getOrCreateNewBrowser(config);
   }
 
   /**

--- a/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -272,7 +272,7 @@ public class WebDriverRunner {
   /**
    * Replace Webdriver in the current thread with the new built with the given config
    */
-  public static void setDriver(Config config) {
+  public static void replaceBrowser(Config config) {
     webdriverContainer.replaceBrowser(config);
   }
 }

--- a/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverRunner.java
@@ -267,4 +267,12 @@ public class WebDriverRunner {
   public static String currentFrameUrl() {
     return webdriverContainer.getCurrentFrameUrl();
   }
+
+
+  /**
+   * Replace Webdriver in the current thread with the new built with the given config
+   */
+  public static void setDriver(Config config) {
+    webdriverContainer.replaceBrowser(config);
+  }
 }

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide.impl;
 
+import com.codeborne.selenide.Config;
 import com.codeborne.selenide.DownloadsFolder;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
 import org.openqa.selenium.Proxy;
@@ -44,6 +45,8 @@ public interface WebDriverContainer {
 
   void using(WebDriver driver, @Nullable SelenideProxyServer proxy, @Nullable DownloadsFolder downloadsFolder, Runnable lambda);
   void inNewBrowser(Runnable lambda);
+
+  WebDriver replaceBrowser(Config config);
 
   void clearBrowserCache();
 

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverContainer.java
@@ -46,7 +46,7 @@ public interface WebDriverContainer {
   void using(WebDriver driver, @Nullable SelenideProxyServer proxy, @Nullable DownloadsFolder downloadsFolder, Runnable lambda);
   void inNewBrowser(Runnable lambda);
 
-  WebDriver replaceBrowser(Config config);
+  WebDriverInstance newBrowser(Config config);
 
   void clearBrowserCache();
 

--- a/statics/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/impl/WebDriverThreadLocalContainer.java
@@ -172,6 +172,12 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
   @Nonnull
   private WebDriverInstance createAndRegisterDriver() {
     WebDriverInstance driver = createDriver();
+    return registerDriver(driver);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  private WebDriverInstance registerDriver(WebDriverInstance driver) {
     long threadId = setWebDriver(driver);
 
     if (config.holdBrowserOpen()) {
@@ -186,6 +192,12 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
   @CheckReturnValue
   @Nonnull
   private WebDriverInstance createDriver() {
+    return createDriver(config);
+  }
+
+  @CheckReturnValue
+  @Nonnull
+  private WebDriverInstance createDriver(Config config) {
     return createDriverCommand.createDriver(config, factory, userProvidedProxy, listeners);
   }
 
@@ -272,6 +284,14 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
   public String getCurrentFrameUrl() {
     //noinspection ConstantConditions
     return executeJavaScript("return window.location.href").toString();
+  }
+
+  @Override
+  public WebDriver replaceBrowser(Config config) {
+    closeWebDriver();
+    var driver = createDriver(config);
+    var webDriverInstance = registerDriver(driver);
+    return webDriverInstance.webDriver();
   }
 
   boolean isDeadThreadsWatchdogStarted() {

--- a/statics/src/test/java/integration/ReopenBrowserTest.java
+++ b/statics/src/test/java/integration/ReopenBrowserTest.java
@@ -12,11 +12,9 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.impl.WebdriverUnwrapper;
-import java.lang.reflect.Method;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.events.WebDriverListener;
 
 final class ReopenBrowserTest extends IntegrationTest {
   @BeforeEach

--- a/statics/src/test/java/integration/ReopenBrowserTest.java
+++ b/statics/src/test/java/integration/ReopenBrowserTest.java
@@ -1,9 +1,13 @@
 package integration;
 
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.WebDriverRunner;
+import com.codeborne.selenide.impl.WebdriverUnwrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 
 import static com.codeborne.selenide.Condition.exactText;
@@ -52,5 +56,21 @@ final class ReopenBrowserTest extends IntegrationTest {
 
     open("about:blank");
     $("body").shouldHave(exactText(""));
+  }
+
+  @Test
+  void open_new_browser_with_custom_config() {
+    var url = "about:blank";
+    open(url);
+    var config = new SelenideConfig();
+    config.browser("firefox");
+    config.pageLoadStrategy("none");
+    WebDriverRunner.setDriver(config);
+    var webDriver = WebDriverRunner.getWebDriver();
+    var capabilities = WebdriverUnwrapper.unwrapRemoteWebDriver(webDriver).getCapabilities();
+    assertThat(capabilities.getBrowserName()).isEqualTo(config.browser());
+    assertThat(capabilities.getCapability("pageLoadStrategy")).isEqualTo(config.pageLoadStrategy());
+    open(url);
+    assertThat(webDriver.getCurrentUrl()).isEqualTo(url);
   }
 }

--- a/statics/src/test/java/integration/ReopenBrowserTest.java
+++ b/statics/src/test/java/integration/ReopenBrowserTest.java
@@ -1,21 +1,19 @@
 package integration;
 
-import com.codeborne.selenide.Configuration;
-import com.codeborne.selenide.Selenide;
-import com.codeborne.selenide.SelenideConfig;
-import com.codeborne.selenide.WebDriverRunner;
-import com.codeborne.selenide.impl.WebdriverUnwrapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.WebDriver;
-
 import static com.codeborne.selenide.Condition.exactText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.open;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.WebDriverRunner;
+import com.codeborne.selenide.impl.WebdriverUnwrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
 
 final class ReopenBrowserTest extends IntegrationTest {
   @BeforeEach
@@ -43,8 +41,7 @@ final class ReopenBrowserTest extends IntegrationTest {
     WebDriver diedWebdriver = WebDriverRunner.getWebDriver();
     diedWebdriver.quit();
 
-    assertThatThrownBy(() -> open("about:blank"))
-      .isInstanceOf(IllegalStateException.class)
+    assertThatThrownBy(() -> open("about:blank")).isInstanceOf(IllegalStateException.class)
       .hasMessageContaining("has been closed meanwhile")
       .hasMessageContaining("cannot create a new webdriver because reopenBrowserOnFail=false");
     assertThat(WebDriverRunner.hasWebDriverStarted()).isFalse();

--- a/statics/src/test/java/integration/ReopenBrowserTest.java
+++ b/statics/src/test/java/integration/ReopenBrowserTest.java
@@ -12,9 +12,11 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.impl.WebdriverUnwrapper;
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.events.WebDriverListener;
 
 final class ReopenBrowserTest extends IntegrationTest {
   @BeforeEach
@@ -59,11 +61,10 @@ final class ReopenBrowserTest extends IntegrationTest {
   @Test
   void open_new_browser_with_custom_config() {
     var url = "about:blank";
-    open(url);
     var config = new SelenideConfig();
     config.browser("firefox");
     config.pageLoadStrategy("none");
-    WebDriverRunner.replaceBrowser(config);
+    WebDriverRunner.getOrCreateNewBrowser(config);
     var webDriver = WebDriverRunner.getWebDriver();
     var capabilities = WebdriverUnwrapper.unwrapRemoteWebDriver(webDriver).getCapabilities();
     assertThat(capabilities.getBrowserName()).isEqualTo(config.browser());
@@ -86,12 +87,13 @@ final class ReopenBrowserTest extends IntegrationTest {
   }
 
   @Test
-  void open_new_browser_with_custom_config_and_open_relative_page() {
+  void open_new_browser_when_exists_old() {
+    open();
     var config = new SelenideConfig();
     config.pageLoadTimeout(10000);
     Selenide.open("/start_page.html", config);
     assertThat(Selenide.$("h1").text()).isEqualTo("Selenide");
     var secondsTimeout = WebDriverRunner.getWebDriver().manage().timeouts().getPageLoadTimeout().getSeconds();
-    assertThat(secondsTimeout * 1000).isEqualTo(config.pageLoadTimeout());
+    assertThat(secondsTimeout * 1000).isEqualTo(Configuration.pageLoadTimeout);
   }
 }

--- a/statics/src/test/java/integration/ReopenBrowserTest.java
+++ b/statics/src/test/java/integration/ReopenBrowserTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.impl.WebdriverUnwrapper;
@@ -62,12 +63,35 @@ final class ReopenBrowserTest extends IntegrationTest {
     var config = new SelenideConfig();
     config.browser("firefox");
     config.pageLoadStrategy("none");
-    WebDriverRunner.setDriver(config);
+    WebDriverRunner.replaceBrowser(config);
     var webDriver = WebDriverRunner.getWebDriver();
     var capabilities = WebdriverUnwrapper.unwrapRemoteWebDriver(webDriver).getCapabilities();
     assertThat(capabilities.getBrowserName()).isEqualTo(config.browser());
     assertThat(capabilities.getCapability("pageLoadStrategy")).isEqualTo(config.pageLoadStrategy());
     open(url);
     assertThat(webDriver.getCurrentUrl()).isEqualTo(url);
+  }
+
+  @Test
+  void open_new_browser_with_custom_window_size() {
+    var height = 800;
+    var width = 544;
+    var config = new SelenideConfig();
+    config.browserSize("%sx%s".formatted(width, height));
+    Selenide.open(config);
+    var driver = WebDriverRunner.getWebDriver();
+    var size = driver.manage().window().getSize();
+    assertThat(size.height).isEqualTo(height);
+    assertThat(size.width).isEqualTo(width);
+  }
+
+  @Test
+  void open_new_browser_with_custom_config_and_open_relative_page() {
+    var config = new SelenideConfig();
+    config.pageLoadTimeout(10000);
+    Selenide.open("/start_page.html", config);
+    assertThat(Selenide.$("h1").text()).isEqualTo("Selenide");
+    var secondsTimeout = WebDriverRunner.getWebDriver().manage().timeouts().getPageLoadTimeout().getSeconds();
+    assertThat(secondsTimeout * 1000).isEqualTo(config.pageLoadTimeout());
   }
 }


### PR DESCRIPTION
## Proposed changes
Selenide already has methods to create a new browser on demand, but it doesn't allow us to change their configuration or we could create our own WebDriver, but in this case, additional selenide functionality wouldn't be applied. So, I introduced a method that creates a new browser but is fully controlled by selenide (listeners, deadwatch etc).

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
