### PR TITLE
fix before/after events order

### DIFF
--- a/src/test/java/integration/LogEventListenerTest.java
+++ b/src/test/java/integration/LogEventListenerTest.java
@@ -38,9 +38,7 @@ final class LogEventListenerTest extends BaseIntegrationTest {
     removeMeButton.shouldNotBe(visible);
 
     SoftAssertions sa = new SoftAssertions();
-    sa.assertThat(beforeEvents).hasSize(1);
-    sa.assertThat(beforeEvents.get(0)).isEqualTo("before: $(#remove) click()");
-
+    sa.assertThat(beforeEvents).hasSize(5);
     sa.assertThat(afterEvents).hasSize(5);
 
     sa.assertThat(afterEvents.get(0)).startsWith("after: $(webdriver)");
@@ -48,6 +46,12 @@ final class LogEventListenerTest extends BaseIntegrationTest {
     sa.assertThat(afterEvents.get(2)).isEqualTo("after: $(#remove) should be(visible)");
     sa.assertThat(afterEvents.get(3)).isEqualTo("after: $(#remove) click()");
     sa.assertThat(afterEvents.get(4)).isEqualTo("after: $(#remove) should not be(visible)");
+
+    sa.assertThat(beforeEvents.get(0)).startsWith("before: $(webdriver)");
+    sa.assertThat(beforeEvents.get(1)).startsWith("before: $(open)");
+    sa.assertThat(beforeEvents.get(2)).isEqualTo("before: $(#remove) should be(visible)");
+    sa.assertThat(beforeEvents.get(3)).isEqualTo("before: $(#remove) click()");
+    sa.assertThat(beforeEvents.get(4)).isEqualTo("before: $(#remove) should not be(visible)");
 
     sa.assertAll();
   }
@@ -61,9 +65,7 @@ final class LogEventListenerTest extends BaseIntegrationTest {
 
     @Override
     public void beforeEvent(LogEvent logEvent) {
-      if (logEvent.getSubject().contains("click()")) {
-        beforeEvents.add(format("before: $(%s) %s", logEvent.getElement(), logEvent.getSubject()));
-      }
+      beforeEvents.add(format("before: $(%s) %s", logEvent.getElement(), logEvent.getSubject()));
     }
   }
 }


### PR DESCRIPTION
## Proposed changes
This pr fix before/after events order if the browser is closed. Now before and after events in the same order
before changes:
![Screenshot 2024-03-04 at 10 57 38](https://github.com/selenide/selenide/assets/10852135/26b118cb-eec2-4dad-adde-6bbd30ad0595)
after changes:
![Screenshot 2024-03-04 at 11 08 46](https://github.com/selenide/selenide/assets/10852135/61c0cd30-98bc-4a2a-83ec-1fa66baedc0f)

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
