### PR TITLE
#2725 show the real error instead of "Element not found"

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -170,6 +170,7 @@ class SelenideElementProxy<T extends SelenideElement> implements InvocationHandl
     if (e instanceof UnhandledAlertException) return false;
     if (e instanceof NoSuchSessionException) return false;
     if (e instanceof UnsupportedCommandException) return false;
+    if (e instanceof WebDriverException && e.getMessage().startsWith("Reached error page: about:neterror")) return false;
 
     return e instanceof Exception || e instanceof AssertionError;
   }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -161,16 +161,24 @@ class SelenideElementProxy<T extends SelenideElement> implements InvocationHandl
     return SelenideElement.class.isAssignableFrom(method.getDeclaringClass());
   }
 
+  private static final Set<Class<? extends Throwable>> TERMINAL_EXCEPTIONS = Set.of(
+    FileNotDownloadedError.class,
+    IllegalArgumentException.class,
+    ReflectiveOperationException.class,
+    JavascriptException.class,
+    UnhandledAlertException.class,
+    NoSuchSessionException.class,
+    UnsupportedCommandException.class
+  );
+
+  private static final Set<String> TERMINAL_MESSAGES = Set.of(
+    "Reached error page: about:neterror"
+  );
+
   @CheckReturnValue
   static boolean shouldRetryAfterError(Throwable e) {
-    if (e instanceof FileNotDownloadedError) return false;
-    if (e instanceof IllegalArgumentException) return false;
-    if (e instanceof ReflectiveOperationException) return false;
-    if (e instanceof JavascriptException) return false;
-    if (e instanceof UnhandledAlertException) return false;
-    if (e instanceof NoSuchSessionException) return false;
-    if (e instanceof UnsupportedCommandException) return false;
-    if (e instanceof WebDriverException && e.getMessage().startsWith("Reached error page: about:neterror")) return false;
+    if (TERMINAL_EXCEPTIONS.stream().anyMatch(te -> te.isAssignableFrom(e.getClass()))) return false;
+    if (TERMINAL_MESSAGES.stream().anyMatch(message -> e.getMessage().startsWith(message))) return false;
 
     return e instanceof Exception || e instanceof AssertionError;
   }

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
@@ -314,6 +314,15 @@ final class SelenideElementProxyTest {
   }
 
   @Test
+  void shouldNotRetry_whenFirefoxShowsNetworkError() {
+    WebDriverException exception = new WebDriverException("""
+      Reached error page: about:neterror?e=dnsNotFound&u=https%3A//example/
+      Build info: version: '4.20.0', revision: '866c76ca80'
+      """);
+    assertThat(shouldRetryAfterError(exception)).isFalse();
+  }
+
+  @Test
   void shouldRetry_onAssertionError() {
     AssertionError error = new AssertionError("bla");
     assertThat(shouldRetryAfterError(error)).isTrue();

--- a/src/test/resources/page_with_invalid_link.html
+++ b/src/test/resources/page_with_invalid_link.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Page with invalid link</title>
+  <meta charset="UTF-8">
+</head>
+<body>
+  <a id="invalid-link" href="https://example">The wrong link</a>
+</body>
+</html>

--- a/statics/src/test/java/integration/ClickInvalidLinkTest.java
+++ b/statics/src/test/java/integration/ClickInvalidLinkTest.java
@@ -1,0 +1,59 @@
+package integration;
+
+import com.codeborne.selenide.ex.UIAssertionError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriverException;
+
+import static com.codeborne.selenide.Configuration.timeout;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
+import static com.codeborne.selenide.WebDriverRunner.isFirefox;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+class ClickInvalidLinkTest extends IntegrationTest {
+
+  @BeforeEach
+  void setUp() {
+    timeout = 100;
+    openFile("page_with_invalid_link.html");
+  }
+
+  @Test
+  void seleniumClick_nonFirefox() {
+    assumeThat(isFirefox()).isFalse();
+
+    getWebDriver().findElement(By.id("invalid-link")).click();
+  }
+
+  @Test
+  void seleniumClick_firefox() {
+    assumeThat(isFirefox()).isTrue();
+
+    assertThatThrownBy(() -> {
+      getWebDriver().findElement(By.id("invalid-link")).click();
+    }).isInstanceOf(WebDriverException.class)
+      .hasMessageStartingWith("Reached error page: about:neterror");
+  }
+
+  @Test
+  void selenideClick_nonFirefox() {
+    assumeThat(isFirefox()).isFalse();
+    $("#invalid-link").click();
+  }
+
+  @Test
+  void selenideClick_firefox() {
+    assumeThat(isFirefox()).isTrue();
+
+    assertThatThrownBy(() -> {
+      $("#invalid-link").click();
+    }).isInstanceOf(UIAssertionError.class)
+      .hasMessageStartingWith("WebDriverException: Reached error page: about:neterror")
+      .cause()
+      .isInstanceOf(WebDriverException.class)
+      .hasMessageStartingWith("Reached error page: about:neterror");
+  }
+}


### PR DESCRIPTION
... when user clicks a link with invalid URL, and Firefox throws an error like "Reached error page: about:neterror?e=dnsNotFound..."
