### PR TITLE
#3189 avoid generating too fast video

### DIFF
--- a/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/VideoMerger.java
+++ b/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/VideoMerger.java
@@ -49,6 +49,7 @@ class VideoMerger {
 
   private void generateVideo() throws IOException {
     FFmpegBuilder builder = new FFmpegBuilder()
+      .addExtraArgs("-framerate", String.valueOf(config.fps()))
       .addInput(screenshotsFolder.getAbsolutePath() + "/screenshot.%d.png")
       .setVideoFilter("pad=iw+mod(iw\\,2):ih+mod(ih\\,2)")
       .addOutput(videoFile.toAbsolutePath().toString())


### PR DESCRIPTION
by default, FFMpeg assumes that 24 screenshots are taken per second. We need to use "-framerate FPS" argument to say FFMpeg that we took FPS screenshots per second.

fixes https://github.com/selenide/selenide/discussions/3189 & #3191 