### PR TITLE
#2906 make method `Click.execute()` overridable again

### DIFF
--- a/src/main/java/com/codeborne/selenide/FluentCommand.java
+++ b/src/main/java/com/codeborne/selenide/FluentCommand.java
@@ -17,9 +17,13 @@ import org.jspecify.annotations.Nullable;
  * </pre>
  */
 public abstract class FluentCommand implements Command<SelenideElement> {
+  /**
+   * @deprecated It's easier to override method {@link #execute(WebElementSource, Object[])} instead.
+   */
   @Override
   @CanIgnoreReturnValue
-  public final SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object @Nullable [] args) {
+  @Deprecated
+  public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object @Nullable [] args) {
     execute(locator, args);
     return proxy;
   }


### PR DESCRIPTION
to avoid breaking backward compatibility in projects that override `$.click()` or other built-in commands.
