### PR TITLE
#2992 Print file paths in a format that Jenkins and GitLab treat as attachments

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
   archunitVersion = '1.4.0'
   jacksonVersion = '2.18.3'
   javacvVersion = '1.5.11'
-  systemStubsVersion = '2.1.8'
+  logcaptorVersion = '2.10.1'
 }
 
 subprojects {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
   archunitVersion = '1.4.0'
   jacksonVersion = '2.18.3'
   javacvVersion = '1.5.11'
-  logcaptorVersion = '2.10.1'
+  systemStubsVersion = '2.1.8'
 }
 
 subprojects {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,6 +16,7 @@ ext {
   archunitVersion = '1.4.0'
   jacksonVersion = '2.18.3'
   javacvVersion = '1.5.11'
+  systemStubsVersion = '2.1.8'
 }
 
 subprojects {

--- a/modules/full-screenshot/build.gradle
+++ b/modules/full-screenshot/build.gradle
@@ -5,6 +5,7 @@ ext {
 dependencies {
   api project(":statics")
   testImplementation project(':statics').sourceSets.test.output
+  testImplementation project(':statics').sourceSets.test.compileClasspath
   testImplementation project(':modules:core').sourceSets.test.output
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.junit.platform:junit-platform-suite-engine")

--- a/src/main/java/com/codeborne/selenide/impl/AttachmentConsolePrinter.java
+++ b/src/main/java/com/codeborne/selenide/impl/AttachmentConsolePrinter.java
@@ -1,0 +1,17 @@
+package com.codeborne.selenide.impl;
+
+import java.io.File;
+
+public class AttachmentConsolePrinter {
+
+  /**
+   * Prints an attachment line to the console. This is recognised by at least
+   * <a href="https://docs.gitlab.com/ci/testing/unit_test_reports/">GitLab Unit test reports</a>
+   * and <a href="https://plugins.jenkins.io/junit-attachments/">Jenkins JUnit Attachments plugin</a>.
+   *
+   * @param file the file to be attached
+   */
+  public static void printAttachmentLine(File file) {
+    System.out.printf("[[ATTACHMENT|%s]]%n", file.getAbsolutePath());
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/AttachmentConsolePrinter.java
+++ b/src/main/java/com/codeborne/selenide/impl/AttachmentConsolePrinter.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
-public class AttachmentConsolePrinter {
+class AttachmentConsolePrinter {
 
   private static final Logger log = LoggerFactory.getLogger(AttachmentConsolePrinter.class);
 
@@ -16,7 +16,7 @@ public class AttachmentConsolePrinter {
    *
    * @param file the file to be attached
    */
-  public static void printAttachmentLine(File file) {
+  static void printAttachmentLine(File file) {
     log.info("[[ATTACHMENT|{}]]", file.getAbsolutePath());
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/AttachmentConsolePrinter.java
+++ b/src/main/java/com/codeborne/selenide/impl/AttachmentConsolePrinter.java
@@ -1,8 +1,13 @@
 package com.codeborne.selenide.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 
 public class AttachmentConsolePrinter {
+
+  private static final Logger log = LoggerFactory.getLogger(AttachmentConsolePrinter.class);
 
   /**
    * Prints an attachment line to the console. This is recognised by at least
@@ -12,6 +17,6 @@ public class AttachmentConsolePrinter {
    * @param file the file to be attached
    */
   public static void printAttachmentLine(File file) {
-    System.out.printf("[[ATTACHMENT|%s]]%n", file.getAbsolutePath());
+    log.info("[[ATTACHMENT|{}]]", file.getAbsolutePath());
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -268,6 +268,7 @@ public class ScreenShotLaboratory {
   private static void writeToFileSafely(byte[] srcFile, File imageFile) {
     try {
       FileUtils.writeByteArrayToFile(imageFile, srcFile);
+      AttachmentConsolePrinter.printAttachmentLine(imageFile);
     }
     catch (IOException e) {
       log.error("Failed to save screenshot to {}", imageFile, e);

--- a/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
@@ -66,6 +66,7 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
   protected void writeToFile(String content, File targetFile) {
     try (ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes(UTF_8))) {
       FileHelper.copyFile(in, targetFile);
+      AttachmentConsolePrinter.printAttachmentLine(targetFile);
     }
     catch (IOException e) {
       log.error("Failed to write file {}", targetFile.getAbsolutePath(), e);

--- a/statics/build.gradle
+++ b/statics/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.mockito:mockito-core:$mockitoVersion")
   testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
-  testImplementation("io.github.hakky54:logcaptor:$logcaptorVersion")
+  testImplementation("uk.org.webcompere:system-stubs-jupiter:$systemStubsVersion")
 }
 
 apply from: rootProject.file('gradle/publish-module.gradle')

--- a/statics/build.gradle
+++ b/statics/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.mockito:mockito-core:$mockitoVersion")
   testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
+  testImplementation("uk.org.webcompere:system-stubs-jupiter:$systemStubsVersion")
 }
 
 apply from: rootProject.file('gradle/publish-module.gradle')

--- a/statics/build.gradle
+++ b/statics/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.mockito:mockito-core:$mockitoVersion")
   testImplementation("org.assertj:assertj-core:$assertjVersion") {transitive false}
-  testImplementation("uk.org.webcompere:system-stubs-jupiter:$systemStubsVersion")
+  testImplementation("io.github.hakky54:logcaptor:$logcaptorVersion")
 }
 
 apply from: rootProject.file('gradle/publish-module.gradle')

--- a/statics/src/test/java/integration/ScreenshotsTest.java
+++ b/statics/src/test/java/integration/ScreenshotsTest.java
@@ -4,7 +4,11 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.impl.ScreenShotLaboratory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.OutputType;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -19,9 +23,14 @@ import static com.codeborne.selenide.impl.Plugins.inject;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.webcompere.systemstubs.stream.output.OutputFactories.tapAndOutput;
 
+@ExtendWith(SystemStubsExtension.class)
 final class ScreenshotsTest extends IntegrationTest {
   private static final ScreenShotLaboratory screenshots = inject();
+
+  @SystemStub
+  SystemOut systemOut = new SystemOut(tapAndOutput());
 
   @BeforeEach
   void openTestPageWithJQuery() {
@@ -63,9 +72,15 @@ final class ScreenshotsTest extends IntegrationTest {
 
     assertThat(screenshot).startsWith("file:/");
     assertThat(screenshot).endsWith(".png");
-    assertThat(new File(new URI(requireNonNull(screenshot)))).exists();
+    assertThatFileExistsAndIsReferencedInSystemOut(screenshot);
 
     String pageSource = screenshot.replace(".png", ".html");
-    assertThat(new File(new URI(pageSource))).exists();
+    assertThatFileExistsAndIsReferencedInSystemOut(pageSource);
+  }
+
+  private void assertThatFileExistsAndIsReferencedInSystemOut(String url) throws URISyntaxException {
+    File file = new File(new URI(url));
+    assertThat(file).exists();
+    assertThat(systemOut.getLines()).containsOnlyOnce("[[ATTACHMENT|%s]]".formatted(file));
   }
 }


### PR DESCRIPTION
## Proposed changes
For each generated file (screenshots and page sources), print a line in the console in the format `[[ATTACHMENT|/path/to/file]]`. This format is recognised by at least
- [GitLab Unit test reports](https://docs.gitlab.com/ci/testing/unit_test_reports/)
- [Jenkins JUnit Attachments plugin](https://plugins.jenkins.io/junit-attachments/)

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
