### PR TITLE
Added ability to use custom types for elements in appium page factory

### DIFF
--- a/modules/appium/README.md
+++ b/modules/appium/README.md
@@ -156,6 +156,40 @@ CombinedBy username = CombinedBy
 $(username).setValue("selenide-rocks");
 ```
 
+10. Want to add additional custom methods to SelenideAppiumElement? Just extend base interface and register your Command.
+
+Custom element type:
+```java
+public interface CustomElement extends SelenideAppiumElement {
+  CustomElement myCommand(Object... args);
+}
+```
+
+Page Object:
+```java
+public class MyPage {
+    @AndroidFindBy(id = "element")
+    public CustomElement element;
+}
+```
+
+Custom Command:
+```java
+public class CustomCommand implements Command<CustomElement> {
+  
+  public CustomElement execute(SelenideElement proxy, WebElementSource source, @Nullable Object[] args) {
+    // your implementation here
+    return (CustomElement) proxy;
+  }
+}
+```
+
+Usage:
+```java
+Commands.getInstance().add("myCommand", new CustomCommand());
+MyPage page = Selenide.page(MyPage.class);
+page.element.myCommand("argument");
+```
 
 
 ### Changelog

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -135,7 +135,7 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
                                                Field field, @Nullable String alias) {
     return shouldCache(field) ?
       LazyWebElementSnapshot.wrap(new ElementFinder(driver, searchContext, selector, 0, alias)) :
-      ElementFinder.wrap(driver, SelenideAppiumElement.class, searchContext, selector, 0, alias);
+      ElementFinder.wrap(driver, getTargetType(field), searchContext, selector, 0, alias);
   }
 
   @Override
@@ -155,5 +155,11 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
 
   private boolean isPlatformAnnotationAdded(Field field) {
     return platformAnnotations.stream().anyMatch(field::isAnnotationPresent);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends SelenideAppiumElement> Class<T> getTargetType(Field field) {
+    return SelenideAppiumElement.class.isAssignableFrom(field.getType()) ?
+      (Class<T>) field.getType() : (Class<T>) SelenideAppiumElement.class;
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -5,8 +5,6 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.CollectionSource;
-import com.codeborne.selenide.impl.ElementFinder;
-import com.codeborne.selenide.impl.LazyWebElementSnapshot;
 import com.codeborne.selenide.impl.NoOpsList;
 import com.codeborne.selenide.impl.SelenidePageFactory;
 import com.codeborne.selenide.impl.WebElementSource;
@@ -126,19 +124,6 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
   }
 
   @Override
-  protected SelenideElement createSelf(WebElementSource searchContext) {
-    return ElementFinder.wrap(SelenideAppiumElement.class, searchContext);
-  }
-
-  @Override
-  protected SelenideElement decorateWebElement(Driver driver, @Nullable WebElementSource searchContext, By selector,
-                                               Field field, @Nullable String alias) {
-    return shouldCache(field) ?
-      LazyWebElementSnapshot.wrap(new ElementFinder(driver, searchContext, selector, 0, alias)) :
-      ElementFinder.wrap(driver, getTargetType(field), searchContext, selector, 0, alias);
-  }
-
-  @Override
   protected BaseElementsCollection<? extends SelenideElement, ? extends BaseElementsCollection<?, ?>> createCollection(
     CollectionSource collection, Class<?> klass
   ) {
@@ -157,9 +142,8 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
     return platformAnnotations.stream().anyMatch(field::isAnnotationPresent);
   }
 
-  @SuppressWarnings("unchecked")
-  private <T extends SelenideAppiumElement> Class<T> getTargetType(Field field) {
-    return SelenideAppiumElement.class.isAssignableFrom(field.getType()) ?
-      (Class<T>) field.getType() : (Class<T>) SelenideAppiumElement.class;
+  @Override
+  protected Class<?> elementsBaseType() {
+    return SelenideAppiumElement.class;
   }
 }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumPageFactoryTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumPageFactoryTest.java
@@ -44,6 +44,15 @@ class SelenideAppiumPageFactoryTest {
       .hasToString("{By.id: element}");
   }
 
+  @Test
+  void mobile_element_with_custom_type_successfully_init() {
+    AndroidDriver androidDriver = mock(AndroidDriver.class);
+    when(androidDriver.getCapabilities()).thenReturn(new DesiredCapabilities());
+    WebDriverRunner.setWebDriver(androidDriver);
+    var page = Selenide.page(PageWithCustomElementType.class);
+    assertThat(page.element).isNotNull();
+  }
+
   private static class PageWithPlatformSelectors {
     @AndroidFindBy(id = "element")
     public SelenideElement element;
@@ -52,5 +61,14 @@ class SelenideAppiumPageFactoryTest {
   private static class PageWithWebSelectors {
     @FindBy(id = "someId")
     public SelenideElement element;
+  }
+
+  private static class PageWithCustomElementType {
+    @AndroidFindBy(id = "element")
+    public CustomSelenideAppiumElement element;
+  }
+
+  private interface CustomSelenideAppiumElement extends SelenideAppiumElement {
+    void method();
   }
 }

--- a/statics/src/test/java/integration/pageobjects/PageObjectWithCustomElementTypeTest.java
+++ b/statics/src/test/java/integration/pageobjects/PageObjectWithCustomElementTypeTest.java
@@ -1,0 +1,55 @@
+package integration.pageobjects;
+
+import java.time.Duration;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.commands.Commands;
+import com.codeborne.selenide.impl.WebElementSource;
+import integration.IntegrationTest;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static com.codeborne.selenide.Condition.value;
+import static com.codeborne.selenide.Selenide.page;
+
+public class PageObjectWithCustomElementTypeTest extends IntegrationTest {
+
+  @BeforeEach
+  void openTestPage() {
+    openFile("page_with_selects_without_jquery.html");
+  }
+
+  @Test
+  void userCanUseCustomElementTypeInPageObject() {
+    Commands.getInstance().add("replaceValue", new CustomCommand());
+    PageObject page = page(PageObject.class);
+    page.textArea.replaceValue("text", "!text!")
+        .shouldHave(value("This is !text! area"));
+  }
+
+  private static class PageObject {
+
+    @FindBy(css = "#text-area")
+    CustomElement textArea;
+  }
+
+  private interface CustomElement extends SelenideElement {
+    CustomElement replaceValue(String oldText, String newText);
+  }
+
+  private static class CustomCommand implements Command<CustomElement> {
+
+    @Override
+    public @Nullable CustomElement execute(SelenideElement proxy, WebElementSource locator, Object @Nullable [] args) {
+      String oldText = (String) args[0];
+      String newText = (String) args[1];
+      String text = proxy.shouldNotBe(Condition.empty, Duration.ofSeconds(3)).text();
+      proxy.setValue(text.replace(oldText, newText));
+      return (CustomElement) proxy;
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes
Ability to use custom element types (extended from `SelenideAppiumElement`) with page factory. Usage example in the readme

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
