### PR TITLE
don't catch all errors

### DIFF
--- a/modules/grid/src/main/java/org/selenide/grid/GridDownloadsFolder.java
+++ b/modules/grid/src/main/java/org/selenide/grid/GridDownloadsFolder.java
@@ -10,7 +10,6 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.codeborne.selenide.impl.WebdriverUnwrapper.unwrapRemoteWebDriver;
 import static java.util.Collections.emptyMap;
@@ -38,7 +37,9 @@ public class GridDownloadsFolder implements DownloadsFolder {
   @CheckReturnValue
   @Override
   public List<File> files() {
-    return webDriver.getDownloadableFiles().stream().map(name -> new File(name)).collect(Collectors.toList());
+    return webDriver.getDownloadableFiles().stream()
+      .map(name -> new File(name))
+      .toList();
   }
 
   @Nonnull

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -87,7 +87,7 @@ class SelenideElementProxy<T extends SelenideElement> implements InvocationHandl
       SelenideLogger.commitStep(log, PASS);
       return result;
     }
-    catch (Error error) {
+    catch (AssertionError error) {
       Throwable wrappedError = UIAssertionError.wrap(driver(), error, timeoutMs);
       SelenideLogger.commitStep(log, wrappedError);
       return continueOrBreak(proxy, method, wrappedError);

--- a/src/main/java/com/codeborne/selenide/impl/WebElementCommunicator.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebElementCommunicator.java
@@ -10,7 +10,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @ParametersAreNonnullByDefault
 public class WebElementCommunicator implements ElementCommunicator {
@@ -47,7 +46,7 @@ public class WebElementCommunicator implements ElementCommunicator {
   protected List<String> textsOneByOne(List<WebElement> elements) {
     return elements.stream()
       .map(element -> element.getText())
-      .collect(Collectors.toList());
+      .toList();
   }
 
   @Override
@@ -66,6 +65,6 @@ public class WebElementCommunicator implements ElementCommunicator {
   protected List<String> attributesOneByOne(List<WebElement> elements, String attributeName) {
     return elements.stream()
       .map(element -> element.getAttribute(attributeName))
-      .collect(Collectors.toList());
+      .toList();
   }
 }

--- a/src/test/java/integration/collections/CollectionWithChangingTextsTest.java
+++ b/src/test/java/integration/collections/CollectionWithChangingTextsTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.partialText;
@@ -59,7 +58,7 @@ final class CollectionWithChangingTextsTest extends ITest {
   void stream() {
     List<String> texts = $$("#collection li").asDynamicIterable()
       .stream()
-      .map(se -> se.getText()).collect(Collectors.toList());
+      .map(se -> se.getText()).toList();
 
     assertThat(texts).containsExactly("Item #1", "Item #2", "Item #3");
   }
@@ -69,7 +68,7 @@ final class CollectionWithChangingTextsTest extends ITest {
     waitForNewElementsRendered();
 
     List<String> texts = $$("#collection li").asDynamicIterable()
-      .stream().map(se -> se.getText()).collect(Collectors.toList());
+      .stream().map(se -> se.getText()).toList();
 
     assertThat(texts).containsExactly(
       "Updated Item #1", "Updated Item #2", "Updated Item #3",

--- a/src/test/java/integration/collections/CollectionWithChangingTextsTest.java
+++ b/src/test/java/integration/collections/CollectionWithChangingTextsTest.java
@@ -89,8 +89,8 @@ final class CollectionWithChangingTextsTest extends ITest {
     assertThat(it.hasNext()).isFalse();
   }
 
-  // File "collection_with_changing_texts.html" contains JavaScript which adds new elements after 840 ms.
+  // File "collection_with_changing_texts.html" contains JavaScript which adds new elements after 280 ms.
   private void waitForNewElementsRendered() throws InterruptedException {
-    sleep(850);
+    sleep(330);
   }
 }

--- a/src/test/resources/collection_with_changing_texts.html
+++ b/src/test/resources/collection_with_changing_texts.html
@@ -15,28 +15,25 @@
 <h2 id="status"></h2>
 
 <script type="text/javascript">
-  const totalTime = new Date();
-  let size = 1;
-
-  function updateNextText() {
-    document.getElementById('item' + size).textContent = 'Updated Item #' + size;
-    size++;
+  function updateText(id, text) {
+    document.getElementById(id).textContent = text;
   }
 
-  function growCollection() {
+  function growCollection(text) {
     const node = document.createElement('li');
-    const textNode = document.createTextNode('Additional text #' + size);
+    const textNode = document.createTextNode(text);
     node.appendChild(textNode);
     document.getElementById("collection").appendChild(node);
-    size++;
   }
 
-  setTimeout(updateNextText, 810);
-  setTimeout(updateNextText, 820);
-  setTimeout(updateNextText, 830);
+  (() => {
+    setTimeout(() => updateText('item1', 'Updated Item #1'), 200);
+    setTimeout(() => updateText('item2', 'Updated Item #2'), 220);
+    setTimeout(() => updateText('item3', 'Updated Item #3'), 240);
 
-  setTimeout(growCollection, 835);
-  setTimeout(growCollection, 840);
+    setTimeout(() => growCollection('Additional text #4'), 260);
+    setTimeout(() => growCollection('Additional text #5'), 280);
+  })()
 </script>
 
 </body>


### PR DESCRIPTION
It may hide technical unrecoverable problems like OutOfMemory, ClassNotFound etc. I have no idea why we wrote "catch (Error e)" many years ago. :)

I got reported one specific case when some unknown error happened during file download in method `DownloadFileToFolder.archiveFile()`. And this error was completely ignored: Selenide tried to download this file again and again.