### PR TITLE
#3057 add method $.unhighlight()

### DIFF
--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -591,15 +591,24 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
 
   /**
    * @see com.codeborne.selenide.commands.Highlight
+   * @since 6.19.0
    */
   @CanIgnoreReturnValue
   SelenideElement highlight();
 
   /**
    * @see com.codeborne.selenide.commands.Highlight
+   * @since 6.19.0
    */
   @CanIgnoreReturnValue
   SelenideElement highlight(HighlightOptions options);
+
+  /**
+   * @see com.codeborne.selenide.commands.Unhighlight
+   * @since 7.12.0
+   */
+  @CanIgnoreReturnValue
+  SelenideElement unhighlight();
 
   /**
    * Give this element a human-readable name

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -78,6 +78,7 @@ public class Commands {
     add("getValue", new GetValue());
     add("pseudo", new GetPseudoValue());
     add("highlight", new Highlight());
+    add("unhighlight", new Unhighlight());
   }
 
   private void addClickCommands() {

--- a/src/main/java/com/codeborne/selenide/commands/Unhighlight.java
+++ b/src/main/java/com/codeborne/selenide/commands/Unhighlight.java
@@ -1,0 +1,15 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.FluentCommand;
+import com.codeborne.selenide.impl.JavaScript;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.jspecify.annotations.Nullable;
+
+public class Unhighlight extends FluentCommand {
+  private final JavaScript js = new JavaScript("unhighlight.js");
+
+  @Override
+  protected void execute(WebElementSource locator, Object @Nullable [] args) {
+    js.execute(locator.driver(), locator.getWebElement());
+  }
+}

--- a/src/main/resources/highlight.js
+++ b/src/main/resources/highlight.js
@@ -1,3 +1,4 @@
 (function (element, style) {
-  element.setAttribute('style', style)
+  element.setAttribute('data-original-style', element.getAttribute('style') || '');
+  element.setAttribute('style', style);
 })(arguments[0], arguments[1]);

--- a/src/main/resources/unhighlight.js
+++ b/src/main/resources/unhighlight.js
@@ -1,0 +1,4 @@
+(function (element) {
+  element.setAttribute('style', element.getAttribute('data-original-style'));
+  element.removeAttribute('data-original-style');
+})(arguments[0]);

--- a/src/test/resources/page_with_inputs_and_hints.html
+++ b/src/test/resources/page_with_inputs_and_hints.html
@@ -37,7 +37,7 @@
                oninput="displayUsernameHint()"
                onblur="hideUsernameHint()"/>
       </label>
-      <div id="usernameHint" style="display: none">username hint</div>
+      <div id="usernameHint" style="display: none; color: red; width: 280px; border: 1px solid red;">username hint</div>
       <br/>
       <label>Password:
         <input id="password" name="password" value=""

--- a/statics/src/test/java/integration/HighlightTest.java
+++ b/statics/src/test/java/integration/HighlightTest.java
@@ -20,12 +20,19 @@ final class HighlightTest extends IntegrationTest {
   void canHighlightElements() {
     $("#username").highlight(border("3px solid blue")).setValue("john");
     sleep(pause);
+    $("#username").unhighlight();
+    sleep(pause);
     $("#usernameHint").highlight();
+    sleep(pause);
+    $("#usernameHint").unhighlight();
     sleep(pause);
     $("#password").highlight(border("3px solid red")).setValue("admin");
     sleep(pause);
+    $("#password").unhighlight();
+    sleep(pause);
     $("#passwordHint").highlight(border("3px solid green")).should(appear);
     sleep(pause);
+    $("#passwordHint").unhighlight();
+    sleep(pause);
   }
-
 }


### PR DESCRIPTION
In addition to existing method `$.highlight()`, we now have a method for the opposite action: `$.unhighlight()`:

```java
$("#username").highlight();
$("#username").sendKeys("Johnny Cash");
$("#username").unhighlight();
```