### PR TITLE
Forbid remove selenide proxy filters. Add ability to remove all request or response filters separately

### DIFF
--- a/src/main/java/com/codeborne/selenide/drivercommands/Navigator.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/Navigator.java
@@ -20,7 +20,7 @@ import static com.codeborne.selenide.FileDownloadMode.PROXY;
 import static com.codeborne.selenide.drivercommands.BasicAuthUtils.appendBasicAuthToURL;
 import static com.codeborne.selenide.drivercommands.BasicAuthUtils.registerBasicAuth;
 import static com.codeborne.selenide.impl.HttpHelper.maskUrlCredentials;
-import static com.codeborne.selenide.proxy.SelenideProxyServer.SELENIDE_PROXY_FILER_PREFIX;
+import static com.codeborne.selenide.proxy.SelenideProxyServer.SELENIDE_PROXY_FILTER_PREFIX;
 import static java.util.Objects.requireNonNull;
 import static java.util.regex.Pattern.DOTALL;
 
@@ -49,7 +49,7 @@ public class Navigator {
   }
 
   private AuthenticationFilter basicAuthRequestFilter(SelenideDriver driver) {
-    return requireNonNull(driver.getProxy().requestFilter(SELENIDE_PROXY_FILER_PREFIX + "authentication"));
+    return requireNonNull(driver.getProxy().requestFilter(SELENIDE_PROXY_FILTER_PREFIX + "authentication"));
   }
 
   String absoluteUrl(Config config, String relativeOrAbsoluteUrl) {

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.function.Supplier;
 
-import static com.codeborne.selenide.proxy.SelenideProxyServer.SELENIDE_PROXY_FILER_PREFIX;
+import static com.codeborne.selenide.proxy.SelenideProxyServer.SELENIDE_PROXY_FILTER_PREFIX;
 
 public class DownloadFileWithProxyServer {
   private static final Logger log = LoggerFactory.getLogger(DownloadFileWithProxyServer.class);
@@ -47,7 +47,7 @@ public class DownloadFileWithProxyServer {
 
     SelenideProxyServer proxyServer = driver.getProxy();
 
-    FileDownloadFilter filter = proxyServer.responseFilter(SELENIDE_PROXY_FILER_PREFIX + "download");
+    FileDownloadFilter filter = proxyServer.responseFilter(SELENIDE_PROXY_FILTER_PREFIX + "download");
     if (filter == null) {
       throw new IllegalStateException("Cannot download file: download filter is not activated");
     }

--- a/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/proxy/SelenideProxyServer.java
@@ -37,7 +37,7 @@ public class SelenideProxyServer {
   private static final Logger log = LoggerFactory.getLogger(SelenideProxyServer.class);
   private static final Pattern REGEX_HOST_NAME = Pattern.compile("(.*):.*");
   private static final Pattern REGEX_PORT = Pattern.compile(".*:(.*)");
-  public static final String SELENIDE_PROXY_FILER_PREFIX = "selenide.proxy.filter.";
+  public static final String SELENIDE_PROXY_FILTER_PREFIX = "selenide.proxy.filter.";
 
   private final Config config;
   @Nullable
@@ -98,10 +98,10 @@ public class SelenideProxyServer {
     }
     FileDownloadFilter downloadFilter = new FileDownloadFilter(config);
 
-    addRequestFilter(SELENIDE_PROXY_FILER_PREFIX + "mockResponse", new MockResponseFilter());
-    addRequestFilter(SELENIDE_PROXY_FILER_PREFIX + "authentication", new AuthenticationFilter());
-    addRequestFilter(SELENIDE_PROXY_FILER_PREFIX + "download", downloadFilter);
-    addResponseFilter(SELENIDE_PROXY_FILER_PREFIX + "download", downloadFilter);
+    addRequestFilter(SELENIDE_PROXY_FILTER_PREFIX + "mockResponse", new MockResponseFilter());
+    addRequestFilter(SELENIDE_PROXY_FILTER_PREFIX + "authentication", new AuthenticationFilter());
+    addRequestFilter(SELENIDE_PROXY_FILTER_PREFIX + "download", downloadFilter);
+    addResponseFilter(SELENIDE_PROXY_FILTER_PREFIX + "download", downloadFilter);
 
     proxy.start(config.proxyPort());
     port.set(proxy.getPort());
@@ -138,8 +138,8 @@ public class SelenideProxyServer {
   @Nullable
   @CanIgnoreReturnValue
   public RequestFilter removeRequestFilter(String name) {
-    if (name.startsWith(SELENIDE_PROXY_FILER_PREFIX)) {
-      return requestFilters.get(name);
+    if (name.startsWith(SELENIDE_PROXY_FILTER_PREFIX)) {
+      throw new RuntimeException("The built-in selenide proxy request filter cannot be removed: " + name);
     }
     RequestFilter filter = requestFilters.remove(name);
     proxy.removeRequestFilter(filter);
@@ -173,8 +173,8 @@ public class SelenideProxyServer {
   @Nullable
   @CanIgnoreReturnValue
   public ResponseFilter removeResponseFilter(String name) {
-    if (name.startsWith(SELENIDE_PROXY_FILER_PREFIX)) {
-      return responseFilters.get(name);
+    if (name.startsWith(SELENIDE_PROXY_FILTER_PREFIX)) {
+      throw new RuntimeException("The built-in selenide proxy response filter cannot be removed: " + name);
     }
     ResponseFilter filter = responseFilters.remove(name);
     proxy.removeResponseFilter(filter);
@@ -196,7 +196,7 @@ public class SelenideProxyServer {
    */
   public void cleanupRequestFilters() {
     requestFilterNames().stream()
-      .filter(name -> !name.startsWith(SELENIDE_PROXY_FILER_PREFIX))
+      .filter(name -> !name.startsWith(SELENIDE_PROXY_FILTER_PREFIX))
       .forEach(this::removeRequestFilter);
   }
 
@@ -206,7 +206,7 @@ public class SelenideProxyServer {
    */
   public void cleanupResponseFilters() {
     responseFilterNames().stream()
-      .filter(name -> !name.startsWith(SELENIDE_PROXY_FILER_PREFIX))
+      .filter(name -> !name.startsWith(SELENIDE_PROXY_FILTER_PREFIX))
       .forEach(this::removeResponseFilter);
   }
 
@@ -332,6 +332,6 @@ public class SelenideProxyServer {
   }
 
   public MockResponseFilter responseMocker() {
-    return requireNonNull(requestFilter(SELENIDE_PROXY_FILER_PREFIX + "mockResponse"));
+    return requireNonNull(requestFilter(SELENIDE_PROXY_FILTER_PREFIX + "mockResponse"));
   }
 }

--- a/src/test/java/com/codeborne/selenide/proxy/SelenideProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/proxy/SelenideProxyServerTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -137,7 +138,7 @@ final class SelenideProxyServerTest {
 
     Map<String, RequestFilter> selenideRequestFilters = proxyServer.requestFilters();
 
-    resetFilters();
+    proxyServer.cleanupFilters();
 
     addRequestFilters(
       "foo-request-filter-1", "foo-request-filter-2", "foo-request-filter-3",
@@ -173,7 +174,7 @@ final class SelenideProxyServerTest {
   @Test
   void canGetRequestFilterNames() {
     proxyServer.start();
-    resetFilters();
+    proxyServer.cleanupFilters();
 
     addRequestFilters(
       "foo-request-filter-1", "foo-request-filter-2", "foo-request-filter-3",
@@ -226,7 +227,7 @@ final class SelenideProxyServerTest {
 
     Map<String, ResponseFilter> selenideResponseFilters = proxyServer.responseFilters();
 
-    resetFilters();
+    proxyServer.cleanupFilters();
 
     addResponseFilters(
       "foo-response-filter-1", "foo-response-filter-2", "foo-response-filter-3",
@@ -262,7 +263,8 @@ final class SelenideProxyServerTest {
   @Test
   void canGetResponseFilterNames() {
     proxyServer.start();
-    resetFilters();
+
+    proxyServer.cleanupFilters();
 
     addResponseFilters(
       "foo-response-filter-1", "foo-response-filter-2", "foo-response-filter-3",
@@ -373,7 +375,8 @@ final class SelenideProxyServerTest {
     RequestFilter requestFilter = proxyServer.requestFilter("selenide.proxy.filter.mockResponse");
     assertThat(requestFilter).isNotNull();
 
-    proxyServer.removeRequestFilter("selenide.proxy.filter.mockResponse");
+    assertThatThrownBy(() -> proxyServer.removeRequestFilter("selenide.proxy.filter.mockResponse"))
+      .hasMessage("The built-in selenide proxy request filter cannot be removed: selenide.proxy.filter.mockResponse");
 
     assertThat(proxyServer.requestFilters()).hasSize(initialRequestFilters);
     assertThat(proxyServer.responseFilters()).hasSize(initialResponseFilters);
@@ -391,7 +394,8 @@ final class SelenideProxyServerTest {
     RequestFilter requestFilter = proxyServer.responseFilter("selenide.proxy.filter.download");
     assertThat(requestFilter).isNotNull();
 
-    proxyServer.removeResponseFilter("selenide.proxy.filter.download");
+    assertThatThrownBy(() -> proxyServer.removeResponseFilter("selenide.proxy.filter.download"))
+      .hasMessage("The built-in selenide proxy response filter cannot be removed: selenide.proxy.filter.download");
 
     assertThat(proxyServer.requestFilters()).hasSize(initialRequestFilters);
     assertThat(proxyServer.responseFilters()).hasSize(initialResponseFilters);
@@ -419,13 +423,5 @@ final class SelenideProxyServerTest {
     for (String name : names) {
       proxyServer.removeResponseFilter(name);
     }
-  }
-
-  private void resetFilters() {
-    proxyServer.requestFilterNames()
-      .forEach(proxyServer::removeRequestFilter);
-
-    proxyServer.responseFilterNames()
-      .forEach(proxyServer::removeResponseFilter);
   }
 }


### PR DESCRIPTION
Forbid remove selenide proxy filters. Add ability to remove all request or response filters separately:

```java
SelenideProxyServer proxy = WebDriverRunner.getSelenideProxy();

proxy.cleanupRequestFilters(); // All request filters (except Selenide owns)
proxy.cleanupResponseFilters(); // All response filters (except Selenide owns)

proxy.cleanupFilters(); // both request and response filters (except Selenide owns)
```


## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
