### PR TITLE
Fix grammatical error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Selenide is a framework for writing easy-to-read and easy-to-maintain automated tests in Java.
 It defines concise fluent API, natural language assertions and does some magic for ajax-based applications to let you focus entirely on the business logic of your tests.
 
-Selenide is based on and is compatible to Selenium WebDriver 4.0+
+Selenide is based on and is compatible with Selenium WebDriver 4.0+
 
 ```java
 @Test


### PR DESCRIPTION
## Proposed changes
"Compatible to," even though (apparently) not entirely wrong grammatically, sounds unnatural, as it's used extremely rarely. "Compatible with" is a better option. Check [this](https://books.google.com/ngrams/graph?content=compatible+with%2C+compatible+to&year_start=1800&year_end=2022&corpus=en&smoothing=3) for reference.

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
