### PR TITLE
fix bug in `setValue`: don't lose focus if the input is already focused

### DIFF
--- a/src/main/resources/set-value.js
+++ b/src/main/resources/set-value.js
@@ -26,8 +26,10 @@
   if (webelement.getAttribute('readonly') !== null) return 'Cannot change value of readonly element';
   if (webelement.getAttribute('disabled') !== null) return 'Cannot change value of disabled element';
 
-  trigger(document.activeElement, ['blur']);
-  webelement.focus();
+  if (document.activeElement !== webelement) {
+    trigger(document.activeElement, ['blur']);
+    webelement.focus();
+  }
   var maxlength = webelement.getAttribute('maxlength') == null ? -1 : parseInt(webelement.getAttribute('maxlength'));
   webelement.value = maxlength === -1 ? text : text.length <= maxlength ? text : text.substring(0, maxlength);
   trigger(webelement, ['focus', 'keydown', 'keypress', 'input', 'keyup', 'change']);

--- a/src/test/resources/page_with_inputs_and_hints.html
+++ b/src/test/resources/page_with_inputs_and_hints.html
@@ -46,8 +46,50 @@
       </label>
       <div id="passwordHint" style="display: none">password hint</div>
       <br/>
+      <br/>
+      <br/>
+      <div id="greeting">
+        <span class="view"></span>
+        <input type="text" style="display: none">
+      </div>
+      <br/>
     </fieldset>
   </form>
 </div>
+<script>
+  let greeting = 'Dear'
+  const greetingContainer = document.querySelector('#greeting');
+  const greetingDisplay = greetingContainer.querySelector('span');
+  const greetingInput = greetingContainer.querySelector('input');
+
+  greetingDisplay.innerText = greeting;
+
+  function toggleGreetingViewMode() {
+    greetingDisplay.innerText = greeting
+    greetingInput.style.display = 'none'
+    greetingDisplay.style.display = 'inline'
+  }
+
+  greetingInput.addEventListener('keyup', (e) => {
+    if (e.key === 'Enter') {
+      greeting = greetingInput.value
+      toggleGreetingViewMode()
+    }
+    else if (e.key === 'Escape') {
+      toggleGreetingViewMode()
+    }
+  })
+
+  greetingInput.addEventListener('blur', () => {
+    toggleGreetingViewMode()
+  })
+
+  greetingContainer.addEventListener('dblclick', () => {
+    greetingDisplay.style.display = 'none'
+    greetingInput.value = greeting
+    greetingInput.style.display = 'inline'
+    greetingInput.focus()
+  })
+</script>
 </body>
 </html>

--- a/statics/src/test/java/integration/FastSetValueTest.java
+++ b/statics/src/test/java/integration/FastSetValueTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import static com.codeborne.selenide.Condition.appear;
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.switchTo;
 import static com.codeborne.selenide.SetValueMethod.JS;
@@ -59,5 +60,16 @@ final class FastSetValueTest extends IntegrationTest {
     $("#password").setValue(withText("admin").sensitive().usingMethod(JS));
     $("#usernameHint").should(disappear);
     $("#passwordHint").should(appear);
+  }
+
+  @Test
+  void setValueInFloatingInput() {
+    $("#greeting").doubleClick();
+    $("#greeting input")
+      .setValue(withText("The lord of the Galaxy").usingMethod(JS))
+      .pressEnter();
+
+    $("#greeting input").should(disappear);
+    $("#greeting .view").shouldBe(visible).shouldHave(text("The lord of the Galaxy"));
   }
 }


### PR DESCRIPTION
Before this change, method `$("input").setValue(JS)` did:
1. blur (move focus from previous active element)
2. focus (put focus on the needed input)

The problem is that on the 1st step, the input (which was already focused by that moment) looses the focus and can disappear.