### PR TITLE
fix usages of aliases in reports

### DIFF
--- a/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
@@ -27,7 +27,7 @@ public class ElementShouldNot extends UIAssertionError {
         String.format("Element: '%s'", describe.fully(driver, element)),
         errorFormatter.actualValue(expectedCondition, driver, element, lastCheckResult)
       ),
-      expectedCondition,
+      "not " + expectedCondition,
       lastCheckResult == null ? null : lastCheckResult.actualValue(),
       cause);
   }

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
@@ -57,7 +57,13 @@ public class CollectionElement extends WebElementSource {
   @CheckReturnValue
   @Nonnull
   public String getSearchCriteria() {
-    return collection.description() + '[' + index + ']';
+    return collection.getSearchCriteria() + '[' + index + ']';
+  }
+
+  @Nonnull
+  @Override
+  public String description() {
+    return getAlias().getOrElse(() -> collection.shortDescription() + '[' + index + ']');
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
@@ -59,6 +59,13 @@ public class CollectionElementByCondition extends WebElementSource {
   @CheckReturnValue
   @Nonnull
   public String getSearchCriteria() {
-    return collection.description() + ".findBy(" + condition + ")";
+    return collection.getSearchCriteria() + ".findBy(" + condition + ")";
+  }
+
+  @Override
+  @CheckReturnValue
+  @Nonnull
+  public String description() {
+    return getAlias().getOrElse(() -> collection.shortDescription() + ".findBy(" + condition + ")");
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
@@ -50,7 +50,13 @@ public class LastCollectionElement extends WebElementSource {
   @CheckReturnValue
   @Nonnull
   public String getSearchCriteria() {
-    return collection.description() + ":last";
+    return collection.getSearchCriteria() + ":last";
+  }
+
+  @Nonnull
+  @Override
+  public String description() {
+    return getAlias().getOrElse(() -> collection.shortDescription() + ":last");
   }
 
   @Override

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
+import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Mocks.mockWebElement;
 import static java.util.Arrays.asList;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 final class CollectionElementByConditionTest {
   private final Driver driver = new DriverStub();
+  private final CollectionSource collection = mock();
 
   @Test
   void wrap() {
@@ -34,7 +36,6 @@ final class CollectionElementByConditionTest {
 
   @Test
   void getWebElement() {
-    CollectionSource collection = mock();
     WebElement mockedWebElement1 = mock();
     WebElement mockedWebElement2 = mock();
 
@@ -49,8 +50,7 @@ final class CollectionElementByConditionTest {
 
   @Test
   void getSearchCriteria() {
-    CollectionSource collection = mock();
-    when(collection.description()).thenReturn("ul#employees li.employee");
+    when(collection.shortDescription()).thenReturn("ul#employees li.employee");
     CollectionElementByCondition collectionElement = new CollectionElementByCondition(collection, visible);
     assertThat(collectionElement)
       .hasToString(String.format("%s.findBy(visible)", "ul#employees li.employee"));
@@ -58,8 +58,7 @@ final class CollectionElementByConditionTest {
 
   @Test
   void testToString() {
-    CollectionSource collection = mock();
-    when(collection.description()).thenReturn("ul#employees li.employee");
+    when(collection.shortDescription()).thenReturn("ul#employees li.employee");
     CollectionElementByCondition collectionElement = new CollectionElementByCondition(collection, visible);
     assertThat(collectionElement)
       .hasToString(String.format("%s.findBy(visible)", "ul#employees li.employee"));
@@ -67,9 +66,8 @@ final class CollectionElementByConditionTest {
 
   @Test
   void createElementNotFoundErrorWithEmptyCollection() {
-    CollectionSource collection = mock();
     when(collection.driver()).thenReturn(driver);
-    when(collection.description()).thenReturn("ul#employees li.employee");
+    when(collection.getSearchCriteria()).thenReturn("ul#employees li.employee");
     CollectionElementByCondition collectionElement = new CollectionElementByCondition(collection, visible);
 
     ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(visible,
@@ -84,20 +82,19 @@ final class CollectionElementByConditionTest {
 
   @Test
   void createElementNotFoundErrorWithNonEmptyCollection() {
-    CollectionSource collection = mock();
     when(collection.driver()).thenReturn(driver);
-    when(collection.description()).thenReturn("ul#employees li.employee");
+    when(collection.getSearchCriteria()).thenReturn("ul#employees li.employee");
     when(collection.getElements()).thenReturn(singletonList(mock()));
     CollectionElementByCondition collectionElement = new CollectionElementByCondition(collection, visible);
 
-    WebElementCondition mockedCollection = mock();
-    when(mockedCollection.toString()).thenReturn("Reason description");
-    ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(mockedCollection, new Error("Error message"));
+    WebElementCondition condition = text("Hello").because("Successfully logged in");
+    ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(condition, new Error("Error message"));
 
     assertThat(elementNotFoundError)
       .hasMessage(String.format("Element not found {ul#employees li.employee.findBy(visible)}%n" +
-        "Expected: Reason description%n" +
-        "Timeout: 0 ms.%n" +
-        "Caused by: java.lang.Error: Error message"));
+                                "Expected: text \"Hello\" (because Successfully logged in)%n" +
+                                "Timeout: 0 ms.%n" +
+                                "Caused by: java.lang.Error: Error message"
+      ));
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
@@ -39,38 +39,32 @@ final class CollectionElementTest {
 
   @Test
   void getSearchCriteria() {
-    String collectionDescription = "Collection description";
-    int index = 1;
     CollectionSource collection = mock();
-    when(collection.description()).thenReturn(collectionDescription);
-    CollectionElement collectionElement = new CollectionElement(collection, 1);
-    assertThat(collectionElement.getSearchCriteria())
-      .isEqualTo(String.format("%s[%s]", collectionDescription, index));
+    when(collection.getSearchCriteria()).thenReturn("#report .line");
+    CollectionElement collectionElement = new CollectionElement(collection, 2);
+    assertThat(collectionElement.getSearchCriteria()).isEqualTo("#report .line[2]");
   }
 
   @Test
   void testToString() {
     CollectionSource collection = mock();
-    String collectionDescription = "Collection description";
-    when(collection.description()).thenReturn(collectionDescription);
-    int index = 1;
+    when(collection.shortDescription()).thenReturn("#report .line");
     CollectionElement collectionElement = new CollectionElement(collection, 1);
-    assertThat(collectionElement)
-      .hasToString(String.format("%s[%s]", collectionDescription, index));
+    assertThat(collectionElement).hasToString("#report .line[1]");
   }
 
   @Test
   void createElementNotFoundErrorWithEmptyCollection() {
     CollectionSource collection = mock();
     when(collection.driver()).thenReturn(driver);
-    when(collection.description()).thenReturn("Collection description");
+    when(collection.getSearchCriteria()).thenReturn("#report .line");
     CollectionElement collectionElement = new CollectionElement(collection, 33);
 
     WebElementCondition mockedCollection = mock();
     ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(mockedCollection, new Error("Error message"));
 
     assertThat(elementNotFoundError)
-      .hasMessage(String.format("Element not found {Collection description[33]}%n" +
+      .hasMessage(String.format("Element not found {#report .line[33]}%n" +
         "Expected: visible%n" +
         "Timeout: 0 ms.%n" +
         "Caused by: java.lang.Error: Error message"));
@@ -80,7 +74,7 @@ final class CollectionElementTest {
   void createElementNotFoundErrorWithNonEmptyCollection() {
     CollectionSource collection = mock();
     when(collection.driver()).thenReturn(driver);
-    when(collection.description()).thenReturn("Collection description");
+    when(collection.getSearchCriteria()).thenReturn("#report .line");
     when(collection.getElements()).thenReturn(singletonList(mock()));
     CollectionElement collectionElement = new CollectionElement(collection, 1);
 
@@ -89,7 +83,7 @@ final class CollectionElementTest {
     ElementNotFound elementNotFoundError = collectionElement.createElementNotFoundError(mockedCollection, new Error("Error message"));
 
     assertThat(elementNotFoundError)
-      .hasMessage(String.format("Element not found {Collection description[1]}%n" +
+      .hasMessage(String.format("Element not found {#report .line[1]}%n" +
         "Expected: Reason description%n" +
         "Timeout: 0 ms.%n" +
         "Caused by: java.lang.Error: Error message"));

--- a/statics/src/test/java/integration/AliasesInReportTest.java
+++ b/statics/src/test/java/integration/AliasesInReportTest.java
@@ -1,0 +1,178 @@
+package integration;
+
+import com.codeborne.selenide.As;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.logevents.EventsCollector;
+import com.codeborne.selenide.logevents.SelenideLogger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.CacheLookup;
+import org.openqa.selenium.support.FindBy;
+
+import static com.codeborne.selenide.Condition.cssClass;
+import static com.codeborne.selenide.Condition.exist;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.$$;
+import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.Selenide.page;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class AliasesInReportTest extends IntegrationTest {
+  private final EventsCollector report = new EventsCollector();
+
+  @BeforeEach
+  void setUp() {
+    open();
+    SelenideLogger.addListener("aliasesTest", report);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SelenideLogger.removeListener("aliasesTest");
+  }
+
+  @Test
+  void elementWithoutAlias() {
+    $("h1").shouldNot(exist);
+    assertName("h1");
+  }
+
+  @Test
+  void elementWithAlias() {
+    $("h1").as("The header").shouldNot(exist);
+    assertName("The header");
+  }
+
+  @Test
+  void elementFoundFromCollection() {
+    $$("h1")
+      .find(cssClass("icon"))
+      .shouldNot(exist);
+    assertName("h1.findBy(css class \"icon\")");
+  }
+
+  @Test
+  void elementFoundFromNamedCollection() {
+    $$("h1")
+      .as("Greetings")
+      .find(cssClass("icon"))
+      .shouldNot(exist);
+    assertName("Greetings.findBy(css class \"icon\")");
+  }
+
+  @Test
+  void elementWithAliasFoundFromCollection() {
+    $$("h1")
+      .find(cssClass("icon"))
+      .as("The icon")
+      .shouldNot(exist);
+    assertName("The icon");
+  }
+
+  @Test
+  void lastElementOfCollectionWithAlias() {
+    $$("h1")
+      .last()
+      .as("The icon")
+      .shouldNot(exist);
+    assertName("The icon");
+  }
+
+  @Test
+  void lastElementOfNamedCollection() {
+    $$("h1")
+      .as("Greetings")
+      .last()
+      .shouldNot(exist);
+    assertName("Greetings:last");
+  }
+
+  @Test
+  void lastElementOfNamedCollectionWithAlias() {
+    $$("h1")
+      .as("Greetings")
+      .last()
+      .as("The icon")
+      .shouldNot(exist);
+    assertName("The icon");
+  }
+
+  @Test
+  void firstElementOfNamedCollection() {
+    $$("h1")
+      .as("Greetings")
+      .first()
+      .shouldNot(exist);
+    assertName("Greetings[0]");
+  }
+
+  @Test
+  void firstElementOfNamedCollectionWithAlias() {
+    $$("h1")
+      .as("Greetings")
+      .first()
+      .as("The first")
+      .shouldNot(exist);
+    assertName("The first");
+  }
+
+  @Test
+  void nthElementOfNamedCollection() {
+    $$("h1")
+      .as("Greetings")
+      .get(42)
+      .shouldNot(exist);
+    assertName("Greetings[42]");
+  }
+
+  @Test
+  void nthElementOfNamedCollectionWithAlias() {
+    $$("h1")
+      .as("Clouds")
+      .get(9)
+      .as("Clould number nine")
+      .shouldNot(exist);
+    assertName("Clould number nine");
+  }
+
+  @Test
+  void getSelectedOptionWithAlias() {
+    $("select")
+      .as("Heaven")
+      .getSelectedOption()
+      .as("Clould number nine")
+      .shouldNot(exist);
+    assertName("Clould number nine");
+  }
+
+  @Test
+  void webElementWrapper() {
+    WebElement web = $("body").toWebElement();
+
+    $(web)
+      .as("The body")
+      .should(exist);
+    assertName("The body");
+  }
+
+  @Test
+  void pageObjectFieldWithAlias() {
+    HeavenPage page = page();
+    page.clouds.shouldNot(exist);
+    assertName("The clouds");
+  }
+
+  private static class HeavenPage {
+    @FindBy(tagName = "select")
+    @As("The clouds")
+    @CacheLookup
+    SelenideElement clouds;
+  }
+
+  private void assertName(String expectedName) {
+    assertThat(report.events()).hasSize(1);
+    assertThat(report.events().get(0).getElement()).isEqualTo(expectedName);
+  }
+}

--- a/statics/src/test/java/integration/errormessages/MissingElementTest.java
+++ b/statics/src/test/java/integration/errormessages/MissingElementTest.java
@@ -27,7 +27,9 @@ import static com.codeborne.selenide.WebDriverRunner.isChrome;
 import static integration.errormessages.Helper.getReportsFolder;
 import static integration.errormessages.Helper.screenshot;
 import static integration.errormessages.Helper.webElementNotFound;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 final class MissingElementTest extends IntegrationTest {
@@ -58,7 +60,8 @@ final class MissingElementTest extends IntegrationTest {
   @Test
   void elementNotFound() {
     String path = path("elementNotFound");
-    assertThatThrownBy(() -> $("#h9").shouldHave(text("expected text")))
+    UIAssertionError e = catchThrowableOfType(() -> $("#h9").shouldHave(text("expected text")), UIAssertionError.class);
+    assertThat(e)
       .isInstanceOf(ElementNotFound.class)
       .hasMessageMatching(String.format("Element not found \\{#h9}%n" +
         "Expected: text \"expected text\"%n" +
@@ -70,14 +73,17 @@ final class MissingElementTest extends IntegrationTest {
       .cause()
       .isInstanceOf(NoSuchElementException.class)
       .is(webElementNotFound("#h9"));
+    assertThat(e.getActual()).isNull();
+    assertThat(e.getExpected()).isNull();
   }
 
   @Test
   void elementTextDoesNotMatch() {
     String path = path("elementTextDoesNotMatch");
-    assertThatThrownBy(() ->
-      $("h2").shouldHave(text("expected text"))
-    )
+    UIAssertionError e = catchThrowableOfType(() ->
+      $("h2").shouldHave(text("expected text")), UIAssertionError.class
+    );
+    assertThat(e)
       .isInstanceOf(ElementShould.class)
       .hasMessageMatching(String.format("Element should have text \"expected text\" \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
@@ -85,14 +91,17 @@ final class MissingElementTest extends IntegrationTest {
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
         "Timeout: 15 ms.", path, png(), path, html()));
+    assertThat(e.getActual().getStringRepresentation()).isEqualTo("text=\"Dropdown list\"");
+    assertThat(e.getExpected().getStringRepresentation()).isEqualTo("text \"expected text\"");
   }
 
   @Test
   void elementAttributeDoesNotMatch() {
     String path = path("elementAttributeDoesNotMatch");
-    assertThatThrownBy(() ->
-      $("h2").shouldHave(attribute("name", "header"))
-    )
+    UIAssertionError e = catchThrowableOfType(() ->
+      $("h2").shouldHave(attribute("name", "header")), UIAssertionError.class
+    );
+    assertThat(e)
       .isInstanceOf(ElementShould.class)
       .hasMessageMatching(String.format("Element should have attribute name=\"header\" \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
@@ -100,14 +109,17 @@ final class MissingElementTest extends IntegrationTest {
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
         "Timeout: 15 ms.", path, png(), path, html()));
+    assertThat(e.getActual().getStringRepresentation()).isEqualTo("name=\"\"");
+    assertThat(e.getExpected().getStringRepresentation()).isEqualTo("attribute name=\"header\"");
   }
 
   @Test
   void wrapperTextDoesNotMatch() {
     String path = path("wrapperTextDoesNotMatch");
-    assertThatThrownBy(() ->
-      $(element(By.tagName("h2"))).shouldHave(text("expected text"))
-    )
+    UIAssertionError e = catchThrowableOfType(() ->
+      $(element(By.tagName("h2"))).shouldHave(text("expected text")), UIAssertionError.class
+    );
+    assertThat(e)
       .isInstanceOf(ElementShould.class)
       .hasMessageMatching(String.format("Element should have text \"expected text\" \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
@@ -115,14 +127,17 @@ final class MissingElementTest extends IntegrationTest {
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
         "Timeout: 15 ms.", path, png(), path, html()));
+    assertThat(e.getActual().getStringRepresentation()).isEqualTo("text=\"Dropdown list\"");
+    assertThat(e.getExpected().getStringRepresentation()).isEqualTo("text \"expected text\"");
   }
 
   @Test
   void clickHiddenElement() {
     String path = path("clickHiddenElement");
-    assertThatThrownBy(() ->
-      $("#theHiddenElement").click()
-    )
+    UIAssertionError e = catchThrowableOfType(() ->
+      $("#theHiddenElement").click(), UIAssertionError.class
+    );
+    assertThat(e)
       .isInstanceOf(ElementShould.class)
       .hasMessageMatching(String.format(
         "Element should be clickable: interactable and enabled \\{#theHiddenElement}%n" +
@@ -131,14 +146,17 @@ final class MissingElementTest extends IntegrationTest {
           "Screenshot: %s%s%n" +
           "Page source: %s%s%n" +
           "Timeout: 15 ms.", path, png(), path, html()));
+    assertThat(e.getActual().getStringRepresentation()).isEqualTo("hidden, opacity=1");
+    assertThat(e.getExpected().getStringRepresentation()).isEqualTo("clickable: interactable and enabled");
   }
 
   @Test
   void pageObjectElementTextDoesNotMatch() {
     String path = path("pageObjectElementTextDoesNotMatch");
-    assertThatThrownBy(() ->
-      $(pageObject.header1).shouldHave(text("expected text"))
-    )
+    UIAssertionError e = catchThrowableOfType(() ->
+      $(pageObject.header1).shouldHave(text("expected text")), UIAssertionError.class
+    );
+    assertThat(e)
       .isInstanceOf(ElementShould.class)
       .hasMessageMatching(String.format("Element should have text \"expected text\" \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
@@ -146,14 +164,17 @@ final class MissingElementTest extends IntegrationTest {
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
         "Timeout: 15 ms.", path, png(), path, html()));
+    assertThat(e.getActual().getStringRepresentation()).isEqualTo("text=\"Dropdown list\"");
+    assertThat(e.getExpected().getStringRepresentation()).isEqualTo("text \"expected text\"");
   }
 
   @Test
   void pageObjectWrapperTextDoesNotMatch() {
     String path = path("pageObjectWrapperTextDoesNotMatch");
-    assertThatThrownBy(() ->
-      $(pageObject.header2).shouldHave(text("expected text"))
-    )
+    UIAssertionError e = catchThrowableOfType(() ->
+      $(pageObject.header2).shouldHave(text("expected text")), UIAssertionError.class
+    );
+    assertThat(e)
       .isInstanceOf(ElementShould.class)
       .hasMessageMatching(String.format("Element should have text \"expected text\" \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
@@ -161,37 +182,47 @@ final class MissingElementTest extends IntegrationTest {
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
         "Timeout: 15 ms.", path, png(), path, html()));
+    assertThat(e.getActual().getStringRepresentation()).isEqualTo("text=\"Dropdown list\"");
+    assertThat(e.getExpected().getStringRepresentation()).isEqualTo("text \"expected text\"");
   }
 
   @Test
-  void selectOptionFromUnexistingList() {
-    assertThatThrownBy(() ->
-      $(pageObject.categoryDropdown).selectOption("SomeOption")
-    ).isInstanceOf(ElementNotFound.class)
+  void selectOptionFromMissingList() {
+    UIAssertionError e = catchThrowableOfType(() ->
+      $(pageObject.categoryDropdown).selectOption("SomeOption"), UIAssertionError.class
+    );
+    assertThat(e)
+      .isInstanceOf(ElementNotFound.class)
       .hasMessageContaining("Element not found {#invalid_id}")
       .hasMessageContaining("Expected: exist");
+    assertThat(e.getActual()).isNull();
+    assertThat(e.getExpected()).isNull();
   }
 
   @Test
-  void clickUnexistingWrappedElement() {
-    String path = path("clickUnexistingWrappedElement");
-    assertThatThrownBy(() ->
-      $(pageObject.categoryDropdown).click()
-    ).isInstanceOf(ElementNotFound.class)
+  void clickMissingWrappedElement() {
+    String path = path("clickMissingWrappedElement");
+    UIAssertionError e = catchThrowableOfType(() ->
+      $(pageObject.categoryDropdown).click(), UIAssertionError.class
+    );
+    assertThat(e).isInstanceOf(ElementNotFound.class)
       .hasMessageMatching(String.format("Element not found \\{#invalid_id}%n" +
         "Expected: clickable: interactable and enabled%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
         "Timeout: 15 ms.%n" +
         "Caused by: NoSuchElementException:.*", path, png(), path, html()));
+    assertThat(e.getActual()).isNull();
+    assertThat(e.getExpected()).isNull();
   }
 
   @Test
   void existingElementShouldNotExist() {
     String path = path("existingElementShouldNotExist");
-    assertThatThrownBy(() ->
-      $("h2").shouldNot(exist)
-    )
+    UIAssertionError e = catchThrowableOfType(() ->
+      $("h2").shouldNot(exist), UIAssertionError.class);
+
+    assertThat(e)
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageMatching(String.format("Element should not exist \\{h2}%n" +
         "Element: '<h2>Dropdown list</h2>'%n" +
@@ -199,14 +230,17 @@ final class MissingElementTest extends IntegrationTest {
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
         "Timeout: 15 ms.", path, png(), path, html()));
+    assertThat(e.getActual().getStringRepresentation()).isEqualTo("exists");
+    assertThat(e.getExpected().getStringRepresentation()).isEqualTo("not exist");
   }
 
   @Test
   void nonExistingElementShouldNotBeHidden() {
     String path = path("nonExistingElementShouldNotBeHidden");
-    assertThatThrownBy(() ->
-      $("h14").shouldNotBe(hidden)
-    )
+    UIAssertionError e = catchThrowableOfType(() ->
+      $("h14").shouldNotBe(hidden), UIAssertionError.class);
+
+    assertThat(e)
       .isInstanceOf(ElementNotFound.class)
       .hasMessageMatching(String.format("Element not found \\{h14}%n" +
         "Expected: not hidden%n" +
@@ -214,6 +248,9 @@ final class MissingElementTest extends IntegrationTest {
         "Page source: %s%s%n" +
         "Timeout: 15 ms.%n" +
         "Caused by: NoSuchElementException:.*", path, png(), path, html()));
+
+    assertThat(e.getActual()).isNull();
+    assertThat(e.getExpected()).isNull();
   }
 
   @Test

--- a/statics/src/test/java/integration/errormessages/WaitMethodFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/WaitMethodFailsOnTest.java
@@ -53,9 +53,9 @@ final class WaitMethodFailsOnTest extends IntegrationTest {
   void wait_while_visible() {
     SelenideElement element = $(".detective").shouldBe(visible);
 
-    assertThatThrownBy(() -> element.shouldNot(visible, Duration.ofMillis(42)))
+    assertThatThrownBy(() -> element.shouldNotBe(visible, Duration.ofMillis(42)))
       .isInstanceOf(ElementShouldNot.class)
-      .hasMessageStartingWith("Element should not visible {.detective}")
+      .hasMessageStartingWith("Element should not be visible {.detective}")
       .hasMessageContaining("Actual value: visible");
   }
 


### PR DESCRIPTION
I discovered that in many cases, *.as("The alias") is not really used in reports.
