### PR TITLE
#2658 disable Chrome warning about stolen passwords (once again)

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -53,6 +53,7 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
     preferences.put("safebrowsing.enabled", true);
     preferences.put("credentials_enable_service", false);
     preferences.put("profile.password_manager_enabled", false);
+    preferences.put("profile.password_manager_leak_detection", false);
     preferences.put("plugins.always_open_pdf_externally", true);
     preferences.put("profile.default_content_setting_values.automatic_downloads", 1);
 

--- a/src/test/java/com/codeborne/selenide/webdriver/EdgeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/EdgeDriverFactoryTest.java
@@ -35,9 +35,10 @@ class EdgeDriverFactoryTest {
     assertThat(options.get("extensions")).isEqualTo(emptyList());
 
     Map<String, Object> prefs = prefs(options);
-    assertThat(prefs).hasSize(6);
+    assertThat(prefs).hasSize(7);
     assertThat(prefs.get("credentials_enable_service")).isEqualTo(false);
     assertThat(prefs.get("profile.password_manager_enabled")).isEqualTo(false);
+    assertThat(prefs.get("profile.password_manager_leak_detection")).isEqualTo(false);
     assertThat(prefs.get("plugins.always_open_pdf_externally")).isEqualTo(true);
     assertThat(prefs.get("profile.default_content_setting_values.automatic_downloads")).isEqualTo(1);
     assertThat(prefs.get("safebrowsing.enabled")).isEqualTo(true);
@@ -58,9 +59,10 @@ class EdgeDriverFactoryTest {
     );
 
     Map<String, Object> prefs = prefs(options);
-    assertThat(prefs).hasSize(6);
+    assertThat(prefs).hasSize(7);
     assertThat(prefs.get("credentials_enable_service")).isEqualTo(false);
     assertThat(prefs.get("profile.password_manager_enabled")).isEqualTo(false);
+    assertThat(prefs.get("profile.password_manager_leak_detection")).isEqualTo(false);
     assertThat(prefs.get("plugins.always_open_pdf_externally")).isEqualTo(true);
     assertThat(prefs.get("profile.default_content_setting_values.automatic_downloads")).isEqualTo(1);
     assertThat(prefs.get("safebrowsing.enabled")).isEqualTo(true);


### PR DESCRIPTION
I already tried to do it in PR #2662, but then I used setting "profile.password_manager_enabled". Seems it was not enough. Now I added setting "profile.password_manager_leak_detection".
