### PR TITLE
#2830 generate error details only once during error construction

### DIFF
--- a/modules/grid/src/main/java/org/selenide/grid/GridDownloader.java
+++ b/modules/grid/src/main/java/org/selenide/grid/GridDownloader.java
@@ -27,7 +27,7 @@ class GridDownloader {
       return localFile;
     }
     catch (IOException e) {
-      throw new FileNotDownloadedError(driver, "Failed to copy downloaded file from grid", driver.config().timeout(), e);
+      throw new FileNotDownloadedError("Failed to copy downloaded file from grid", driver.config().timeout(), e);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
@@ -199,7 +199,7 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
     while (!stopwatch.isTimeoutReached());
 
     if (lastError instanceof IndexOutOfBoundsException) {
-      throw new ElementNotFound(collection.driver(), collection.getAlias(), collection.description(), exist, lastError);
+      throw new ElementNotFound(collection.getAlias(), collection.description(), exist, lastError);
     }
     else if (lastError instanceof UIAssertionError uiAssertionError) {
       throw uiAssertionError;

--- a/src/main/java/com/codeborne/selenide/Modal.java
+++ b/src/main/java/com/codeborne/selenide/Modal.java
@@ -84,7 +84,7 @@ public class Modal {
 
   private static void checkDialogText(Driver driver, @Nullable String expectedDialogText, String actualDialogText) {
     if (expectedDialogText != null && !expectedDialogText.equals(actualDialogText)) {
-      DialogTextMismatch assertionError = new DialogTextMismatch(driver, expectedDialogText, actualDialogText);
+      DialogTextMismatch assertionError = new DialogTextMismatch(expectedDialogText, actualDialogText);
       throw UIAssertionError.wrap(driver, assertionError, driver.config().timeout());
     }
   }

--- a/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
+++ b/src/main/java/com/codeborne/selenide/SelenideTargetLocator.java
@@ -297,17 +297,17 @@ public class SelenideTargetLocator implements TargetLocator {
   }
 
   private Error frameNotFoundError(String message, Throwable cause) {
-    FrameNotFoundError error = new FrameNotFoundError(driver, message, cause);
+    FrameNotFoundError error = new FrameNotFoundError(message, cause);
     return UIAssertionError.wrap(driver, error, config.timeout());
   }
 
   private Error windowNotFoundError(String message, Throwable cause) {
-    WindowNotFoundError error = new WindowNotFoundError(driver, message, cause);
+    WindowNotFoundError error = new WindowNotFoundError(message, cause);
     return UIAssertionError.wrap(driver, error, config.timeout());
   }
 
   private Error alertNotFoundError(Throwable cause, long timeoutMs) {
-    var error = new AlertNotFoundError(driver, cause);
+    var error = new AlertNotFoundError(cause);
     return UIAssertionError.wrap(driver, error, timeoutMs);
   }
 }

--- a/src/main/java/com/codeborne/selenide/WebElementsCondition.java
+++ b/src/main/java/com/codeborne/selenide/WebElementsCondition.java
@@ -40,7 +40,7 @@ public abstract class WebElementsCondition {
    * Override this method if you want to customize error class or description
    */
   public void fail(CollectionSource collection, CheckResult lastCheckResult, @Nullable Exception cause, long timeoutMs) {
-    throw new UIAssertionError(collection.driver(),
+    throw new UIAssertionError(
       errorMessage() +
       lineSeparator() + "Actual: " + lastCheckResult.getActualValue() +
       lineSeparator() + "Expected: " + expectedValue() +

--- a/src/main/java/com/codeborne/selenide/collections/Attributes.java
+++ b/src/main/java/com/codeborne/selenide/collections/Attributes.java
@@ -70,7 +70,7 @@ public class Attributes extends WebElementsCondition {
     }
 
     String message = lastCheckResult.getMessageOrElse(() -> String.format("Attribute '%s' values mismatch", attribute));
-    throw new AttributesMismatch(collection.driver(), message, collection, expectedValues,
+    throw new AttributesMismatch(message, collection, expectedValues,
       actualAttributeValues, explanation, timeoutMs, cause);
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByTextOrIndex.java
@@ -52,17 +52,17 @@ public class SelectOptionByTextOrIndex implements Command<Void> {
       throw new IllegalArgumentException("Cannot select option from a non-select element");
     }
     if (error.containsKey("disabledSelect")) {
-      throw new InvalidStateError(selectField.driver(), selectField.description(), "Cannot select option in a disabled select");
+      throw new InvalidStateError(selectField.description(), "Cannot select option in a disabled select");
     }
     if (error.containsKey("disabledOptions")) {
       List<String> optionsTexts = cast(error.get("disabledOptions"));
       String elementDescription = String.format("%s/option[text:%s]", selectField.description(), arrayToString(optionsTexts));
-      throw new InvalidStateError(selectField.driver(), elementDescription, "Cannot select a disabled option");
+      throw new InvalidStateError(elementDescription, "Cannot select a disabled option");
     }
     if (error.containsKey("optionsNotFound")) {
       List<String> optionsTexts = cast(error.get("optionsNotFound"));
       String elementDescription = String.format("%s/option[text:%s]", selectField.getSearchCriteria(), arrayToString(optionsTexts));
-      throw new ElementNotFound(selectField.driver(), selectField.getAlias(), elementDescription, exist);
+      throw new ElementNotFound(selectField.getAlias(), elementDescription, exist);
     }
   }
 
@@ -72,17 +72,17 @@ public class SelectOptionByTextOrIndex implements Command<Void> {
       throw new IllegalArgumentException("Cannot select option from a non-select element");
     }
     if (error.containsKey("disabledSelect")) {
-      throw new InvalidStateError(selectField.driver(), selectField.description(), "Cannot select option in a disabled select");
+      throw new InvalidStateError(selectField.description(), "Cannot select option in a disabled select");
     }
     if (error.containsKey("disabledOptions")) {
       List<Integer> index = cast(error.get("disabledOptions"));
       String elementDescription = String.format("%s/option[index:%s]", selectField.description(), arrayToString(index));
-      throw new InvalidStateError(selectField.driver(), elementDescription, "Cannot select a disabled option");
+      throw new InvalidStateError(elementDescription, "Cannot select a disabled option");
     }
     if (error.containsKey("optionsNotFound")) {
       List<Integer> index = cast(error.get("optionsNotFound"));
       String elementDescription = String.format("%s/option[index:%s]", selectField.getSearchCriteria(), arrayToString(index));
-      throw new ElementNotFound(selectField.driver(), selectField.getAlias(), elementDescription, exist);
+      throw new ElementNotFound(selectField.getAlias(), elementDescription, exist);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionByValue.java
@@ -36,17 +36,17 @@ public class SelectOptionByValue implements Command<Void> {
       throw new IllegalArgumentException("Cannot select option from a non-select element");
     }
     if (error.containsKey("disabledSelect")) {
-      throw new InvalidStateError(selectField.driver(), selectField.description(), "Cannot select option in a disabled select");
+      throw new InvalidStateError(selectField.description(), "Cannot select option in a disabled select");
     }
     if (error.containsKey("disabledOptions")) {
       List<String> value = cast(error.get("disabledOptions"));
       String elementDescription = String.format("%s/option[value:%s]", selectField.description(), arrayToString(value));
-      throw new InvalidStateError(selectField.driver(), elementDescription, "Cannot select a disabled option");
+      throw new InvalidStateError(elementDescription, "Cannot select a disabled option");
     }
     if (error.containsKey("optionsNotFound")) {
       List<String> value = cast(error.get("optionsNotFound"));
       String elementDescription = String.format("%s/option[value:%s]", selectField.getSearchCriteria(), arrayToString(value));
-      throw new ElementNotFound(selectField.driver(), selectField.getAlias(), elementDescription, exist);
+      throw new ElementNotFound(selectField.getAlias(), elementDescription, exist);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/SelectOptionContainingText.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectOptionContainingText.java
@@ -32,17 +32,17 @@ public class SelectOptionContainingText implements Command<Void> {
       throw new IllegalArgumentException("Cannot select option from a non-select element");
     }
     if (error.containsKey("disabledSelect")) {
-      throw new InvalidStateError(selectField.driver(), selectField.description(), "Cannot select option in a disabled select");
+      throw new InvalidStateError(selectField.description(), "Cannot select option in a disabled select");
     }
     if (error.containsKey("disabledOptions")) {
       List<String> text = cast(error.get("disabledOptions"));
       String elementDescription = String.format("%s/option[text containing:%s]", selectField.description(), arrayToString(text));
-      throw new InvalidStateError(selectField.driver(), elementDescription, "Cannot select a disabled option");
+      throw new InvalidStateError(elementDescription, "Cannot select a disabled option");
     }
     if (error.containsKey("optionsNotFound")) {
       List<String> text = cast(error.get("optionsNotFound"));
       String elementDescription = String.format("%s/option[text containing:%s]", selectField.getSearchCriteria(), arrayToString(text));
-      throw new ElementNotFound(selectField.driver(), selectField.getAlias(), elementDescription, exist);
+      throw new ElementNotFound(selectField.getAlias(), elementDescription, exist);
     }
     return null;
   }

--- a/src/main/java/com/codeborne/selenide/commands/SelectRadio.java
+++ b/src/main/java/com/codeborne/selenide/commands/SelectRadio.java
@@ -37,13 +37,13 @@ public class SelectRadio implements Command<SelenideElement> {
     for (WebElement radio : matchingRadioButtons) {
       if (value.equals(radio.getAttribute("value"))) {
         if (radio.getAttribute("readonly") != null) {
-          throw new InvalidStateError(locator.driver(), locator.description(), "Cannot select readonly radio button");
+          throw new InvalidStateError(locator.description(), "Cannot select readonly radio button");
         }
 
         click.click(locator.driver(), radio, usingDefaultMethod());
         return wrap(locator.driver(), radio, locator.getSearchCriteria());
       }
     }
-    throw new ElementNotFound(locator.driver(), locator.getAlias(), locator.getSearchCriteria(), value(value));
+    throw new ElementNotFound(locator.getAlias(), locator.getSearchCriteria(), value(value));
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/SetSelected.java
+++ b/src/main/java/com/codeborne/selenide/commands/SetSelected.java
@@ -30,22 +30,22 @@ public class SetSelected implements Command<SelenideElement> {
     boolean selected = firstOf(args);
     WebElement element = locator.getWebElement();
     if (!element.isDisplayed()) {
-      throw new InvalidStateError(locator.driver(), locator.description(), "Cannot change invisible element");
+      throw new InvalidStateError(locator.description(), "Cannot change invisible element");
     }
     String tag = element.getTagName();
     if (!tag.equals("option")) {
       if (tag.equals("input")) {
         String type = element.getAttribute("type");
         if (!type.equals("checkbox") && !type.equals("radio")) {
-          throw new InvalidStateError(locator.driver(), locator.description(), "Only use setSelected on checkbox/option/radio");
+          throw new InvalidStateError(locator.description(), "Only use setSelected on checkbox/option/radio");
         }
       }
       else {
-        throw new InvalidStateError(locator.driver(), locator.description(), "Only use setSelected on checkbox/option/radio");
+        throw new InvalidStateError(locator.description(), "Only use setSelected on checkbox/option/radio");
       }
     }
     if (element.getAttribute("readonly") != null || element.getAttribute("disabled") != null) {
-      throw new InvalidStateError(locator.driver(), locator.description(), "Cannot change value of readonly/disabled element");
+      throw new InvalidStateError(locator.description(), "Cannot change value of readonly/disabled element");
     }
     if (element.isSelected() != selected) {
       click.execute(proxy, locator, NO_ARGS);

--- a/src/main/java/com/codeborne/selenide/commands/SetValue.java
+++ b/src/main/java/com/codeborne/selenide/commands/SetValue.java
@@ -62,7 +62,7 @@ public class SetValue implements Command<SelenideElement> {
       String error = setValueByJs(driver, element, value);
       if (isNotEmpty(error)) {
         String elementDescription = locator.description();
-        throw new InvalidStateError(driver, elementDescription, error);
+        throw new InvalidStateError(elementDescription, error);
       }
     }
     else {

--- a/src/main/java/com/codeborne/selenide/ex/AlertNotFoundError.java
+++ b/src/main/java/com/codeborne/selenide/ex/AlertNotFoundError.java
@@ -1,12 +1,10 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class AlertNotFoundError extends UIAssertionError {
-  public AlertNotFoundError(Driver driver, Throwable cause) {
-    super(driver, "Alert not found", cause);
+  public AlertNotFoundError(Throwable cause) {
+    super("Alert not found", cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/AttributesMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/AttributesMismatch.java
@@ -1,6 +1,5 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.CollectionSource;
 
 import javax.annotation.Nullable;
@@ -11,10 +10,10 @@ import static java.lang.System.lineSeparator;
 
 @ParametersAreNonnullByDefault
 public class AttributesMismatch extends UIAssertionError {
-  public AttributesMismatch(Driver driver, String message, CollectionSource collection,
+  public AttributesMismatch(String message, CollectionSource collection,
                             List<String> expectedValues, List<String> actualValues,
                             @Nullable String explanation, long timeoutMs, @Nullable Exception cause) {
-    super(driver, message +
+    super(message +
         lineSeparator() + "Actual (" + actualValues.size() + "): " + actualValues +
         lineSeparator() + "Expected (" + expectedValues.size() + "): " + expectedValues +
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +

--- a/src/main/java/com/codeborne/selenide/ex/ConditionMetError.java
+++ b/src/main/java/com/codeborne/selenide/ex/ConditionMetError.java
@@ -1,7 +1,6 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.ObjectCondition;
 
 import javax.annotation.Nullable;
@@ -9,10 +8,9 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class ConditionMetError extends ObjectConditionError {
-  public <T> ConditionMetError(Driver driver, ObjectCondition<T> condition, T subject,
+  public <T> ConditionMetError(ObjectCondition<T> condition, T subject,
                                @Nullable CheckResult checkResult, @Nullable Exception cause) {
     super(
-      driver,
       condition.describe(subject) + " " + condition.negativeDescription(),
       condition.expectedValue(),
       checkResult == null ? null : checkResult.getActualValue(),

--- a/src/main/java/com/codeborne/selenide/ex/ConditionNotMetError.java
+++ b/src/main/java/com/codeborne/selenide/ex/ConditionNotMetError.java
@@ -1,7 +1,6 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.CheckResult;
-import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.ObjectCondition;
 
 import javax.annotation.Nullable;
@@ -9,10 +8,9 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class ConditionNotMetError extends ObjectConditionError {
-  public <T> ConditionNotMetError(Driver driver, ObjectCondition<T> condition, T subject,
+  public <T> ConditionNotMetError(ObjectCondition<T> condition, T subject,
                                   @Nullable CheckResult checkResult, @Nullable Exception cause) {
     super(
-      driver,
       condition.describe(subject) + " " + condition.description(),
       condition.expectedValue(),
       checkResult == null ? null : checkResult.getActualValue(),

--- a/src/main/java/com/codeborne/selenide/ex/DialogTextMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/DialogTextMismatch.java
@@ -1,14 +1,11 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class DialogTextMismatch extends UIAssertionError {
-  public DialogTextMismatch(Driver driver, String expectedText, String actualText) {
+  public DialogTextMismatch(String expectedText, String actualText) {
     super(
-      driver,
       String.format("Dialog text mismatch" +
         "%nActual: %s" +
         "%nExpected: %s", actualText, expectedText),

--- a/src/main/java/com/codeborne/selenide/ex/DoesNotContainTextsError.java
+++ b/src/main/java/com/codeborne/selenide/ex/DoesNotContainTextsError.java
@@ -14,7 +14,7 @@ public class DoesNotContainTextsError extends UIAssertionError {
   public DoesNotContainTextsError(CollectionSource collection,
                                   List<String> expectedTexts, List<String> actualTexts, List<String> difference,
                                   @Nullable String explanation, long timeoutMs, @Nullable Throwable cause) {
-    super(collection.driver(),
+    super(
       "The collection with text elements: " + actualTexts +
         lineSeparator() + "should contain all of the following text elements: " + expectedTexts +
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +

--- a/src/main/java/com/codeborne/selenide/ex/ElementIsNotClickableError.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementIsNotClickableError.java
@@ -1,12 +1,10 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class ElementIsNotClickableError extends UIAssertionError {
-  public ElementIsNotClickableError(Driver driver, String elementDescription, Throwable cause) {
-    super(driver, "Element is not clickable: " + elementDescription, cause);
+  public ElementIsNotClickableError(String elementDescription, Throwable cause) {
+    super("Element is not clickable: " + elementDescription, cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementNotFound.java
@@ -1,6 +1,5 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.WebElementCondition;
 import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.CollectionSource;
@@ -12,28 +11,28 @@ import java.util.List;
 
 @ParametersAreNonnullByDefault
 public class ElementNotFound extends UIAssertionError {
-  public ElementNotFound(Driver driver, Alias alias, By searchCriteria, WebElementCondition expectedCondition) {
-    this(driver, alias, searchCriteria.toString(), expectedCondition, null);
+  public ElementNotFound(Alias alias, By searchCriteria, WebElementCondition expectedCondition) {
+    this(alias, searchCriteria.toString(), expectedCondition, null);
   }
 
-  public ElementNotFound(Driver driver, Alias alias, String searchCriteria, WebElementCondition expectedCondition) {
-    super(driver, String.format("Element%s not found {%s}" +
+  public ElementNotFound(Alias alias, String searchCriteria, WebElementCondition expectedCondition) {
+    super(String.format("Element%s not found {%s}" +
       "%nExpected: %s", alias.appendable(), searchCriteria, expectedCondition));
   }
 
-  public ElementNotFound(Driver driver, Alias alias, String searchCriteria, WebElementCondition expectedCondition,
+  public ElementNotFound(Alias alias, String searchCriteria, WebElementCondition expectedCondition,
                          @Nullable Throwable cause) {
-    super(driver, String.format("Element%s not found {%s}" +
+    super(String.format("Element%s not found {%s}" +
       "%nExpected: %s", alias.appendable(), searchCriteria, expectedCondition), cause);
   }
 
   public ElementNotFound(CollectionSource collection, List<String> expectedTexts, @Nullable Throwable cause) {
-    super(collection.driver(), String.format("Element%s not found {%s}" +
+    super(String.format("Element%s not found {%s}" +
       "%nExpected: %s", collection.getAlias().appendable(), collection.getSearchCriteria(), expectedTexts), cause);
   }
 
   public ElementNotFound(CollectionSource collection, String description, long timeoutMs, @Nullable Throwable cause) {
-    super(collection.driver(), String.format("Element%s not found {%s}%nExpected: %s",
+    super(String.format("Element%s not found {%s}%nExpected: %s",
         collection.getAlias().appendable(), collection.getSearchCriteria(), description),
       timeoutMs,
       cause);

--- a/src/main/java/com/codeborne/selenide/ex/ElementShould.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShould.java
@@ -21,7 +21,6 @@ public class ElementShould extends UIAssertionError {
                        WebElementCondition expectedCondition, @Nullable CheckResult lastCheckResult,
                        WebElement element, @Nullable Throwable cause) {
     super(
-      driver,
       join(
         String.format("Element%s should %s%s {%s}", alias.appendable(), prefix, expectedCondition, searchCriteria),
         String.format("Element: '%s'", describe.fully(driver, element)),

--- a/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementShouldNot.java
@@ -21,7 +21,6 @@ public class ElementShouldNot extends UIAssertionError {
                           WebElementCondition expectedCondition, @Nullable CheckResult lastCheckResult,
                           WebElement element, @Nullable Throwable cause) {
     super(
-      driver,
       join(
         String.format("Element%s should not %s%s {%s}", alias.appendable(), prefix, expectedCondition, searchCriteria),
         String.format("Element: '%s'", describe.fully(driver, element)),

--- a/src/main/java/com/codeborne/selenide/ex/ElementWithTextNotFound.java
+++ b/src/main/java/com/codeborne/selenide/ex/ElementWithTextNotFound.java
@@ -16,7 +16,6 @@ public class ElementWithTextNotFound extends UIAssertionError {
                                  @Nullable String explanation,
                                  long timeoutMs, @Nullable Throwable cause) {
     super(
-      collection.driver(),
       "Element with text not found" +
         lineSeparator() + "Actual: " + actualTexts +
         lineSeparator() + "Expected: " + expectedTexts +

--- a/src/main/java/com/codeborne/selenide/ex/ErrorFormatter.java
+++ b/src/main/java/com/codeborne/selenide/ex/ErrorFormatter.java
@@ -17,6 +17,10 @@ public interface ErrorFormatter {
 
   @CheckReturnValue
   @Nonnull
+  String causedBy(@Nullable Throwable cause);
+
+  @CheckReturnValue
+  @Nonnull
   default String formatActualValue(@Nullable String actualValue) {
     return actualValue == null ? "" : String.format("Actual value: %s", actualValue);
   }

--- a/src/main/java/com/codeborne/selenide/ex/FileNotDownloadedError.java
+++ b/src/main/java/com/codeborne/selenide/ex/FileNotDownloadedError.java
@@ -1,15 +1,13 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-
 import javax.annotation.Nullable;
 
 public class FileNotDownloadedError extends UIAssertionError {
-  public FileNotDownloadedError(Driver driver, String message, long timeout) {
-    super(driver, message, timeout, null);
+  public FileNotDownloadedError(String message, long timeout) {
+    super(message, timeout, null);
   }
 
-  public FileNotDownloadedError(Driver driver, String message, long timeout, @Nullable Exception cause) {
-    super(driver, message, timeout, cause);
+  public FileNotDownloadedError(String message, long timeout, @Nullable Exception cause) {
+    super(message, timeout, cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/FrameNotFoundError.java
+++ b/src/main/java/com/codeborne/selenide/ex/FrameNotFoundError.java
@@ -1,12 +1,10 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class FrameNotFoundError extends UIAssertionError {
-  public FrameNotFoundError(Driver driver, String message, Throwable cause) {
-    super(driver, message, cause);
+  public FrameNotFoundError(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/InvalidStateError.java
+++ b/src/main/java/com/codeborne/selenide/ex/InvalidStateError.java
@@ -1,18 +1,17 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Cleanup;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class InvalidStateError extends UIAssertionError {
-  public InvalidStateError(Driver driver, String elementDescription, Throwable cause) {
-    super(driver, "Invalid element state [" + elementDescription + "]: " +
+  public InvalidStateError(String elementDescription, Throwable cause) {
+    super("Invalid element state [" + elementDescription + "]: " +
       Cleanup.of.webdriverExceptionMessage(cause.getMessage()), cause);
   }
 
-  public InvalidStateError(Driver driver, String elementDescription, String message) {
-    super(driver, "Invalid element state [" + elementDescription + "]: " + message);
+  public InvalidStateError(String elementDescription, String message) {
+    super("Invalid element state [" + elementDescription + "]: " + message);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/ListSizeMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/ListSizeMismatch.java
@@ -15,7 +15,6 @@ public class ListSizeMismatch extends UIAssertionError {
                           @Nullable Exception cause,
                           long timeoutMs) {
     super(
-      collection.driver(),
       "List size mismatch: expected: " + operator + ' ' + expectedSize +
         (explanation == null ? "" : " (because " + explanation + ")") +
         ", actual: " + actualSize +

--- a/src/main/java/com/codeborne/selenide/ex/MatcherError.java
+++ b/src/main/java/com/codeborne/selenide/ex/MatcherError.java
@@ -16,7 +16,6 @@ public class MatcherError extends UIAssertionError {
                       @Nullable Exception cause,
                       long timeoutMs) {
     super(
-      collection.driver(),
       "Collection matcher error" +
         lineSeparator() + "Expected: " + expected +
         (explanation == null ? "" : lineSeparator() + "Because: " + explanation) +

--- a/src/main/java/com/codeborne/selenide/ex/ObjectConditionError.java
+++ b/src/main/java/com/codeborne/selenide/ex/ObjectConditionError.java
@@ -1,16 +1,13 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-
 import javax.annotation.Nullable;
 
 import static com.codeborne.selenide.ex.Strings.join;
 
 class ObjectConditionError extends UIAssertionError {
-  protected ObjectConditionError(Driver driver, String message, String expectedValue, String actualValue,
+  protected ObjectConditionError(String message, String expectedValue, String actualValue,
                                  @Nullable Exception cause) {
     super(
-      driver,
       join(message, errorFormatter.formatActualValue(actualValue)),
       expectedValue,
       actualValue,

--- a/src/main/java/com/codeborne/selenide/ex/SelenideErrorFormatter.java
+++ b/src/main/java/com/codeborne/selenide/ex/SelenideErrorFormatter.java
@@ -47,7 +47,8 @@ public class SelenideErrorFormatter implements ErrorFormatter {
 
   @CheckReturnValue
   @Nonnull
-  protected String causedBy(@Nullable Throwable cause) {
+  @Override
+  public String causedBy(@Nullable Throwable cause) {
     if (cause == null) {
       return "";
     }

--- a/src/main/java/com/codeborne/selenide/ex/TextsMismatch.java
+++ b/src/main/java/com/codeborne/selenide/ex/TextsMismatch.java
@@ -15,7 +15,6 @@ public class TextsMismatch extends UIAssertionError {
                        @Nullable String explanation, long timeoutMs,
                        @Nullable Throwable cause) {
     super(
-      collection.driver(),
       message +
         lineSeparator() + "Actual (" + actualTexts.size() + "): " + actualTexts +
         lineSeparator() + "Expected (" + expectedTexts.size() + "): " + expectedTexts +

--- a/src/main/java/com/codeborne/selenide/ex/UIAssertionError.java
+++ b/src/main/java/com/codeborne/selenide/ex/UIAssertionError.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -23,69 +22,68 @@ public class UIAssertionError extends AssertionFailedError {
   private static final Logger log = LoggerFactory.getLogger(UIAssertionError.class);
   protected static final ErrorFormatter errorFormatter = inject(ErrorFormatter.class);
 
-  private final Driver driver;
   private Screenshot screenshot = Screenshot.none();
   private long timeoutMs;
+  private final String initialErrorMessage;
+  private String detailedErrorMessage;
 
-  protected UIAssertionError(Driver driver, String message) {
+  protected UIAssertionError(String message) {
     super(message);
-    this.driver = driver;
+    initialErrorMessage = message;
   }
 
-  public UIAssertionError(Driver driver, String message, @Nullable Object expected, @Nullable Object actual) {
+  public UIAssertionError(String message, @Nullable Object expected, @Nullable Object actual) {
     super(message, expected, actual);
-    this.driver = driver;
+    initialErrorMessage = message;
   }
 
-  protected UIAssertionError(Driver driver, String message, @Nullable Object expected, @Nullable Object actual, long timeoutMs) {
+  protected UIAssertionError(String message, @Nullable Object expected, @Nullable Object actual, long timeoutMs) {
     super(message, expected, actual);
-    this.driver = driver;
     this.timeoutMs = timeoutMs;
+    initialErrorMessage = message;
   }
 
-  protected UIAssertionError(Driver driver, String message, @Nullable Throwable cause) {
+  protected UIAssertionError(String message, @Nullable Throwable cause) {
     super(message, cause);
-    this.driver = driver;
+    initialErrorMessage = message;
   }
 
-  protected UIAssertionError(Driver driver, String message, long timeoutMs, @Nullable Throwable cause) {
+  protected UIAssertionError(String message, long timeoutMs, @Nullable Throwable cause) {
     super(message, cause);
-    this.driver = driver;
     this.timeoutMs = timeoutMs;
+    initialErrorMessage = message;
   }
 
-  protected UIAssertionError(Driver driver, String message,
+  protected UIAssertionError(String message,
                              @Nullable Object expected, @Nullable Object actual,
                              @Nullable Throwable cause) {
     super(message, expected, actual, cause);
-    this.driver = driver;
+    initialErrorMessage = message;
   }
 
-  protected UIAssertionError(Driver driver, String message,
+  protected UIAssertionError(String message,
                              @Nullable Object expected, @Nullable Object actual,
                              @Nullable Throwable cause,
                              long timeoutMs) {
     super(message, expected, actual, cause);
-    this.driver = driver;
     this.timeoutMs = timeoutMs;
+    initialErrorMessage = message;
   }
 
   @CheckReturnValue
   @Override
   public final String getMessage() {
-    return join(super.getMessage(), generateErrorDetails());
+    if (detailedErrorMessage == null) {
+      // if e.getMessage() was occasionally called before wrapThrowable()
+      return join(initialErrorMessage, errorFormatter.causedBy(getCause()));
+    }
+    return detailedErrorMessage;
   }
 
   @CheckReturnValue
   @Override
   public final String toString() {
     return getMessage();
-  }
-
-  @CheckReturnValue
-  @Nonnull
-  private String generateErrorDetails() {
-    return errorFormatter.generateErrorDetails(this, driver, screenshot, timeoutMs);
   }
 
   /**
@@ -111,7 +109,7 @@ public class UIAssertionError extends AssertionFailedError {
   @CheckReturnValue
   private static UIAssertionError wrapThrowable(Driver driver, Throwable error, long timeoutMs) {
     UIAssertionError uiError = error instanceof UIAssertionError uiAssertionError ?
-      uiAssertionError : wrapToUIAssertionError(driver, error);
+      uiAssertionError : wrapToUIAssertionError(error);
     uiError.timeoutMs = timeoutMs;
     if (uiError.screenshot.isPresent()) {
       log.warn("UIAssertionError already has screenshot: {} {} -> {}",
@@ -121,13 +119,15 @@ public class UIAssertionError extends AssertionFailedError {
       Config config = driver.config();
       uiError.screenshot = ScreenShotLaboratory.getInstance()
         .takeScreenshot(driver, config.screenshots(), config.savePageSource());
+      uiError.detailedErrorMessage = join(uiError.initialErrorMessage,
+        errorFormatter.generateErrorDetails(uiError, driver, uiError.screenshot, uiError.timeoutMs));
     }
     return uiError;
   }
 
   @CheckReturnValue
-  private static UIAssertionError wrapToUIAssertionError(Driver driver, Throwable error) {
+  private static UIAssertionError wrapToUIAssertionError(Throwable error) {
     String message = Cleanup.of.webdriverExceptionMessage(error);
-    return new UIAssertionError(driver, message, error);
+    return new UIAssertionError(message, error);
   }
 }

--- a/src/main/java/com/codeborne/selenide/ex/WindowNotFoundError.java
+++ b/src/main/java/com/codeborne/selenide/ex/WindowNotFoundError.java
@@ -1,12 +1,10 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class WindowNotFoundError extends UIAssertionError {
-  public WindowNotFoundError(Driver driver, String message, Throwable cause) {
-    super(driver, message, cause);
+  public WindowNotFoundError(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElement.java
@@ -71,7 +71,7 @@ public class CollectionElement extends WebElementSource {
   @Nonnull
   public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     if (collection.getElements().isEmpty()) {
-      return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, cause);
+      return new ElementNotFound(getAlias(), getSearchCriteria(), visible, cause);
     }
     return super.createElementNotFoundError(condition, cause);
   }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
@@ -90,7 +90,7 @@ public class DownloadFileToFolder {
       log.debug("All downloaded files: {}", folder.filesAsString());
     }
 
-    File downloadedFile = newDownloads.firstDownloadedFile(driver, timeout, fileFilter);
+    File downloadedFile = newDownloads.firstDownloadedFile(timeout, fileFilter);
     return archiveFile(driver, downloadedFile);
   }
 
@@ -125,7 +125,7 @@ public class DownloadFileToFolder {
     if (folder.hasFiles(extension, filter)) {
       String message = String.format("Folder %s still contains files %s after %s ms. " +
                                      "Apparently, the downloading hasn't completed in time.", folder, extension, timeout);
-      throw new FileNotDownloadedError(driver, message, timeout);
+      throw new FileNotDownloadedError(message, timeout);
     }
   }
 
@@ -187,7 +187,7 @@ public class DownloadFileToFolder {
         filter.description(), timeout, folder, filesHasNotBeenUpdatedForMs,
         start, lastFileUpdate, now, incrementTimeout,
         folder.modificationTimes());
-      throw new FileNotDownloadedError(driver, message, timeout);
+      throw new FileNotDownloadedError(message, timeout);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
@@ -84,7 +84,7 @@ public class DownloadFileWithCdp {
       if (!fileFilter.match(new DownloadedFile(file, emptyMap()))) {
         String message = String.format("Failed to download file%s in %d ms.%s;%n actually downloaded: %s",
           fileFilter.description(), timeout, fileFilter.description(), file.getAbsolutePath());
-        throw new FileNotDownloadedError(driver, message, timeout);
+        throw new FileNotDownloadedError(message, timeout);
       }
 
       // Move file to unique folder
@@ -116,7 +116,7 @@ public class DownloadFileWithCdp {
         return downloadedFile.get().file();
       }
       else {
-        failFastIfNoChanges(driver, downloads, fileFilter, downloadStartedAt, timeout, incrementTimeout);
+        failFastIfNoChanges(downloads, fileFilter, downloadStartedAt, timeout, incrementTimeout);
       }
       stopwatch.sleep(pollingInterval);
     }
@@ -124,7 +124,7 @@ public class DownloadFileWithCdp {
 
     String message = "Failed to download file%s in %d ms., found files: %s".formatted(
       fileFilter.description(), timeout, downloads.folder().files());
-    throw new FileNotDownloadedError(driver, message, timeout);
+    throw new FileNotDownloadedError(message, timeout);
   }
 
   private DevTools initDevTools(Driver driver) {
@@ -249,7 +249,7 @@ public class DownloadFileWithCdp {
         case CANCELED -> {
           String message = "File download is %s (received bytes: %s, total bytes: %s, guid: %s)".formatted(
             e.getState(), e.getReceivedBytes(), e.getTotalBytes(), e.getGuid());
-          throw new FileNotDownloadedError(driver, message, timeout);
+          throw new FileNotDownloadedError(message, timeout);
         }
         case COMPLETED -> downloads.finish(e.getGuid());
         case INPROGRESS -> downloads.inProgress(e);
@@ -262,7 +262,7 @@ public class DownloadFileWithCdp {
     }
   }
 
-  private void failFastIfNoChanges(Driver driver, CdpDownloads downloads, FileFilter filter,
+  private void failFastIfNoChanges(CdpDownloads downloads, FileFilter filter,
                                    long downloadStartedAt, long timeout, long incrementTimeout) {
     long now = currentTimeMillis();
     long lastModifiedAt = downloads.lastModificationTime().orElse(downloadStartedAt);
@@ -273,7 +273,7 @@ public class DownloadFileWithCdp {
         "(lastUpdate: %s, now: %s, incrementTimeout: %s)",
         filter.description(), timeout, downloads.folder, filesHasNotBeenUpdatedForMs,
         lastModifiedAt, now, incrementTimeout);
-      throw new FileNotDownloadedError(driver, message, timeout);
+      throw new FileNotDownloadedError(message, timeout);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
@@ -117,7 +117,7 @@ public class DownloadFileWithHttpRequest {
       );
     }
     catch (IOException e) {
-      throw new FileNotDownloadedError(driver, "Failed to download " + url + " in " + timeout + " ms.", timeout, e);
+      throw new FileNotDownloadedError("Failed to download " + url + " in " + timeout + " ms.", timeout, e);
     }
   }
 
@@ -133,7 +133,7 @@ public class DownloadFileWithHttpRequest {
       throw new RuntimeException("Failed to download file " + url + ": " + response);
     }
     if (response.getCode() >= 400) {
-      throw new FileNotDownloadedError(driver, "Failed to download file " + url + ": " + response, timeout);
+      throw new FileNotDownloadedError("Failed to download file " + url + ": " + response, timeout);
     }
 
     String fileName = getFileName(url, response);
@@ -143,7 +143,7 @@ public class DownloadFileWithHttpRequest {
     if (!fileFilter.match(new DownloadedFile(downloadedFile, emptyMap()))) {
       String message = String.format("Failed to download file from %s in %d ms.%s;%n actually downloaded: %s",
         url, timeout, fileFilter.description(), downloadedFile.getAbsolutePath());
-      throw new FileNotDownloadedError(driver, message, timeout);
+      throw new FileNotDownloadedError(message, timeout);
     }
     return downloadedFile;
   }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
@@ -77,7 +77,7 @@ public class DownloadFileWithProxyServer {
         log.info("Downloaded {}", filter.downloads().filesAsString());
         log.info("Just in case, intercepted {}", filter.responsesAsString());
       }
-      return filter.downloads().firstDownloadedFile(driver, timeout, fileFilter);
+      return filter.downloads().firstDownloadedFile(timeout, fileFilter);
     }
     finally {
       filter.deactivate();

--- a/src/main/java/com/codeborne/selenide/impl/Downloads.java
+++ b/src/main/java/com/codeborne/selenide/impl/Downloads.java
@@ -1,6 +1,5 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.ex.FileNotDownloadedError;
 import com.codeborne.selenide.files.DownloadedFile;
 import com.codeborne.selenide.files.FileFilter;
@@ -78,11 +77,11 @@ public class Downloads {
 
   @CheckReturnValue
   @Nonnull
-  public File firstDownloadedFile(Driver driver, long timeout, FileFilter fileFilter) {
+  public File firstDownloadedFile(long timeout, FileFilter fileFilter) {
     return firstMatchingFile(fileFilter)
       .orElseThrow(() -> {
         String message = String.format("Failed to download file%s in %d ms.", fileFilter.description(), timeout);
-          return new FileNotDownloadedError(driver, message.trim(), timeout);
+          return new FileNotDownloadedError(message.trim(), timeout);
         }
       ).getFile();
   }

--- a/src/main/java/com/codeborne/selenide/impl/ElementsContainerCollection.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementsContainerCollection.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.Container;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.ex.ElementNotFound;
 import com.codeborne.selenide.ex.PageObjectException;
+import com.codeborne.selenide.ex.UIAssertionError;
 import org.openqa.selenium.NoSuchElementException;
 
 import javax.annotation.CheckReturnValue;
@@ -58,7 +59,7 @@ public class ElementsContainerCollection extends AbstractList<Container> {
     try {
       return collection.getElements().size();
     } catch (NoSuchElementException e) {
-      throw new ElementNotFound(driver, NONE, collection.getSearchCriteria(), exist, e);
+      throw UIAssertionError.wrap(driver, new ElementNotFound(NONE, collection.getSearchCriteria(), exist, e), 0L);
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/ExceptionWrapper.java
+++ b/src/main/java/com/codeborne/selenide/impl/ExceptionWrapper.java
@@ -23,10 +23,10 @@ class ExceptionWrapper {
       return error;
     }
     else if (error instanceof InvalidElementStateException) {
-      return new InvalidStateError(webElementSource.driver(), webElementSource.description(), error);
+      return new InvalidStateError(webElementSource.description(), error);
     }
     else if (isElementNotClickableException(error)) {
-      return new ElementIsNotClickableError(webElementSource.driver(), webElementSource.description(), error);
+      return new ElementIsNotClickableError(webElementSource.description(), error);
     }
     else if (error instanceof StaleElementReferenceException || error instanceof NotFoundException) {
       return webElementSource.createElementNotFoundError(exist, error);

--- a/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
@@ -64,7 +64,7 @@ public class LastCollectionElement extends WebElementSource {
   @Nonnull
   public ElementNotFound createElementNotFoundError(WebElementCondition condition, Throwable cause) {
     if (collection.getElements().isEmpty()) {
-      return new ElementNotFound(driver(), getAlias(), getSearchCriteria(), visible, cause);
+      return new ElementNotFound(getAlias(), getSearchCriteria(), visible, cause);
     }
     return super.createElementNotFoundError(condition, cause);
   }

--- a/src/main/java/com/codeborne/selenide/impl/Waiter.java
+++ b/src/main/java/com/codeborne/selenide/impl/Waiter.java
@@ -61,7 +61,7 @@ public class Waiter {
       sleep(pollingInterval);
     }
 
-    Error failure = UIAssertionError.wrap(driver, new ConditionNotMetError(driver, condition, subject, result, error), timeout);
+    Error failure = UIAssertionError.wrap(driver, new ConditionNotMetError(condition, subject, result, error), timeout);
     SelenideLogger.commitStep(log, failure);
     throw failure;
   }
@@ -93,7 +93,7 @@ public class Waiter {
       sleep(pollingInterval);
     }
 
-    Error failure = UIAssertionError.wrap(driver, new ConditionMetError(driver, condition, subject, result, error), timeout);
+    Error failure = UIAssertionError.wrap(driver, new ConditionMetError(condition, subject, result, error), timeout);
     SelenideLogger.commitStep(log, failure);
     throw failure;
   }

--- a/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementSource.java
@@ -87,7 +87,7 @@ public abstract class WebElementSource {
     if (cause instanceof UIAssertionError) {
       throw new IllegalArgumentException("Unexpected UIAssertionError as a cause of ElementNotFound: " + cause, cause);
     }
-    return new ElementNotFound(driver(), alias, getSearchCriteria(), condition, cause);
+    return new ElementNotFound(alias, getSearchCriteria(), condition, cause);
   }
 
   @CheckReturnValue

--- a/src/test/java/com/codeborne/selenide/ex/DialogTextMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/DialogTextMismatchTest.java
@@ -1,21 +1,16 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.DriverStub;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class DialogTextMismatchTest {
-  private final Driver driver = new DriverStub();
-
   @Test
   void dialogMismatchTextStringTest() {
-    DialogTextMismatch dialogTextMismatch = new DialogTextMismatch(driver, "Expected text", "Actual text");
+    DialogTextMismatch dialogTextMismatch = new DialogTextMismatch("Expected text", "Actual text");
 
     assertThat(dialogTextMismatch).hasMessage(String.format("Dialog text mismatch%n" +
       "Actual: Actual text%n" +
-      "Expected: Expected text%n" +
-      "Timeout: 0 ms."));
+      "Expected: Expected text"));
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/ElementIsNotClickableErrorTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementIsNotClickableErrorTest.java
@@ -1,19 +1,15 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.DriverStub;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriverException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class ElementIsNotClickableErrorTest {
-  private final Driver driver = new DriverStub();
-
   @Test
   void errorMessage() {
     WebDriverException cause = new WebDriverException("Sorry, is not clickable at the moment");
-    ElementIsNotClickableError e = new ElementIsNotClickableError(driver, "#link", cause);
+    ElementIsNotClickableError e = new ElementIsNotClickableError("#link", cause);
 
     assertThat(e).hasMessageStartingWith("Element is not clickable");
     assertThat(e).hasMessageContaining("WebDriverException: Sorry, is not clickable at the moment");

--- a/src/test/java/com/codeborne/selenide/ex/ElementNotFoundTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementNotFoundTest.java
@@ -1,8 +1,6 @@
 package com.codeborne.selenide.ex;
 
 import com.codeborne.selenide.Condition;
-import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.collections.ExactTexts;
 import com.codeborne.selenide.impl.Alias;
 import com.codeborne.selenide.impl.CollectionSource;
@@ -17,41 +15,35 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class ElementNotFoundTest {
-  private final Driver driver = new DriverStub();
-
   @Test
   void elementNotFoundWithByCriteria() {
-    ElementNotFound elementNotFoundById = new ElementNotFound(driver, NONE, By.id("Hello"), Condition.exist);
+    ElementNotFound elementNotFoundById = new ElementNotFound(NONE, By.id("Hello"), Condition.exist);
     String expectedMessage = String.format("Element not found {By.id: Hello}%n" +
-      "Expected: exist%n" +
-      "Timeout: 0 ms.");
+      "Expected: exist");
     assertThat(elementNotFoundById).hasMessage(expectedMessage);
   }
 
   @Test
   void elementNotFoundWithAlias() {
-    ElementNotFound elementNotFoundById = new ElementNotFound(driver, new Alias("The Hello title"), By.id("Hello"), Condition.exist);
+    ElementNotFound elementNotFoundById = new ElementNotFound(new Alias("The Hello title"), By.id("Hello"), Condition.exist);
     String expectedMessage = String.format("Element \"The Hello title\" not found {By.id: Hello}%n" +
-      "Expected: exist%n" +
-      "Timeout: 0 ms.");
+      "Expected: exist");
     assertThat(elementNotFoundById).hasMessage(expectedMessage);
   }
 
   @Test
   void elementNotFoundWithStringCriteria() {
-    ElementNotFound elementNotFoundById = new ElementNotFound(driver, NONE, "Hello", Condition.exist);
+    ElementNotFound elementNotFoundById = new ElementNotFound(NONE, "Hello", Condition.exist);
     String expectedMessage = String.format("Element not found {Hello}%n" +
-      "Expected: exist%n" +
-      "Timeout: 0 ms.");
+      "Expected: exist");
     assertThat(elementNotFoundById).hasMessage(expectedMessage);
   }
 
   @Test
   void elementNotFoundWithStringCriteriaAndThrowableError() {
-    ElementNotFound elementNotFoundById = new ElementNotFound(driver, NONE, "Hello", Condition.exist, new Throwable("Error message"));
+    ElementNotFound elementNotFoundById = new ElementNotFound(NONE, "Hello", Condition.exist, new Throwable("Error message"));
     String expectedMessage = String.format("Element not found {Hello}%n" +
       "Expected: exist%n" +
-      "Timeout: 0 ms.%n" +
       "Caused by: java.lang.Throwable: Error message");
     assertThat(elementNotFoundById).hasMessage(expectedMessage);
   }
@@ -66,7 +58,6 @@ final class ElementNotFoundTest {
       new Throwable("Error message"));
     String expectedMessage = String.format("Element not found {mock collection description}%n" +
       "Expected: Exact texts [One, Two, Three]%n" +
-      "Timeout: 8 s.%n" +
       "Caused by: java.lang.Throwable: Error message");
     assertThat(elementNotFoundById).hasMessage(expectedMessage);
   }

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldNotTest.java
@@ -23,7 +23,6 @@ final class ElementShouldNotTest {
     assertThat(elementShould).hasMessage("Element should not be visible {by.name: selenide}" + lineSeparator() +
       "Element: '<null displayed:false></null>'" + lineSeparator() +
       "Actual value: visible:false" + lineSeparator() +
-      "Timeout: 0 ms." + lineSeparator() +
       "Caused by: java.lang.Throwable: Error message");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementShouldTest.java
@@ -30,7 +30,6 @@ final class ElementShouldTest {
       .hasMessage("Element should be visible {By.name: selenide}" + lineSeparator() +
         "Element: '<h1>Hello boy</h1>'" + lineSeparator() +
         "Actual value: visible:false" + lineSeparator() +
-        "Timeout: 0 ms." + lineSeparator() +
         "Caused by: NoSuchElementException: By.name: q");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/ElementWithTextNotFoundTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ElementWithTextNotFoundTest.java
@@ -23,7 +23,6 @@ final class ElementWithTextNotFoundTest {
       "Actual: [Niff, Naff, Nuff]%n" +
       "Expected: [Piff, Paff, Puff]%n" +
       "Collection: .characters%n" +
-      "Timeout: 9 s.%n" +
       "Caused by: NoSuchElementException: ups"));
   }
 
@@ -38,7 +37,6 @@ final class ElementWithTextNotFoundTest {
       "Expected: [Piff, Paff, Puff]%n" +
       "Because: we expect favorite characters%n" +
       "Collection: .characters%n" +
-      "Timeout: 9 s.%n" +
       "Caused by: NoSuchElementException: ups"));
 
   }

--- a/src/test/java/com/codeborne/selenide/ex/InvalidStateErrorTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/InvalidStateErrorTest.java
@@ -1,36 +1,29 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.DriverStub;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.StaleElementReferenceException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class InvalidStateErrorTest {
-  private final Driver driver = new DriverStub();
-
   @Test
   void constructorWithCause() {
     StaleElementReferenceException cause = new StaleElementReferenceException("Houston, we have a problem");
-    InvalidStateError error = new InvalidStateError(driver, "#link", cause);
+    InvalidStateError error = new InvalidStateError("#link", cause);
 
     assertThat(error).hasMessageStartingWith("Invalid element state");
     assertThat(error).hasMessageEndingWith("StaleElementReferenceException: Houston, we have a problem");
     assertThat(error).hasToString(String.format(
       "Invalid element state [#link]: " +
       "Houston, we have a problem%n" +
-      "Timeout: 0 ms.%n" +
       "Caused by: StaleElementReferenceException: Houston, we have a problem"));
   }
 
   @Test
   void constructorWithMessage() {
-    InvalidStateError error = new InvalidStateError(driver, "#link", "Houston, we have a problem");
+    InvalidStateError error = new InvalidStateError("#link", "Houston, we have a problem");
 
     assertThat(error).hasMessageStartingWith("Invalid element state [#link]: Houston, we have a problem");
-    assertThat(error).hasToString(String.format(
-      "Invalid element state [#link]: Houston, we have a problem%n" +
-      "Timeout: 0 ms."));
+    assertThat(error).hasToString("Invalid element state [#link]: Houston, we have a problem");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/ListSizeMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/ListSizeMismatchTest.java
@@ -30,7 +30,6 @@ final class ListSizeMismatchTest {
 
     assertThat(listSizeMismatch)
       .hasMessage(String.format("List size mismatch: expected: <= 10, actual: 3, collection: Collection description%n" +
-        "Timeout: 1 s.%n" +
         "Caused by: java.lang.Exception: Something happened"));
   }
 
@@ -47,7 +46,6 @@ final class ListSizeMismatchTest {
     assertThat(listSizeMismatch)
       .hasMessage(String.format("List size mismatch: expected: > 10" +
         " (because it's said in customer requirement #12345), actual: 3, collection: Collection description%n" +
-        "Timeout: 1 s.%n" +
         "Caused by: java.lang.Exception: Something happened"));
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/MatcherErrorTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/MatcherErrorTest.java
@@ -28,7 +28,6 @@ final class MatcherErrorTest {
         "Expected: all of elements to match [class=active] predicate" + lineSeparator() +
         "Collection: .rows" + lineSeparator() +
         "Elements: <actual-elements>" + lineSeparator() +
-        "Timeout: 4 s." + lineSeparator() +
         "Caused by: NoSuchElementException: .third");
   }
 
@@ -42,7 +41,6 @@ final class MatcherErrorTest {
         "Because: I think so" + lineSeparator() +
         "Collection: .rows" + lineSeparator() +
         "Elements: <actual-elements>" + lineSeparator() +
-        "Timeout: 4 s." + lineSeparator() +
         "Caused by: NoSuchElementException: .third");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsMismatchTest.java
@@ -21,8 +21,7 @@ final class TextsMismatchTest {
     assertThat(error).hasMessage(String.format("Texts mismatch%n" +
       "Actual (3): [Niff, Naff, Nuff]%n" +
       "Expected (3): [Piff, Paff, Puff]%n" +
-      "Collection: .characters%n" +
-      "Timeout: 9 s."));
+      "Collection: .characters"));
   }
 
   @Test
@@ -34,8 +33,7 @@ final class TextsMismatchTest {
       "Actual (3): [Niff, Naff, Nuff]%n" +
       "Expected (3): [Piff, Paff, Puff]%n" +
       "Because: we expect favorite characters%n" +
-      "Collection: .characters%n" +
-      "Timeout: 9 s."));
+      "Collection: .characters"));
   }
 
   @Test
@@ -45,8 +43,7 @@ final class TextsMismatchTest {
     assertThat(error).hasMessage(String.format("Texts mismatch%n" +
                                                "Actual (3): [Niff, Naff, Nuff]%n" +
                                                "Expected (2): [Chip, Dale]%n" +
-                                               "Collection: .characters%n" +
-                                               "Timeout: 9 s."));
+                                               "Collection: .characters"));
   }
 
 }

--- a/src/test/java/com/codeborne/selenide/ex/UIAssertionErrorTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/UIAssertionErrorTest.java
@@ -1,20 +1,15 @@
 package com.codeborne.selenide.ex;
 
-import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.DriverStub;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class UIAssertionErrorTest {
-  private final Driver driver = new DriverStub();
-
   @Test
   void errorMessage() {
-    UIAssertionError uiAssertionError = new UIAssertionError(driver, "Some it happened", new Throwable("Error message"));
+    UIAssertionError uiAssertionError = new UIAssertionError("Some it happened", new Throwable("Error message"));
 
     assertThat(uiAssertionError).hasMessage(String.format("Some it happened%n" +
-      "Timeout: 0 ms.%n" +
       "Caused by: java.lang.Throwable: Error message"));
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
@@ -76,7 +76,6 @@ final class CollectionElementByConditionTest {
     assertThat(elementNotFoundError)
       .hasMessage(String.format("Element not found {ul#employees li.employee.findBy(visible)}%n" +
         "Expected: visible%n" +
-        "Timeout: 0 ms.%n" +
         "Caused by: NoSuchElementException: with class: employee"));
   }
 
@@ -93,7 +92,6 @@ final class CollectionElementByConditionTest {
     assertThat(elementNotFoundError)
       .hasMessage(String.format("Element not found {ul#employees li.employee.findBy(visible)}%n" +
                                 "Expected: text \"Hello\" (because Successfully logged in)%n" +
-                                "Timeout: 0 ms.%n" +
                                 "Caused by: java.lang.Error: Error message"
       ));
   }

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementTest.java
@@ -66,7 +66,6 @@ final class CollectionElementTest {
     assertThat(elementNotFoundError)
       .hasMessage(String.format("Element not found {#report .line[33]}%n" +
         "Expected: visible%n" +
-        "Timeout: 0 ms.%n" +
         "Caused by: java.lang.Error: Error message"));
   }
 
@@ -85,7 +84,6 @@ final class CollectionElementTest {
     assertThat(elementNotFoundError)
       .hasMessage(String.format("Element not found {#report .line[1]}%n" +
         "Expected: Reason description%n" +
-        "Timeout: 0 ms.%n" +
         "Caused by: java.lang.Error: Error message"));
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
@@ -1,6 +1,5 @@
 package com.codeborne.selenide.impl;
 
-import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.SelenideDriver;
 import com.codeborne.selenide.SelenideElement;
@@ -285,7 +284,7 @@ final class SelenideElementProxyTest {
 
   @Test
   void shouldNotRetry_onFileNotDownloadedError() {
-    FileNotDownloadedError exception = new FileNotDownloadedError(new DriverStub(webdriver), "bla", 2000);
+    FileNotDownloadedError exception = new FileNotDownloadedError("bla", 2000);
     assertThat(shouldRetryAfterError(exception)).isFalse();
   }
 


### PR DESCRIPTION
... instead of generating error message every time when `e.getMessage()` is called. Otherwise, custom `ErrorFormatter` implementations try to get driver URL etc. in a different thread with a different (or missing) driver.

this PR fixes https://github.com/selenide/selenide/discussions/2830#discussioncomment-10586793

P.S. UIAssertionErrors need a bigger refactoring. They are thrown from conditions without screenshots, and later screeenshot is appended in method `UIAssertionError.wrapThrowable()`.

