### PR TITLE
Change of <select> element must also dispatch 'input' event

### DIFF
--- a/src/main/resources/select-options-by-index.js
+++ b/src/main/resources/select-options-by-index.js
@@ -26,12 +26,11 @@
     select.options[index].selected = 'selected';
   }
 
-  const event = document.createEvent('HTMLEvents');
-  event.initEvent('click', true, true);
-  select.dispatchEvent(event);
+  select.dispatchEvent(new Event('click'));
+
   if (getSelectedOptionsString(select) !== previousSelectedOptions) {
-    event.initEvent('change', true, true);
-    select.dispatchEvent(event);
+    select.dispatchEvent(new Event('input'));
+    select.dispatchEvent(new Event('change'));
   }
 
   return {};

--- a/src/main/resources/select-options-by-partial-text.js
+++ b/src/main/resources/select-options-by-partial-text.js
@@ -30,12 +30,11 @@
     optionByText(requestedPartialText).selected = 'selected';
   }
 
-  const event = document.createEvent('HTMLEvents');
-  event.initEvent('click', true, true);
-  select.dispatchEvent(event);
+  select.dispatchEvent(new Event('click'));
+
   if (getSelectedOptionsString(select) !== previousSelectedOptions) {
-    event.initEvent('change', true, true);
-    select.dispatchEvent(event);
+    select.dispatchEvent(new Event('input'));
+    select.dispatchEvent(new Event('change'));
   }
 
   return {};

--- a/src/main/resources/select-options-by-text.js
+++ b/src/main/resources/select-options-by-text.js
@@ -30,12 +30,11 @@
     optionByText(requestedText).selected = 'selected';
   }
 
-  const event = document.createEvent('HTMLEvents');
-  event.initEvent('click', true, true);
-  select.dispatchEvent(event);
+  select.dispatchEvent(new Event('click'));
+
   if (getSelectedOptionsString(select) !== previousSelectedOptions) {
-    event.initEvent('change', true, true);
-    select.dispatchEvent(event);
+    select.dispatchEvent(new Event('input'));
+    select.dispatchEvent(new Event('change'));
   }
 
   return {};

--- a/src/main/resources/select-options-by-value.js
+++ b/src/main/resources/select-options-by-value.js
@@ -30,12 +30,12 @@
     optionByValue(requestedValue).selected = 'selected';
   }
 
-  const event = document.createEvent('HTMLEvents');
-  event.initEvent('click', true, true);
-  select.dispatchEvent(event);
+
+  select.dispatchEvent(new Event('click'));
+
   if (getSelectedOptionsString(select) !== previousSelectedOptions) {
-    event.initEvent('change', true, true);
-    select.dispatchEvent(event);
+    select.dispatchEvent(new Event('input'));
+    select.dispatchEvent(new Event('change'));
   }
 
   return {};


### PR DESCRIPTION
## Proposed changes
Select option change natively dispatches 'input' and 'change' event. If code relies on listening 'input' event then it will not work inside test.

## Checklist
How to reproduce:
* Add a <select> element with input event handler
* Select a value from that <select> using any of the .selectOption...() methods
* Input event handler is not called with current version of Selenide
