### PR TITLE
add method $.scrollIntoView(options)

### DIFF
--- a/src/main/java/com/codeborne/selenide/ScrollIntoViewOptions.java
+++ b/src/main/java/com/codeborne/selenide/ScrollIntoViewOptions.java
@@ -1,0 +1,55 @@
+package com.codeborne.selenide;
+
+import static com.codeborne.selenide.ScrollIntoViewOptions.Behavior.instant;
+import static com.codeborne.selenide.ScrollIntoViewOptions.Block.start;
+import static com.codeborne.selenide.ScrollIntoViewOptions.Inline.nearest;
+
+/**
+ * See <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">scrollIntoView documentation</a>
+ *
+ * @param behavior whether scrolling is instant or animates smoothly
+ * @param block the vertical alignment of the element within the scrollable ancestor container
+ * @param inline the horizontal alignment of the element within the scrollable ancestor container
+ */
+public record ScrollIntoViewOptions(
+  Behavior behavior,
+  Block block,
+  Inline inline
+) {
+
+  public static ScrollIntoViewOptions instant() {
+    return new ScrollIntoViewOptions(instant, start, nearest);
+  }
+
+  public ScrollIntoViewOptions block(Block block) {
+    return new ScrollIntoViewOptions(behavior, block, inline);
+  }
+
+  public ScrollIntoViewOptions inline(Inline inline) {
+    return new ScrollIntoViewOptions(behavior, block, inline);
+  }
+
+  public String toJson() {
+    return "{behavior: '%s', block: '%s', inline: '%s'}".formatted(behavior, block, inline);
+  }
+
+  public enum Behavior {
+    smooth,
+    instant,
+    auto
+  }
+
+  public enum Block {
+    start,
+    center,
+    end,
+    nearest
+  }
+
+  public enum Inline {
+    start,
+    center,
+    end,
+    nearest
+  }
+}

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1048,26 +1048,32 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   /**
    * Ask browser to scroll to this element
    *
+   * The scrolling is performed instantly (ignoring CSS property "scroll-behavior: smooth").
+   *
    * @see com.codeborne.selenide.commands.ScrollTo
    */
   @CanIgnoreReturnValue
   SelenideElement scrollTo();
 
   /**
-   * Ask browser to scroll the element on which it's called into the visible area of the browser window.<p>
+   * Scroll the element into the visible area of the browser window.<p>
    *
    * If <b>alignToTop</b> boolean value is <i>true</i> - the top of the element will be aligned to the top.<p>
    *
    * If <b>alignToTop</b> boolean value is <i>false</i> - the bottom of the element will be aligned to the bottom.<p>
    *
    * <b>Usage:</b>
-   * <pre>
+   * <pre>{@code
    *   element.scrollIntoView(true);
-   *   // Corresponds to scrollIntoViewOptions: {block: "start", inline: "nearest"}
+   *   // Equivalent to $.scrollIntoView(instant().block(start))
    *
    *   element.scrollIntoView(false);
-   *   // Corresponds to scrollIntoViewOptions: {block: "end", inline: "nearest"}
-   * </pre>
+   *   // Equivalent to $.scrollIntoView(instant().block(end))
+   * }</pre>
+   *
+   * <p>
+   *   The scrolling is performed instantly (ignoring CSS property "scroll-behavior: smooth").
+   * </p>
    *
    * @param alignToTop boolean value that indicate how element will be aligned to the visible area of the scrollable ancestor.
    * @see com.codeborne.selenide.commands.ScrollIntoView
@@ -1110,8 +1116,22 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement scrollIntoView(String scrollIntoViewOptions);
 
   /**
+   * For example:
+   * <pre>
+   * {@code $(".logo").scrollIntoView(instant().block(center).inline(end));}
+   * </pre>
+   * @see com.codeborne.selenide.commands.ScrollIntoView
+   * @since 7.10.0
+   */
+  @CanIgnoreReturnValue
+  SelenideElement scrollIntoView(ScrollIntoViewOptions options);
+
+  /**
    * Scroll element vertically to the center of viewport.
-   * Same as {@code $.scrollIntoView("{block: 'center'}")}
+   *
+   * The scrolling is performed instantly (ignoring CSS property "scroll-behavior: smooth").
+   *
+   * Same as {@code $.scrollIntoView("{block: 'center', behavior: 'instant'}")}
    * @see ScrollIntoCenter
    * @since 7.6.0
    */
@@ -1125,14 +1145,16 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * For example, if you want to scroll the element down by 100 pixels, you can do:
    *
    * <pre>
-   * {@code element.scroll(ScrollOptions.direction(ScrollDirection.DOWN).distance(100))}
+   * {@code element.scroll(direction(DOWN).distance(100))}
    * </pre>
    *
    * If you want to scroll the element right by 250 pixels, you can do:
    *
    * <pre>
-   * {@code element.scroll(ScrollOptions.direction(ScrollDirection.RIGHT).distance(250))}
+   * {@code element.scroll(direction(RIGHT).distance(250))}
    * </pre>
+   *
+   * The scrolling is performed instantly (ignoring CSS property "scroll-behavior: smooth").
    *
    * @param scrollOptions direction, distance etc.
    * @see com.codeborne.selenide.commands.Scroll

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -1056,20 +1056,11 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
   SelenideElement scrollTo();
 
   /**
-   * Scroll the element into the visible area of the browser window.<p>
+   * <p>Scroll the element into the visible area of the browser window.</p>
    *
-   * If <b>alignToTop</b> boolean value is <i>true</i> - the top of the element will be aligned to the top.<p>
+   * <p>If <b>alignToTop</b> boolean value is <i>true</i> - the top of the element will be aligned to the top.</p>
    *
-   * If <b>alignToTop</b> boolean value is <i>false</i> - the bottom of the element will be aligned to the bottom.<p>
-   *
-   * <b>Usage:</b>
-   * <pre>{@code
-   *   element.scrollIntoView(true);
-   *   // Equivalent to $.scrollIntoView(instant().block(start))
-   *
-   *   element.scrollIntoView(false);
-   *   // Equivalent to $.scrollIntoView(instant().block(end))
-   * }</pre>
+   * <p>If <b>alignToTop</b> boolean value is <i>false</i> - the bottom of the element will be aligned to the bottom.</p>
    *
    * <p>
    *   The scrolling is performed instantly (ignoring CSS property "scroll-behavior: smooth").
@@ -1078,7 +1069,16 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @param alignToTop boolean value that indicate how element will be aligned to the visible area of the scrollable ancestor.
    * @see com.codeborne.selenide.commands.ScrollIntoView
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">Web API reference</a>
+   *
+   * @deprecated The boolean parameter is not well-readable.
+   * We recommend using method {@link #scrollIntoView(ScrollIntoViewOptions)} instead:
+   * <ol>
+   *   <li>replace {@code $.scrollIntoView(true)} by {@code $.scrollIntoView(instant().block(start))}</li>
+   *   <li>replace {@code $.scrollIntoView(false)} by {@code $.scrollIntoView(instant().block(end))}</li>
+   * </ol>
+   * Option {@code instant()} ignores "scroll-behavior" and performs the scrolling instantly.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   SelenideElement scrollIntoView(boolean alignToTop);
 
@@ -1111,7 +1111,16 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @param scrollIntoViewOptions is an object with the align properties: behavior, block and inline.
    * @see com.codeborne.selenide.commands.ScrollIntoView
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">Web API reference</a>
+   *
+   * @deprecated The String parameter is not convenient to write.
+   * We recommend using method {@link #scrollIntoView(ScrollIntoViewOptions)} instead:
+   * <ol>
+   *   <li>{@code $.scrollIntoView(instant().block(start))}</li>
+   *   <li>{@code $.scrollIntoView(instant().block(end).inline(nearest))}</li>
+   * </ol>
+   * Option {@code instant()} ignores "scroll-behavior" and performs the scrolling instantly.
    */
+  @Deprecated
   @CanIgnoreReturnValue
   SelenideElement scrollIntoView(String scrollIntoViewOptions);
 

--- a/src/main/java/com/codeborne/selenide/commands/Scroll.java
+++ b/src/main/java/com/codeborne/selenide/commands/Scroll.java
@@ -14,10 +14,10 @@ public class Scroll extends FluentCommand {
     WebElement webElement = locator.getWebElement();
     int distance = options.distance();
     String js = switch (options.direction()) {
-      case DOWN -> "arguments[0].scrollBy(0, arguments[1])";
-      case UP -> "arguments[0].scrollBy(0, -arguments[1])";
-      case RIGHT -> "arguments[0].scrollBy(arguments[1], 0)";
-      case LEFT -> "arguments[0].scrollBy(-arguments[1], 0)";
+      case DOWN -> "arguments[0].scrollBy({left: 0, top: arguments[1], behavior: 'instant'})";
+      case UP -> "arguments[0].scrollBy({left: 0, top: -arguments[1], behavior: 'instant'})";
+      case RIGHT -> "arguments[0].scrollBy({left: arguments[1], top: 0, behavior: 'instant'})";
+      case LEFT -> "arguments[0].scrollBy({left: -arguments[1], top: 0, behavior: 'instant'})";
     };
     locator.driver().executeJavaScript(js, webElement, distance);
   }

--- a/src/main/java/com/codeborne/selenide/commands/ScrollIntoCenter.java
+++ b/src/main/java/com/codeborne/selenide/commands/ScrollIntoCenter.java
@@ -5,9 +5,12 @@ import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.jspecify.annotations.Nullable;
 
+import static com.codeborne.selenide.ScrollIntoViewOptions.Block.center;
+import static com.codeborne.selenide.ScrollIntoViewOptions.instant;
+
 public class ScrollIntoCenter implements Command<SelenideElement> {
   @Override
   public SelenideElement execute(SelenideElement proxy, WebElementSource locator, Object @Nullable [] args) {
-    return proxy.scrollIntoView("{block: 'center'}");
+    return proxy.scrollIntoView(instant().block(center));
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/ScrollIntoView.java
+++ b/src/main/java/com/codeborne/selenide/commands/ScrollIntoView.java
@@ -1,17 +1,28 @@
 package com.codeborne.selenide.commands;
 
 import com.codeborne.selenide.FluentCommand;
+import com.codeborne.selenide.ScrollIntoViewOptions;
 import com.codeborne.selenide.impl.WebElementSource;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.WebElement;
 
+import static com.codeborne.selenide.ScrollIntoViewOptions.Block.end;
+import static com.codeborne.selenide.ScrollIntoViewOptions.Block.start;
+import static com.codeborne.selenide.ScrollIntoViewOptions.Inline.nearest;
+import static com.codeborne.selenide.ScrollIntoViewOptions.instant;
 import static com.codeborne.selenide.commands.Util.firstOf;
 
 public class ScrollIntoView extends FluentCommand {
   @Override
   protected void execute(WebElementSource locator, Object @Nullable [] args) {
-    Object param = firstOf(args);
+    Object parameter = firstOf(args);
+    Object scrollOptions =
+      parameter instanceof ScrollIntoViewOptions options ? options.toJson() :
+        parameter.equals(Boolean.TRUE) ? instant().block(start).inline(nearest).toJson() :
+          parameter.equals(Boolean.FALSE) ? instant().block(end).inline(nearest).toJson() :
+            parameter;
+
     WebElement webElement = locator.getWebElement();
-    locator.driver().executeJavaScript("arguments[0].scrollIntoView(" + param + ")", webElement);
+    locator.driver().executeJavaScript("arguments[0].scrollIntoView(" + scrollOptions + ")", webElement);
   }
 }

--- a/src/main/java/com/codeborne/selenide/commands/ScrollTo.java
+++ b/src/main/java/com/codeborne/selenide/commands/ScrollTo.java
@@ -9,6 +9,8 @@ public class ScrollTo extends FluentCommand {
   @Override
   public void execute(WebElementSource locator, Object @Nullable [] args) {
     Point location = locator.getWebElement().getLocation();
-    locator.driver().executeJavaScript("window.scrollTo(" + location.getX() + ", " + location.getY() + ')');
+    locator.driver().executeJavaScript(
+      "window.scrollTo({top: %s, left: %s, behavior: 'instant'})".formatted(location.getY(), location.getX())
+    );
   }
 }

--- a/src/test/java/integration/ScrollTest.java
+++ b/src/test/java/integration/ScrollTest.java
@@ -5,11 +5,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.hidden;
+import static com.codeborne.selenide.Condition.partialText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.ScrollDirection.LEFT;
 import static com.codeborne.selenide.ScrollDirection.RIGHT;
 import static com.codeborne.selenide.ScrollDirection.UP;
+import static com.codeborne.selenide.ScrollIntoViewOptions.Block.center;
+import static com.codeborne.selenide.ScrollIntoViewOptions.instant;
 import static com.codeborne.selenide.ScrollOptions.defaultScrollOptions;
 import static com.codeborne.selenide.ScrollOptions.direction;
 
@@ -22,6 +25,7 @@ final class ScrollTest extends ITest {
   private final SelenideElement hiddenButtonRight = $("#button2");
   private final SelenideElement hiddenButtonUp = $("#button3");
   private final SelenideElement hiddenButtonLeft = $("#button4");
+  private final SelenideElement outOfViewportButton = $("#out-of-viewport-button");
 
   @BeforeEach
   void openTestPage() {
@@ -42,6 +46,14 @@ final class ScrollTest extends ITest {
     hiddenButtonRight.shouldBe(hidden);
     scrollableDivRight.scroll(direction(RIGHT).distance(2000));
     hiddenButtonRight.shouldBe(visible);
+  }
+
+  @Test
+  void scrollIntoView() {
+    outOfViewportButton.shouldBe(visible);
+    outOfViewportButton.scrollIntoView(instant().block(center));
+    outOfViewportButton.click();
+    $("#debug").shouldHave(partialText("[#out-of-viewport-button] CLICKED"));
   }
 
   @Test

--- a/src/test/resources/page_with_big_divs.html
+++ b/src/test/resources/page_with_big_divs.html
@@ -5,6 +5,9 @@
   <meta charset="UTF-8">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <style>
+    html {
+      scroll-behavior: smooth;
+    }
     #huge_div div {
       text-align: center;
       border: red 3px solid;

--- a/src/test/resources/page_with_scroll_element.html
+++ b/src/test/resources/page_with_scroll_element.html
@@ -5,6 +5,9 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>Scroll Down to See Button</title>
   <style>
+    html {
+      scroll-behavior: smooth;
+    }
     #debug {
       position: absolute;
       top: 20px;
@@ -96,6 +99,11 @@
   <p> ⇠ Scroll to the left to see the button. Scroll more. And more. And even more. ⇠ </p>
 </div>
 
+<div id="out-of-viewport-container" style="height: 800px">
+  <button id="out-of-viewport-button">Out of viewport button</button>
+  <p>This button is not visible initially. Need to scroll it into view.</p>
+</div>
+
 <div id="debug"></div>
 
 <script>
@@ -118,7 +126,7 @@
   }
   function debug(message) {
     debugContainer.innerHTML += `<pre>${message}</pre>`
-    debugContainer.scrollBy(0, 1000);
+    debugContainer.scrollBy({left: 0, top: 1000, behavior: 'instant'});
   }
   function toggleButton1() {
     const result = scrollableDiv.scrollTop + scrollableDiv.clientHeight >= scrollableDiv.scrollHeight - tolerance;
@@ -144,6 +152,10 @@
   scrollableDiv2.addEventListener('scroll', toggleButton2);
   scrollableDiv3.addEventListener('scroll', toggleButton3);
   scrollableDiv4.addEventListener('scroll', toggleButton4);
+
+  document.querySelector('#out-of-viewport-button').addEventListener('click', () => {
+    debug(`<pre>[#out-of-viewport-button] CLICKED</pre>`);
+  });
 
   setTimeout(() => {
     toggleButton1();

--- a/statics/src/test/java/integration/ScrollTest.java
+++ b/statics/src/test/java/integration/ScrollTest.java
@@ -5,10 +5,13 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.List;
 
+import static com.codeborne.selenide.Condition.animated;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.executeJavaScript;
+import static com.codeborne.selenide.Selenide.sleep;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,15 +51,21 @@ final class ScrollTest extends IntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void scrollIntoView_alignToTop() {
     $("#rabbit").scrollIntoView(true);
+    sleep(100);
+    $("#rabbit").shouldNotBe(animated, Duration.ofSeconds(1));
 
     assertTopPosition(rabbitPosition(), 0);
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void scrollIntoView_alignToBottom() {
     $("#rabbit").scrollIntoView(false);
+    sleep(100);
+    $("#rabbit").shouldNotBe(animated, Duration.ofSeconds(1));
 
     assertTopPosition(rabbitPosition(), windowHeight() - rabbitHeight);
   }
@@ -95,10 +104,10 @@ final class ScrollTest extends IntegrationTest {
   }
 
   private Location rabbitPosition() {
-    List<Number> array = executeJavaScript("""
+    List<Number> array = requireNonNull(executeJavaScript("""
         const rect = document.querySelector('#rabbit').getBoundingClientRect();
         return [rect.left, rect.top]
-      """);
+      """));
     return new Location(array.get(0).intValue(), array.get(1).intValue());
   }
 


### PR DESCRIPTION
`ScrollIntoViewOptions` has benefits over boolean or String parameter:
1. A convenient factory method for constructing `ScrollIntoViewOptions` is  `instant()` which performs scrolling instantly, thus avoiding flaky tests.
2. compile-safe (compared to String parameter)

Also,
* deprecated method `$.scrollIntoView(boolean)`
* changed behaviour of these methods - now they perform the scrolling **instantly** (ignoring CSS property "scroll-behavior: smooth").
  1. `$.scrollTo()`
  2. `$.scrollIntoCenter()`
  3. `$.scroll(ScrollOptions)`
