### PR TITLE
fix double click with appium

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
@@ -28,6 +28,7 @@ public class AppiumClick extends Click {
   public void execute(WebElementSource locator, Object @Nullable [] args) {
     if (!isMobile(locator.driver())) {
       super.execute(locator, args);
+      return;
     }
 
     ClickOptions options = options(args);


### PR DESCRIPTION
## Proposed changes
This change fixes bug after https://github.com/selenide/selenide/pull/2889. Other methods have return call as example AppiumDoubleClick

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
