### PR TITLE
Bump checkstyle from 9.3 to 10.17.0

### DIFF
--- a/gradle/code-analysis.gradle
+++ b/gradle/code-analysis.gradle
@@ -41,6 +41,10 @@ subprojects {
     }
   }
 
+  checkstyle {
+    toolVersion = "10.17.0"
+  }
+
   tasks.withType(Checkstyle).configureEach {
     maxWarnings = 0
     showViolations = true


### PR DESCRIPTION
- Default version of checkstyle is 9.3
- Latest release: https://mvnrepository.com/artifact/com.puppycrawl.tools/checkstyle

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

See #2754

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
