### PR TITLE
Add DeepShadow annotation

### DIFF
--- a/src/main/java/com/codeborne/selenide/DeepShadow.java
+++ b/src/main/java/com/codeborne/selenide/DeepShadow.java
@@ -1,7 +1,5 @@
 package com.codeborne.selenide;
 
-import org.openqa.selenium.support.FindBy;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,23 +9,17 @@ import java.lang.annotation.Target;
  * Provides to find specific page factory locators inside shadow roots. For example:
  *
  * <pre>{@code
- *    @ShadowHost({@FindBy(...shadowHost...), @FindBy(...innerShadowHost...)})
+ *    @DeepShadow
  *    @FindBy(...targetLocator...)
  *    public SelenideElement locatorInShadowRoot;
  * }</pre>
  * <p>
- * The order of locators inside this annotation is important. Every next locator means more deep shadow host.
+ * This mechanism does not care how deep the desired locator is situated inside the Shadow DOM, it would traverse across the whole
+ * tree to find it.
  *
- * @see DeepShadow
- * @since 7.8.0
+ * @see ShadowHost
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface ShadowHost {
-
-  /**
-   * @return array of shadow hosts
-   */
-  FindBy[] value();
-
+public @interface DeepShadow {
 }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideAnnotations.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideAnnotations.java
@@ -1,6 +1,8 @@
 package com.codeborne.selenide.impl;
 
+import com.codeborne.selenide.DeepShadow;
 import com.codeborne.selenide.ShadowHost;
+import com.codeborne.selenide.selector.ByDeepShadow;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.pagefactory.Annotations;
 
@@ -21,11 +23,33 @@ class SelenideAnnotations extends Annotations {
       ans = buildShadowHost(ans, field);
     }
 
+    if (field.isAnnotationPresent(DeepShadow.class)) {
+      ans = buildByDeepShadow(ans);
+    }
+
     return ans;
+  }
+
+  @Override
+  protected void assertValidAnnotations() {
+    super.assertValidAnnotations();
+
+    Field field = getField();
+    ShadowHost shadowHost = field.getAnnotation(ShadowHost.class);
+    DeepShadow deepShadow = field.getAnnotation(DeepShadow.class);
+    if (shadowHost != null && deepShadow != null) {
+      throw new IllegalArgumentException(
+        "If you use a '@ShadowHost' annotation, you must not also use a '@DeepShadow' annotation"
+      );
+    }
   }
 
   private By buildShadowHost(By target, Field field) {
     ShadowHost shadowHost = field.getAnnotation(ShadowHost.class);
     return new ShadowHostBuilder(target).buildIt(shadowHost, field);
+  }
+
+  private By buildByDeepShadow(By target) {
+    return new ByDeepShadow(target);
   }
 }

--- a/src/main/java/com/codeborne/selenide/selector/ByDeepShadow.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByDeepShadow.java
@@ -1,0 +1,65 @@
+package com.codeborne.selenide.selector;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebElement;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class ByDeepShadow extends By implements Serializable {
+
+  private final By target;
+
+  public ByDeepShadow(By target) {
+    //noinspection ConstantConditions
+    if (target == null) {
+      throw new IllegalArgumentException("Cannot find elements when the selector is null");
+    }
+    this.target = target;
+  }
+
+  @Override
+  public WebElement findElement(SearchContext context) {
+    List<WebElement> elements = findElements(context, target, false);
+    if (elements.isEmpty()) {
+      throw new NoSuchElementException("Cannot locate an element in shadow dom " + this);
+    }
+    return elements.get(0);
+  }
+
+  @Override
+  public List<WebElement> findElements(SearchContext context) {
+    return findElements(context, target, true);
+  }
+
+  private static List<WebElement> findElements(SearchContext context, By target, boolean findAll) {
+    List<WebElement> result = context.findElements(target);
+    if (!result.isEmpty() && !findAll) {
+      return result;
+    }
+
+    List<SearchContext> shadowRoots = findShadowRoots(context);
+    for (SearchContext shadowRoot : shadowRoots) {
+      List<WebElement> elements = findElements(shadowRoot, target, findAll);
+      if (!elements.isEmpty()) {
+        if (!findAll) {
+          return elements;
+        }
+        result.addAll(elements);
+      }
+    }
+    return result;
+  }
+
+  private static List<SearchContext> findShadowRoots(SearchContext context) {
+    // an attempt to find All the Shadow Roots under the giving context
+    return ByShadow.findShadowRoots(context, By.cssSelector("*"));
+  }
+
+  @Override
+  public String toString() {
+    return "By.shadowDeep: " + target;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/selector/ByShadow.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByShadow.java
@@ -63,8 +63,15 @@ public class ByShadow extends By implements Serializable {
       .toList();
   }
 
-  private static List<SearchContext> findShadowRoots(SearchContext searchContext, By shadowHost) {
-    return searchContext.findElements(shadowHost)
+  /**
+   * Looks for shadow roots by the provided shadow host selector inside the giving context.
+   *
+   * @param context search context where the search has to be performed
+   * @param shadowHost shadow host selector
+   * @return list of shadow roots
+   */
+  public static List<SearchContext> findShadowRoots(SearchContext context, By shadowHost) {
+    return context.findElements(shadowHost)
       .stream()
       .map(ByShadow::getShadowRoot)
       .filter(Optional::isPresent)


### PR DESCRIPTION
## Proposed changes
This PR introduces ```@DeepShadow``` annotation which works the same as ```ByShadowCss#cssSelector```:
```
class PageObject {
    
    @DeepShadow
    @FindBy(css = "#myelementid")
    private SelenideElement myElement;

    @DeepShadow
    @FindBy(css = ".my-elements")
    private List<SelenideElement> myElements;
}
```

- Unfortunately, as for the case with the ```@ShadowHost``` annotation, currently still can be used only with CSS selectors.
- As the ```ByShadowCss#cssSelector``` method, this annotation also uses [Depth-first search](https://en.wikipedia.org/wiki/Depth-first_search) algorithm to traverse shadow DOM.


## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
