### PR TITLE
Add few builder methods for DownloadOptions

### DIFF
--- a/modules/grid/src/test/java/integration/DownloadFileFromGridToFolderTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridToFolderTest.java
@@ -16,7 +16,7 @@ import java.nio.file.Files;
 
 import static com.codeborne.selenide.Configuration.downloadsFolder;
 import static com.codeborne.selenide.Configuration.timeout;
-import static com.codeborne.selenide.DownloadOptions.using;
+import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.FileDownloadMode.FOLDER;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
@@ -52,8 +52,7 @@ final class DownloadFileFromGridToFolderTest extends AbstractGridTest {
 
   @Test
   void downloadsFileWithAlert() {
-    File downloadedFile = $(byText("Download me with alert")).download(
-      using(FOLDER).withFilter(withExtension("txt")).withAction(
+    File downloadedFile = $(byText("Download me with alert")).download(file().withExtension("txt").withAction(
         clickAndConfirm("Are you sure to download it?")
       )
     );

--- a/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
@@ -24,7 +24,7 @@ import java.nio.file.Files;
 
 import static com.codeborne.selenide.Configuration.downloadsFolder;
 import static com.codeborne.selenide.Configuration.timeout;
-import static com.codeborne.selenide.DownloadOptions.using;
+import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.FileDownloadMode.CDP;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
@@ -66,8 +66,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
 
   @Test
   void downloadsFileWithAlert() {
-    File downloadedFile = $(byText("Download me with alert")).download(
-      using(CDP).withFilter(withExtension("txt")).withAction(
+    File downloadedFile = $(byText("Download me with alert")).download(file().withExtension("txt").withAction(
         clickAndConfirm("Are you sure to download it?")
       )
     );
@@ -97,7 +96,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
 
   @Test
   void downloadsPdfFile() {
-    File downloadedFile = $(byText("Download a PDF")).download(timeout, withExtension("pdf"));
+    File downloadedFile = $(byText("Download a PDF")).download(file().withExtension("pdf").withTimeout(timeout));
 
     assertThat(downloadedFile.getName()).matches("minimal.*.pdf");
     assertThat(downloadedFile).content().startsWith("%PDF-1.1");
@@ -136,7 +135,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
 
   @Test
   void downloadsFileWithPartExtension() {
-    File downloadedFile = $(byText("Download file *part")).download(withExtension("part"));
+    File downloadedFile = $(byText("Download file *part")).download(file().withExtension("part"));
 
     assertThat(downloadedFile.getName()).matches("hello_world.*\\.part");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, part WinRar!");
@@ -145,7 +144,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
 
   @Test
   void downloadsFileWithCrdownloadExtension() {
-    File downloadedFile = $(byText("Download file *crdownload")).download(900, withName("hello_world.crdownload"));
+    File downloadedFile = $(byText("Download file *crdownload")).download(file().withName("hello_world.crdownload").withTimeout(900));
 
     assertThat(downloadedFile.getName()).matches("hello_world.*\\.crdownload");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, crdownload WinRar!");
@@ -155,7 +154,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
   @Test
   public void download_slowly() {
     File downloadedFile = $(byText("Download me slowly"))
-      .download(4000, withName("hello_world.txt"));
+      .download(file().withName("hello_world.txt").withTimeout(4000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -163,7 +162,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
 
   @Test
   public void download_super_slowly() {
-    File downloadedFile = $(byText("Download me super slowly")).download(6000, withExtension("txt"));
+    File downloadedFile = $(byText("Download me super slowly")).download(file().withExtension("txt").withTimeout(6000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -171,7 +170,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
 
   @Test
   void downloadLargeFile() {
-    File downloadedFile = $(byText("Download large file")).download(8000, withExtension("txt"));
+    File downloadedFile = $(byText("Download large file")).download(file().withExtension("txt").withTimeout(8000));
 
     assertThat(downloadedFile).hasName("large_file.txt");
     assertThat(downloadedFile).hasSize(5 * 1024 * 1024);

--- a/modules/proxy/src/test/java/integration/FileDownloadViaProxyTest.java
+++ b/modules/proxy/src/test/java/integration/FileDownloadViaProxyTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.function.Consumer;
 
 import static com.codeborne.selenide.Configuration.timeout;
+import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.FOLDER;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
@@ -24,8 +25,6 @@ import static com.codeborne.selenide.Selenide.using;
 import static com.codeborne.selenide.WebDriverRunner.isChrome;
 import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static com.codeborne.selenide.files.FileFilters.withExtension;
-import static com.codeborne.selenide.files.FileFilters.withName;
-import static com.codeborne.selenide.files.FileFilters.withNameMatching;
 import static java.nio.file.Files.createTempDirectory;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +38,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
   void setUp() {
     openFile("page_with_uploads.html");
     timeout = 1000;
+    Configuration.fileDownload = PROXY;
   }
 
   @Test
@@ -53,7 +53,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
   @Test
   void downloadsFileWithAlert() {
     File downloadedFile = $(byText("Download me with alert")).download(
-      using(PROXY).withFilter(withExtension("txt")).withAction((driver, link) -> {
+      file().withExtension("txt").withAction((driver, link) -> {
         link.click();
         Alert alert = driver.switchTo().alert();
         assertThat(alert.getText()).isEqualTo("Are you sure to download it?");
@@ -67,7 +67,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
 
   @Test
   void downloadsFileWithCyrillicName() {
-    File downloadedFile = $(byText("Download file with cyrillic name")).download(withExtension("txt"));
+    File downloadedFile = $(byText("Download file with cyrillic name")).download(file().withExtension("txt"));
 
     assertThat(downloadedFile.getName()).isEqualTo("файл-с-русским-названием.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Превед медвед!");
@@ -76,7 +76,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
 
   @Test
   void downloadsFileWithNorwayCharactersInName() {
-    File downloadedFile = $(byText("Download file with \"ø\" in name")).download(withExtension("txt"));
+    File downloadedFile = $(byText("Download file with \"ø\" in name")).download(file().withExtension("txt"));
 
     assertThat(downloadedFile.getName()).isEqualTo("ø-report.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, Nørway!");
@@ -105,7 +105,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
 
   @Test
   public void download_withCustomTimeout() {
-    File downloadedFile = $(byText("Download me slowly")).download(2000, withExtension("txt"));
+    File downloadedFile = $(byText("Download me slowly")).download(file().withExtension("txt").withTimeout(2000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -113,7 +113,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
 
   @Test
   public void download_byName() {
-    File downloadedFile = $(byText("Download me slowly")).download(2000, withName("hello_world.txt"));
+    File downloadedFile = $(byText("Download me slowly")).download(file().withName("hello_world.txt").withTimeout(2000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -121,7 +121,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
 
   @Test
   public void download_byNameRegex() {
-    File downloadedFile = $(byText("Download me slowly")).download(2000, withNameMatching("hello_.\\w+\\.txt"));
+    File downloadedFile = $(byText("Download me slowly")).download(file().withNameMatching("hello_.\\w+\\.txt").withTimeout(2000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -129,7 +129,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
 
   @Test
   public void download_byExtension() {
-    File downloadedFile = $(byText("Download me slowly")).download(2000, withExtension("txt"));
+    File downloadedFile = $(byText("Download me slowly")).download(file().withExtension("txt").withTimeout(2000));
 
     assertThat(downloadedFile.getName()).matches("hello_world.*\\.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -157,7 +157,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
 
   @Test
   void downloadsPdfFile() {
-    File downloadedFile = $(byText("Download a PDF")).download(timeout, withExtension("pdf"));
+    File downloadedFile = $(byText("Download a PDF")).download(file().withExtension("pdf").withTimeout(timeout));
 
     assertThat(downloadedFile).hasName("minimal.pdf");
     assertThat(downloadedFile).content().startsWith("%PDF-1.1");
@@ -185,7 +185,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
     Configuration.timeout = 1;
 
     File downloadedFile = $(byText("Download me")).download(using(PROXY)
-      .withFilter(withExtension("txt"))
+      .withExtension("txt")
       .withTimeout(4000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
@@ -194,7 +194,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
 
   @Test
   public void download_super_slowly() {
-    File downloadedFile = $(byText("Download me super slowly")).download(6000, withExtension("txt"));
+    File downloadedFile = $(byText("Download me super slowly")).download(file().withExtension("txt").withTimeout(6000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -209,14 +209,14 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
   }
 
   @Test
-  void canDownloadFilesAfterUsing() {
+  void canDownloadFilesAfterUsingAnotherBrowser() {
     assumeThat(isChrome() || isFirefox()).isTrue();
 
     openFile("page_with_uploads.html");
     useAnotherBrowser();
 
     File downloadedFile = $(byText("Download me")).download(
-      using(PROXY).withTimeout(ofSeconds(2)).withFilter(withExtension("txt"))
+      using(PROXY).withTimeout(ofSeconds(2)).withExtension("txt")
     );
 
     assertThat(downloadedFile.getName()).matches("hello_world.*\\.txt");

--- a/modules/proxy/src/test/java/integration/proxy/MultipleDownloadsTest.java
+++ b/modules/proxy/src/test/java/integration/proxy/MultipleDownloadsTest.java
@@ -10,7 +10,6 @@ import java.io.File;
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
 import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.files.FileFilters.withName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MultipleDownloadsTest extends ProxyIntegrationTest {
@@ -19,9 +18,7 @@ public class MultipleDownloadsTest extends ProxyIntegrationTest {
   void downloadMultipleFiles(String fileName) {
     openFile("downloadMultipleFiles.html");
 
-    File text = $("#multiple-downloads").download(
-      using(PROXY).withTimeout(4000).withFilter(withName(fileName))
-    );
+    File text = $("#multiple-downloads").download(using(PROXY).withTimeout(4000).withName(fileName));
 
     assertThat(text.getName()).isEqualTo(fileName);
     assertThat(text.length()).isEqualTo(new FileContent(fileName).content().length());

--- a/modules/selenoid/src/test/java/it/selenoid/FileDownloadTest.java
+++ b/modules/selenoid/src/test/java/it/selenoid/FileDownloadTest.java
@@ -15,7 +15,6 @@ import static com.codeborne.selenide.FileDownloadMode.PROXY;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.WebDriverRunner.isFirefox;
-import static com.codeborne.selenide.files.FileFilters.withExtension;
 import static it.selenoid.SelenoidSetup.checkDownload;
 import static it.selenoid.SelenoidSetup.resetSelenoidSettings;
 import static org.apache.commons.lang3.StringUtils.rightPad;
@@ -63,7 +62,7 @@ public class FileDownloadTest {
     $("[name=delay]").setValue("3000");
     $("#lore-ipsum").setValue(fileContent);
 
-    File file = $("#slow-download").download(using(FOLDER).withFilter(withExtension("txt")));
+    File file = $("#slow-download").download(using(FOLDER).withExtension("txt"));
 
     assertThat(file).hasName("hello.txt");
     assertThat(file).content().isEqualToIgnoringWhitespace(fileContent);

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1248,9 +1248,11 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @throws RuntimeException      if 50x status code was returned from server
    * @throws FileNotDownloadedError     if 40x status code was returned from server
    * @see com.codeborne.selenide.commands.DownloadFile
+   * @deprecated Use method {{@link #download(DownloadOptions)}} instead
    */
   @CheckReturnValue
   @Nonnull
+  @Deprecated
   File download(long timeout) throws FileNotDownloadedError;
 
   /**
@@ -1283,9 +1285,11 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @throws FileNotDownloadedError     if 40x status code was returned from server, or the downloaded file didn't match given filter.
    * @see com.codeborne.selenide.files.FileFilters
    * @see com.codeborne.selenide.commands.DownloadFile
+   * @deprecated Use method {{@link #download(DownloadOptions)}} instead
    */
   @CheckReturnValue
   @Nonnull
+  @Deprecated
   File download(long timeout, FileFilter fileFilter) throws FileNotDownloadedError;
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/Arguments.java
+++ b/src/main/java/com/codeborne/selenide/impl/Arguments.java
@@ -43,7 +43,8 @@ public class Arguments {
     return ofType(Duration.class).map(Duration::toMillis)
       .orElseGet(() ->
         ofType(HasTimeout.class).map(HasTimeout::timeout).map(Duration::toMillis)
-          .orElse(defaultTimeout)
+          .orElseGet(() ->
+            ofType(Long.class).orElse(defaultTimeout))
       );
   }
 }

--- a/src/test/java/com/codeborne/selenide/DownloadOptionsTest.java
+++ b/src/test/java/com/codeborne/selenide/DownloadOptionsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
+import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.FOLDER;
 import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
@@ -27,13 +28,13 @@ final class DownloadOptionsTest {
     DownloadOptions options = using(PROXY).withTimeout(9999);
 
     assertThat(options.getMethod()).isEqualTo(PROXY);
-    assertThat(options.timeout().toMillis()).isEqualTo(9999);
+    assertThat(options.timeout()).isEqualTo(Duration.ofMillis(9999));
     assertThat(options.getFilter()).isEqualTo(none());
   }
 
   @Test
   void customFileFilter() {
-    DownloadOptions options = using(FOLDER).withFilter(withExtension("pdf"));
+    DownloadOptions options = using(FOLDER).withExtension("pdf");
 
     assertThat(options.getMethod()).isEqualTo(FOLDER);
     assertThat(options.timeout()).isNull();
@@ -42,10 +43,10 @@ final class DownloadOptionsTest {
 
   @Test
   void customSettings() {
-    DownloadOptions options = using(FOLDER).withFilter(withExtension("ppt")).withTimeout(Duration.ofMillis(1234));
+    DownloadOptions options = using(FOLDER).withExtension("ppt").withTimeout(Duration.ofMillis(1234));
 
     assertThat(options.getMethod()).isEqualTo(FOLDER);
-    assertThat(options.timeout().toMillis()).isEqualTo(1234);
+    assertThat(options.timeout()).isEqualTo(Duration.ofMillis(1234));
     assertThat(options.getFilter()).usingRecursiveComparison().isEqualTo(withExtension("ppt"));
   }
 
@@ -57,10 +58,16 @@ final class DownloadOptionsTest {
     assertThat(using(PROXY).withTimeout(9999))
       .hasToString("method: PROXY, timeout: 9999 ms");
 
-    assertThat(using(HTTPGET).withTimeout(9999).withFilter(withExtension("ppt")))
-      .hasToString("method: HTTPGET, timeout: 9999 ms, filter: with extension \"ppt\"");
+    assertThat(using(HTTPGET).withTimeout(9999).withExtension("ppt"))
+      .hasToString("method: HTTPGET, timeout: 9999 ms, with extension \"ppt\"");
 
     assertThat(using(FOLDER).withFilter(withExtension("exe")))
-      .hasToString("method: FOLDER, filter: with extension \"exe\"");
+      .hasToString("method: FOLDER, with extension \"exe\"");
+
+    assertThat(using(FOLDER).withExtension("exe"))
+      .hasToString("method: FOLDER, with extension \"exe\"");
+
+    assertThat(file().withExtension("exe"))
+      .hasToString("with extension \"exe\"");
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/ArgumentsTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/ArgumentsTest.java
@@ -37,6 +37,12 @@ class ArgumentsTest {
   }
 
   @Test
+  void extractsTimeout_fromArgumentOfTypeLong() {
+    Arguments arguments = new Arguments(8000L, usingJavaScript());
+    assertThat(arguments.getTimeoutMs(4000)).isEqualTo(8000);
+  }
+
+  @Test
   void returnsDefaultTimeout() {
     assertThat(new Arguments(visible).getTimeoutMs(4000)).isEqualTo(4000);
   }

--- a/statics/src/test/java/integration/CustomOneTimeWebdriverTest.java
+++ b/statics/src/test/java/integration/CustomOneTimeWebdriverTest.java
@@ -19,8 +19,6 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.inNewBrowser;
 import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
-import static com.codeborne.selenide.files.FileFilters.withExtension;
-import static com.codeborne.selenide.files.FileFilters.withNameMatching;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class CustomOneTimeWebdriverTest extends IntegrationTest {
@@ -54,7 +52,7 @@ final class CustomOneTimeWebdriverTest extends IntegrationTest {
       checkDownload(FOLDER);
     });
 
-    File downloadedFile = $(byText("Download me")).download(using(FOLDER).withFilter(withExtension("txt")));
+    File downloadedFile = $(byText("Download me")).download(using(FOLDER).withExtension("txt"));
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
   }
 
@@ -69,7 +67,7 @@ final class CustomOneTimeWebdriverTest extends IntegrationTest {
       checkDownload(PROXY, "hello_world.*\\.txt", "hello_world.txt");
     });
 
-    File downloadedFile = $(byText("Download me")).download(using(PROXY).withFilter(withExtension("txt")));
+    File downloadedFile = $(byText("Download me")).download(using(PROXY).withExtension("txt"));
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
   }
@@ -81,9 +79,7 @@ final class CustomOneTimeWebdriverTest extends IntegrationTest {
   }
 
   private void checkDownload(FileDownloadMode mode, String fileName, String referenceFile) {
-    File text = $("#multiple-downloads").download(
-      using(mode).withFilter(withNameMatching(fileName))
-    );
+    File text = $("#multiple-downloads").download(using(mode).withNameMatching(fileName));
     assertThat(text.getName()).matches(fileName);
     assertThat(text.length()).isEqualTo(new FileContent(referenceFile).content().length());
   }

--- a/statics/src/test/java/integration/CustomWebdriverTest.java
+++ b/statics/src/test/java/integration/CustomWebdriverTest.java
@@ -11,8 +11,7 @@ import java.io.File;
 
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.DownloadOptions.using;
-import static com.codeborne.selenide.FileDownloadMode.FOLDER;
+import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.using;
@@ -20,7 +19,6 @@ import static com.codeborne.selenide.WebDriverRunner.closeWebDriver;
 import static com.codeborne.selenide.WebDriverRunner.isChrome;
 import static com.codeborne.selenide.WebDriverRunner.isFirefox;
 import static com.codeborne.selenide.WebDriverRunner.setWebDriver;
-import static com.codeborne.selenide.files.FileFilters.withExtension;
 import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -107,15 +105,13 @@ final class CustomWebdriverTest extends IntegrationTest {
   }
 
   @Test
-  void canDownloadFilesAfterUsing() {
+  void canDownloadFilesAfterUsingAnotherBrowser() {
     openFile("page_with_uploads.html");
     using(browser2, () -> {
       openFile("page_with_selects_without_jquery.html");
     });
 
-    File downloadedFile = $(byText("Download me")).download(
-      using(FOLDER).withTimeout(ofSeconds(2)).withFilter(withExtension("txt"))
-    );
+    File downloadedFile = $(byText("Download me")).download(file().withTimeout(ofSeconds(2)).withExtension("txt"));
 
     assertThat(downloadedFile.getName()).matches("hello_world.*\\.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -75,7 +75,7 @@ final class FileDownloadToFolderTest extends IntegrationTest {
   @Test
   void downloadsFileWithAlert() {
     File downloadedFile = $(byText("Download me with alert")).download(
-      using(FOLDER).withFilter(withExtension("txt")).withAction(
+      using(FOLDER).withExtension("txt").withAction(
         clickAndConfirm("Are you sure to download it?")
       )
     );
@@ -174,7 +174,7 @@ final class FileDownloadToFolderTest extends IntegrationTest {
     Configuration.timeout = 1;
 
     File downloadedFile = $(byText("Download me")).download(using(FOLDER)
-      .withFilter(withExtension("txt"))
+      .withExtension("txt")
       .withTimeout(4000)
     );
 
@@ -215,7 +215,7 @@ final class FileDownloadToFolderTest extends IntegrationTest {
     var shortIncrementTimeout = using(FOLDER)
       .withTimeout(ofSeconds(10))
       .withIncrementTimeout(ofMillis(1001))
-      .withFilter(withName("hello_world.txt"));
+      .withName("hello_world.txt");
     assertThatThrownBy(() -> $("h1")
       .download(shortIncrementTimeout))
       .isInstanceOf(FileNotDownloadedError.class)
@@ -232,7 +232,7 @@ final class FileDownloadToFolderTest extends IntegrationTest {
     var shortIncrementTimeout = using(FOLDER)
       .withTimeout(ofSeconds(10))
       .withIncrementTimeout(ofMillis(100))
-      .withFilter(withName("hello_world.txt"));
+      .withName("hello_world.txt");
     assertThatThrownBy(() -> {
       File file = $(byText("Download me super slowly")).download(shortIncrementTimeout);
       assertThat(file).content(UTF_8).isEqualToIgnoringNewLines("Hello, WinRar!");

--- a/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
@@ -73,7 +73,7 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
   @Test
   void downloadsFileWithAlert() {
     File downloadedFile = $(byText("Download me with alert")).download(
-      using(CDP).withFilter(withExtension("txt")).withAction(
+      using(CDP).withExtension("txt").withAction(
         clickAndConfirm("Are you sure to download it?")
       )
     );
@@ -187,7 +187,7 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
     Configuration.timeout = 1;
 
     File downloadedFile = $(byText("Download me")).download(using(CDP)
-      .withFilter(withExtension("txt"))
+      .withExtension("txt")
       .withTimeout(4000)
     );
 
@@ -229,7 +229,7 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
     var shortIncrementTimeout = using(CDP)
       .withTimeout(ofSeconds(10))
       .withIncrementTimeout(ofMillis(201))
-      .withFilter(withName("hello_world.txt"));
+      .withName("hello_world.txt");
     assertThatThrownBy(() -> $("h1")
       .download(shortIncrementTimeout))
       .isInstanceOf(FileNotDownloadedError.class)

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 
+import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
@@ -147,7 +148,7 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
 
   @Test
   void downloadWithCustomTimeout() {
-    File downloadedFile = $(byText("Download me slowly")).download(3000);
+    File downloadedFile = $(byText("Download me slowly")).download(file().withTimeout(3000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -156,7 +157,7 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
   @Test
   void downloadsGetsTimeoutException() {
     assertThatThrownBy(() -> {
-      File downloadedFile = $(byText("Start download after delay (2000 ms)")).download(100);
+      File downloadedFile = $(byText("Start download after delay (2000 ms)")).download(file().withTimeout(100));
       assertThat(downloadedFile).hasContent("File downloading should fail with timeout");
     })
       .isInstanceOf(FileNotDownloadedError.class)
@@ -199,7 +200,7 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
     Configuration.timeout = 1;
 
     File downloadedFile = $(byText("Download me")).download(using(HTTPGET)
-      .withFilter(withExtension("txt"))
+      .withExtension("txt")
       .withTimeout(4000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
@@ -211,7 +212,7 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
     Configuration.fileDownload = PROXY;
     Configuration.timeout = 4000;
 
-    File downloadedFile = $(byText("Download me")).download(using(HTTPGET).withFilter(withExtension("txt")));
+    File downloadedFile = $(byText("Download me")).download(using(HTTPGET).withExtension("txt"));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -220,7 +221,7 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
   @Test
   public void download_super_slowly() {
     File downloadedFile = $(byText("Download me super slowly"))
-      .download(4000, withName("hello_world.txt"));
+      .download(file().withTimeout(4000).withName("hello_world.txt"));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");
@@ -228,7 +229,7 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
 
   @Test
   public void download_super_slowly_without_filter() {
-    File downloadedFile = $(byText("Download me super slowly")).download(4000);
+    File downloadedFile = $(byText("Download me super slowly")).download(file().withTimeout(4000));
 
     assertThat(downloadedFile).hasName("hello_world.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Hello, WinRar!");


### PR DESCRIPTION
Now you can replace long constructs like `using(FOLDER).withFilter(withExtension("txt"))` by a shorter form `file().withExtension("txt")`.
