### PR TITLE
#3196 fix NPE in BiDi log listener

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/BiDiUti.java
+++ b/src/main/java/com/codeborne/selenide/impl/BiDiUti.java
@@ -68,7 +68,7 @@ public class BiDiUti {
   }
 
   private static String readBiDiLogMessage(GenericLogEntry log) {
-    if (log.getStackTrace().getCallFrames().isEmpty()) {
+    if (log.getStackTrace() == null || log.getStackTrace().getCallFrames().isEmpty()) {
       return log.getText();
     }
     StackFrame frame = log.getStackTrace().getCallFrames().get(0);


### PR DESCRIPTION
some logs don't have stack trace. We just need to use their `text`.

For example,
```js
type: javascript
level: error
stacktrace: null
text: Content-Security-Policy: The page’s settings blocked the loading of a resource (default-src) at https://duckduckgo.com/_next/static/chunks/pages/about-5678df504e82d61d.js because it violates the following directive: “default-src 'none'”
```

fixes #3196