### PR TITLE
#2786 allow page objects with fields of type `List<SelenideElement>` and `List<SelenideAppiumElement>`

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/DeepLinkLauncher.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/DeepLinkLauncher.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.logevents.SelenideLogger;
 import com.google.common.collect.ImmutableMap;
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.ios.IOSDriver;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.HasCapabilities;
 import org.slf4j.Logger;
@@ -15,47 +16,33 @@ import java.time.Duration;
 import java.util.Map;
 
 import static com.codeborne.selenide.Condition.enabled;
-import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static io.appium.java_client.AppiumBy.iOSNsPredicateString;
 import static io.appium.java_client.ios.options.wda.SupportsAutoAcceptAlertsOption.AUTO_ACCEPT_ALERTS_OPTION;
 
 @ParametersAreNonnullByDefault
 public class DeepLinkLauncher {
-  public static Duration SAFARI_ELEMENTS_TIMEOUT = Duration.ofSeconds(10);
+  public static Duration SAFARI_ELEMENTS_TIMEOUT = Duration.ofSeconds(1);
   private static final String SAFARI_BUNDLE_ID = "com.apple.mobilesafari";
   private static final Logger log = LoggerFactory.getLogger(DeepLinkLauncher.class);
 
   // adopted from https://bit.ly/3OKVsvq
   // see also https://appiumpro.com/editions/84-reliably-opening-deep-links-across-platforms-and-devices
-  public void openDeepLinkOnIos(AppiumDriver driver, String deepLinkUrl) {
+  public void openDeepLinkOnIos(IOSDriver driver, String deepLinkUrl) {
     SelenideLogger.run("open ios deeplink", deepLinkUrl, () -> {
       openSafari(driver);
-      // Add the deep link url in Safari in the `URL`-field
-      // This can be 2 different elements, or the button, or the text field
-      // Use the predicate string because the accessibility label will return 2 different types
-      // of elements making it flaky to use. With predicate string we can be more precise
-      SelenideElement addressBar = $(iOSNsPredicateString("label == 'Address' OR label == 'Адрес' OR name == 'URL'"));
-      SelenideElement urlField = $(iOSNsPredicateString("type == 'XCUIElementTypeTextField' && name CONTAINS 'URL'"));
-      // Wait for the url button to appear and click on it so the text field will appear
-      // iOS 13 now has the keyboard open by default because the URL field has focus when opening the Safari browser
+      driver.navigate().to(deepLinkUrl);
 
-      addressBar.shouldBe(visible).click();
-
-      // Submit the url and add a break
-      urlField.shouldBe(visible, SAFARI_ELEMENTS_TIMEOUT).setValue(deepLinkUrl + "\uE007");
       // if you started the iOS device with `autoAcceptAlerts:true` in the capabilities
       // then Appium will auto accept the alert that should be shown now.
       if (!canAutoAcceptAlerts(driver)) {
         // Wait for the notification and accept it
         // When using an iOS simulator you will only get the pop-up once, all the other times it won't be shown
-        try {
-          SelenideElement openButton =
-            $(iOSNsPredicateString("type == 'XCUIElementTypeButton' && (name CONTAINS 'Open' OR name CONTAINS 'Открыть')"));
-          openButton.shouldBe(enabled, SAFARI_ELEMENTS_TIMEOUT).click();
-        } catch (AssertionError openButtonNotFound) {
-          log.warn("Open button not found", openButtonNotFound);
+        SelenideElement openButton =
+          $(iOSNsPredicateString("type == 'XCUIElementTypeButton' && (name CONTAINS 'Open' OR name CONTAINS 'Открыть')"));
+        if (openButton.is(enabled, SAFARI_ELEMENTS_TIMEOUT)) {
+          openButton.click();
         }
       }
     });

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -43,7 +43,7 @@ public class SelenideAppium {
     if (!WebDriverRunner.hasWebDriverStarted()) {
       launchApp();
     }
-    deepLinkLauncher.openDeepLinkOnIos(AppiumDriverRunner.getMobileDriver(), deepLinkUrl);
+    deepLinkLauncher.openDeepLinkOnIos(AppiumDriverRunner.getIosDriver(), deepLinkUrl);
   }
   /**
    * Open a deep link for an Android application

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -7,6 +7,7 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.CollectionSource;
 import com.codeborne.selenide.impl.ElementFinder;
 import com.codeborne.selenide.impl.LazyWebElementSnapshot;
+import com.codeborne.selenide.impl.NoOpsList;
 import com.codeborne.selenide.impl.SelenidePageFactory;
 import com.codeborne.selenide.impl.WebElementSource;
 import io.appium.java_client.HasBrowserCheck;
@@ -108,8 +109,14 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
   protected BaseElementsCollection<? extends SelenideElement, ? extends BaseElementsCollection<?, ?>> createCollection(
     CollectionSource collection, Class<?> klass
   ) {
-    return SelenideAppiumCollection.class.isAssignableFrom(klass) ?
-      new SelenideAppiumCollection(collection) :
+    return klass.isAssignableFrom(SelenideAppiumList.class) ?
+      new SelenideAppiumList(collection) :
       super.createCollection(collection, klass);
+  }
+
+  private static class SelenideAppiumList extends SelenideAppiumCollection implements NoOpsList<SelenideAppiumElement> {
+    SelenideAppiumList(CollectionSource collection) {
+      super(collection);
+    }
   }
 }

--- a/modules/appium/src/test/java/it/mobile/ITTest.java
+++ b/modules/appium/src/test/java/it/mobile/ITTest.java
@@ -1,6 +1,7 @@
 package it.mobile;
 
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.junit5.ScreenShooterExtension;
 import com.codeborne.selenide.junit5.TextReportExtension;
 import com.codeborne.selenide.webdriver.HttpClientTimeouts;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
@@ -17,7 +18,7 @@ import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static io.appium.java_client.service.local.flags.GeneralServerFlag.RELAXED_SECURITY;
 import static java.time.Duration.ofMinutes;
 
-@ExtendWith(TextReportExtension.class)
+@ExtendWith({TextReportExtension.class, ScreenShooterExtension.class})
 public abstract class ITTest {
   private static AppiumDriverLocalService service;
 

--- a/modules/appium/src/test/java/it/mobile/android/AppiumCollectionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AppiumCollectionsTest.java
@@ -21,7 +21,8 @@ public class AppiumCollectionsTest extends BaseSwagLabsAndroidTest {
 
   @Test
   void appiumCollectionMethods() {
-    SelenideAppiumCollection inputFields = $$(By.xpath("//android.widget.EditText"));
+    SelenideAppiumCollection inputFields = $$(By.xpath("//android.widget.EditText")).shouldHave(size(2));
+
     assertThat(inputFields.first(1))
       .isInstanceOf(SelenideAppiumCollection.class)
       .hasSize(1);

--- a/modules/appium/src/test/java/it/mobile/android/LoginTestWithCollectionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/LoginTestWithCollectionsTest.java
@@ -18,11 +18,14 @@ import java.util.List;
 
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selenide.page;
+import static com.codeborne.selenide.Selenide.sleep;
 import static com.codeborne.selenide.appium.AppiumScrollOptions.up;
 import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static com.codeborne.selenide.appium.SelenideAppium.$$;
 import static com.codeborne.selenide.appium.SelenideAppium.$x;
+import static java.lang.System.currentTimeMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
@@ -52,6 +55,10 @@ public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
   @Test
   public void pageObjectWithSelenideElementList() {
     LoginPageWithSelenideElementList loginPage = page();
+    for (long start = currentTimeMillis();
+         currentTimeMillis() - start < timeout && loginPage.elements.size() != 2; ) {
+      sleep(100);
+    }
     assertThat(loginPage.elements).hasSize(2);
     loginPage.elements.get(0).setValue("bob@example.com");
     loginPage.elements.get(1).setValue("secret");

--- a/modules/appium/src/test/java/it/mobile/android/LoginTestWithCollectionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/LoginTestWithCollectionsTest.java
@@ -1,6 +1,7 @@
 package it.mobile.android;
 
 import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.appium.SelenideAppium;
 import com.codeborne.selenide.appium.SelenideAppiumCollection;
 import com.codeborne.selenide.appium.SelenideAppiumElement;
@@ -9,7 +10,11 @@ import io.appium.java_client.pagefactory.AndroidFindBy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+
+import java.util.Iterator;
+import java.util.List;
 
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.text;
@@ -18,6 +23,7 @@ import static com.codeborne.selenide.appium.AppiumScrollOptions.up;
 import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static com.codeborne.selenide.appium.SelenideAppium.$$;
 import static com.codeborne.selenide.appium.SelenideAppium.$x;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
   @BeforeEach
@@ -41,6 +47,33 @@ public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
     loginPage.selenideElements.shouldHave(size(2));
     loginPage.selenideElements.first().setValue("bob@example.com");
     loginPage.selenideElements.last().setValue("secret");
+  }
+
+  @Test
+  public void pageObjectWithSelenideElementList() {
+    LoginPageWithSelenideElementList loginPage = page();
+    assertThat(loginPage.elements).hasSize(2);
+    loginPage.elements.get(0).setValue("bob@example.com");
+    loginPage.elements.get(1).setValue("secret");
+  }
+
+  @Test
+  public void pageObjectWithSelenideAppiumElementList() {
+    LoginPageWithSelenideAppiumElementList loginPage = page();
+    assertThat(loginPage.elements).hasSize(2);
+    loginPage.elements.get(0).scroll(up()).setValue("bob@example.com");
+    loginPage.elements.get(1).scroll(up()).setValue("secret");
+
+    assertThat(loginPage.nonWebElements).isNull();
+  }
+
+  @Test
+  public void pageObjectWithSelenideAppiumElementIterable() {
+    LoginPageWithSelenideAppiumElementIterable loginPage = page();
+    assertThat(loginPage.elements).hasSize(2);
+    Iterator<SelenideAppiumElement> iterator = loginPage.elements.iterator();
+    iterator.next().scroll(up()).setValue("bob@example.com");
+    iterator.next().scroll(up()).setValue("secret");
   }
 
   @Test
@@ -72,4 +105,22 @@ class LoginPageWithCollections {
 class LoginPageWithSelenideCollection {
   @AndroidFindBy(xpath = "//android.widget.EditText")
   ElementsCollection selenideElements;
+}
+
+class LoginPageWithSelenideElementList {
+  @AndroidFindBy(xpath = "//android.widget.EditText")
+  List<SelenideElement> elements;
+}
+
+class LoginPageWithSelenideAppiumElementList {
+  @AndroidFindBy(xpath = "//android.widget.EditText")
+  List<SelenideAppiumElement> elements;
+
+  @AndroidFindBy(xpath = "//android.widget.EditText")
+  List<WebDriver> nonWebElements;
+}
+
+class LoginPageWithSelenideAppiumElementIterable {
+  @AndroidFindBy(xpath = "//android.widget.EditText")
+  Iterable<SelenideAppiumElement> elements;
 }

--- a/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
@@ -526,6 +526,23 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
     return collection.getAlias().getOrElse(collection::toString);
   }
 
+  /**
+   * Displays the collection in human-readable format.
+   * Useful for logging and debugging.
+   * Not recommended to use for test verifications.
+   * May work relatively slowly because it fetches actual element information from browser.
+   *
+   * @since 7.4.0
+   * @return e.g. [<strong id=orderConfirmedStatus class=>Order has been confirmed</strong>]
+   * @see com.codeborne.selenide.commands.DescribeElement
+   * @see <a href="https://github.com/selenide/selenide/wiki/do-not-use-getters-in-tests">NOT RECOMMENDED</a>
+   */
+  @CheckReturnValue
+  @Nonnull
+  public String describe() {
+    return stream().map(el -> el.describe()).toList().toString();
+  }
+
   @CheckReturnValue
   @Nonnull
   private Driver driver() {

--- a/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
@@ -486,7 +486,7 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
   @CheckReturnValue
   @Nonnull
   public SelenideElementIterable<T> asFixedIterable() {
-    return () -> new SelenideElementIterator<>(new CollectionSnapshot(collection));
+    return () -> new SelenideElementIterator<>(new CollectionSnapshot(collection), clazz);
   }
 
   /**
@@ -500,7 +500,7 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
   @CheckReturnValue
   @Nonnull
   public SelenideElementIterable<T> asDynamicIterable() {
-    return () -> new SelenideElementIterator<>(collection);
+    return () -> new SelenideElementIterator<>(collection, clazz);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/NoOpsList.java
+++ b/src/main/java/com/codeborne/selenide/impl/NoOpsList.java
@@ -1,0 +1,110 @@
+package com.codeborne.selenide.impl;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Collection;
+import java.util.List;
+import java.util.ListIterator;
+
+@ParametersAreNonnullByDefault
+public interface NoOpsList<T> extends List<T> {
+  @Override
+  default boolean contains(Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  @Nonnull
+  default Object[] toArray() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  @Nonnull
+  default <T1> T1[] toArray(T1[] a) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default boolean add(T selenideElement) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default boolean remove(Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default boolean containsAll(Collection<?> c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default boolean addAll(Collection<? extends T> c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default boolean addAll(int index, Collection<? extends T> c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default boolean removeAll(Collection<?> c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default boolean retainAll(Collection<?> c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default void clear() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default T set(int index, T element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default void add(int index, T element) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default T remove(int index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default int indexOf(Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default int lastIndexOf(Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  @Nonnull
+  default ListIterator<T> listIterator() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  @Nonnull
+  default ListIterator<T> listIterator(int index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  @Nonnull
+  default List<T> subList(int fromIndex, int toIndex) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementIterator.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementIterator.java
@@ -8,7 +8,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import static com.codeborne.selenide.commands.Util.classOf;
 
 @ParametersAreNonnullByDefault
 public class SelenideElementIterator<T extends SelenideElement> implements Iterator<T> {
@@ -16,10 +15,9 @@ public class SelenideElementIterator<T extends SelenideElement> implements Itera
   private final Class<T> clazz;
   protected int index;
 
-  @SafeVarargs
-  public SelenideElementIterator(CollectionSource collection, T... clazz) {
+  public SelenideElementIterator(CollectionSource collection, Class<T> clazz) {
     this.collection = collection;
-    this.clazz = classOf(clazz);
+    this.clazz = clazz;
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
@@ -217,6 +217,10 @@ public class SelenidePageFactory implements PageObjectFactory {
     if (BaseElementsCollection.class.isAssignableFrom(field.getType())) {
       return createElementsCollection(driver, searchContext, selector, field, alias);
     }
+
+    if (field.getType().isAssignableFrom(ElementsList.class) && isCollectionOfSelenideElements(field, genericTypes)) {
+      return createElementsCollection(driver, searchContext, selector, field, alias);
+    }
     else if (Container.class.isAssignableFrom(field.getType())) {
       return createElementsContainer(driver, searchContext, field, selector);
     }
@@ -228,6 +232,11 @@ public class SelenidePageFactory implements PageObjectFactory {
     }
 
     return defaultFieldDecorator(driver, searchContext).decorate(loader, field);
+  }
+
+  private boolean isCollectionOfSelenideElements(Field field, Type[] genericTypes) {
+    Class<?> listGenericType = getListGenericType(field, genericTypes);
+    return listGenericType != null && SelenideElement.class.isAssignableFrom(listGenericType);
   }
 
   @Nonnull
@@ -275,9 +284,8 @@ public class SelenidePageFactory implements PageObjectFactory {
 
   @Nonnull
   protected BaseElementsCollection<? extends SelenideElement, ? extends BaseElementsCollection<?, ?>> createCollection(
-    CollectionSource collection, Class<?> klass
-  ) {
-    return new ElementsCollection(collection);
+    CollectionSource collection, Class<?> klass) {
+    return new ElementsList(collection);
   }
 
   @CheckReturnValue
@@ -346,5 +354,11 @@ public class SelenidePageFactory implements PageObjectFactory {
       if (objects[i].equals(firstArgument)) return i;
     }
     return -1;
+  }
+
+  private static class ElementsList extends ElementsCollection implements NoOpsList<SelenideElement> {
+    ElementsList(CollectionSource collection) {
+      super(collection);
+    }
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementIteratorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementIteratorTest.java
@@ -15,7 +15,7 @@ final class SelenideElementIteratorTest {
   @Test
   void hasNext() {
     CollectionSource collection = mockCollection("collection with 1 element", webElement);
-    SelenideElementIterator<SelenideElement> selenideElementIterator = new SelenideElementIterator<>(collection);
+    SelenideElementIterator<SelenideElement> selenideElementIterator = new SelenideElementIterator<>(collection, SelenideElement.class);
 
     assertThat(selenideElementIterator.hasNext()).isTrue();
   }
@@ -23,7 +23,7 @@ final class SelenideElementIteratorTest {
   @Test
   void doesNotHasNext() {
     CollectionSource collection = mockCollection("empty collection");
-    SelenideElementIterator selenideElementIterator = new SelenideElementIterator(collection);
+    SelenideElementIterator<SelenideElement> selenideElementIterator = new SelenideElementIterator<>(collection, SelenideElement.class);
 
     assertThat(selenideElementIterator.hasNext()).isFalse();
   }
@@ -31,7 +31,7 @@ final class SelenideElementIteratorTest {
   @Test
   void next() {
     CollectionSource collection = mockCollection("collection with 1 element", webElement);
-    SelenideElementIterator selenideElementIterator = new SelenideElementIterator(collection);
+    SelenideElementIterator<SelenideElement> selenideElementIterator = new SelenideElementIterator<>(collection, SelenideElement.class);
     SelenideElement nextElement = selenideElementIterator.next();
 
     assertThat(nextElement).isNotNull();
@@ -42,7 +42,7 @@ final class SelenideElementIteratorTest {
   @Test
   void remove() {
     CollectionSource collection = mockCollection("collection with 1 element", webElement);
-    SelenideElementIterator selenideElementIterator = new SelenideElementIterator(collection);
+    SelenideElementIterator<SelenideElement> selenideElementIterator = new SelenideElementIterator<>(collection, SelenideElement.class);
 
     assertThatThrownBy(selenideElementIterator::remove)
       .isInstanceOf(UnsupportedOperationException.class)

--- a/src/test/java/integration/collections/CollectionMethodsTest.java
+++ b/src/test/java/integration/collections/CollectionMethodsTest.java
@@ -58,6 +58,16 @@ final class CollectionMethodsTest extends ITest {
   }
 
   @Test
+  void describeCollection() {
+    assertThat($$("#radioButtons input").describe()).isEqualTo(
+      "[<input name=\"me\" type=\"radio\" value=\"master\"></input>," +
+      " <input name=\"me\" type=\"radio\" value=\"margarita\"></input>," +
+      " <input name=\"me\" type=\"radio\" value=\"cat\"></input>," +
+      " <input name=\"me\" type=\"radio\" value=\"woland\"></input>]"
+    );
+  }
+
+  @Test
   void invalidSelector() {
     assertThatThrownBy(() -> $$(By.xpath("//xxx[@'")).shouldHave(size(0)))
       .isInstanceOf(InvalidSelectorException.class);

--- a/statics/src/test/java/integration/pageobjects/ElementsContainerWithManuallyInitializedFieldsTest.java
+++ b/statics/src/test/java/integration/pageobjects/ElementsContainerWithManuallyInitializedFieldsTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.support.FindBy;
 
+import java.util.Iterator;
+import java.util.List;
+
 import static com.codeborne.selenide.CollectionCondition.texts;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
@@ -36,6 +39,21 @@ final class ElementsContainerWithManuallyInitializedFieldsTest extends Integrati
   }
 
   @Test
+  void listWithFindByAnnotation() {
+    MyContainerWithList page = page();
+    page.options.get(0).shouldHave(text("-- Select your hero --"));
+    page.options.get(1).shouldHave(text("John Mc'Lain"));
+  }
+
+  @Test
+  void iterableWithFindByAnnotation() {
+    MyContainerWithIterable page = page();
+    Iterator<SelenideElement> iterator = page.options.iterator();
+    iterator.next().shouldHave(text("-- Select your hero --"));
+    iterator.next().shouldHave(text("John Mc'Lain"));
+  }
+
+  @Test
   void cannotInitializeElementsContainerOutsidePageObject() {
     assertThatThrownBy(() -> page(InvalidContainer.class))
       .isInstanceOf(IllegalArgumentException.class)
@@ -50,6 +68,16 @@ final class ElementsContainerWithManuallyInitializedFieldsTest extends Integrati
   private static class MyContainer implements Container {
     SelenideElement headerLink = $("h2>a");
     ElementsCollection options = $$("#hero>option");
+  }
+
+  private static class MyContainerWithList implements Container {
+    @FindBy(css = "#hero>option")
+    List<SelenideElement> options;
+  }
+
+  private static class MyContainerWithIterable implements Container {
+    @FindBy(css = "#hero>option")
+    Iterable<SelenideElement> options;
   }
 
   private static class InvalidContainer implements Container {


### PR DESCRIPTION
as a side effect, I fixed method $$.iterator() for mobile elements. Before now, it returned `Iterator<SelenideElement>` instead of `Iterator<SelenideAppiumElement>`.
