### PR TITLE
#3107 remove any "unwrapping" of webdriver (using Augmenter)

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumClipboard.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumClipboard.java
@@ -4,10 +4,9 @@ import com.codeborne.selenide.Clipboard;
 import com.codeborne.selenide.DefaultClipboard;
 import com.codeborne.selenide.Driver;
 import io.appium.java_client.clipboard.HasClipboard;
+import org.openqa.selenium.WebDriver;
 
-import java.util.Optional;
-
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isMobile;
 
 public class AppiumClipboard implements Clipboard {
   private final Driver driver;
@@ -30,23 +29,23 @@ public class AppiumClipboard implements Clipboard {
 
   @Override
   public String getText() {
-    return getWebDriver()
-      .map(HasClipboard::getClipboardText)
-      .orElseGet(defaultClipboard::getText);
+    WebDriver webDriver = driver.getWebDriver();
+    if (isMobile(webDriver)) {
+      return ((HasClipboard) webDriver).getClipboardText();
+    }
+    else {
+      return defaultClipboard.getText();
+    }
   }
 
   @Override
   public void setText(String text) {
-    Optional<HasClipboard> mobileDriver = getWebDriver();
-    if (mobileDriver.isPresent()) {
-      mobileDriver.get().setClipboardText(text);
+    WebDriver webDriver = driver.getWebDriver();
+    if (isMobile(webDriver)) {
+      ((HasClipboard) webDriver).setClipboardText(text);
     }
     else {
       defaultClipboard.setText(text);
     }
-  }
-
-  private Optional<HasClipboard> getWebDriver() {
-    return cast(driver, HasClipboard.class);
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumDriverRunner.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumDriverRunner.java
@@ -2,8 +2,11 @@ package com.codeborne.selenide.appium;
 
 import com.codeborne.selenide.WebDriverRunner;
 import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.HidesKeyboard;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.remote.SupportsRotation;
+import org.openqa.selenium.WebDriver;
 
 import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isAndroid;
 import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isIos;
@@ -14,7 +17,12 @@ public class AppiumDriverRunner {
   /**
    * Get the underlying instance of AndroidDriver
    * This can be used for any operations directly with AndroidDriver.
+   *
+   * @deprecated instead of retrieving {@link AndroidDriver},
+   * cast your {@link WebDriver} to the needed interface, e.g. {@link SupportsRotation} or {@link HidesKeyboard}.
    */
+  @Deprecated(forRemoval = true)
+  @SuppressWarnings("removal")
   public static AndroidDriver getAndroidDriver() {
     return cast(WebDriverRunner.getWebDriver(), AndroidDriver.class)
       .orElseThrow(() -> new ClassCastException("WebDriver cannot be casted to AndroidDriver"));
@@ -23,7 +31,12 @@ public class AppiumDriverRunner {
   /**
    * Get the underlying instance of IOSDriver
    * This can be used for any operations directly with IOSDriver.
+   *
+   * @deprecated instead of retrieving {@link IOSDriver},
+   * cast your {@link WebDriver} to the needed interface, e.g. {@link SupportsRotation} or {@link HidesKeyboard}.
    */
+  @Deprecated(forRemoval = true)
+  @SuppressWarnings("removal")
   public static IOSDriver getIosDriver() {
     return cast(WebDriverRunner.getWebDriver(), IOSDriver.class)
       .orElseThrow(() -> new ClassCastException("WebDriver cannot be casted to IosDriver"));
@@ -32,8 +45,12 @@ public class AppiumDriverRunner {
   /**
    * Get the underlying instance of AppiumDriver
    * This can be used for any operations directly with AppiumDriver.
+   *
+   * @deprecated instead of retrieving {@link AndroidDriver},
+   * cast your {@link WebDriver} to the needed interface, e.g. {@link SupportsRotation} or {@link HidesKeyboard}.
    */
   @SuppressWarnings("unchecked")
+  @Deprecated(forRemoval = true)
   public static <T extends AppiumDriver> T getMobileDriver() {
     if (isAndroidDriver() || isIosDriver()) {
       return isAndroidDriver() ? (T) getAndroidDriver() : (T) getIosDriver();

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumDriverUnwrapper.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumDriverUnwrapper.java
@@ -23,14 +23,14 @@ public class AppiumDriverUnwrapper {
   public static boolean isMobile(SearchContext driver) {
     if (hasCapability(driver, APPIUM_PREFIX + AUTOMATION_NAME_OPTION)) return true;
     if (isWeb(driver)) return false;
-    return instanceOf(driver, AppiumDriver.class);
+    return instanceOf(driver, AppiumDriver.class); // TODO replace by {@code return false;}
   }
 
   public static boolean isAndroid(SearchContext driver) {
     if (isPlatform(driver, Platform.ANDROID)) return true;
     if (isPlatform(driver, Platform.IOS)) return false;
     if (isWeb(driver)) return false;
-    return instanceOf(driver, AndroidDriver.class);
+    return instanceOf(driver, AndroidDriver.class); // TODO replace by {@code return false;}
   }
 
   public static boolean isAndroid(Driver driver) {
@@ -41,7 +41,7 @@ public class AppiumDriverUnwrapper {
     if (isPlatform(driver, Platform.IOS)) return true;
     if (isPlatform(driver, Platform.ANDROID)) return false;
     if (isWeb(driver)) return false;
-    return instanceOf(driver, IOSDriver.class);
+    return instanceOf(driver, IOSDriver.class); // TODO replace by {@code return false;}
   }
 
   public static boolean isIos(Driver driver) {

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumElementDescriber.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumElementDescriber.java
@@ -3,12 +3,12 @@ package com.codeborne.selenide.appium;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.ElementDescriber;
 import com.codeborne.selenide.impl.SelenideElementDescriber;
-import io.appium.java_client.AppiumDriver;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.UnsupportedCommandException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 
 import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isAndroid;
 import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isIos;
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isMobile;
 import static java.util.Arrays.asList;
 import static java.util.regex.Pattern.DOTALL;
 import static java.util.regex.Pattern.compile;
@@ -53,13 +53,13 @@ public class AppiumElementDescriber implements ElementDescriber {
       return "null";
     }
 
-    return cast(driver, AppiumDriver.class).map(appiumDriver ->
-      new Builder(element, appiumDriver, supportedAttributes(driver))
+    return isMobile(driver) ?
+      new Builder(element, driver.getWebDriver(), supportedAttributes(driver))
         .appendTagName()
         .appendAttributes()
         .finish()
-        .build()
-    ).orElseGet(() -> webVersion.fully(driver, element));
+        .build() :
+      webVersion.fully(driver, element);
   }
 
   protected List<String> supportedAttributes(Driver driver) {
@@ -92,12 +92,12 @@ public class AppiumElementDescriber implements ElementDescriber {
 
   @Override
   public String briefly(Driver driver, WebElement element) {
-    return cast(driver, AppiumDriver.class).map(appiumDriver ->
-      new Builder(element, appiumDriver, supportedAttributes(driver))
+    return isMobile(driver) ?
+      new Builder(element, driver.getWebDriver(), supportedAttributes(driver))
         .appendTagName()
         .finish()
-        .build()
-    ).orElseGet(() -> webVersion.fully(driver, element));
+        .build() :
+      webVersion.fully(driver, element);
   }
 
   @Override
@@ -112,7 +112,7 @@ public class AppiumElementDescriber implements ElementDescriber {
 
   private static class Builder {
     private final WebElement element;
-    private final AppiumDriver webDriver;
+    private final WebDriver webDriver;
     private final List<String> supportedAttributes;
     private String tagName = "?";
     private String text = "?";
@@ -120,7 +120,7 @@ public class AppiumElementDescriber implements ElementDescriber {
     @Nullable
     private WebDriverException unforgivableException;
 
-    private Builder(WebElement element, AppiumDriver webDriver, List<String> supportedAttributes) {
+    private Builder(WebElement element, WebDriver webDriver, List<String> supportedAttributes) {
       this.element = element;
       this.webDriver = webDriver;
       this.supportedAttributes = supportedAttributes;

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumNavigator.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumNavigator.java
@@ -2,16 +2,14 @@ package com.codeborne.selenide.appium;
 
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.logevents.SelenideLogger;
-import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.InteractsWithApps;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.android.appmanagement.AndroidTerminateApplicationOptions;
 import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.WebDriver;
 
 import java.time.Duration;
 import java.util.function.Supplier;
-
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 
 public class AppiumNavigator {
 
@@ -21,32 +19,27 @@ public class AppiumNavigator {
     SelenideLogger.run("launch app", "", driverSupplier.get());
   }
 
-  public void activateApp(AppiumDriver driver, String appId) {
+  public void activateApp(WebDriver driver, String appId) {
     SelenideLogger.run(
       "activate app",
       appId,
-      () -> cast(driver, InteractsWithApps.class)
-        .map(mobileDriver -> {
-          mobileDriver.activateApp(appId);
-          return true;
-        })
-        .orElseThrow(() -> new UnsupportedOperationException("Driver does not support app activation: " + driver.getClass()))
+      () -> ((InteractsWithApps) driver).activateApp(appId)
     );
   }
 
-  public void terminateApp(AppiumDriver driver, String appId, @Nullable Duration timeout) {
+  public void terminateApp(WebDriver driver, String appId, @Nullable Duration timeout) {
     SelenideLogger.run(
       "terminate app",
       appId,
-      () -> cast(driver, InteractsWithApps.class)
-        .map(mobileDriver -> {
-          if (mobileDriver instanceof AndroidDriver androidDriver && timeout != null) {
-            return androidDriver.terminateApp(appId, options(timeout));
-          } else {
-            return mobileDriver.terminateApp(appId);
-          }
-        })
-        .orElseThrow(() -> new UnsupportedOperationException("Driver does not support app termination: " + driver.getClass()))
+      () -> {
+        InteractsWithApps mobileDriver = (InteractsWithApps) driver;
+        if (mobileDriver instanceof AndroidDriver androidDriver && timeout != null) {
+          androidDriver.terminateApp(appId, options(timeout));
+        }
+        else {
+          mobileDriver.terminateApp(appId);
+        }
+      }
     );
   }
 

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/DeepLinkLauncher.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/DeepLinkLauncher.java
@@ -2,17 +2,15 @@ package com.codeborne.selenide.appium;
 
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.logevents.SelenideLogger;
-import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.ios.IOSDriver;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.HasCapabilities;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
 
 import java.time.Duration;
 import java.util.Map;
 
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.appium.SelenideAppium.$;
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static io.appium.java_client.AppiumBy.iOSNsPredicateString;
 import static io.appium.java_client.ios.options.wda.SupportsAutoAcceptAlertsOption.AUTO_ACCEPT_ALERTS_OPTION;
 
@@ -22,7 +20,7 @@ public class DeepLinkLauncher {
 
   // adopted from https://bit.ly/3OKVsvq
   // see also https://appiumpro.com/editions/84-reliably-opening-deep-links-across-platforms-and-devices
-  public void openDeepLinkOnIos(IOSDriver driver, String deepLinkUrl) {
+  public void openDeepLinkOnIos(WebDriver driver, String deepLinkUrl) {
     SelenideLogger.run("open ios deeplink", deepLinkUrl, () -> {
       openSafari(driver);
       driver.navigate().to(deepLinkUrl);
@@ -42,27 +40,26 @@ public class DeepLinkLauncher {
   }
 
   // Life is so much easier
-  public void openDeepLinkOnAndroid(AppiumDriver driver, String deepLinkUrl, String appPackage) {
+  public void openDeepLinkOnAndroid(WebDriver driver, String deepLinkUrl, String appPackage) {
     SelenideLogger.run("open android deeplink", deepLinkUrl, () -> {
       Map<String, String> params = Map.of(
         "url", deepLinkUrl,
         "package", appPackage
       );
-      driver.executeScript("mobile: deepLink", params);
+      //noinspection UnnecessaryLabelJS,JSUnresolvedReference
+      ((JavascriptExecutor) driver).executeScript("mobile: deepLink", params);
     });
   }
 
-  private void openSafari(AppiumDriver driver) {
-    driver.executeScript(
+  private void openSafari(WebDriver driver) {
+    //noinspection UnnecessaryLabelJS,JSUnresolvedReference
+    ((JavascriptExecutor) driver).executeScript(
       "mobile:launchApp",
       Map.of("bundleId", SAFARI_BUNDLE_ID)
     );
   }
 
-  private boolean canAutoAcceptAlerts(AppiumDriver driver) {
-    HasCapabilities hasCapabilities = cast(driver, HasCapabilities.class)
-      .orElseThrow(() -> new IllegalArgumentException("Driver doesn't support HasCapabilities"));
-    Capabilities capabilities = hasCapabilities.getCapabilities();
-    return capabilities.is(AUTO_ACCEPT_ALERTS_OPTION);
+  private boolean canAutoAcceptAlerts(WebDriver driver) {
+    return ((HasCapabilities) driver).getCapabilities().is(AUTO_ACCEPT_ALERTS_OPTION);
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -44,7 +44,7 @@ public class SelenideAppium {
     if (!hasWebDriverStarted()) {
       launchApp();
     }
-    deepLinkLauncher.openDeepLinkOnIos(AppiumDriverRunner.getIosDriver(), deepLinkUrl);
+    deepLinkLauncher.openDeepLinkOnIos(WebDriverRunner.getWebDriver(), deepLinkUrl);
   }
 
   /**
@@ -57,7 +57,7 @@ public class SelenideAppium {
     if (!hasWebDriverStarted()) {
       launchApp();
     }
-    deepLinkLauncher.openDeepLinkOnAndroid(AppiumDriverRunner.getMobileDriver(), deepLinkUrl, appPackage);
+    deepLinkLauncher.openDeepLinkOnAndroid(WebDriverRunner.getWebDriver(), deepLinkUrl, appPackage);
   }
 
   /**
@@ -66,7 +66,7 @@ public class SelenideAppium {
    * @param appId - applicationId for Android or bundleId for iOS
    */
   public static void activateApp(String appId) {
-    appiumNavigator.activateApp(AppiumDriverRunner.getMobileDriver(), appId);
+    appiumNavigator.activateApp(WebDriverRunner.getWebDriver(), appId);
   }
 
   /**
@@ -85,7 +85,7 @@ public class SelenideAppium {
    * @param timeout - The count of milliseconds to wait until the app is terminated
    */
   public static void terminateApp(String appId, @Nullable Duration timeout) {
-    appiumNavigator.terminateApp(AppiumDriverRunner.getMobileDriver(), appId, timeout);
+    appiumNavigator.terminateApp(WebDriverRunner.getWebDriver(), appId, timeout);
   }
 
   /**

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ByIdOrName;
@@ -41,9 +42,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static io.appium.java_client.remote.options.SupportsAutomationNameOption.AUTOMATION_NAME_OPTION;
 
 public class SelenideAppiumPageFactory extends SelenidePageFactory {
@@ -70,14 +69,14 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
       throw new WebDriverException("The SelenideAppiumPageFactory requires a webdriver instance to be created before page" +
         " initialization; No webdriver is bound to current thread. You need to call open() first");
     }
-    Optional<HasBrowserCheck> hasBrowserCheck = cast(driver, HasBrowserCheck.class);
-    if (hasBrowserCheck.isPresent() && hasBrowserCheck.get().isBrowser()) {
+
+    WebDriver webDriver = driver.getWebDriver();
+    if (webDriver instanceof HasBrowserCheck hasBrowserCheck && hasBrowserCheck.isBrowser()) {
       return new DefaultElementByBuilder(null, null);
     }
 
-    Optional<HasCapabilities> hasCapabilities = cast(driver, HasCapabilities.class);
-    if (hasCapabilities.isPresent()) {
-      Capabilities d = hasCapabilities.get().getCapabilities();
+    if (webDriver instanceof HasCapabilities hasCapabilities) {
+      Capabilities d = hasCapabilities.getCapabilities();
       String platform = String.valueOf(d.getPlatformName());
       String automationName = String.valueOf(d.getCapability(AUTOMATION_NAME_OPTION));
       return new DefaultElementByBuilder(platform, automationName);

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumTargetLocator.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumTargetLocator.java
@@ -3,10 +3,9 @@ package com.codeborne.selenide.appium;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.logevents.SelenideLogger;
 import io.appium.java_client.remote.SupportsContextSwitching;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
-
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 
 public class SelenideAppiumTargetLocator {
   private final Driver driver;
@@ -17,21 +16,19 @@ public class SelenideAppiumTargetLocator {
 
   public void context(String contextName) {
     SelenideLogger.run("set context", contextName, () -> {
-      cast(driver, SupportsContextSwitching.class)
-        .map(contextAware -> contextAware.context(contextName))
-        .orElseThrow(() -> new UnsupportedOperationException("Context not found" + contextName));
+      SupportsContextSwitching contextAware = (SupportsContextSwitching) driver.getWebDriver();
+      contextAware.context(contextName);
     });
   }
 
   public Set<String> getContextHandles() {
-    return cast(driver, SupportsContextSwitching.class)
-      .map(SupportsContextSwitching::getContextHandles)
-      .orElseThrow(() -> new UnsupportedOperationException("Cannot get contexts from mobile driver"));
+    SupportsContextSwitching contextAware = (SupportsContextSwitching) driver.getWebDriver();
+    return contextAware.getContextHandles();
   }
 
+  @Nullable
   public String getCurrentContext() {
-    return cast(driver, SupportsContextSwitching.class)
-      .map(SupportsContextSwitching::getContext)
-      .orElseThrow(() -> new UnsupportedOperationException("Cannot get current context from mobile driver"));
+    SupportsContextSwitching contextAware = (SupportsContextSwitching) driver.getWebDriver();
+    return contextAware.getContext();
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
@@ -5,18 +5,17 @@ import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.appium.AppiumClickOptions;
 import com.codeborne.selenide.commands.Click;
 import com.codeborne.selenide.impl.WebElementSource;
-import io.appium.java_client.AppiumDriver;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Interactive;
 import org.openqa.selenium.interactions.Pause;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
 
 import static com.codeborne.selenide.ClickMethod.JS;
 import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isMobile;
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static java.time.Duration.ofMillis;
 import static java.util.Collections.singletonList;
 
@@ -98,8 +97,7 @@ public class AppiumClick extends Click {
 
   private void perform(Driver driver, Sequence sequence) {
     WebDriver webDriver = driver.getWebDriver();
-    AppiumDriver appiumDriver = cast(webDriver, AppiumDriver.class)
-      .orElseThrow(() -> new IllegalStateException("Not a mobile webdriver: " + webDriver));
+    Interactive appiumDriver = (Interactive) webDriver;
     appiumDriver.perform(singletonList(sequence));
   }
 

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumDragAndDrop.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumDragAndDrop.java
@@ -4,22 +4,20 @@ import com.codeborne.selenide.DragAndDropOptions;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.commands.DragAndDrop;
 import com.codeborne.selenide.impl.WebElementSource;
-import io.appium.java_client.AppiumDriver;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Interactive;
 import org.openqa.selenium.interactions.Pause;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
-
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.DragAndDropOptions.DragAndDropMethod.ACTIONS;
 import static com.codeborne.selenide.DragAndDropOptions.DragAndDropMethod.JS;
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isMobile;
 import static java.time.Duration.ofMillis;
 import static java.util.Collections.singletonList;
 
@@ -28,13 +26,10 @@ public class AppiumDragAndDrop extends DragAndDrop {
 
   @Override
   protected void execute(WebElementSource locator, Object @Nullable [] args) {
-    Optional<AppiumDriver> appiumDriverOptional = cast(locator.driver(), AppiumDriver.class);
-    if (!appiumDriverOptional.isPresent()) {
+    if (!isMobile(locator.driver())) {
       super.execute(locator, args);
       return;
     }
-
-    AppiumDriver appiumDriver = appiumDriverOptional.get();
 
     DragAndDropOptions options = dragAndDropOptions(args, ACTIONS);
     if (options.getMethod() == JS) {
@@ -44,7 +39,7 @@ public class AppiumDragAndDrop extends DragAndDrop {
     target.shouldBe(visible);
 
     Sequence sequence = getSequenceToPerformDragAndDrop(getCenter(locator.getWebElement()), getCenter(target));
-    appiumDriver.perform(singletonList(sequence));
+    ((Interactive) locator.driver().getWebDriver()).perform(singletonList(sequence));
   }
 
   private Sequence getSequenceToPerformDragAndDrop(Point source, Point target) {

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumSwipeTo.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumSwipeTo.java
@@ -5,20 +5,20 @@ import com.codeborne.selenide.appium.AppiumScrollCoordinates;
 import com.codeborne.selenide.appium.AppiumSwipeDirection;
 import com.codeborne.selenide.appium.AppiumSwipeOptions;
 import com.codeborne.selenide.impl.WebElementSource;
-import io.appium.java_client.AppiumDriver;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.interactions.Interactive;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
 
 import java.util.Arrays;
-import java.util.Optional;
 
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isMobile;
 import static com.codeborne.selenide.appium.AppiumSwipeDirection.RIGHT;
 import static com.codeborne.selenide.appium.AppiumSwipeOptions.right;
 import static com.codeborne.selenide.commands.Util.firstOf;
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static java.time.Duration.ofMillis;
 import static java.util.Collections.singletonList;
 
@@ -28,17 +28,17 @@ public class AppiumSwipeTo extends FluentCommand {
   @Override
   protected void execute(WebElementSource locator, Object @Nullable [] args) {
     AppiumSwipeOptions appiumSwipeOptions = extractOptions(args);
-    Optional<AppiumDriver> driver = cast(locator.driver(), AppiumDriver.class);
 
-    if (!driver.isPresent()) {
+    if (!isMobile(locator.driver())) {
       throw new IllegalArgumentException("Swipe is supported only in Appium");
     }
-    swipeInMobile(driver.get(), locator, appiumSwipeOptions);
+    swipeInMobile(locator, appiumSwipeOptions);
   }
 
-  private void swipeInMobile(AppiumDriver appiumDriver, WebElementSource locator, AppiumSwipeOptions appiumSwipeOptions) {
-    int currentSwipeCount = 0;
+  private void swipeInMobile(WebElementSource locator, AppiumSwipeOptions appiumSwipeOptions) {
+    WebDriver appiumDriver = locator.driver().getWebDriver();
 
+    int currentSwipeCount = 0;
     while (isElementNotDisplayed(locator)
       && isLessThanMaxSwipeCount(currentSwipeCount, appiumSwipeOptions.getMaxSwipeCounts())) {
       performSwipe(appiumDriver, appiumSwipeOptions.getAppiumSwipeDirection());
@@ -58,16 +58,16 @@ public class AppiumSwipeTo extends FluentCommand {
     }
   }
 
-  private Dimension getMobileDeviceSize(AppiumDriver appiumDriver) {
+  private Dimension getMobileDeviceSize(WebDriver appiumDriver) {
     return appiumDriver.manage().window().getSize();
   }
 
-  private void performSwipe(AppiumDriver appiumDriver, AppiumSwipeDirection swipeDirection) {
+  private void performSwipe(WebDriver appiumDriver, AppiumSwipeDirection swipeDirection) {
     Dimension size = getMobileDeviceSize(appiumDriver);
     AppiumScrollCoordinates scrollCoordinates = getScrollCoordinates(swipeDirection, size);
     PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, "finger");
     Sequence sequenceToPerformScroll = getSequenceToPerformSwipe(finger, scrollCoordinates);
-    appiumDriver.perform(singletonList(sequenceToPerformScroll));
+    ((Interactive) appiumDriver).perform(singletonList(sequenceToPerformScroll));
   }
 
   private AppiumScrollCoordinates getScrollCoordinates(AppiumSwipeDirection swipeDirection, Dimension size) {

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/HideKeyboard.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/HideKeyboard.java
@@ -2,39 +2,38 @@ package com.codeborne.selenide.appium.commands;
 
 import com.codeborne.selenide.FluentCommand;
 import com.codeborne.selenide.impl.WebElementSource;
-import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.HasOnScreenKeyboard;
+import io.appium.java_client.HidesKeyboard;
 import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import java.util.Optional;
-
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isAndroid;
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isIos;
 
 public class HideKeyboard extends FluentCommand {
   @Override
   protected void execute(WebElementSource locator, Object @Nullable [] args) {
-    Optional<AndroidDriver> androidDriver = cast(locator.driver().getWebDriver(), AndroidDriver.class);
-    Optional<IOSDriver> iosDriver = cast(locator.driver().getWebDriver(), IOSDriver.class);
+    WebDriver webDriver = locator.driver().getWebDriver();
 
-    if (androidDriver.isPresent()) {
-      hideKeyBoardForAndroid(androidDriver.get());
+    if (isAndroid(webDriver)) {
+      hideKeyBoardForAndroid((HasOnScreenKeyboard & HidesKeyboard) webDriver);
     }
-    else if (iosDriver.isPresent()) {
-      hideKeyBoardForIos(iosDriver.get(), locator.getWebElement());
+    else if (isIos(webDriver)) {
+      hideKeyBoardForIos((HasOnScreenKeyboard) webDriver, locator.getWebElement());
     }
     else {
-      throw new UnsupportedOperationException("Cannot hide keyboard for webdriver " + locator.driver().getWebDriver());
+      throw new UnsupportedOperationException("Cannot hide keyboard for webdriver " + webDriver);
     }
   }
 
-  private void hideKeyBoardForAndroid(AndroidDriver driver) {
+  private <T extends HasOnScreenKeyboard & HidesKeyboard> void hideKeyBoardForAndroid(T driver) {
     if (driver.isKeyboardShown()) {
       driver.hideKeyboard();
     }
   }
 
-  private void hideKeyBoardForIos(IOSDriver driver, WebElement element) {
+  private void hideKeyBoardForIos(HasOnScreenKeyboard driver, WebElement element) {
     if (driver.isKeyboardShown()) {
       element.sendKeys("\n");
     }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumDriverUnwrapperTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumDriverUnwrapperTest.java
@@ -2,19 +2,14 @@ package com.codeborne.selenide.appium;
 
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
-import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.options.UiAutomator2Options;
 import io.appium.java_client.ios.IOSDriver;
-import io.appium.java_client.ios.options.XCUITestOptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.Browser;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.events.EventFiringDecorator;
 import org.openqa.selenium.support.events.WebDriverListener;
 
@@ -25,10 +20,7 @@ import java.util.stream.Stream;
 import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isAndroid;
 import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isIos;
 import static com.codeborne.selenide.appium.AppiumDriverUnwrapper.isMobile;
-import static com.codeborne.selenide.appium.AppiumDriverUnwrapperTest.add;
-import static com.codeborne.selenide.appium.AppiumDriverUnwrapperTest.getUrl;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
 
 class AppiumDriverUnwrapperTest {
   private final MutableCapabilities capabilities = new MutableCapabilities();
@@ -49,10 +41,8 @@ class AppiumDriverUnwrapperTest {
 
   @ParameterizedTest
   @MethodSource("webBrowsers")
-  void isMobile_false_forWebBrowser(String webBrowser) {
-    capabilities.setCapability(BROWSER_NAME, webBrowser);
-
-    WebDriver webDriver = new FakeWebDriver(capabilities);
+  void isMobile_false_forWebBrowser(Browser webBrowser) {
+    WebDriver webDriver = new FakeWebDriver(capabilities, webBrowser);
     assertThat(isMobile(driver(webDriver))).isFalse();
     assertThat(isMobile(driver(webDriver).getWebDriver())).isFalse();
   }
@@ -61,26 +51,26 @@ class AppiumDriverUnwrapperTest {
   void test_isIos() {
     assertThat(isIos(driver(new FakeIOSDriver(capabilities)))).isTrue();
     assertThat(isIos(driver(new FakeAndroidDriver(capabilities)))).isFalse();
-    assertThat(isIos(driver(new FakeWebDriver(capabilities)))).isFalse();
+    assertThat(isIos(driver(new FakeWebDriver(capabilities, Browser.CHROME)))).isFalse();
   }
 
   @Test
   void test_isAndroid() {
     assertThat(isAndroid(driver(new FakeAndroidDriver(capabilities)))).isTrue();
     assertThat(isAndroid(driver(new FakeIOSDriver(capabilities)))).isFalse();
-    assertThat(isAndroid(driver(new FakeWebDriver(capabilities)))).isFalse();
+    assertThat(isAndroid(driver(new FakeWebDriver(capabilities, Browser.CHROME)))).isFalse();
   }
 
-  private static Stream<Arguments> webBrowsers() {
+  static Stream<Arguments> webBrowsers() {
     return Stream.of(
-      Arguments.of(Browser.IE.browserName()),
-      Arguments.of(Browser.EDGE.browserName()),
-      Arguments.of(Browser.CHROME.browserName()),
-      Arguments.of(Browser.FIREFOX.browserName()),
-      Arguments.of(Browser.HTMLUNIT.browserName()),
-      Arguments.of(Browser.OPERA.browserName()),
-      Arguments.of(Browser.SAFARI.browserName()),
-      Arguments.of(Browser.SAFARI_TECH_PREVIEW.browserName())
+      Arguments.of(Browser.IE),
+      Arguments.of(Browser.EDGE),
+      Arguments.of(Browser.CHROME),
+      Arguments.of(Browser.FIREFOX),
+      Arguments.of(Browser.HTMLUNIT),
+      Arguments.of(Browser.OPERA),
+      Arguments.of(Browser.SAFARI),
+      Arguments.of(Browser.SAFARI_TECH_PREVIEW)
     );
   }
 
@@ -110,34 +100,4 @@ class AppiumDriverUnwrapperTest {
 }
 
 class EmptyWebDriverListener implements WebDriverListener {
-}
-
-class FakeIOSDriver extends IOSDriver {
-  FakeIOSDriver(Capabilities capabilities) {
-    super(getUrl(), new XCUITestOptions(capabilities));
-  }
-
-  @Override
-  protected void startSession(Capabilities capabilities) {
-  }
-}
-
-class FakeAndroidDriver extends AndroidDriver {
-  FakeAndroidDriver(Capabilities capabilities) {
-    super(getUrl(), new UiAutomator2Options(capabilities));
-  }
-
-  @Override
-  protected void startSession(Capabilities capabilities) {
-  }
-}
-
-class FakeWebDriver extends RemoteWebDriver {
-  FakeWebDriver(MutableCapabilities capabilities) {
-    super(getUrl(), add(capabilities, BROWSER_NAME, Browser.CHROME.browserName()));
-  }
-
-  @Override
-  protected void startSession(Capabilities capabilities) {
-  }
 }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumElementDescriberTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumElementDescriberTest.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.appium;
 
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.ios.IOSDriver;
 import org.junit.jupiter.api.Test;
@@ -22,24 +23,11 @@ import static org.mockito.Mockito.when;
 
 public class AppiumElementDescriberTest {
   private final AppiumElementDescriber describer = new AppiumElementDescriber();
-  private final Driver driver = mock(Driver.class);
   private final WebElement element = mock(WebElement.class);
-
-  void givenAndroidDriver() {
-    AndroidDriver webdriver = mock(AndroidDriver.class);
-    when(webdriver.getCapabilities()).thenReturn(new DesiredCapabilities());
-    when(driver.getWebDriver()).thenReturn(webdriver);
-  }
-
-  void givenIosDriver() {
-    IOSDriver webdriver = mock(IOSDriver.class);
-    when(webdriver.getCapabilities()).thenReturn(new DesiredCapabilities());
-    when(driver.getWebDriver()).thenReturn(webdriver);
-  }
 
   @Test
   public void printsTagName_ifPresent() {
-    givenIosDriver();
+    Driver driver = iosDriver();
     when(element.getTagName()).thenReturn("XCUIElementTypeImage");
     when(element.getAttribute("class")).thenThrow(new UnsupportedCommandException("Oops"));
 
@@ -50,7 +38,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void printsText_ifPresent() {
-    givenIosDriver();
+    Driver driver = iosDriver();
     when(element.getTagName()).thenReturn("XCUIElementTypeImage");
     when(element.getText()).thenReturn("element text");
 
@@ -60,7 +48,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void canExtractTextFromAttributeText() {
-    givenIosDriver();
+    Driver driver = iosDriver();
     when(element.getTagName()).thenReturn("XCUIElementTypeImage");
     when(element.getText()).thenReturn("");
     when(element.getAttribute("text")).thenReturn("element text");
@@ -71,7 +59,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void canExtractTextFromAttributeLabel() {
-    givenIosDriver();
+    Driver driver = iosDriver();
     when(element.getTagName()).thenReturn("XCUIElementTypeImage");
     when(element.getAttribute("label")).thenReturn("element text");
 
@@ -81,7 +69,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void canExtractTextFromAttributeValue() {
-    givenIosDriver();
+    Driver driver = iosDriver();
     when(element.getTagName()).thenReturn("XCUIElementTypeImage");
     when(element.getAttribute("value")).thenReturn("element text");
 
@@ -91,7 +79,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void extractsTagNameFromClassName_inAndroid() {
-    givenAndroidDriver();
+    Driver driver = androidDriver();
     when(element.getTagName()).thenReturn("");
     when(element.getAttribute("class")).thenReturn("android.widget.TextView");
     when(element.getAttribute("className")).thenReturn("android.widget.TextView");
@@ -103,7 +91,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void fully() {
-    givenAndroidDriver();
+    Driver driver = androidDriver();
     when(element.getAttribute("class")).thenReturn("android.widget.TextView");
     when(element.getAttribute("className")).thenReturn("android.widget.TextView");
     when(element.getAttribute("text")).thenReturn("Hello, world");
@@ -114,7 +102,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void addAllPossibleAttributes() {
-    givenAndroidDriver();
+    Driver driver = androidDriver();
     when(element.getAttribute("class")).thenReturn("android.widget.TextView");
     when(element.getAttribute("className")).thenReturn("android.widget.TextView");
     when(element.getAttribute("text")).thenReturn("Hello, world");
@@ -140,7 +128,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void ignoresErrorsWhenGettingAnyOfAttributes_android() {
-    givenAndroidDriver();
+    Driver driver = androidDriver();
     when(element.getAttribute(anyString())).thenThrow(new WebDriverException("Not implemented"));
     doReturn("android.widget.TextView").when(element).getAttribute("class");
     doReturn("android.widget.TextView").when(element).getAttribute("className");
@@ -158,10 +146,7 @@ public class AppiumElementDescriberTest {
 
   @Test
   public void ignoresErrorsWhenGettingAnyOfAttributes_ios() {
-    givenIosDriver();
-    IOSDriver webdriver = mock(IOSDriver.class);
-    when(webdriver.getCapabilities()).thenReturn(new DesiredCapabilities());
-    when(driver.getWebDriver()).thenReturn(webdriver);
+    Driver driver = iosDriver();
     when(element.getTagName()).thenReturn("XCUIElementTypeImage");
     when(element.getAttribute(anyString())).thenThrow(new WebDriverException("Not implemented"));
     doReturn("Hello, world").when(element).getAttribute("label");
@@ -193,5 +178,15 @@ public class AppiumElementDescriberTest {
   void removesPackageFromAndroidClassName() {
     assertThat(removePackage("android.widget.TextView")).isEqualTo("TextView");
     assertThat(removePackage("JustSomeClass")).isEqualTo("JustSomeClass");
+  }
+
+  private static Driver androidDriver() {
+    AndroidDriver webdriver = new FakeAndroidDriver(new DesiredCapabilities());
+    return new DriverStub(webdriver);
+  }
+
+  private static Driver iosDriver() {
+    IOSDriver webdriver = new FakeIOSDriver(new DesiredCapabilities());
+    return new DriverStub(webdriver);
   }
 }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumScreenSourceExtractorTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumScreenSourceExtractorTest.java
@@ -3,42 +3,46 @@ package com.codeborne.selenide.appium;
 import com.codeborne.selenide.Config;
 import com.codeborne.selenide.SelenideConfig;
 import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.ios.IOSDriver;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.edge.EdgeDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Browser;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class AppiumScreenSourceExtractorTest {
+  private final Config config = new SelenideConfig().reportsFolder("foo");
+  private final AppiumScreenSourceExtractor extractor = new AppiumScreenSourceExtractor();
+
   @ParameterizedTest
-  @ValueSource(classes = {AndroidDriver.class, IOSDriver.class})
-  void shouldUseXMLFileExtension_forMobileDriver(Class<AppiumDriver> webdriver) {
-    AppiumDriver driver = mock(webdriver);
-    DesiredCapabilities capabilities = new DesiredCapabilities();
-    capabilities.setCapability("appium:automationName", "Android Emulator");
-    when(driver.getCapabilities()).thenReturn(capabilities);
-    Config config = new SelenideConfig().reportsFolder("foo");
-    File sourceFile = new AppiumScreenSourceExtractor().createFile(config, driver, "test123");
+  @MethodSource("mobileDrivers")
+  void shouldUseXMLFileExtension_forMobileDriver(AppiumDriver driver) {
+    File sourceFile = extractor.createFile(config, driver, "test123");
     assertThat(sourceFile.getName()).isEqualTo("test123.xml");
   }
 
   @ParameterizedTest
-  @ValueSource(classes = {ChromeDriver.class, FirefoxDriver.class, EdgeDriver.class})
-  void shouldUseHTMLFileExtension_forWebBrowser(Class<RemoteWebDriver> webdriver) {
-    RemoteWebDriver driver = mock(webdriver);
-    when(driver.getCapabilities()).thenReturn(new DesiredCapabilities());
-    Config config = new SelenideConfig().reportsFolder("foo");
-    File sourceFile = new AppiumScreenSourceExtractor().createFile(config, driver, "test456");
+  @MethodSource("webBrowsers")
+  void shouldUseHTMLFileExtension_forWebBrowser(Browser browser) {
+    WebDriver webDriver = new FakeWebDriver(new DesiredCapabilities(), browser);
+
+    File sourceFile = extractor.createFile(config, webDriver, "test456");
     assertThat(sourceFile.getName()).isEqualTo("test456.html");
+  }
+
+  private static Stream<Arguments> mobileDrivers() {
+    return Stream.of(
+      Arguments.of(new FakeAndroidDriver(new DesiredCapabilities())),
+      Arguments.of(new FakeIOSDriver(new DesiredCapabilities()))
+    );
+  }
+
+  static Stream<Arguments> webBrowsers() {
+    return AppiumDriverUnwrapperTest.webBrowsers();
   }
 }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/FakeAndroidDriver.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/FakeAndroidDriver.java
@@ -1,0 +1,17 @@
+package com.codeborne.selenide.appium;
+
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.options.UiAutomator2Options;
+import org.openqa.selenium.Capabilities;
+
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapperTest.getUrl;
+
+class FakeAndroidDriver extends AndroidDriver {
+  FakeAndroidDriver(Capabilities capabilities) {
+    super(getUrl(), new UiAutomator2Options(capabilities));
+  }
+
+  @Override
+  protected void startSession(Capabilities capabilities) {
+  }
+}

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/FakeIOSDriver.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/FakeIOSDriver.java
@@ -1,0 +1,17 @@
+package com.codeborne.selenide.appium;
+
+import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.ios.options.XCUITestOptions;
+import org.openqa.selenium.Capabilities;
+
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapperTest.getUrl;
+
+class FakeIOSDriver extends IOSDriver {
+  FakeIOSDriver(Capabilities capabilities) {
+    super(getUrl(), new XCUITestOptions(capabilities));
+  }
+
+  @Override
+  protected void startSession(Capabilities capabilities) {
+  }
+}

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/FakeWebDriver.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/FakeWebDriver.java
@@ -1,0 +1,20 @@
+package com.codeborne.selenide.appium;
+
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.remote.Browser;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapperTest.add;
+import static com.codeborne.selenide.appium.AppiumDriverUnwrapperTest.getUrl;
+import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
+
+class FakeWebDriver extends RemoteWebDriver {
+  FakeWebDriver(MutableCapabilities capabilities, Browser browser) {
+    super(getUrl(), add(capabilities, BROWSER_NAME, browser.browserName()));
+  }
+
+  @Override
+  protected void startSession(Capabilities capabilities) {
+  }
+}

--- a/modules/appium/src/test/java/it/mobile/BrowserstackUtils.java
+++ b/modules/appium/src/test/java/it/mobile/BrowserstackUtils.java
@@ -5,14 +5,16 @@ import java.net.URL;
 import java.util.Map;
 
 public class BrowserstackUtils {
-  private static final Map<String, Object> bstackOptions = Map.of(
-    "userName", "githubactions_qxmgVeB",
-    "accessKey", System.getProperty("selenide.bs_key"),
-    "appiumVersion", "2.6.0",
-    "projectName", "Selenide-Appium",
-    "buildName", getPrettyJobName(),
-    "interactiveDebugging", true
-  );
+  public static Map<String, Object> getBrowserstackOptions() {
+    return Map.of(
+      "userName", "githubactions_qxmgVeB",
+      "accessKey", System.getProperty("selenide.bs_key"),
+      "appiumVersion", "2.6.0",
+      "projectName", "Selenide-Appium",
+      "buildName", getPrettyJobName(),
+      "interactiveDebugging", true
+    );
+  }
 
   public static URL browserstackUrl() {
     try {
@@ -20,10 +22,6 @@ public class BrowserstackUtils {
     } catch (MalformedURLException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  public static Map<String, Object> getBrowserstackOptions() {
-    return bstackOptions;
   }
 
   private static String getPrettyJobName() {

--- a/modules/appium/src/test/java/it/mobile/android/AndroidClipboardTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AndroidClipboardTest.java
@@ -1,0 +1,14 @@
+package it.mobile.android;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Selenide.clipboard;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AndroidClipboardTest extends BaseApiDemosTest {
+  @Test
+  void canReadAndWriteClipboard() {
+    clipboard().setText("Clipboard works in Android");
+    assertThat(clipboard().getText()).isEqualTo("Clipboard works in Android");
+  }
+}

--- a/modules/appium/src/test/java/it/mobile/android/BaseApiDemosTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/BaseApiDemosTest.java
@@ -11,10 +11,10 @@ import it.mobile.android.driverproviders.local.LocalAndroidDriverWithDemos;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.events.WebDriverListener;
 
 import static com.codeborne.selenide.appium.SelenideAppium.launchApp;
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static it.mobile.BrowserstackUtils.isCi;
 
 public abstract class BaseApiDemosTest extends ITTest {
@@ -38,8 +38,13 @@ public abstract class BaseApiDemosTest extends ITTest {
       launchApp();
       return;
     }
-    cast(WebDriverRunner.getWebDriver(), InteractsWithApps.class)
-      .ifPresentOrElse(mobileDriver -> prepareApp(mobileDriver, AndroidDriverWithDemos.appId), SelenideAppium::launchApp);
+    WebDriver webDriver = WebDriverRunner.getWebDriver();
+    if (webDriver instanceof InteractsWithApps mobileDriver) {
+      prepareApp(mobileDriver, AndroidDriverWithDemos.appId);
+    }
+    else {
+      SelenideAppium.launchApp();
+    }
   }
 }
 

--- a/modules/appium/src/test/java/it/mobile/android/BaseSwagLabsAndroidTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/BaseSwagLabsAndroidTest.java
@@ -11,9 +11,9 @@ import it.mobile.android.driverproviders.local.LocalAndroidDriverWithSwagLabs;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.events.WebDriverListener;
 
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static it.mobile.BrowserstackUtils.isCi;
 
 public abstract class BaseSwagLabsAndroidTest extends ITTest {
@@ -37,7 +37,12 @@ public abstract class BaseSwagLabsAndroidTest extends ITTest {
       // test will run the app
       return;
     }
-    cast(WebDriverRunner.getWebDriver(), InteractsWithApps.class)
-      .ifPresentOrElse(mobileDriver -> prepareApp(mobileDriver, AndroidDriverWithSwagLabs.appId), SelenideAppium::launchApp);
+    WebDriver webDriver = WebDriverRunner.getWebDriver();
+    if (webDriver instanceof InteractsWithApps mobileDriver) {
+      prepareApp(mobileDriver, AndroidDriverWithSwagLabs.appId);
+    }
+    else {
+      SelenideAppium.launchApp();
+    }
   }
 }

--- a/modules/appium/src/test/java/it/mobile/ios/IosClipboardTest.java
+++ b/modules/appium/src/test/java/it/mobile/ios/IosClipboardTest.java
@@ -3,12 +3,19 @@ package it.mobile.ios;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Selenide.clipboard;
+import static it.mobile.BrowserstackUtils.isCi;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 class IosClipboardTest extends BaseSwagLabsAppIosTest {
   @Test
   void canReadAndWriteClipboard() {
     clipboard().setText("Clipboard works in iOS");
+
+    assumeThat(isCi())
+      .as("in October 2025, clipboard was empty on BrowserStack..")
+      .isFalse();
+
     assertThat(clipboard().getText()).isEqualTo("Clipboard works in iOS");
   }
 }

--- a/modules/appium/src/test/java/it/mobile/ios/IosClipboardTest.java
+++ b/modules/appium/src/test/java/it/mobile/ios/IosClipboardTest.java
@@ -1,0 +1,14 @@
+package it.mobile.ios;
+
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Selenide.clipboard;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IosClipboardTest extends BaseSwagLabsAppIosTest {
+  @Test
+  void canReadAndWriteClipboard() {
+    clipboard().setText("Clipboard works in iOS");
+    assertThat(clipboard().getText()).isEqualTo("Clipboard works in iOS");
+  }
+}

--- a/modules/appium/src/test/java/it/mobile/ios/driverproviders/IosDriverProvider.java
+++ b/modules/appium/src/test/java/it/mobile/ios/driverproviders/IosDriverProvider.java
@@ -34,6 +34,7 @@ public class IosDriverProvider implements WebDriverProvider {
     options.setFullReset(false);
     options.setShouldTerminateApp(true);
     options.setCapability("bstack:options", getBrowserstackOptions());
+    options.setCapability("browserstack.video", false);
     return options;
   }
 

--- a/modules/full-screenshot/src/main/java/com/codeborne/selenide/fullscreenshot/FullSizePhotographer.java
+++ b/modules/full-screenshot/src/main/java/com/codeborne/selenide/fullscreenshot/FullSizePhotographer.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.unwrap;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -53,7 +52,7 @@ public class FullSizePhotographer implements Photographer {
   }
 
   private <T> Optional<T> takeFullSizeScreenshot(Driver driver, OutputType<T> outputType) {
-    WebDriver webDriver = unwrap(driver.getWebDriver());
+    WebDriver webDriver = driver.getWebDriver();
 
     if (webDriver instanceof HasFullPageScreenshot firefoxDriver) {
       return Optional.of(firefoxDriver.getFullPageScreenshotAs(outputType));

--- a/modules/grid/src/test/java/integration/CustomWebdriverFactoryWithRemoteBrowser.java
+++ b/modules/grid/src/test/java/integration/CustomWebdriverFactoryWithRemoteBrowser.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
@@ -43,7 +44,7 @@ final class CustomWebdriverFactoryWithRemoteBrowser extends AbstractGridTest {
     public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, @Nullable File browserDownloadsFolder) {
       RemoteWebDriver webDriver = new RemoteWebDriver(requireNonNull(url), chromeOptions(proxy));
       webDriver.setFileDetector(new LocalFileDetector());
-      return webDriver;
+      return new Augmenter().augment(webDriver);
     }
   }
 }

--- a/modules/grid/src/test/java/integration/CustomWebdriverProviderWithRemoteBrowserTest.java
+++ b/modules/grid/src/test/java/integration/CustomWebdriverProviderWithRemoteBrowserTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
@@ -34,7 +35,7 @@ final class CustomWebdriverProviderWithRemoteBrowserTest extends AbstractGridTes
     public WebDriver createDriver(Capabilities capabilities) {
       RemoteWebDriver webDriver = new RemoteWebDriver(requireNonNull(gridUrl()), chromeOptions(null));
       webDriver.setFileDetector(new LocalFileDetector());
-      return webDriver;
+      return new Augmenter().augment(webDriver);
     }
   }
 }

--- a/modules/grid/src/test/java/integration/RemoteWebDriverTest.java
+++ b/modules/grid/src/test/java/integration/RemoteWebDriverTest.java
@@ -4,6 +4,8 @@ import com.codeborne.selenide.WebDriverRunner;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.File;
@@ -17,7 +19,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class RemoteWebDriverTest extends AbstractGridTest {
   @Nullable
-  private RemoteWebDriver driver;
+  private WebDriver driver;
 
   @BeforeEach
   void setUp() {
@@ -27,7 +29,7 @@ public class RemoteWebDriverTest extends AbstractGridTest {
 
   @Test
   void canOpenCustomRemoteWebDriver() {
-    driver = new RemoteWebDriver(gridUrl(), chromeOptions(null));
+    driver = new Augmenter().augment(new RemoteWebDriver(gridUrl(), chromeOptions(null)));
     WebDriverRunner.setWebDriver(driver);
     openFile("page_with_uploads.html");
 

--- a/modules/moon/src/test/java/it/moon/RemoteWebdriverTest.java
+++ b/modules/moon/src/test/java/it/moon/RemoteWebdriverTest.java
@@ -6,6 +6,8 @@ import integration.LogTestNameExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.IOException;
@@ -27,7 +29,7 @@ public class RemoteWebdriverTest {
 
   @Test
   void canStartRemoteWebDriver() throws IOException {
-    RemoteWebDriver driver = new RemoteWebDriver(new URL(moonUrl()), capabilities(), false);
+    WebDriver driver = new Augmenter().augment(new RemoteWebDriver(new URL(moonUrl()), capabilities(), false));
     setWebDriver(driver);
     checkDownload();
   }

--- a/modules/selenoid/src/test/java/it/selenoid/RemoteWebdriverTest.java
+++ b/modules/selenoid/src/test/java/it/selenoid/RemoteWebdriverTest.java
@@ -4,6 +4,8 @@ import com.codeborne.selenide.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.io.IOException;
@@ -25,7 +27,7 @@ public class RemoteWebdriverTest {
 
   @Test
   void canStartRemoteWebDriver() throws IOException {
-    RemoteWebDriver driver = new RemoteWebDriver(new URL(selenoidUrl()), capabilities(), false);
+    WebDriver driver = new Augmenter().augment(new RemoteWebDriver(new URL(selenoidUrl()), capabilities(), false));
     setWebDriver(driver);
     checkDownload();
   }

--- a/src/main/java/com/codeborne/selenide/DefaultClipboard.java
+++ b/src/main/java/com/codeborne/selenide/DefaultClipboard.java
@@ -1,6 +1,5 @@
 package com.codeborne.selenide;
 
-import org.openqa.selenium.chromium.ChromiumDriver;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.HasDevTools;
 import org.openqa.selenium.devtools.v140.browser.Browser;
@@ -11,10 +10,7 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.instanceOf;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.empty;
 import static org.openqa.selenium.devtools.v140.browser.model.PermissionType.CLIPBOARDREADWRITE;
@@ -38,9 +34,8 @@ public class DefaultClipboard implements Clipboard {
   }
 
   private boolean grantPermission() {
-    Optional<HasDevTools> cdpBrowser = cast(driver, HasDevTools.class);
-    if (cdpBrowser.isPresent() && instanceOf(driver, ChromiumDriver.class)) {
-      DevTools devTools = cdpBrowser.get().getDevTools();
+    if (driver.getWebDriver() instanceof HasDevTools cdpBrowser) {
+      DevTools devTools = cdpBrowser.getDevTools();
       devTools.send(Browser.grantPermissions(List.of(CLIPBOARDREADWRITE, CLIPBOARDSANITIZEDWRITE), empty(), empty()));
       return true;
     }

--- a/src/main/java/com/codeborne/selenide/impl/WebdriverUnwrapper.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebdriverUnwrapper.java
@@ -2,29 +2,52 @@ package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
 import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.WrapsElement;
-import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.util.Optional;
 
 public class WebdriverUnwrapper {
+  /**
+   * @deprecated instead of using this method, just
+   * cast your {@link WebDriver} to the needed interface, e.g. {@link JavascriptExecutor} or {@link TakesScreenshot}.
+   */
+  @Deprecated(forRemoval = true)
+  @SuppressWarnings("DeprecatedIsStillUsed")
   public static <T> boolean instanceOf(Driver driver, Class<T> klass) {
     return cast(driver, klass).isPresent();
   }
 
+  /**
+   * @deprecated instead of using this method, just
+   * cast your {@link WebDriver} to the needed interface, e.g. {@link JavascriptExecutor} or {@link TakesScreenshot}.
+   */
+  @Deprecated(forRemoval = true)
+  @SuppressWarnings("DeprecatedIsStillUsed")
   public static <T> boolean instanceOf(SearchContext driver, Class<T> klass) {
     return cast(driver, klass).isPresent();
   }
 
+  /**
+   * @deprecated instead of using this method, just
+   * cast your {@link WebDriver} to the needed interface, e.g. {@link JavascriptExecutor} or {@link TakesScreenshot}.
+   */
+  @Deprecated(forRemoval = true)
   public static <T> Optional<T> cast(Driver driver, Class<T> klass) {
     return cast(driver.getWebDriver(), klass);
   }
 
+  /**
+   * @deprecated instead of using this method, just
+   * cast your {@link WebDriver} to the needed interface, e.g. {@link JavascriptExecutor} or {@link TakesScreenshot}.
+   */
+  @Deprecated(forRemoval = true)
   @SuppressWarnings("unchecked")
   public static <T> Optional<T> cast(SearchContext driverOrElement, Class<T> klass) {
     if (klass.isAssignableFrom(driverOrElement.getClass())) {
@@ -47,19 +70,17 @@ public class WebdriverUnwrapper {
     return (T) unwrappedWebElement;
   }
 
+  /**
+   * @deprecated instead of using this method, just
+   * cast your {@link WebDriver} to the needed interface, e.g. {@link JavascriptExecutor} or {@link TakesScreenshot}.
+   */
+  @Deprecated(forRemoval = true)
   @Nullable
   public static WebDriver unwrap(SearchContext driverOrElement) {
     if (driverOrElement instanceof WrapsDriver wrapper) {
       return unwrap(wrapper.getWrappedDriver());
     }
-    try {
-      if (driverOrElement instanceof RemoteWebDriver remoteWebDriver) {
-        return new Augmenter().augment(remoteWebDriver);
-      }
-    } catch (IllegalStateException e) {
-      return (WebDriver) driverOrElement;
-    }
-    return null;
+    return (WebDriver) driverOrElement;
   }
 
   public static RemoteWebDriver unwrapRemoteWebDriver(WebDriver driver) {

--- a/src/main/java/com/codeborne/selenide/webdriver/RemoteDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/RemoteDriverFactory.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.webdriver;
 import com.codeborne.selenide.Config;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.HttpCommandExecutor;
 import org.openqa.selenium.remote.LocalFileDetector;
@@ -21,7 +22,7 @@ public class RemoteDriverFactory {
       CommandExecutor commandExecutor = createExecutor(config);
       RemoteWebDriver webDriver = new RemoteWebDriver(commandExecutor, capabilities);
       webDriver.setFileDetector(new LocalFileDetector());
-      return webDriver;
+      return new Augmenter().augment(webDriver);
     }
     catch (MalformedURLException e) {
       throw new IllegalArgumentException("Invalid 'remote' parameter: " + config.remote(), e);

--- a/src/test/java/com/codeborne/selenide/impl/WebdriverUnwrapperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebdriverUnwrapperTest.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.Capabilities;
@@ -13,21 +14,19 @@ import org.openqa.selenium.support.events.WebDriverListener;
 import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static com.codeborne.selenide.impl.WebdriverUnwrapper.instanceOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class WebdriverUnwrapperTest {
   private final WebDriver pureDriver = new FakeFirefoxDriver();
   private final WebDriver wrappedDriver = addWebDriverListeners(pureDriver, new EmptyWebDriverListener());
-  private final Driver driver = mock(Driver.class);
+  private final Driver driver = new DriverStub(wrappedDriver);
 
   @BeforeEach
   void setUp() {
-    when(driver.getWebDriver()).thenReturn(wrappedDriver);
     assertThat(wrappedDriver).isNotInstanceOf(FirefoxDriver.class);
   }
 
   @Test
+  @SuppressWarnings({"removal"})
   void test_instanceOf() {
     assertThat(instanceOf(wrappedDriver, FirefoxDriver.class)).isTrue();
     assertThat(instanceOf(driver, FirefoxDriver.class)).isTrue();
@@ -35,6 +34,7 @@ class WebdriverUnwrapperTest {
   }
 
   @Test
+  @SuppressWarnings({"removal"})
   void test_cast() {
     assertThat(cast(wrappedDriver, FirefoxDriver.class).get()).isInstanceOf(FirefoxDriver.class);
     assertThat(cast(driver, FirefoxDriver.class).get()).isInstanceOf(FirefoxDriver.class);

--- a/src/test/java/integration/ITest.java
+++ b/src/test/java/integration/ITest.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
-import static com.codeborne.selenide.impl.WebdriverUnwrapper.cast;
 import static java.lang.ThreadLocal.withInitial;
 
 public abstract class ITest extends BaseIntegrationTest {
@@ -111,14 +110,14 @@ public abstract class ITest extends BaseIntegrationTest {
       }
       else {
         driver().open();
-        cast(driver().getWebDriver(), HasDevTools.class).ifPresent(webdriver -> {
+        if (driver().getWebDriver() instanceof HasDevTools webdriver) {
           var devTools = webdriver.getDevTools();
           devTools.createSessionIfThereIsNotOne();
           devTools.send(Log.enable());
           devTools.addListener(Log.entryAdded(), log ->
             browserLogs.info("[{}] {} source:{} url:{}", log.getLevel(), log.getText(), log.getSource(), log.getUrl().orElse("-"))
           );
-        });
+        }
       }
       driver().open("/" + fileName + "?browser=" + browser +
                     "&timeout=" + driver().config().timeout());


### PR DESCRIPTION
instead of un-wrapping to get an instance of `AndroidDriver` or `IOSDriver` (which doesn't always work well in `Augmenter`), we should cast WebDriver directly to the needed interface (e.g. `HasDevTools`). This always works.

But it's important to always call `new Augmenter().augment(webdriver)` every time when you call `new RemoteWebDriver()` - otherwise the casting doesn't work. 

Continuation of https://github.com/selenide/selenide/pull/3109