### PR TITLE
Fix browser not created exception with AppiumPageFactory

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -16,12 +16,18 @@ import com.codeborne.selenide.impl.WebElementSource;
 import io.appium.java_client.HasBrowserCheck;
 import io.appium.java_client.pagefactory.AndroidFindAll;
 import io.appium.java_client.pagefactory.AndroidFindBy;
+import io.appium.java_client.pagefactory.AndroidFindByAllSet;
+import io.appium.java_client.pagefactory.AndroidFindByChainSet;
+import io.appium.java_client.pagefactory.AndroidFindBySet;
 import io.appium.java_client.pagefactory.AndroidFindBys;
 import io.appium.java_client.pagefactory.AppiumFieldDecorator;
 import io.appium.java_client.pagefactory.DefaultElementByBuilder;
 import io.appium.java_client.pagefactory.bys.builder.AppiumByBuilder;
 import io.appium.java_client.pagefactory.iOSXCUITFindAll;
 import io.appium.java_client.pagefactory.iOSXCUITFindBy;
+import io.appium.java_client.pagefactory.iOSXCUITFindByAllSet;
+import io.appium.java_client.pagefactory.iOSXCUITFindByChainSet;
+import io.appium.java_client.pagefactory.iOSXCUITFindBySet;
 import io.appium.java_client.pagefactory.iOSXCUITFindBys;
 import java.lang.annotation.Annotation;
 import java.util.List;
@@ -29,6 +35,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ByIdOrName;
 import org.openqa.selenium.support.pagefactory.FieldDecorator;
@@ -47,6 +54,10 @@ import java.util.Optional;
 @ParametersAreNonnullByDefault
 public class SelenideAppiumPageFactory extends SelenidePageFactory {
   private static final Logger logger = LoggerFactory.getLogger(SelenideAppiumPageFactory.class);
+  private final List<Class<? extends Annotation>> platformAnnotations =
+    List.of(AndroidFindBy.class, AndroidFindBys.class, AndroidFindAll.class, AndroidFindByAllSet.class, AndroidFindByChainSet.class,
+      AndroidFindBySet.class, iOSXCUITFindBy.class, iOSXCUITFindBys.class, iOSXCUITFindAll.class, iOSXCUITFindByAllSet.class,
+      iOSXCUITFindByChainSet.class, iOSXCUITFindBySet.class);
 
   @Override
   @Nonnull
@@ -58,7 +69,6 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
     return selector != null ? selector : super.findSelector(driver, field);
   }
 
-
   @Nonnull
   @CheckReturnValue
   private DefaultElementByBuilder byBuilder(Driver driver, Field field) {
@@ -67,8 +77,8 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
     }
 
     if (!driver.hasWebDriverStarted()) {
-      throw new RuntimeException("The Appium Page factory requires a browser instance to be created before calling" +
-        " initialization via page(); please ensure the browser or WebDriver session created");
+      throw new WebDriverException("The SelenideAppiumPageFactory requires a webdriver instance to be created before page" +
+        " initialization; No webdriver is bound to current thread. You need to call open() first");
     }
 
     Optional<HasBrowserCheck> hasBrowserCheck = cast(driver, HasBrowserCheck.class);
@@ -156,9 +166,6 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
   }
 
   private boolean isPlatformAnnotationAdded(Field field) {
-    List<Class<? extends Annotation>> classes =
-      List.of(AndroidFindBy.class, AndroidFindBys.class, AndroidFindAll.class, iOSXCUITFindBy.class, iOSXCUITFindBys.class,
-        iOSXCUITFindAll.class);
-    return classes.stream().anyMatch(field::isAnnotationPresent);
+    return platformAnnotations.stream().anyMatch(field::isAnnotationPresent);
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.BaseElementsCollection;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.impl.CollectionSource;
 import com.codeborne.selenide.impl.ElementFinder;
 import com.codeborne.selenide.impl.LazyWebElementSnapshot;
@@ -53,6 +54,10 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
   @Nonnull
   @CheckReturnValue
   private DefaultElementByBuilder byBuilder(Driver driver) {
+    if (!WebDriverRunner.hasWebDriverStarted()) {
+      return new DefaultElementByBuilder(null, null);
+    }
+
     Optional<HasBrowserCheck> hasBrowserCheck = cast(driver, HasBrowserCheck.class);
     if (hasBrowserCheck.isPresent() && hasBrowserCheck.get().isBrowser()) {
       return new DefaultElementByBuilder(null, null);

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -67,7 +67,7 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
     }
     if (!driver.hasWebDriverStarted()) {
       throw new RuntimeException("The Appium Page factory requires a browser instance to be created before calling" +
-        " initialization via page; please ensure the browser or WebDriver session is initialized first.");
+        " initialization via page(); please ensure the browser or WebDriver session created");
     }
 
     Optional<HasBrowserCheck> hasBrowserCheck = cast(driver, HasBrowserCheck.class);

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.BaseElementsCollection;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
-import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.impl.CollectionSource;
 import com.codeborne.selenide.impl.ElementFinder;
 import com.codeborne.selenide.impl.LazyWebElementSnapshot;
@@ -54,7 +53,7 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
   @Nonnull
   @CheckReturnValue
   private DefaultElementByBuilder byBuilder(Driver driver) {
-    if (!WebDriverRunner.hasWebDriverStarted()) {
+    if (!driver.hasWebDriverStarted()) {
       return new DefaultElementByBuilder(null, null);
     }
 

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -59,12 +59,13 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
   }
 
 
-@Nonnull
+  @Nonnull
   @CheckReturnValue
   private DefaultElementByBuilder byBuilder(Driver driver, Field field) {
     if (!isPlatformAnnotationAdded(field)) {
       return new DefaultElementByBuilder(null, null);
     }
+
     if (!driver.hasWebDriverStarted()) {
       throw new RuntimeException("The Appium Page factory requires a browser instance to be created before calling" +
         " initialization via page(); please ensure the browser or WebDriver session created");

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumPageFactoryTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumPageFactoryTest.java
@@ -1,4 +1,4 @@
-package it.mobile;
+package com.codeborne.selenide.appium;
 
 import static com.codeborne.selenide.Selenide.open;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,16 +16,16 @@ class SelenideAppiumPageFactoryTest {
   @Test
   void exception_on_init_mobile_element_without_webdriver() {
     Selenide.closeWebDriver();
-    assertThatThrownBy(PageWithPlatformSelectors::new)
+    assertThatThrownBy(() -> Selenide.page(PageWithPlatformSelectors.class))
       .isInstanceOf(WebDriverException.class)
-        .hasMessageStartingWith("The Appium Page factory requires a webdriver instance to be created before page initialization;" +
-        " No webdriver is bound to current thread. You need to call open() first");
+        .hasMessageStartingWith("The SelenideAppiumPageFactory requires a webdriver instance to be created before page " +
+          "initialization; No webdriver is bound to current thread. You need to call open() first");
   }
 
   @Test
   void web_element_page_factory_doesnt_require_webdriver_instance() {
     Selenide.closeWebDriver();
-    var page = new PageWithWebSelectors();
+    var page = Selenide.page(PageWithWebSelectors.class);
     assertThat(page.element).isNotNull()
       .hasToString("{By.id: someId}");
   }
@@ -33,7 +33,7 @@ class SelenideAppiumPageFactoryTest {
   @Test
   void mobile_platform_element_successfully_init_with_created_webdriver() {
     open();
-    var page = new PageWithPlatformSelectors();
+    var page = Selenide.page(PageWithPlatformSelectors.class);
     assertThat(page.element).isNotNull()
       .hasToString("{By.id: element}");
   }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumPageFactoryTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumPageFactoryTest.java
@@ -1,14 +1,18 @@
 package com.codeborne.selenide.appium;
 
-import static com.codeborne.selenide.Selenide.open;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebDriverRunner;
+import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.pagefactory.AndroidFindBy;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.FindBy;
 
 class SelenideAppiumPageFactoryTest {
@@ -32,7 +36,9 @@ class SelenideAppiumPageFactoryTest {
 
   @Test
   void mobile_platform_element_successfully_init_with_created_webdriver() {
-    open();
+    AndroidDriver androidDriver = mock(AndroidDriver.class);
+    when(androidDriver.getCapabilities()).thenReturn(new DesiredCapabilities());
+    WebDriverRunner.setWebDriver(androidDriver);
     var page = Selenide.page(PageWithPlatformSelectors.class);
     assertThat(page.element).isNotNull()
       .hasToString("{By.id: element}");

--- a/modules/appium/src/test/java/it/mobile/SelenideAppiumPageFactoryTest.java
+++ b/modules/appium/src/test/java/it/mobile/SelenideAppiumPageFactoryTest.java
@@ -1,0 +1,50 @@
+package it.mobile;
+
+import static com.codeborne.selenide.Selenide.open;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.SelenideElement;
+import io.appium.java_client.pagefactory.AndroidFindBy;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.support.FindBy;
+
+class SelenideAppiumPageFactoryTest {
+
+  @Test
+  void exception_on_init_mobile_element_without_webdriver() {
+    Selenide.closeWebDriver();
+    assertThatThrownBy(PageWithPlatformSelectors::new)
+      .isInstanceOf(WebDriverException.class)
+        .hasMessageStartingWith("The Appium Page factory requires a webdriver instance to be created before page initialization;" +
+        " No webdriver is bound to current thread. You need to call open() first");
+  }
+
+  @Test
+  void web_element_page_factory_doesnt_require_webdriver_instance() {
+    Selenide.closeWebDriver();
+    var page = new PageWithWebSelectors();
+    assertThat(page.element).isNotNull()
+      .hasToString("{By.id: someId}");
+  }
+
+  @Test
+  void mobile_platform_element_successfully_init_with_created_webdriver() {
+    open();
+    var page = new PageWithPlatformSelectors();
+    assertThat(page.element).isNotNull()
+      .hasToString("{By.id: element}");
+  }
+
+  private static class PageWithPlatformSelectors {
+    @AndroidFindBy(id = "element")
+    public SelenideElement element;
+  }
+
+  private static class PageWithWebSelectors {
+    @FindBy(id = "someId")
+    public SelenideElement element;
+  }
+}


### PR DESCRIPTION
## Proposed changes
This is a potential solution for cases where a page initializes at the field level, but the driver hasn't been created yet. This issue occurs specifically when using the Appium plugin.
It's probably ok for Appium-only tests, but it is a problem if WEB and Mobile tests in the same repo

example code:
code https://pastebin.com/G4Y9gbmv
stacktrace: https://pastebin.com/JU3vLM2n

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
