### PR TITLE
fix page object initialization without webdriver

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenidePageFactory.java
@@ -14,8 +14,6 @@ import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.pagefactory.DefaultElementLocatorFactory;
 import org.openqa.selenium.support.pagefactory.DefaultFieldDecorator;
-import org.openqa.selenium.support.pagefactory.ElementLocator;
-import org.openqa.selenium.support.pagefactory.ElementLocatorFactory;
 import org.openqa.selenium.support.pagefactory.FieldDecorator;
 
 import java.lang.reflect.Constructor;
@@ -212,7 +210,7 @@ public class SelenidePageFactory implements PageObjectFactory {
       return createElementsContainerList(driver, searchContext, field, genericTypes, selector);
     }
     else if (isDecoratableList(field, selector, genericTypes, WebElement.class)) {
-      return createWebElementsList(loader, driver, searchContext, field);
+      return createElementsCollection(driver, searchContext, selector, field, alias);
     }
 
     return defaultFieldDecorator(driver, searchContext).decorate(loader, field);
@@ -236,14 +234,6 @@ public class SelenidePageFactory implements PageObjectFactory {
 
   protected <T extends SelenideElement> SelenideElement createSelf(WebElementSource searchContext, Class<T> targetType) {
     return ElementFinder.wrap(targetType, searchContext);
-  }
-
-  private List<WebElement> createWebElementsList(ClassLoader loader, Driver driver, @Nullable WebElementSource searchContext,
-                                                 Field field) {
-    ElementLocatorFactory factory = fieldLocatorFactory(driver, searchContext);
-    ElementLocator locator = factory.createLocator(field);
-    SelenideFieldDecorator decorator = new SelenideFieldDecorator(factory);
-    return decorator.proxyForListLocator(loader, locator);
   }
 
   protected SelenideElement decorateWebElement(Driver driver, @Nullable WebElementSource searchContext, By selector,
@@ -333,7 +323,6 @@ public class SelenidePageFactory implements PageObjectFactory {
   }
 
   @Nullable
-  @SuppressWarnings("DataFlowIssue")
   private static As aliasOf(Field field) {
     return field.getAnnotation(As.class);
   }

--- a/statics/src/test/java/integration/pageobjects/LazyPageObjectTest.java
+++ b/statics/src/test/java/integration/pageobjects/LazyPageObjectTest.java
@@ -17,20 +17,23 @@ import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.tagName;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.page;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class LazyPageObjectTest extends IntegrationTest {
+  private MyPage myPage;
+
   @BeforeEach
   final void setUp() {
+    closeWebDriver();
+    myPage = page(MyPage.class);
     openFile("fortest.html");
   }
 
   @Test
   public void pageObject() {
-    MyPage myPage = page(MyPage.class);
-
     // level 2
     assertThat(myPage.myContent.forms).hasSize(1);
 
@@ -52,7 +55,6 @@ public class LazyPageObjectTest extends IntegrationTest {
 
   @Test
   public void shouldLoadElementsLazily() {
-    MyPage myPage = page(MyPage.class);
     myPage.wrongContent.h42.shouldNot(exist);
     myPage.h3.shouldNot(exist);
     List<MyForm> thisLineShouldNotFail = myPage.wrongContent.forms;
@@ -77,6 +79,9 @@ public class LazyPageObjectTest extends IntegrationTest {
 
     @FindBy(tagName = "h3")
     private SelenideElement h3;
+
+    @FindBy(tagName = "h3")
+    private List<WebElement> webElements;
   }
 
   static class MyContent implements Container {


### PR DESCRIPTION
When a page object contains a field of type `List<WebElement>` then it could not be lazy loaded. Selenide called the Selenium's page factory which requires an open webdriver.

Now Selenide initialized such a field with Selenide's `ElementsCollection` which is lazy loaded.
