### PR TITLE
check for empty expected text

### DIFF
--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -200,7 +200,7 @@ public final class Condition {
 
   /**
    * Assert that element contains given "value" attribute as substring
-   * NB! Ignores difference in non-visible characters like spaces, non-breakable spaces, tabs, newlines  etc.
+   * NB! Ignores difference in non-visible characters like spaces, non-breakable spaces, tabs, newlines etc.
    *
    * <p>Sample: {@code $("input").shouldHave(value("12345 666 77"));}</p>
    *

--- a/src/main/java/com/codeborne/selenide/conditions/CaseInsensitiveTextCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/CaseInsensitiveTextCondition.java
@@ -3,6 +3,8 @@ package com.codeborne.selenide.conditions;
 import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.impl.Html;
 
+import static java.util.Objects.requireNonNull;
+
 abstract class CaseInsensitiveTextCondition extends TextCondition {
   protected CaseInsensitiveTextCondition(String name, String expectedText) {
     super(name, expectedText);
@@ -15,6 +17,7 @@ abstract class CaseInsensitiveTextCondition extends TextCondition {
 
   @Override
   protected boolean match(TextCheck textCheck, String actualText, String expectedText) {
+    requireNonNull(expectedText, "Expected text must not be null");
     return switch (textCheck) {
       case FULL_TEXT -> Html.text.equals(actualText, expectedText);
       case PARTIAL_TEXT -> Html.text.contains(actualText, expectedText);

--- a/src/main/java/com/codeborne/selenide/conditions/Text.java
+++ b/src/main/java/com/codeborne/selenide/conditions/Text.java
@@ -4,8 +4,6 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.commands.GetSelectedOptionText;
 import org.openqa.selenium.WebElement;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 public class Text extends CaseInsensitiveTextCondition {
 
   private final GetSelectedOptionText getSelectedOptionsTexts;
@@ -16,11 +14,6 @@ public class Text extends CaseInsensitiveTextCondition {
 
   Text(final String text, GetSelectedOptionText getSelectedOptionsTexts) {
     super("text", text);
-
-    if (isEmpty(text)) {
-      throw new IllegalArgumentException("Argument must not be null or empty string. " +
-        "Use $.shouldBe(empty) or $.shouldHave(exactText(\"\").");
-    }
     this.getSelectedOptionsTexts = getSelectedOptionsTexts;
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/Html.java
+++ b/src/main/java/com/codeborne/selenide/impl/Html.java
@@ -4,6 +4,7 @@ import java.util.regex.Pattern;
 
 import static java.util.Locale.ROOT;
 import static java.util.regex.Pattern.DOTALL;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class Html {
   private static final Pattern REGEX_SPACES = Pattern.compile("[\\s\\p{Zs}\u200B\u200C\u200D\u2060]+");
@@ -19,7 +20,16 @@ public class Html {
   }
 
   public boolean contains(String text, String subtext) {
-    return reduceSpaces(text.toLowerCase(ROOT)).contains(reduceSpaces(subtext.toLowerCase(ROOT)));
+    String expected = reduceSpaces(subtext.toLowerCase(ROOT));
+    verifyNotEmptySubstring(expected);
+    return reduceSpaces(text.toLowerCase(ROOT)).contains(expected);
+  }
+
+  private static void verifyNotEmptySubstring(String expectedText) {
+    if (isEmpty(expectedText)) {
+      throw new IllegalArgumentException("Expected substring must not be null or empty string. " +
+                                         "Consider setting Configuration.textCheck = FULL_TEXT;");
+    }
   }
 
   public boolean containsCaseSensitive(String text, String subtext) {

--- a/src/test/java/com/codeborne/selenide/ConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/ConditionTest.java
@@ -31,11 +31,9 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.type;
 import static com.codeborne.selenide.Condition.value;
 import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.Mocks.*;
+import static com.codeborne.selenide.Mocks.elementWithAttribute;
 import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -425,30 +423,6 @@ final class ConditionTest {
   void conditionToString() {
     WebElementCondition condition = attribute("name").because("it's awesome");
     assertThat(condition).hasToString("attribute name (because it's awesome)");
-  }
-
-  @Test
-  void shouldHaveText_doesNotAccept_nullParameter() {
-    //noinspection ConstantConditions
-    assertThatThrownBy(() -> text(null))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Argument must not be null or empty string. Use $.shouldBe(empty) or $.shouldHave(exactText(\"\").");
-  }
-
-  @Test
-  @SuppressWarnings("SelenideEmptyMatchText")
-  void shouldHaveText_doesNotAccept_emptyString() {
-    assertThatThrownBy(() -> text(""))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Argument must not be null or empty string. Use $.shouldBe(empty) or $.shouldHave(exactText(\"\").");
-  }
-
-  @Test
-  void shouldHaveText_accepts_blankNonEmptyString() {
-    assertThatNoException().isThrownBy(() -> text(" "));
-    assertThatNoException().isThrownBy(() -> text("  "));
-    assertThatNoException().isThrownBy(() -> text("\t"));
-    assertThatNoException().isThrownBy(() -> text("\n"));
   }
 
   private WebElement mockElement(boolean isSelected, String text) {

--- a/src/test/resources/page_with_divs.html
+++ b/src/test/resources/page_with_divs.html
@@ -16,6 +16,7 @@
 </div>
 
 <h5 id="upper-case">THIS IS SPARTA!</h5>
+<span id="error"><!--Empty text--></span>
 
 </body>
 </html>


### PR DESCRIPTION
* not only in `text("")`, but also in `value("")`.
* only when `Configuration.textCheck = PARTIAL_TEXT`
