### PR TITLE
#2705 add method to mock http response with specific content type

### DIFF
--- a/modules/proxy/src/test/java/integration/proxy/MockResponseTest.java
+++ b/modules/proxy/src/test/java/integration/proxy/MockResponseTest.java
@@ -1,0 +1,108 @@
+package integration.proxy;
+
+import com.codeborne.selenide.proxy.MockResponseFilter;
+import integration.ProxyIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.remote.http.HttpResponse;
+
+import static com.codeborne.selenide.Condition.exactText;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Configuration.timeout;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.WebDriverRunner.getSelenideProxy;
+import static com.codeborne.selenide.proxy.RequestMatcher.HttpMethod.GET;
+import static com.codeborne.selenide.proxy.RequestMatchers.urlContains;
+import static java.util.Objects.requireNonNull;
+import static org.openqa.selenium.remote.http.Contents.utf8String;
+
+final class MockResponseTest extends ProxyIntegrationTest {
+  @BeforeEach
+  void setUp() {
+    timeout = 1000;
+    open();
+    proxyMocker().resetAll();
+  }
+
+  @AfterEach
+  void tearDown() {
+    proxyMocker().resetAll();
+  }
+
+  @Test
+  void withoutMock() {
+    open("/page_with_json_request.html");
+    verifyRealProduct();
+
+    $("#status").shouldHave(text("200"));
+    $("#content-length").shouldHave(text("89"));
+    $("#content-type").shouldHave(text("application/json"));
+  }
+
+  @Test
+  void canMockServerResponse() {
+    proxyMocker().mockText("product-mock", urlContains(GET, "/product.json"), this::mockedResponse);
+    open("/page_with_json_request.html");
+    verifyMockedProduct();
+
+    $("#status").shouldHave(text("200"));
+    $("#content-length").shouldHave(text("98"));
+    $("#content-type").shouldHave(exactText(""));
+  }
+
+  @Test
+  void canMockServerResponseWithAnyHttpStatus() {
+    proxyMocker().mockText("product-mock", urlContains(GET, "/product.json"), 429, this::mockedResponse);
+    open("/page_with_json_request.html");
+
+    verifyMockedProduct();
+    $("#status").shouldHave(text("429"));
+    $("#content-length").shouldHave(text("98"));
+    $("#content-type").shouldHave(exactText(""));
+  }
+
+  @Test
+  void canMockServerResponseWithAnyHttpStatusAndContentType() {
+    proxyMocker().mockResponse("product-mock", urlContains(GET, "/product.json"), () -> new HttpResponse()
+      .setStatus(429)
+      .addHeader("Content-Type", "image/jpeg")
+      .setContent(utf8String(mockedResponse()))
+    );
+    open("/page_with_json_request.html");
+    verifyMockedProduct();
+    $("#status").shouldHave(text("429"));
+    $("#content-length").shouldHave(text("98"));
+    $("#content-type").shouldHave(text("image/jpeg"));
+  }
+
+  private void verifyRealProduct() {
+    verifyResponse("Fridge", "999.99 USD", "yes");
+  }
+
+  private void verifyMockedProduct() {
+    verifyResponse("Vacuum cleaner", "222.22 EUR", "no");
+  }
+
+  private void verifyResponse(String name, String price, String availability) {
+    $("#name").shouldHave(text(name));
+    $("#price").shouldHave(text(price));
+    $("#availability").shouldHave(text(availability));
+  }
+
+  private String mockedResponse() {
+    return """
+      {
+        "name": "Vacuum cleaner",
+        "price": "222.22",
+        "currency": "EUR",
+        "availability": false
+      }
+      """;
+  }
+
+  private static MockResponseFilter proxyMocker() {
+    return requireNonNull(getSelenideProxy()).responseMocker();
+  }
+}

--- a/src/test/java/integration/server/BaseHandler.java
+++ b/src/test/java/integration/server/BaseHandler.java
@@ -76,6 +76,7 @@ public abstract class BaseHandler extends HttpServlet {
     String fileExtension = RE_FILE_EXTENSION.matcher(fileName).replaceFirst("$1");
 
     return switch (fileExtension) {
+      case "json" -> "application/json";
       case "txt" -> CONTENT_TYPE_PLAIN_TEXT;
       case "html" -> CONTENT_TYPE_HTML_TEXT;
       case "pdf" -> "application/pdf";

--- a/src/test/resources/page_with_cross-origin-request.html
+++ b/src/test/resources/page_with_cross-origin-request.html
@@ -6,7 +6,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 </head>
 <body>
-<h1>Page with dynamic select</h1>
+<h1>Page with CORS request</h1>
 <h2></h2>
 <br/>
 

--- a/src/test/resources/page_with_json_request.html
+++ b/src/test/resources/page_with_json_request.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Test::background user</title>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+</head>
+<body>
+<h1>Page with background request</h1>
+<h2></h2>
+<br/>
+
+<h3>Product</h3>
+<table id="product" style="width: 600px; margin: 0 auto; border: 1px solid grey;">
+  <tr>
+    <td>Name: </td>
+    <td id="name"></td>
+  </tr>
+  <tr>
+    <td>Price: </td>
+    <td id="price"></td>
+  </tr>
+  <tr>
+    <td>Available: </td>
+    <td id="availability"></td>
+  </tr>
+</table>
+
+<h6 style="margin-top: 100px;">Http response info</h6>
+<table id="debug" style="width: 200px; background-color: lightgrey;">
+  <tr>
+    <td>Http status: </td>
+    <td id="status"></td>
+  </tr>
+  <tr>
+    <td>Content length: </td>
+    <td id="content-length"></td>
+  </tr>
+  <tr>
+    <td>Content type: </td>
+    <td id="content-type"></td>
+  </tr>
+</table>
+
+<script type="text/javascript">
+
+  function loadData() {
+    fetch(`product.json`, {method: 'GET'}).then(response => {
+      response.json().then((product) => {
+        document.getElementById('name').textContent = product.name
+        document.getElementById('price').textContent = product.price + ' ' + product.currency
+        document.getElementById('availability').textContent = product.availability ? 'yes' : 'no'
+        document.getElementById('status').textContent = response.status
+        document.getElementById('content-length').textContent = response.headers.get('content-length')
+        document.getElementById('content-type').textContent = response.headers.get('content-type')
+      })
+    })
+      .catch((e) => document.getElementById('name').textContent = e)
+  }
+
+  loadData();
+</script>
+
+</body>
+</html>

--- a/src/test/resources/product.json
+++ b/src/test/resources/product.json
@@ -1,0 +1,6 @@
+{
+  "name": "Fridge",
+  "price": "999.99",
+  "currency": "USD",
+  "availability": true
+}


### PR DESCRIPTION
To allow user set content type, we leverage Selenium own class "org.openqa.selenium.remote.http.HttpResponse" that was already used by Selenium in CDP-specific code. It allows to set  status+headers+content.

feature request #2705