### PR TITLE
#3142 Allow using shadow host as context in ByShadowCss

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selectors.java
+++ b/src/main/java/com/codeborne/selenide/Selectors.java
@@ -118,15 +118,15 @@ public class Selectors {
   }
 
   /**
-   * @see ByShadowCss#cssSelector(java.lang.String, java.lang.String, java.lang.String...)
+   * @see ByShadowCss#cssSelector(java.lang.String, java.lang.String...)
    * @since 5.10
    */
-  public static By shadowCss(String target, String shadowHost, String... innerShadowHosts) {
-    return ByShadowCss.cssSelector(target, shadowHost, innerShadowHosts);
+  public static By shadowCss(String target, String... shadowHostsChain) {
+    return ByShadowCss.cssSelector(target, shadowHostsChain);
   }
 
   /**
-   * @see ByDeepShadowCss#cssSelector(java.lang.String)
+   * @see ByDeepShadowCss#ByDeepShadowCss(java.lang.String)
    * @since v6.8.0
    */
   public static By shadowDeepCss(String target) {

--- a/src/main/java/com/codeborne/selenide/selector/ByShadow.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByShadow.java
@@ -103,7 +103,7 @@ public class ByShadow extends By implements Serializable {
       .collect(joining(" -> "));
   }
 
-  public static By cssSelector(String target, String shadowHost, String... innerShadowHosts) {
-    return ByShadowCss.cssSelector(target, shadowHost, innerShadowHosts);
+  public static By cssSelector(String target, String... shadowHostsChain) {
+    return ByShadowCss.cssSelector(target, shadowHostsChain);
   }
 }

--- a/src/main/java/com/codeborne/selenide/selector/ByShadowCss.java
+++ b/src/main/java/com/codeborne/selenide/selector/ByShadowCss.java
@@ -11,7 +11,6 @@ import org.openqa.selenium.WebElement;
 import java.io.Serializable;
 import java.util.List;
 
-import static com.codeborne.selenide.impl.Lists.list;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNullElse;
 
@@ -22,18 +21,17 @@ public class ByShadowCss extends By implements Serializable {
   private final List<String> shadowHostsChain;
   private final String target;
 
-  public ByShadowCss(String target, String shadowHost, String... innerShadowHosts) {
+  public ByShadowCss(String target, String... shadowHostsChain) {
     //noinspection ConstantConditions
-    if (shadowHost == null || target == null) {
+    if (target == null) {
       throw new IllegalArgumentException("Cannot find elements when the selector is null");
     }
-    this.shadowHostsChain = list(shadowHost, innerShadowHosts);
+    this.shadowHostsChain = List.of(shadowHostsChain);
     this.target = target;
   }
 
-
-  public static By cssSelector(String target, String shadowHost, String... innerShadowHosts) {
-    return new ByShadowCss(target, shadowHost, innerShadowHosts);
+  public static By cssSelector(String target, String... shadowHostsChain) {
+    return new ByShadowCss(target, shadowHostsChain);
   }
 
   @Override

--- a/src/test/java/integration/ShadowElementTest.java
+++ b/src/test/java/integration/ShadowElementTest.java
@@ -105,6 +105,20 @@ final class ShadowElementTest extends ITest {
   }
 
   @Test
+  void getTargetElementViaShadowHostWithShadowHostAsContext() {
+    $("#shadow-host")
+      .find(shadowCss("p"))
+      .shouldHave(text("Inside Shadow-DOM"));
+  }
+
+  @Test
+  void getElementInsideInnerShadowHostWithShadowHostAsContext() {
+    $("#shadow-host")
+      .find(shadowCss("p", "#inner-shadow-host"))
+      .shouldHave(text("The Shadow-DOM inside another shadow tree"));
+  }
+
+  @Test
   void throwErrorWhenGetNonExistingTargetInsideShadowRoot() {
     assertThatThrownBy(() -> $(shadowCss("#nonexistent", "#shadow-host")).text())
       .isInstanceOf(ElementNotFound.class);


### PR DESCRIPTION
## Changes
Allow using shadow host as context in `ByShadowCss`, so that if we already have a `SelenideElement` that is a shadow host itself, we don't need to get its parent and locate it again to access an element in the shadow root.

## Motivation

This code is now possible:
```java
$("#shadow-host")
      .find(shadowCss("p")) // before, a second parameter was required here
      .shouldHave(text("Inside Shadow-DOM"));
```