### PR TITLE
restore throwing InvalidSelectorException after upgrading to Chrome 123

### DIFF
--- a/statics/src/test/java/integration/InvalidSelectorTest.java
+++ b/statics/src/test/java/integration/InvalidSelectorTest.java
@@ -1,0 +1,48 @@
+package integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.InvalidSelectorException;
+
+import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class InvalidSelectorTest extends IntegrationTest {
+  @BeforeEach
+  void setUp() {
+    open();
+  }
+
+  @Test
+  void checkFailsForInvalidSelector_xpath() {
+    assertThatThrownBy(() -> $(By.xpath("//input[:attr='al]")).shouldBe(visible))
+      .isInstanceOf(InvalidSelectorException.class);
+  }
+
+  @Test
+  void checkFailsForInvalidSelector_cssSElector() {
+    assertThatThrownBy(() -> $(By.cssSelector("//input[:attr='al]")).shouldBe(visible))
+      .isInstanceOf(InvalidSelectorException .class);
+  }
+
+  @Test
+  void checkFailsForInvalidSelector_id() {
+    assertThatThrownBy(() -> $(By.id("")).shouldBe(visible))
+      .isInstanceOf(InvalidSelectorException.class);
+  }
+
+  @Test
+  void checkFailsForInvalidSelector_name() {
+    assertThatThrownBy(() -> $(By.name("invalid ' \" name <>")).shouldBe(visible))
+      .isInstanceOf(InvalidSelectorException.class);
+  }
+
+  // @Test // Chrome/Firefox don't complain :)
+  void checkFailsForInvalidSelector_tagName() {
+    assertThatThrownBy(() -> $(By.tagName("invalid ' tag \" name <>")).shouldBe(visible))
+      .isInstanceOf(InvalidSelectorException.class);
+  }
+}

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -10,7 +10,6 @@ import com.codeborne.selenide.ex.UIAssertionError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.InvalidSelectorException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
@@ -465,12 +464,6 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isFalse();
     assertThat($("#multirowTable").has(text("Ninja")))
       .isFalse();
-  }
-
-  @Test
-  void checkFailsForInvalidSelector() {
-    assertThatThrownBy(() -> $(By.xpath("//input[:attr='al]")).shouldBe(visible))
-      .isInstanceOf(InvalidSelectorException.class);
   }
 
   @Test


### PR DESCRIPTION
I think it's a bug in Chrome: now it throws non-w3s-standard "javascript error: {"status":32,"value":"Unable to locate an element with the xpath expression //input[:attr='al] because of the following error:\nSyntaxError: Failed to execute 'evaluate' on 'Document': The string '//input[:attr='al]' is not a valid XPath expression."}" in case of invalid locator.
