### PR TITLE
#2931 Inherit @As alias for elements extended from the Container

### DIFF
--- a/modules/appium/src/test/java/it/mobile/android/LoginTestWithCollectionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/LoginTestWithCollectionsTest.java
@@ -1,5 +1,6 @@
 package it.mobile.android;
 
+import com.codeborne.selenide.As;
 import com.codeborne.selenide.Container;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
@@ -8,6 +9,8 @@ import com.codeborne.selenide.appium.SelenideAppiumCollection;
 import com.codeborne.selenide.appium.SelenideAppiumElement;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.pagefactory.AndroidFindBy;
+import it.mobile.android.LoginPageWithContainer.ErrorsWidget;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -19,6 +22,7 @@ import java.util.List;
 
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selenide.page;
 import static com.codeborne.selenide.Selenide.sleep;
@@ -56,6 +60,20 @@ public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
     loginPage.loginButton.click();
     assertThat(loginPage.errors).hasSize(1);
     loginPage.errors.get(0).message.shouldHave(text("Provided credentials do not match any user in this service."));
+    loginPage.error.message.shouldHave(text("Provided credentials do not match any user in this service."));
+    loginPage.error.self.shouldBe(visible);
+  }
+
+  @Test
+  public void pageObjectWithErrors() {
+    LoginPageWithContainer loginPage = page();
+    loginPage.inputFields.get(0).sendKeys("bob@example.com");
+    loginPage.inputFields.get(1).setValue("wrongpassword");
+    loginPage.loginButton.click();
+
+    LoginPageWithErrors page = page();
+    assertThat(page.errors).hasSize(1);
+    page.errors.get(0).message.shouldHave(text("Provided credentials do not match any user in this service."));
   }
 
   @Test
@@ -119,23 +137,33 @@ public class LoginTestWithCollectionsTest extends BaseSwagLabsAndroidTest {
 }
 
 class LoginPageWithCollections {
+  @As("inputs")
   @AndroidFindBy(xpath = "//android.widget.EditText")
   SelenideAppiumCollection inputFields;
 
+  @As("Login button")
   @AndroidFindBy(accessibility = "Login button")
   WebElement loginButton;
 
+  @As("Error message")
   @AndroidFindBy(xpath = "//*[@content-desc='generic-error-message']/android.widget.TextView")
   SelenideAppiumElement errorMessage;
 }
 
 class LoginPageWithContainer {
+  @As("inputs")
   @AndroidFindBy(xpath = "//android.widget.EditText")
   List<SelenideAppiumElement> inputFields;
 
+  @As("Login button")
   @AndroidFindBy(accessibility = "Login button")
   WebElement loginButton;
 
+  @As("error")
+  @AndroidFindBy(xpath = "//*[@content-desc='generic-error-message']")
+  ErrorsWidget error;
+
+  @As("errors")
   @AndroidFindBy(xpath = "//*[@content-desc='generic-error-message']")
   List<ErrorsWidget> errors;
 
@@ -143,30 +171,41 @@ class LoginPageWithContainer {
     @Self
     SelenideAppiumElement self;
 
+    // @As("message")
     @AndroidFindBy(xpath = ".//android.widget.TextView")
     SelenideAppiumElement message;
   }
 }
+class LoginPageWithErrors {
+  @As("errors")
+  @AndroidFindBy(xpath = "//*[@content-desc='generic-error-message']")
+  List<ErrorsWidget> errors;
+}
 
 class LoginPageWithSelenideCollection {
+  @As("inputs")
   @AndroidFindBy(xpath = "//android.widget.EditText")
   ElementsCollection selenideElements;
 }
 
 class LoginPageWithSelenideElementList {
+  @As("inputs")
   @AndroidFindBy(xpath = "//android.widget.EditText")
   List<SelenideElement> elements;
 }
 
 class LoginPageWithSelenideAppiumElementList {
+  @As("inputs")
   @AndroidFindBy(xpath = "//android.widget.EditText")
   List<SelenideAppiumElement> elements;
 
   @AndroidFindBy(xpath = "//android.widget.EditText")
+  @Nullable
   List<WebDriver> nonWebElements;
 }
 
 class LoginPageWithSelenideAppiumElementIterable {
+  @As("inputs")
   @AndroidFindBy(xpath = "//android.widget.EditText")
   Iterable<SelenideAppiumElement> elements;
 }

--- a/src/main/java/com/codeborne/selenide/impl/CollectionSnapshot.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionSnapshot.java
@@ -6,16 +6,15 @@ import org.openqa.selenium.WebElement;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.codeborne.selenide.impl.Alias.NONE;
-
 public class CollectionSnapshot implements CollectionSource {
 
   private final CollectionSource originalCollection;
   private final List<WebElement> elementsSnapshot;
-  private Alias alias = NONE;
+  private Alias alias;
 
   public CollectionSnapshot(CollectionSource collection) {
     this.originalCollection = collection;
+    this.alias = collection.getAlias();
     this.elementsSnapshot = new ArrayList<>(collection.getElements());
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
+++ b/src/main/java/com/codeborne/selenide/impl/ElementFinder.java
@@ -81,6 +81,11 @@ public class ElementFinder extends WebElementSource {
   }
 
   @Override
+  public final void setAlias(String alias) {
+    super.setAlias(alias);
+  }
+
+  @Override
   public SelenideElement find(SelenideElement proxy, Object arg, int index) {
     if (arg instanceof By by) {
       return wrap(driver, this, by, index);

--- a/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
@@ -138,7 +138,7 @@ public class SelenidePageFactory implements PageObjectFactory {
   @Override
   public Container createElementsContainer(Driver driver, @Nullable WebElementSource searchContext, Field field, By selector) {
     try {
-      WebElementSource self = new ElementFinder(driver, searchContext, selector, 0);
+      WebElementSource self = new ElementFinder(driver, searchContext, selector, 0, alias(field));
       if (shouldCache(field)) {
         self = new LazyWebElementSnapshot(self);
       }

--- a/src/test/java/com/codeborne/selenide/impl/CollectionSnapshotTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionSnapshotTest.java
@@ -2,11 +2,13 @@ package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 
 import java.util.List;
 
+import static com.codeborne.selenide.impl.Alias.NONE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,9 +22,15 @@ final class CollectionSnapshotTest {
 
   private final CollectionSource originalCollection = mock();
 
+  @BeforeEach
+  void setUp() {
+    when(originalCollection.getAlias()).thenReturn(NONE);
+  }
+
   @AfterEach
   void verifyNoMoreInteractionsOnOriginalCollection() {
     verify(originalCollection).getElements();
+    verify(originalCollection).getAlias();
     verifyNoMoreInteractions(originalCollection);
   }
 
@@ -71,7 +79,6 @@ final class CollectionSnapshotTest {
 
     verify(originalCollection, times(2)).description();
   }
-
 
   @Test
   void driver() {

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -2,6 +2,7 @@ org.slf4j.simpleLogger.defaultLogLevel=info
 org.slf4j.simpleLogger.showShortLogName=true
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS
+org.slf4j.simpleLogger.showThreadName=true
 org.slf4j.simpleLogger.log.integration=debug
 #org.slf4j.simpleLogger.log.org.selenide.videorecorder=debug
 org.slf4j.simpleLogger.log.com.codeborne.selenide=debug

--- a/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
+++ b/statics/src/test/java/integration/pageobjects/PageObjectWithAliasesTest.java
@@ -1,6 +1,7 @@
 package integration.pageobjects;
 
 import com.codeborne.selenide.As;
+import com.codeborne.selenide.Container;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementShould;
@@ -54,15 +55,29 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
   }
 
   @Test
-  void collectionWithAlias() {
-    assertThatThrownBy(() ->
-      page.header2.shouldHave(size(666))
-    )
-      .isInstanceOf(ListSizeMismatch.class)
+  void selfWithAlias() {
+    assertThatThrownBy(() -> $(page.header.self).shouldHave(text("Nope")))
+      .isInstanceOf(ElementShould.class)
       .hasMessageStartingWith("""
-          List size mismatch: expected: = 666, actual: 4, collection: Middle headers {h2}
+          Element "The header" should have text "Nope" {h1}
           """.trim()
       );
+  }
+
+  @Test
+  void collectionWithAlias() {
+    assertThatThrownBy(() -> page.header2.shouldHave(size(666))).isInstanceOf(ListSizeMismatch.class)
+      .hasMessageStartingWith("""
+        List size mismatch: expected: = 666, actual: 4, collection: Middle headers {h2}
+        """.trim());
+  }
+
+  @Test
+  void collectionWithAlias_singleElement() {
+    assertThatThrownBy(() -> page.header2.get(2).shouldHave(text("Nope"))).isInstanceOf(ElementShould.class)
+      .hasMessageStartingWith("""
+        Element should have text "Nope" {h2[2]}
+        """.trim());
   }
 
   @Test
@@ -90,6 +105,10 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
   }
 
   static class PageObject {
+    @As("The header")
+    @FindBy(tagName = "h1")
+    Header header;
+
     @As("Large header")
     @FindBy(tagName = "h1")
     SelenideElement header1;
@@ -107,5 +126,10 @@ public class PageObjectWithAliasesTest extends IntegrationTest {
 
     @As("Dollar collection")
     ElementsCollection header5 = $$("h2");
+  }
+
+  static class Header implements Container {
+    @Self
+    SelenideElement self;
   }
 }


### PR DESCRIPTION
Now `@As` annotation from page object field of type `Container` is inherited by its field `self`.

See #2931