### PR TITLE
keep proxy filters in the same order they were added

### DIFF
--- a/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -44,8 +44,8 @@ public class SelenideProxyServer {
   @Nullable
   private Proxy seleniumProxy;
   private final BrowserUpProxy proxy;
-  private final Map<String, RequestFilter> requestFilters = new HashMap<>();
-  private final Map<String, ResponseFilter> responseFilters = new HashMap<>();
+  private final Map<String, RequestFilter> requestFilters = new LinkedHashMap<>();
+  private final Map<String, ResponseFilter> responseFilters = new LinkedHashMap<>();
   private final AtomicInteger port = new AtomicInteger();
 
   /**

--- a/src/test/java/com/codeborne/selenide/proxy/SelenideProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/SelenideProxyServerTest.java
@@ -178,8 +178,7 @@ final class SelenideProxyServerTest {
 
     List<String> requestFilterNames = proxyServer.requestFilterNames();
     assertThat(requestFilterNames)
-      .hasSize(6)
-      .containsExactlyInAnyOrder(
+      .containsExactly(
         "foo-request-filter-1",
         "foo-request-filter-2",
         "foo-request-filter-3",
@@ -195,8 +194,7 @@ final class SelenideProxyServerTest {
 
     List<String> updatedRequestFilterNames = proxyServer.requestFilterNames();
     assertThat(updatedRequestFilterNames)
-      .hasSize(4)
-      .containsExactlyInAnyOrder(
+      .containsExactly(
         "foo-request-filter-1",
         "foo-request-filter-2",
         "foo-request-filter-3",
@@ -285,8 +283,7 @@ final class SelenideProxyServerTest {
 
     List<String> responseFilterNames = proxyServer.responseFilterNames();
     assertThat(responseFilterNames)
-      .hasSize(6)
-      .containsExactlyInAnyOrder(
+      .containsExactly(
         "foo-response-filter-1",
         "foo-response-filter-2",
         "foo-response-filter-3",
@@ -302,8 +299,7 @@ final class SelenideProxyServerTest {
 
     List<String> updatedResponseFilterNames = proxyServer.responseFilterNames();
     assertThat(updatedResponseFilterNames)
-      .hasSize(4)
-      .containsExactlyInAnyOrder(
+      .containsExactly(
         "foo-response-filter-1",
         "foo-response-filter-2",
         "foo-response-filter-3",


### PR DESCRIPTION
Users might depend on the order of filters.
