### PR TITLE
#2790 fix AppiumElementDescriber to work correctly in web browser

### DIFF
--- a/modules/appium/src/test/java/integration/web/WebTest.java
+++ b/modules/appium/src/test/java/integration/web/WebTest.java
@@ -2,14 +2,17 @@ package integration.web;
 
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.appium.SelenideAppiumElement;
+import com.codeborne.selenide.ex.ElementShould;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
+import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.appium.AppiumScrollOptions.up;
 import static com.codeborne.selenide.appium.SelenideAppium.$;
+import static java.time.Duration.ZERO;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class WebTest {
@@ -29,5 +32,9 @@ public class WebTest {
     assertThatThrownBy(() -> testimonials.scroll(up()))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Scrolling with options is only supported for mobile drivers");
+
+    assertThatThrownBy(() -> $(By.cssSelector(".service-links #lang_eng")).shouldHave(text("This.Is.Web."), ZERO))
+      .isInstanceOf(ElementShould.class)
+      .hasMessageContaining("Element: '<a href=\"https://selenide.org/\" id=\"lang_eng\">EN</a>'");
   }
 }

--- a/modules/appium/src/test/java/it/mobile/android/LoginTestWithCollectionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/LoginTestWithCollectionsTest.java
@@ -27,6 +27,7 @@ import static com.codeborne.selenide.appium.SelenideAppium.$$;
 import static com.codeborne.selenide.appium.SelenideAppium.$x;
 import static java.lang.System.currentTimeMillis;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.IterableUtil.sizeOf;
 
 public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
   @BeforeEach
@@ -55,10 +56,7 @@ public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
   @Test
   public void pageObjectWithSelenideElementList() {
     LoginPageWithSelenideElementList loginPage = page();
-    for (long start = currentTimeMillis();
-         currentTimeMillis() - start < timeout && loginPage.elements.size() != 2; ) {
-      sleep(100);
-    }
+    waitUntilCollectionFullyLoaded(loginPage.elements, 2);
     assertThat(loginPage.elements).hasSize(2);
     loginPage.elements.get(0).setValue("bob@example.com");
     loginPage.elements.get(1).setValue("secret");
@@ -67,6 +65,7 @@ public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
   @Test
   public void pageObjectWithSelenideAppiumElementList() {
     LoginPageWithSelenideAppiumElementList loginPage = page();
+    waitUntilCollectionFullyLoaded(loginPage.elements, 2);
     assertThat(loginPage.elements).hasSize(2);
     loginPage.elements.get(0).scroll(up()).setValue("bob@example.com");
     loginPage.elements.get(1).scroll(up()).setValue("secret");
@@ -77,6 +76,7 @@ public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
   @Test
   public void pageObjectWithSelenideAppiumElementIterable() {
     LoginPageWithSelenideAppiumElementIterable loginPage = page();
+    waitUntilCollectionFullyLoaded(loginPage.elements, 2);
     assertThat(loginPage.elements).hasSize(2);
     Iterator<SelenideAppiumElement> iterator = loginPage.elements.iterator();
     iterator.next().scroll(up()).setValue("bob@example.com");
@@ -95,6 +95,13 @@ public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
 
     SelenideAppiumElement errorMessage = $x("//*[@content-desc='generic-error-message']/android.widget.TextView").as("Error message");
     errorMessage.shouldHave(text("Provided credentials do not match any user in this service."));
+  }
+
+  private static void waitUntilCollectionFullyLoaded(Iterable<?> collection, int expectedSize) {
+    for (long start = currentTimeMillis();
+         currentTimeMillis() - start < timeout && sizeOf(collection) != expectedSize; ) {
+      sleep(100);
+    }
   }
 }
 


### PR DESCRIPTION
when a project has "selenide-appium" dependency, but opens a web browser (not mobile app), the default web element describer should be used instead of AppiumElementDescriber.
