### PR TITLE
Extend appium interacts with apps abilities

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumNavigator.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumNavigator.java
@@ -4,7 +4,12 @@ import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.logevents.SelenideLogger;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.InteractsWithApps;
+import io.appium.java_client.appmanagement.BaseTerminateApplicationOptions;
+import org.jspecify.annotations.Nullable;
 
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
@@ -17,12 +22,33 @@ public class AppiumNavigator {
     SelenideLogger.run("launch app", "", driverSupplier.get());
   }
 
-  public void terminateApp(AppiumDriver driver, String appId) {
-    SelenideLogger.run("terminate app", appId, () -> {
-      cast(driver, InteractsWithApps.class)
-        .map(mobileDriver -> mobileDriver.terminateApp(appId))
-        .orElseThrow(() -> new UnsupportedOperationException("Driver does not support app termination: " + driver.getClass()));
-    });
+  public void activateApp(AppiumDriver driver, String appId) {
+    SelenideLogger.run(
+      "activate app",
+      appId,
+      () -> cast(driver, InteractsWithApps.class)
+        .map(mobileDriver -> {
+          mobileDriver.activateApp(appId);
+          return true;
+        })
+        .orElseThrow(() -> new UnsupportedOperationException("Driver does not support app activation: " + driver.getClass()))
+    );
   }
 
+  public void terminateApp(AppiumDriver driver, String appId, @Nullable Duration timeout) {
+    SelenideLogger.run(
+      "terminate app",
+      appId,
+      () -> cast(driver, InteractsWithApps.class)
+        .map(mobileDriver -> {
+          if (Objects.nonNull(timeout)) {
+            BaseTerminateApplicationOptions options = (BaseTerminateApplicationOptions) Map.of("timeout", timeout.toMillis());
+            return mobileDriver.terminateApp(appId, options);
+          } else {
+            return mobileDriver.terminateApp(appId);
+          }
+        })
+        .orElseThrow(() -> new UnsupportedOperationException("Driver does not support app termination: " + driver.getClass()))
+    );
+  }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -104,7 +104,7 @@ public class SelenideAppium {
    * @param timeout - The count of milliseconds to wait until the app is terminated
    */
   public static void relaunchApp(String appId, @Nullable Duration timeout) {
-    appiumNavigator.terminateApp(AppiumDriverRunner.getMobileDriver(), appId, timeout);
+    terminateApp(appId, timeout);
     activateApp(appId);
   }
 

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -4,9 +4,11 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.impl.ElementFinder;
 import com.codeborne.selenide.impl.WebElementWrapper;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Set;
 
@@ -35,6 +37,7 @@ public class SelenideAppium {
 
   /**
    * Open a deep link for an IOS application
+   *
    * @param deepLinkUrl - deep link url
    */
   public static void openIOSDeepLink(String deepLinkUrl) {
@@ -43,10 +46,12 @@ public class SelenideAppium {
     }
     deepLinkLauncher.openDeepLinkOnIos(AppiumDriverRunner.getIosDriver(), deepLinkUrl);
   }
+
   /**
    * Open a deep link for an Android application
+   *
    * @param deepLinkUrl - deep link url
-   * @param appPackage - Android application package
+   * @param appPackage  - Android application package
    */
   public static void openAndroidDeepLink(String deepLinkUrl, String appPackage) {
     if (!hasWebDriverStarted()) {
@@ -56,11 +61,51 @@ public class SelenideAppium {
   }
 
   /**
+   * Activate application
+   *
+   * @param appId - applicationId for Android or bundleId for iOS
+   */
+  public static void activateApp(String appId) {
+    appiumNavigator.activateApp(AppiumDriverRunner.getMobileDriver(), appId);
+  }
+
+  /**
    * Terminate application
+   *
    * @param appId - applicationId for Android or bundleId for iOS
    */
   public static void terminateApp(String appId) {
-    appiumNavigator.terminateApp(AppiumDriverRunner.getMobileDriver(), appId);
+    terminateApp(appId, null);
+  }
+
+  /**
+   * Terminate application
+   *
+   * @param appId   - applicationId for Android or bundleId for iOS
+   * @param timeout - The count of milliseconds to wait until the app is terminated
+   */
+  public static void terminateApp(String appId, @Nullable Duration timeout) {
+    appiumNavigator.terminateApp(AppiumDriverRunner.getMobileDriver(), appId, timeout);
+  }
+
+  /**
+   * Re-launch application
+   *
+   * @param appId - applicationId for Android or bundleId for iOS
+   */
+  public static void relaunchApp(String appId) {
+    relaunchApp(appId, null);
+  }
+
+  /**
+   * Re-launch application
+   *
+   * @param appId   - applicationId for Android or bundleId for iOS
+   * @param timeout - The count of milliseconds to wait until the app is terminated
+   */
+  public static void relaunchApp(String appId, @Nullable Duration timeout) {
+    appiumNavigator.terminateApp(AppiumDriverRunner.getMobileDriver(), appId, timeout);
+    activateApp(appId);
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

Added abilities:
- activate app
- terminate app with timeout
- relaunch app (terminate + activate)
- relaunch app with timeout

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
