### PR TITLE
#2850 disable smooth scrolling by default

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -35,6 +35,7 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
     arguments.add("--disable-dev-shm-usage");
     arguments.add("--disable-search-engine-choice-screen");
     arguments.add("--unsafely-disable-devtools-self-xss-warnings");
+    arguments.add("--disable-smooth-scrolling");
     arguments.addAll(parseArguments(externalArguments));
     arguments.addAll(createHeadlessArguments(config));
 

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -91,6 +91,7 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
     firefoxOptions.addPreference("security.csp.enable", false);
     firefoxOptions.addPreference("network.proxy.no_proxies_on", "");
     firefoxOptions.addPreference("network.proxy.allow_hijacking_localhost", true);
+    firefoxOptions.addPreference("general.smoothScroll", false);
   }
 
   protected void setupDownloadsFolder(FirefoxOptions firefoxOptions, @Nullable File browserDownloadsFolder) {

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -191,6 +191,14 @@ final class ChromeDriverFactoryTest {
   }
 
   @Test
+  void disablesSmoothScrollingByDefault() {
+    Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
+    List<String> optionArguments = getBrowserLaunchArgs(CAPABILITY, chromeOptions);
+
+    assertThat(optionArguments).contains("--disable-smooth-scrolling");
+  }
+
+  @Test
   void doesNotDisableSandboxByDefault() {
     Capabilities chromeOptions = factory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
     List<String> optionArguments = getBrowserLaunchArgs(CAPABILITY, chromeOptions);

--- a/src/test/java/com/codeborne/selenide/webdriver/EdgeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/EdgeDriverFactoryTest.java
@@ -59,6 +59,7 @@ class EdgeDriverFactoryTest {
       "--disable-dev-shm-usage",
       "--disable-search-engine-choice-screen",
       "--unsafely-disable-devtools-self-xss-warnings",
+      "--disable-smooth-scrolling",
       "--window-size=1366,768"
     );
 


### PR DESCRIPTION
... to avoid flaky failures when the test tries to click an element while it's still moving.

* disabled in Chrome, Edge and FireFox (created by Selenide)
* could not find an option for Safari.

@ASTRO-CZ @MatteoPalese @USSQA @mwdle