### PR TITLE
#2755 TestNG SoftAssert not failing (downgrade TestNG from 7.9.0 to 7.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 build
 hs_err_pid*
 !.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.3.3
+* downgraded TestNG from 7.9.0 to 7.4.0 (#2755)
+
 ## 7.3.2 (released 17.05.2024)
 * bump Selenium from 4.20.0 to 4.21.0 (#2744)
 * refactoring: instead of catching all Errors, catch only AssertionErrors (#2745)

--- a/modules/testng/build.gradle
+++ b/modules/testng/build.gradle
@@ -1,6 +1,6 @@
 ext {
   artifactId = 'selenide-testng'
-  testngVersion = '7.9.0'
+  testngVersion = '7.4.0'
 }
 
 dependencies {

--- a/modules/testng/src/test/java/integration/TestNgSoftTest.java
+++ b/modules/testng/src/test/java/integration/TestNgSoftTest.java
@@ -56,4 +56,12 @@ public class TestNgSoftTest extends BaseTest {
     $("#empty-text-area").val("text for textarea");
     $("#empty-text-area").shouldHave(value("text for textarea"));
   }
+
+  @Test
+  public void textAreaShouldFail() {
+    $("#empty-text-area").val("text for textarea");
+    // Will fail (on purpose) test will continue but should be marked as a FAILED test is in SOFT mode
+    $("#empty-text-area").shouldNotHave(value("text for textarea"));
+    $("#empty-text-area").shouldHave(value("text for textarea"));
+  }
 }


### PR DESCRIPTION
## Proposed changes
In Soft Assert mode with a FAIL step is not marking the whole test as FAILED

See #2755 

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
-- Sort of... I added a test that fails now with TestNg 7.4.0. I tried to write a test that checks the status but that is the root of the problem. That does not work in a higher version of TestNg. The ITestResult is FAILED but the test shows as passed. I can remove the test since it is bad to have a test fail all the time. Any other ideas?
- [x] I have added necessary documentation (if appropriate)

This is my first contribution. Please let me know if anything needs changing.
Thank you