### PR TITLE
bump LittleProxy from 2.2.4 to 2.3.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
   mockitoVersion = '5.13.0'
   slf4jVersion = '2.0.16'
   browserupProxyVersion = '2.2.18'
-  littleProxyVersion = '2.2.4'
+  littleProxyVersion = '2.3.0'
   jabelVersion = '1.0.0'
   byteBuddyVersion = '1.14.9'
   archunitVersion = '1.3.0'
@@ -29,6 +29,7 @@ subprojects {
 
   dependencies {
     constraints {
+      testImplementation("com.github.valfirst.browserup-proxy:browserup-proxy-core:$browserupProxyVersion")
       api("com.fasterxml.jackson.core:jackson-core:${jacksonVersion}") {because 'used by browserup-proxy'}
       testImplementation("io.github.littleproxy:littleproxy:$littleProxyVersion") {because 'used by browserup-proxy'}
     }
@@ -39,7 +40,10 @@ subprojects {
     implementation("com.google.guava:guava:33.3.0-jre")
     implementation("org.apache.commons:commons-lang3:3.17.0")
     implementation("commons-io:commons-io:2.16.1")
-    testImplementation("com.github.valfirst.browserup-proxy:browserup-proxy-core:$browserupProxyVersion")
+    testImplementation("com.github.valfirst.browserup-proxy:browserup-proxy-core") {
+      exclude group: 'xyz.rogfam' // "xyz.rogfam:littleproxy" was moved to "io.github.littleproxy:littleproxy"
+    }
+    testImplementation("io.github.littleproxy:littleproxy") {because 'used by browserup-proxy'}
     testImplementation("io.netty:netty-all:$nettyVersion")
     testImplementation("io.netty:netty-codec:$nettyVersion")
     testImplementation("org.eclipse.jetty:jetty-servlet:${jettyVersion}")


### PR DESCRIPTION
Version 2.3.0 removes support for UDT protocol. I guess we don't use it in Selenide.

Also, remove occasional dependency "xyz.rogfam:littleproxy".
