### PR TITLE
Change return type to SelenideAppiumElement on appium methods

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumElement.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumElement.java
@@ -1,6 +1,9 @@
 package com.codeborne.selenide.appium;
 
+import java.time.Duration;
+
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebElementCondition;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 public interface SelenideAppiumElement extends SelenideElement {
@@ -56,4 +59,52 @@ public interface SelenideAppiumElement extends SelenideElement {
    */
   @CanIgnoreReturnValue
   SelenideAppiumElement doubleTap();
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldNotBe(WebElementCondition condition, Duration timeout);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldNotBe(WebElementCondition... condition);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldNotHave(WebElementCondition condition, Duration timeout);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldNotHave(WebElementCondition... condition);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldNot(WebElementCondition condition, Duration timeout);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldNot(WebElementCondition... condition);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldBe(WebElementCondition condition, Duration timeout);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldBe(WebElementCondition... condition);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldHave(WebElementCondition condition, Duration timeout);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement shouldHave(WebElementCondition... condition);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement should(WebElementCondition condition, Duration timeout);
+
+  @Override
+  @CanIgnoreReturnValue
+  SelenideAppiumElement should(WebElementCondition... condition);
 }

--- a/modules/appium/src/test/java/it/mobile/android/AppiumCollectionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AppiumCollectionsTest.java
@@ -2,12 +2,14 @@ package it.mobile.android;
 
 import com.codeborne.selenide.appium.SelenideAppium;
 import com.codeborne.selenide.appium.SelenideAppiumCollection;
+import com.codeborne.selenide.appium.SelenideAppiumElement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.attribute;
+import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.appium.AppiumScrollOptions.down;
 import static com.codeborne.selenide.appium.AppiumScrollOptions.up;
 import static com.codeborne.selenide.appium.SelenideAppium.$$;
@@ -34,7 +36,13 @@ public class AppiumCollectionsTest extends BaseSwagLabsAndroidTest {
     inputFields.first(1).shouldHave(size(1));
     inputFields.last(2).shouldHave(size(2));
 
+    assertThat(inputFields.first()).isInstanceOf(SelenideAppiumElement.class);
+    assertThat(inputFields.last()).isInstanceOf(SelenideAppiumElement.class);
+
     inputFields.first(1).get(0).scroll(up()).shouldHave(attribute("password", "false"));
     inputFields.last(1).get(0).scroll(down()).shouldHave(attribute("password", "true"));
+
+    SelenideAppiumElement field = inputFields.find(attribute("password", "true")).shouldBe(visible);
+    assertThat(field).isInstanceOf(SelenideAppiumElement.class);
   }
 }

--- a/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
@@ -262,8 +262,8 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
    * @return SelenideElement
    * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
    */
-  public SelenideElement find(WebElementCondition condition) {
-    return CollectionElementByCondition.wrap(collection, condition);
+  public T find(WebElementCondition condition) {
+    return CollectionElementByCondition.wrap(collection, condition, clazz);
   }
 
   /**
@@ -274,7 +274,7 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
    * @see #find(WebElementCondition)
    * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
    */
-  public SelenideElement findBy(WebElementCondition condition) {
+  public T findBy(WebElementCondition condition) {
     return find(condition);
   }
 
@@ -323,7 +323,7 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
    * @return the first element of the collection
    * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
    */
-  public SelenideElement first() {
+  public T first() {
     return get(0);
   }
 
@@ -333,8 +333,8 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
    * @return the last element of the collection
    * @see <a href="https://github.com/selenide/selenide/wiki/lazy-loading">Lazy loading</a>
    */
-  public SelenideElement last() {
-    return LastCollectionElement.wrap(collection);
+  public T last() {
+    return LastCollectionElement.wrap(collection, clazz);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
+++ b/src/main/java/com/codeborne/selenide/impl/CollectionElementByCondition.java
@@ -13,9 +13,10 @@ import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
 
 public class CollectionElementByCondition extends WebElementSource {
 
-  public static SelenideElement wrap(CollectionSource collection, WebElementCondition condition) {
-    return (SelenideElement) Proxy.newProxyInstance(
-      collection.getClass().getClassLoader(), new Class<?>[]{SelenideElement.class},
+  @SuppressWarnings("unchecked")
+  public static <T extends SelenideElement> T wrap(CollectionSource collection, WebElementCondition condition, Class<T> clazz) {
+    return (T) Proxy.newProxyInstance(
+      collection.getClass().getClassLoader(), new Class<?>[]{clazz},
       new SelenideElementProxy<>(new CollectionElementByCondition(collection, condition)));
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
+++ b/src/main/java/com/codeborne/selenide/impl/LastCollectionElement.java
@@ -13,9 +13,11 @@ import java.util.List;
 import static com.codeborne.selenide.Condition.visible;
 
 public class LastCollectionElement extends WebElementSource {
-  public static SelenideElement wrap(CollectionSource collection) {
-    return (SelenideElement) Proxy.newProxyInstance(
-      collection.getClass().getClassLoader(), new Class<?>[]{SelenideElement.class},
+
+  @SuppressWarnings("unchecked")
+  public static <T extends SelenideElement> T wrap(CollectionSource collection, Class<T> clazz) {
+    return (T) Proxy.newProxyInstance(
+      collection.getClass().getClassLoader(), new Class<?>[]{clazz},
       new SelenideElementProxy<>(new LastCollectionElement(collection)));
   }
 

--- a/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CollectionElementByConditionTest.java
@@ -29,7 +29,7 @@ final class CollectionElementByConditionTest {
     WebElement mockedWebElement = mockWebElement("a", "hello");
 
     SelenideElement selenideElement = CollectionElementByCondition.wrap(
-      new WebElementsCollectionWrapper(driver, singletonList(mockedWebElement)), visible);
+      new WebElementsCollectionWrapper(driver, singletonList(mockedWebElement)), visible, SelenideElement.class);
     assertThat(selenideElement)
       .hasToString("$$(1 elements).findBy(visible)");
   }


### PR DESCRIPTION
Change return type to SelenideAppiumElement on SelenideAppiumCollection inherited methods and should() methods of SelenideAppiumElement interface

## Proposed changes
- override should() methods in SelenideAppiumElement in order to return SelenideAppiumElement (it's way to simple then try to use T parameter...)
- change return type to T on some BaseElementsCollection methods in order to get SelenideAppiumElement if we use SelenideAppiumCollection

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
