### PR TITLE
#2896 fix method `Selenide.screeshot(filename)` to match the desription in javadoc

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -358,13 +358,14 @@ public class SelenideDriver {
   }
 
   /**
-   * Take a screenshot of the current page
+   * Take a screenshot of the current page and save to file "fileName.png" (and optionally, "fileName.html")
    *
-   * @return absolute path of the screenshot taken or null if failed to create screenshot
+   * @param fileName Name of file (without extension) to save PNG (and HTML) to
+   * @return URL of the screenshot taken, or null if failed to create screenshot
    */
   @Nullable
   public String screenshot(String fileName) {
-    return screenshots.takeScreenshot(driver(), fileName, true, false).getImage();
+    return screenshots.takeScreenshot(driver(), fileName, true, driver().config().savePageSource()).getImage();
   }
 
   /**

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -265,10 +265,13 @@ public class Selenide {
   }
 
   /**
-   * Take the screenshot of current page and save to file fileName.html and fileName.png
-   *
-   * @param fileName Name of file (without extension) to save HTML and PNG to
-   * @return The name of resulting file
+   * Take the screenshot of current page and save to file "fileName.png" (and optionally, "fileName.html")
+   * <ul>
+   *   <li>File "fileName.png" is created always, even if {@code Configuration.screenshots == false}</li>
+   *   <li>File "fileName.html" is created only if {@code Configuration.savePageSource == true}</li>
+   * </ul>
+   * @param fileName Name of file (without extension) to save PNG (and HTML) to
+   * @return URL of screenshot file
    */
   @Nullable
   @CanIgnoreReturnValue

--- a/statics/src/test/java/integration/ScreenshotsTest.java
+++ b/statics/src/test/java/integration/ScreenshotsTest.java
@@ -11,8 +11,12 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Base64;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class ScreenshotsTest extends IntegrationTest {
@@ -40,13 +44,27 @@ final class ScreenshotsTest extends IntegrationTest {
   @Test
   void canTakeScreenshotAsTemporaryFile() throws IOException {
     File screenshot = Selenide.screenshot(OutputType.FILE);
-    BufferedImage img = ImageIO.read(screenshot);
+    BufferedImage img = ImageIO.read(requireNonNull(screenshot));
     assertThat(img.getWidth()).isBetween(50, 3000);
     assertThat(img.getHeight()).isBetween(50, 3000);
+    assertThat(screenshot).exists();
 
     assertThat(screenshots.getContextScreenshots())
       .as("Temporary files screenshots are added to history")
       .hasSize(1);
     assertThat(screenshots.getContextScreenshots().get(0)).isEqualTo(screenshot);
+  }
+
+  @Test
+  void canTakeScreenshotAtEveryMoment() throws URISyntaxException {
+    String fileName = "screenshot-" + randomUUID();
+    String screenshot = Selenide.screenshot(fileName);
+
+    assertThat(screenshot).startsWith("file:/");
+    assertThat(screenshot).endsWith(".png");
+    assertThat(new File(new URI(requireNonNull(screenshot)))).exists();
+
+    String pageSource = screenshot.replace(".png", ".html");
+    assertThat(new File(new URI(pageSource))).exists();
   }
 }


### PR DESCRIPTION
now it saves not only "*.png", but also "*.html" file (depending on Configuration).
