### PR TITLE
#2967 improve how the Android/iOS combined attribute looks in error messages

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/conditions/AppiumAttributeValues.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/conditions/AppiumAttributeValues.java
@@ -52,4 +52,9 @@ public class AppiumAttributeValues extends ExactTexts {
       .map(element -> attribute.getAttributeValue(driver, element))
       .toList();
   }
+
+  @Override
+  public String toString() {
+    return "%s %s".formatted(attribute, expectedTexts);
+  }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/conditions/CombinedAttribute.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/conditions/CombinedAttribute.java
@@ -43,4 +43,9 @@ public class CombinedAttribute {
     }
     throw new UnsupportedOperationException("Unsupported webdriver: " + WebDriverRunner.getWebDriver());
   }
+
+  @Override
+  public String toString() {
+    return "@%s|@%s".formatted(androidAttribute, iosAttribute);
+  }
 }

--- a/modules/appium/src/test/java/it/mobile/android/AndroidAppiumConditionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AndroidAppiumConditionsTest.java
@@ -2,8 +2,10 @@ package it.mobile.android;
 
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.appium.SelenideAppium;
+import com.codeborne.selenide.appium.SelenideAppiumElement;
+import com.codeborne.selenide.ex.ElementShould;
 import com.codeborne.selenide.ex.TextsMismatch;
-import io.appium.java_client.AppiumBy;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
@@ -15,6 +17,7 @@ import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.appium.AppiumCollectionCondition.attributes;
 import static com.codeborne.selenide.appium.AppiumCondition.attribute;
 import static com.codeborne.selenide.appium.conditions.CombinedAttribute.android;
+import static io.appium.java_client.AppiumBy.accessibilityId;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -35,12 +38,27 @@ class AndroidAppiumConditionsTest extends BaseApiDemosTest {
 
     Configuration.timeout = 1;
     List<String> expectedAttributes = asList("API Demos", "KeyEventText", "Linkify", "LogTextBox");
-    assertThatThrownBy(() -> elements.shouldHave(attributes(android("text"), expectedAttributes)))
+    assertThatThrownBy(() -> elements.shouldHave(attributes(android("text").ios("ioz"), expectedAttributes)))
       .isInstanceOf(TextsMismatch.class)
       .hasMessageStartingWith("List size mismatch (expected: 4, actual: 6)")
       .hasMessageContaining("Actual (6): [API Demos, KeyEventText, Linkify, LogTextBox, Marquee, Unicode]")
       .hasMessageContaining("Expected (4): [API Demos, KeyEventText, Linkify, LogTextBox]")
       .hasMessageContaining("Collection: By.xpath: //android.widget.TextView");
+  }
+
+  @Test
+  void appiumConditionAttribute_textMismatch() {
+    $(By.xpath(".//*[@text='Text']")).click();
+    SelenideAppiumElement element = SelenideAppium.$(By.xpath("//android.widget.TextView"));
+
+    Configuration.timeout = 1;
+    assertThatThrownBy(() -> element.shouldHave(attribute(android("text").ios("ioz"), "WRONG")))
+      .isInstanceOf(ElementShould.class)
+      .hasMessageStartingWith("Element should have attribute @text|@ioz=\"WRONG\" {By.xpath: //android.widget.TextView}")
+      .hasMessageContaining("Element: '<TextView ")
+      .hasMessageContaining("Actual value: @text|@ioz=\"API Demos\"")
+      .hasMessageContaining("Screenshot:")
+      .hasMessageContaining("Page source:");
   }
 
   @Test
@@ -61,7 +79,7 @@ class AndroidAppiumConditionsTest extends BaseApiDemosTest {
 
   @Test
   void appiumConditionAttribute() {
-    $(AppiumBy.accessibilityId("Accessibility"))
+    $(accessibilityId("Accessibility"))
       .shouldHave(attribute(android("content-desc").ios("name"), "Accessibility"));
   }
 }

--- a/modules/appium/src/test/java/it/mobile/ios/IosAppiumConditionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/ios/IosAppiumConditionsTest.java
@@ -1,9 +1,6 @@
 package it.mobile.ios;
 
 import com.codeborne.selenide.SelenideElement;
-import com.codeborne.selenide.appium.AppiumCondition;
-import com.codeborne.selenide.appium.AppiumSelectors;
-import com.codeborne.selenide.appium.SelenideAppium;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.CollectionCondition.size;
@@ -11,27 +8,30 @@ import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.appium.AppiumCollectionCondition.attributes;
+import static com.codeborne.selenide.appium.AppiumCondition.attribute;
+import static com.codeborne.selenide.appium.AppiumSelectors.byAttribute;
+import static com.codeborne.selenide.appium.SelenideAppium.openIOSDeepLink;
 import static com.codeborne.selenide.appium.conditions.CombinedAttribute.android;
 
 class IosAppiumConditionsTest extends BaseSwagLabsAppIosTest {
 
   @Test
   void testAppiumCollectionConditionAttribute() {
-    SelenideAppium.openIOSDeepLink("mydemoapprn://login");
-    $$(AppiumSelectors.byAttribute("type", "XCUIElementTypeTextField"))
+    openIOSDeepLink("mydemoapprn://login");
+    $$(byAttribute("type", "XCUIElementTypeTextField"))
       .shouldBe(size(1))
       .shouldHave(attributes(android("text").ios("name"), "Username input field"));
   }
 
   @Test
   void testAppiumConditionAttribute() {
-    SelenideAppium.openIOSDeepLink("mydemoapprn://login");
-    SelenideElement element = $(AppiumSelectors.byAttribute("type", "XCUIElementTypeTextField"));
+    openIOSDeepLink("mydemoapprn://login");
+    SelenideElement element = $(byAttribute("type", "XCUIElementTypeTextField"));
 
     // Selenide style:
     element.shouldHave(attribute("name", "Username input field"));
 
     // Selenide-Appium style:
-    element.shouldHave(AppiumCondition.attribute(android("").ios("name"), "Username input field"));
+    element.shouldHave(attribute(android("").ios("name"), "Username input field"));
   }
 }


### PR DESCRIPTION
Before: `Element should have attribute com.codeborne.selenide.appium.conditions.CombinedAttribute@47b530e0="My Projects"`
After: `Element should have attribute @text|@ioz="My Projects"`
