### PR TITLE
#3187 apply date/time conditions for texts too

### DIFF
--- a/src/main/java/com/codeborne/selenide/conditions/datetime/DateConditions.java
+++ b/src/main/java/com/codeborne/selenide/conditions/datetime/DateConditions.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.conditions.datetime;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Assert that element contains "value" attribute with date value that is satisfied to the provided `options`
@@ -23,12 +24,20 @@ public class DateConditions {
     return new DateEquals(date, new DateFormatCondition(pattern));
   }
 
+  public static TemporalCondition<LocalDate> date(LocalDate date, DateTimeFormatter format) {
+    return new DateEquals(date, new DateFormatCondition(format));
+  }
+
   public static TemporalCondition<LocalDate> dateBetween(LocalDate from, LocalDate until) {
     return dateBetween(from, until, DEFAULT_PATTERN);
   }
 
   public static TemporalCondition<LocalDate> dateBetween(LocalDate from, LocalDate until, String pattern) {
     return new DateBetween(from, until, new DateFormatCondition(pattern));
+  }
+
+  public static TemporalCondition<LocalDate> dateBetween(LocalDate from, LocalDate until, DateTimeFormatter format) {
+    return new DateBetween(from, until, new DateFormatCondition(format));
   }
 
   public static TemporalFormatCondition<LocalDate> dateFormat(String pattern) {

--- a/src/main/java/com/codeborne/selenide/conditions/datetime/DateFormatCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/datetime/DateFormatCondition.java
@@ -1,12 +1,17 @@
 package com.codeborne.selenide.conditions.datetime;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalQuery;
 
 class DateFormatCondition extends TemporalFormatCondition<LocalDate> {
 
   DateFormatCondition(String pattern) {
     super("date format", pattern);
+  }
+
+  DateFormatCondition(DateTimeFormatter format) {
+    super("date format", format);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/datetime/DateTimeConditions.java
+++ b/src/main/java/com/codeborne/selenide/conditions/datetime/DateTimeConditions.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.conditions.datetime;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Assert that element contains "value" attribute with datetime value
@@ -24,12 +25,20 @@ public class DateTimeConditions {
     return new DateTimeEquals(dateTime, new DateTimeFormatCondition(pattern));
   }
 
+  public static TemporalCondition<LocalDateTime> dateTime(LocalDateTime dateTime, DateTimeFormatter format) {
+    return new DateTimeEquals(dateTime, new DateTimeFormatCondition(format));
+  }
+
   public static TemporalCondition<LocalDateTime> dateTimeBetween(LocalDateTime from, LocalDateTime until) {
     return dateTimeBetween(from, until, DEFAULT_PATTERN);
   }
 
   public static TemporalCondition<LocalDateTime> dateTimeBetween(LocalDateTime from, LocalDateTime until, String pattern) {
     return new DateTimeBetween(from, until, new DateTimeFormatCondition(pattern));
+  }
+
+  public static TemporalCondition<LocalDateTime> dateTimeBetween(LocalDateTime from, LocalDateTime until, DateTimeFormatter format) {
+    return new DateTimeBetween(from, until, new DateTimeFormatCondition(format));
   }
 
   public static TemporalFormatCondition<LocalDateTime> dateTimeFormat(String pattern) {

--- a/src/main/java/com/codeborne/selenide/conditions/datetime/DateTimeFormatCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/datetime/DateTimeFormatCondition.java
@@ -1,12 +1,17 @@
 package com.codeborne.selenide.conditions.datetime;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalQuery;
 
 class DateTimeFormatCondition extends TemporalFormatCondition<LocalDateTime> {
 
   DateTimeFormatCondition(String pattern) {
     super("datetime format", pattern);
+  }
+
+  DateTimeFormatCondition(DateTimeFormatter format) {
+    super("datetime format", format);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/datetime/TemporalFormatCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/datetime/TemporalFormatCondition.java
@@ -4,16 +4,19 @@ import com.codeborne.selenide.CheckResult;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.WebElementCondition;
 import org.openqa.selenium.WebElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQuery;
 
-import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
-import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static java.util.Objects.requireNonNull;
 
 public abstract class TemporalFormatCondition<T extends TemporalAccessor> extends WebElementCondition {
+  private static final Logger log = LoggerFactory.getLogger(TemporalFormatCondition.class);
+
   private final String pattern;
   private final DateTimeFormatter format;
 
@@ -23,15 +26,22 @@ public abstract class TemporalFormatCondition<T extends TemporalAccessor> extend
     this.format = DateTimeFormatter.ofPattern(pattern);
   }
 
+  protected TemporalFormatCondition(String name, DateTimeFormatter format) {
+    super(name);
+    this.pattern = format.toString();
+    this.format = format;
+  }
+
   protected abstract TemporalQuery<T> queryFromTemporal();
 
   @Override
   public CheckResult check(Driver driver, WebElement element) {
-    String value = getValueAttribute(element);
+    String value = getActualValue(element);
     try {
-      return new CheckResult(ACCEPT, format.parse(value, queryFromTemporal()));
+      return CheckResult.accepted(format.parse(value, queryFromTemporal()));
     } catch (DateTimeParseException exception) {
-      return new CheckResult(REJECT, value);
+      log.debug("Unable to parse date string {}: {}", value, exception.toString());
+      return CheckResult.rejected(exception.toString(), value);
     }
   }
 
@@ -40,9 +50,9 @@ public abstract class TemporalFormatCondition<T extends TemporalAccessor> extend
     return String.format("%s \"%s\"", getName(), pattern);
   }
 
-  private String getValueAttribute(WebElement element) {
+  private String getActualValue(WebElement element) {
     String value = element.getAttribute("value");
-    return value == null ? "" : value;
+    return requireNonNull(value, element::getText);
   }
 
   public String format(T value) {

--- a/src/test/java/integration/DateConditionsTest.java
+++ b/src/test/java/integration/DateConditionsTest.java
@@ -10,10 +10,13 @@ import static com.codeborne.selenide.SetValueOptions.withDate;
 import static com.codeborne.selenide.conditions.datetime.DateConditions.date;
 import static com.codeborne.selenide.conditions.datetime.DateConditions.dateBetween;
 import static com.codeborne.selenide.conditions.datetime.DateConditions.dateFormat;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class DateConditionsTest extends ITest {
-  private final LocalDate birthday = LocalDate.of(1993, 12, 30);
+  private final LocalDate birthday = LocalDate.of(1993, DECEMBER, 30);
+  private final LocalDate judgmentDay = LocalDate.of(1997, AUGUST, 29);
 
   @BeforeEach
   void openTestPage() {
@@ -21,14 +24,20 @@ public class DateConditionsTest extends ITest {
   }
 
   @Test
-  public void successCases() {
+  public void canCheckValueAttribute() {
     $("#birthdate").shouldHave(date(birthday, "yyyy-MM-dd"));
     $("#birthdate").shouldHave(date(birthday));
     $("#birthdate").shouldHave(dateBetween(birthday.minusDays(1), birthday, "yyyy-MM-dd"));
     $("#birthdate").shouldHave(dateFormat("yyyy-MM-dd"));
+  }
 
-    dateBetween(birthday.minusDays(1), birthday, "yyyy-MM-dd");
-    dateFormat("yyyy-MM-dd");
+  @Test
+  public void canCheckText() {
+    $("#judgment-day #iso").shouldHave(date(judgmentDay));
+    $("#judgment-day #custom").shouldHave(date(judgmentDay, "MMMM d, yyyy"));
+    $("#judgment-day #iso").shouldHave(dateFormat("yyyy-MM-dd"));
+    $("#judgment-day #iso").shouldHave(date(judgmentDay));
+    $("#judgment-day #iso").shouldHave(dateBetween(judgmentDay.minusDays(2), judgmentDay));
   }
 
   @Test

--- a/src/test/java/integration/DateTimeConditionsTest.java
+++ b/src/test/java/integration/DateTimeConditionsTest.java
@@ -10,10 +10,13 @@ import static com.codeborne.selenide.SetValueOptions.withDateTime;
 import static com.codeborne.selenide.conditions.datetime.DateTimeConditions.dateTime;
 import static com.codeborne.selenide.conditions.datetime.DateTimeConditions.dateTimeBetween;
 import static com.codeborne.selenide.conditions.datetime.DateTimeConditions.dateTimeFormat;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class DateTimeConditionsTest extends ITest {
-  private final LocalDateTime birthday = LocalDateTime.of(1983, 12, 26, 23, 49, 59);
+  private final LocalDateTime birthday = LocalDateTime.of(1983, DECEMBER, 26, 23, 49, 59);
+  private final LocalDateTime judgmentDay = LocalDateTime.of(1997, AUGUST, 29, 2, 14, 0);
 
   @BeforeEach
   void openTestPage() {
@@ -21,10 +24,20 @@ public class DateTimeConditionsTest extends ITest {
   }
 
   @Test
-  public void successCases() {
+  public void canCheckValueAttribute() {
+    $("#birthdate").shouldHave(dateTime(birthday));
     $("#birthdate").shouldHave(dateTime(birthday, "yyyy-MM-dd'T'HH:mm:ss"));
     $("#birthdate").shouldHave(dateTimeBetween(birthday.minusDays(1), birthday.plusDays(1), "yyyy-MM-dd'T'HH:mm:ss"));
     $("#birthdate").shouldHave(dateTimeFormat("yyyy-MM-dd'T'HH:mm:ss"));
+  }
+
+  @Test
+  public void canCheckText() {
+    $("#judgment-day #iso").shouldHave(dateTime(judgmentDay));
+    $("#judgment-day #custom").shouldHave(dateTime(judgmentDay, "MMMM d, yyyy 'at' H:mm"));
+    $("#judgment-day #iso").shouldHave(dateTimeBetween(judgmentDay.minusMinutes(2), judgmentDay.plusHours(1)));
+    $("#judgment-day #mm-dd").shouldHave(dateTimeFormat("yyyy/MM/dd HH:mm"));
+    $("#judgment-day #mm-dd").shouldHave(dateTime(judgmentDay, "yyyy/MM/dd HH:mm"));
   }
 
   @Test

--- a/src/test/resources/page_with_date_inputs.html
+++ b/src/test/resources/page_with_date_inputs.html
@@ -15,5 +15,27 @@
       </label>
   </form>
 </div>
+
+<div id="judgment-day">
+  Judgment Day
+  <table>
+    <thead>
+    <tr>
+      <th>Format</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>ISO</td>
+      <td id="iso">1997-08-29</td>
+    </tr>
+    <tr>
+      <td>Custom</td>
+      <td id="custom">August 29, 1997</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
 </body>
 </html>

--- a/src/test/resources/page_with_datetime_inputs.html
+++ b/src/test/resources/page_with_datetime_inputs.html
@@ -10,19 +10,51 @@
 
 <div>
   <form>
+    <div>
       <label> Birthdate:
         <input id="birthdate" type="datetime-local" value="1983-12-26T23:49:59"/>
       </label>
+    </div>
 
-      <label> Pass issue date:
+    <div>
+      <label> Passport issue date:
         <input id="issueDate" type="text" value="2018/10/28 14:45"/>
       </label>
+    </div>
 
+    <div>
       <label> Working hours :
         <input id="open" type="time" value="08:30"/>
         <input id="close" type="time" value="17:15"/>
       </label>
+    </div>
   </form>
+</div>
+
+<div id="judgment-day">
+  Judgment Day
+  <table>
+    <thead>
+      <tr>
+        <th>Format</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>ISO</td>
+        <td id="iso">1997-08-29T02:14:00</td>
+      </tr>
+      <tr>
+        <td>/mm/dd</td>
+        <td id="mm-dd">1997/08/29 02:14</td>
+      </tr>
+      <tr>
+        <td>Custom</td>
+        <td id="custom">August 29, 1997 at 2:14</td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 </body>
 </html>


### PR DESCRIPTION
initially, there were applicable only for input's "value" attribute:

```htmljava
<label> Birthdate:
  <input id="birthdate" type="datetime-local" value="1983-12-26T23:49:59"/>
</label>
```

Now they can be used for text elements as well:

```html
<h1>Birthdate:</h1>
<div>1983-12-26T23:49:59</div>
```
