### PR TITLE
#2094 enable/disable mobile emulation in an opened browser

### DIFF
--- a/src/main/java/com/codeborne/selenide/Device.java
+++ b/src/main/java/com/codeborne/selenide/Device.java
@@ -1,0 +1,9 @@
+package com.codeborne.selenide;
+
+public record Device(String name, int width, int height, double pixelRatio) {
+  public static final Device IPHONE_SE = new Device("iPhone SE", 375, 667, 2.0);
+  public static final Device IPHONE_14 = new Device("iPhone 14", 390, 844, 3.0);
+  public static final Device PIXEL_7 = new Device("Pixel 7", 412, 915, 2.625);
+  public static final Device ONEPLUS_7T = new Device("OnePlus 7T", 480, 194, 2.625);
+  public static final Device GALAXY_S21 = new Device("Samsung Galaxy S21", 360, 800, 3.0);
+}

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -15,9 +15,14 @@ import com.codeborne.selenide.selector.FocusedElementLocator;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.bidi.browsingcontext.BrowsingContext;
+import org.openqa.selenium.devtools.DevTools;
+import org.openqa.selenium.devtools.HasDevTools;
+import org.openqa.selenium.devtools.v142.emulation.Emulation;
 import org.openqa.selenium.remote.SessionId;
 import org.openqa.selenium.support.events.WebDriverListener;
 
@@ -27,14 +32,17 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import static com.codeborne.selenide.commands.Util.classOf;
 import static com.codeborne.selenide.files.FileFilters.none;
+import static com.codeborne.selenide.impl.BiDiUti.isBiDiEnabled;
 import static com.codeborne.selenide.impl.Lazy.lazyEvaluated;
 import static com.codeborne.selenide.impl.Plugins.inject;
 import static com.codeborne.selenide.impl.WebElementWrapper.wrap;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
 
 /**
  * "Selenide driver" is a container for WebDriver + proxy server + settings
@@ -479,5 +487,45 @@ public class SelenideDriver {
 
   public Conditional<WebDriver> webdriver() {
     return new WebDriverConditional(driver);
+  }
+
+  public void emulateDevice(Device device) {
+    int width = device.width();
+    int height = device.height();
+    double pixelRatio = device.pixelRatio();
+    WebDriver webDriver = driver().getWebDriver();
+    if (webDriver instanceof HasDevTools devToolsBrowser) { // Chromium browsers
+      DevTools devTools = devToolsBrowser.getDevTools();
+      devTools.createSessionIfThereIsNotOne();
+      devTools.send(Emulation.setDeviceMetricsOverride(
+        width, height, pixelRatio, true, empty(),
+        Optional.of(width), Optional.of(height),
+        empty(), empty(), empty(), empty(), empty(), empty(), empty()
+      ));
+    }
+    else if (isBiDiEnabled(webDriver)) { // Firefox
+      BrowsingContext browsingContext = new BrowsingContext(webDriver, webDriver.getWindowHandle());
+      browsingContext.setViewport(width, height, pixelRatio);
+    }
+    else {
+      throw new UnsupportedOperationException("Mobile emulation is not enabled in " + webDriver);
+    }
+  }
+
+  public void resetEmulation() {
+    WebDriver webDriver = driver().getWebDriver();
+    if (webDriver instanceof HasDevTools devToolsBrowser) { // Chromium browsers
+      DevTools devTools = devToolsBrowser.getDevTools();
+      devTools.createSessionIfThereIsNotOne();
+      devTools.send(Emulation.clearDeviceMetricsOverride());
+    }
+    else if (isBiDiEnabled(webDriver)) { // Firefox
+      BrowsingContext browsingContext = new BrowsingContext(webDriver, webDriver.getWindowHandle());
+      Dimension size = webDriver.manage().window().getSize();
+      browsingContext.setViewport(size.getWidth(), size.getHeight());
+    }
+    else {
+      throw new UnsupportedOperationException("Mobile emulation is not enabled in " + webDriver);
+    }
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/EdgeDriverFactory.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.openqa.selenium.remote.CapabilityType.ACCEPT_INSECURE_CERTS;
@@ -47,6 +48,7 @@ public class EdgeDriverFactory extends AbstractChromiumDriverFactory {
 
     options.addArguments(createEdgeArguments(config));
     options.setExperimentalOption("prefs", prefs(browserDownloadsFolder, System.getProperty("edgeoptions.prefs", "")));
+    setMobileEmulation(options);
     return options;
   }
 
@@ -56,5 +58,17 @@ public class EdgeDriverFactory extends AbstractChromiumDriverFactory {
 
   protected List<String> createEdgeArguments(Config config) {
     return createChromiumArguments(config, System.getProperty("edgeoptions.args"));
+  }
+
+  private void setMobileEmulation(EdgeOptions options) {
+    Map<String, Object> mobileEmulation = mobileEmulation();
+    if (!mobileEmulation.isEmpty()) {
+      options.setExperimentalOption("mobileEmulation", mobileEmulation);
+    }
+  }
+
+  protected Map<String, Object> mobileEmulation() {
+    String mobileEmulation = System.getProperty("edgeoptions.mobileEmulation", "");
+    return parsePreferencesFromString(mobileEmulation);
   }
 }

--- a/src/test/resources/page_with_responsive_ui.html
+++ b/src/test/resources/page_with_responsive_ui.html
@@ -12,12 +12,18 @@
       #mobile {
         display: block;
       }
+      body {
+        background-color: pink;
+      }
       @media (min-width: 800px) {
         #desktop {
           display: block;
         }
         #mobile {
           display: none;
+        }
+        body {
+          background-color: #eeeeee;
         }
       }
     </style>
@@ -26,5 +32,22 @@
     <h1>Responsive UI</h1>
     <h2 id="desktop">Desktop</h2>
     <h2 id="mobile">Mobile</h2>
+
+    <h5 id="width"></h5>
+    <h5 id="height"></h5>
+    <h5 id="ratio"></h5>
+
+    <script>
+      function showDeviceInfo() {
+        document.getElementById('width').innerText = `Width: ${window.innerWidth}`
+        document.getElementById('height').innerText = `Height: ${window.innerHeight}`
+        document.getElementById('ratio').innerText = `Device Pixel Ratio: ${window.devicePixelRatio.toFixed(3)}`
+      }
+
+      showDeviceInfo();
+      window.addEventListener('resize', showDeviceInfo);
+      window.addEventListener('orientationchange', showDeviceInfo);
+      setInterval(showDeviceInfo, 500)
+    </script>
   </body>
 </html>

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -129,6 +129,14 @@ public class Selenide {
     return getSelenideDriver().webdriver();
   }
 
+  public static void emulateDevice(Device device) {
+    getSelenideDriver().emulateDevice(device);
+  }
+
+  public static void resetEmulation() {
+    getSelenideDriver().resetEmulation();
+  }
+
   public static void using(WebDriver webDriver, Runnable lambda) {
     WebDriverRunner.using(webDriver, lambda);
   }

--- a/statics/src/test/java/integration/MobileEmulationTest.java
+++ b/statics/src/test/java/integration/MobileEmulationTest.java
@@ -1,50 +1,122 @@
 package integration;
 
+import com.codeborne.selenide.Device;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.stream.Stream;
 
 import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Configuration.timeout;
+import static com.codeborne.selenide.Device.GALAXY_S21;
+import static com.codeborne.selenide.Device.IPHONE_14;
+import static com.codeborne.selenide.Device.IPHONE_SE;
+import static com.codeborne.selenide.Device.ONEPLUS_7T;
+import static com.codeborne.selenide.Device.PIXEL_7;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.closeWebDriver;
-import static com.codeborne.selenide.WebDriverRunner.isChrome;
+import static com.codeborne.selenide.Selenide.emulateDevice;
+import static com.codeborne.selenide.Selenide.getWebDriverLogs;
+import static com.codeborne.selenide.Selenide.resetEmulation;
+import static com.codeborne.selenide.WebDriverRunner.isFirefox;
+import static com.codeborne.selenide.WebDriverRunner.isSafari;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.openqa.selenium.logging.LogType.BROWSER;
 
 final class MobileEmulationTest extends IntegrationTest {
   @BeforeEach
   void setUp() {
-    assumeThat(isChrome()).isTrue();
-
-    closeWebDriver();
+    assumeThat(isSafari()).isFalse();
     assertThat(System.getProperty("chromeoptions.mobileEmulation")).isNull();
+    assertThat(System.getProperty("edgeoptions.mobileEmulation")).isNull();
+    timeout = 2000;
   }
 
   @AfterEach
   void tearDown() {
-    if (isChrome()) {
-      closeWebDriver();
-      System.clearProperty("chromeoptions.mobileEmulation");
-    }
+    System.clearProperty("chromeoptions.mobileEmulation");
+    System.clearProperty("edgeoptions.mobileEmulation");
+  }
+
+  @AfterAll
+  static void closeBrowser() {
+    closeWebDriver();
   }
 
   @Test
   void canOpenBrowserInMobileEmulationMode() {
-    System.setProperty("chromeoptions.mobileEmulation", "deviceName=Nexus 5");
+    assumeThat(isFirefox())
+      .as("Firefox cannot enable mobile emulation via FirefoxOptions")
+      .isFalse();
 
-    openFile("page_with_responsive_ui.html");
-    $("#desktop").shouldBe(hidden);
-    $("#mobile").shouldHave(text("Mobile"), visible);
+    closeWebDriver();
+    System.setProperty("chromeoptions.mobileEmulation", "deviceName=Nexus 5");
+    System.setProperty("edgeoptions.mobileEmulation", "deviceName=iPhone X");
+
+    try {
+      openFile("page_with_responsive_ui.html");
+      $("#desktop").shouldBe(hidden);
+      $("#mobile").shouldHave(text("Mobile"), visible);
+    }
+    finally {
+      closeWebDriver();
+    }
   }
 
   @Test
-  void canOpenBrowserInDesktopMode() {
-    System.clearProperty("chromeoptions.mobileEmulation");
-
+  void opensBrowserInDesktopModeByDefault() {
     openFile("page_with_responsive_ui.html");
     $("#desktop").shouldHave(text("Desktop"), visible);
     $("#mobile").shouldBe(hidden);
+  }
+
+  @ParameterizedTest
+  @MethodSource("supportedDevices")
+  void canSwitchToMobileModeOnTheFly(Device device) {
+    openFile("page_with_responsive_ui.html");
+
+    try {
+
+      resetEmulation();
+      $("#desktop").shouldHave(text("Desktop"), visible);
+      $("#mobile").shouldBe(hidden);
+      $("#width").shouldHave(text("Width: 1200").or(text("Width: 1192")));
+
+      emulateDevice(device);
+
+      $("#desktop").shouldBe(hidden);
+      $("#mobile").shouldHave(text("Mobile"), visible);
+      $("#width").shouldHave(text("Width: " + device.width()));
+      $("#height").shouldHave(text("Height: " + device.height()));
+      $("#ratio").shouldHave(text("Device Pixel Ratio: %.3f".formatted(device.pixelRatio())));
+
+      resetEmulation();
+      $("#mobile").shouldBe(hidden);
+      $("#width").shouldHave(text("Width: 1200").or(text("Width: 1192")));
+    }
+    finally {
+      List<String> webDriverLogs = getWebDriverLogs(BROWSER, Level.ALL);
+      System.out.println(webDriverLogs);
+    }
+  }
+
+  private static Stream<Arguments> supportedDevices() {
+    return Stream.of(
+      Arguments.of(IPHONE_SE),
+      Arguments.of(IPHONE_14),
+      Arguments.of(PIXEL_7),
+      Arguments.of(ONEPLUS_7T),
+      Arguments.of(GALAXY_S21)
+    );
   }
 }


### PR DESCRIPTION
Now it's possible to enable/disable mobile emulation mode in an opened browser:

```java
import static com.codeborne.selenide.Selenide.emulateDevice;
import com.codeborne.selenide.Device;

emulateDevice(Device.ONEPLUS_7T);
emulateDevice(Device.GALAXY_S21);
emulateDevice(new Device("Nokia 3210", 240, 320, 0.5));
```

And disable it:
```java
resetEmulation();
```

P.S. Also, allow enabling mobile emulation in Edge browser via system property:

```java
System.setProperty("edgeoptions.mobileEmulation", "deviceName=iPhone X");
```