### PR TITLE
export Video Recorder

### DIFF
--- a/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/ScreenShooter.java
+++ b/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/ScreenShooter.java
@@ -1,8 +1,7 @@
 package org.selenide.videorecorder.core;
 
-import com.codeborne.selenide.drivercommands.WebdriversRegistry;
 import com.codeborne.selenide.impl.Photographer;
-import com.codeborne.selenide.impl.WebDriverInstance;
+import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.slf4j.Logger;
@@ -13,14 +12,15 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import static com.codeborne.selenide.impl.Plugins.inject;
 import static java.lang.System.nanoTime;
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.commons.io.FileUtils.copyInputStreamToFile;
-import static org.openqa.selenium.OutputType.BYTES;
 
 class ScreenShooter implements Runnable {
   private static final Logger log = LoggerFactory.getLogger(ScreenShooter.class);
@@ -29,11 +29,14 @@ class ScreenShooter implements Runnable {
   private final long threadId;
   private final File screenshotsFolder;
   private final List<Screenshot> screenshots;
+  private final Supplier<Optional<WebDriver>> webDriverSupplier;
 
-  ScreenShooter(long threadId, File screenshotsFolder, List<Screenshot> screenshots) {
+  ScreenShooter(long threadId, File screenshotsFolder, List<Screenshot> screenshots,
+                Supplier<Optional<WebDriver>> webDriverSupplier) {
     this.threadId = threadId;
     this.screenshots = screenshots;
     this.screenshotsFolder = screenshotsFolder;
+    this.webDriverSupplier = webDriverSupplier;
   }
 
   @Override
@@ -48,7 +51,7 @@ class ScreenShooter implements Runnable {
       originalName, threadId, screenshotsFolder.getName(), screenshots.size()));
 
     try {
-      WebdriversRegistry.webdriver(threadId).ifPresentOrElse(driver -> {
+      webDriverSupplier.get().ifPresentOrElse(driver -> {
         takeScreenshot(driver);
       }, () -> {
         log.trace("Skip taking a screenshot because webdriver is not started in thread {}", threadId);
@@ -69,22 +72,17 @@ class ScreenShooter implements Runnable {
     }
   }
 
-  private void takeScreenshot(WebDriverInstance driver) {
+  private void takeScreenshot(WebDriver webDriver) {
     long start = nanoTime();
     log.debug("Taking a screenshot for webdriver in thread {} at {} ...", threadId, start);
 
-    WebDriver webDriver = driver.webDriver();
-    byte[] screenshotBytes = takeScreenshot(webDriver);
+    byte[] screenshotBytes = photographer.takeScreenshot(webDriver, OutputType.BYTES)
+      .orElseThrow(() -> new RuntimeException("Webdriver does not support taking screenshots"));
     File screenshot = saveScreenshot(screenshotBytes);
     long timestamp = nanoTime();
     screenshots.add(new Screenshot(start, new ImageSource(screenshot)));
     long duration = NANOSECONDS.toMillis(timestamp - start);
     log.debug("Taken a screenshot in thread {} at {} in {} ms: {}", threadId, timestamp, duration, screenshot);
-  }
-
-  private byte[] takeScreenshot(WebDriver webDriver) {
-    return photographer.takeScreenshot(webDriver, BYTES)
-      .orElseThrow(() -> new RuntimeException("Webdriver does not support taking screenshots"));
   }
 
   private File saveScreenshot(byte[] screenshot) {

--- a/modules/video-recorder/src/test/java/integration/videorecorder/core/VideoRecorder1Test.java
+++ b/modules/video-recorder/src/test/java/integration/videorecorder/core/VideoRecorder1Test.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static com.codeborne.selenide.Configuration.config;
 import static com.codeborne.selenide.Selenide.$;
@@ -52,10 +53,12 @@ public class VideoRecorder1Test {
   @AfterEach
   public void checkVideo() {
     log.info("finishing first test");
-    videoRecorder.finish();
+    Optional<Path> result = videoRecorder.finish();
     log.info("finished first test");
+
     Path videoFile = getRecordedVideo(currentThread().getId())
       .orElseThrow(() -> new AssertionError("video file not found in thread " + currentThread()));
+    assertThat(result).contains(videoFile);
     assertThat(videoFile).as(() -> "video file not found in thread " + currentThread()).exists();
     assertThat(videoFile).hasExtension("mp4");
     assertThat(videoFile.toFile().length())

--- a/modules/video-recorder/src/test/java/integration/videorecorder/core/VideoRecorder2Test.java
+++ b/modules/video-recorder/src/test/java/integration/videorecorder/core/VideoRecorder2Test.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static com.codeborne.selenide.Configuration.config;
 import static com.codeborne.selenide.Selenide.$;
@@ -55,10 +56,12 @@ public class VideoRecorder2Test {
   @AfterEach
   public void checkVideo() {
     log.info("finishing second test");
-    videoRecorder.finish();
+    Optional<Path> result = videoRecorder.finish();
     log.info("finished second test");
     Path videoFile = getRecordedVideo(currentThread().getId())
       .orElseThrow(() -> new AssertionError("video file not found in thread " + currentThread()));
+
+    assertThat(result).contains(videoFile);
     assertThat(videoFile).as(() -> "video file not found in thread " + currentThread()).exists();
     assertThat(videoFile).hasExtension("mp4");
     assertThat(videoFile.toFile().length())

--- a/modules/video-recorder/src/test/java/integration/videorecorder/core/VideoRecorder3Test.java
+++ b/modules/video-recorder/src/test/java/integration/videorecorder/core/VideoRecorder3Test.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static com.codeborne.selenide.Configuration.config;
 import static com.codeborne.selenide.Selenide.$;
@@ -52,10 +53,12 @@ public class VideoRecorder3Test {
   @AfterEach
   public void checkVideo() {
     log.info("finishing third test");
-    videoRecorder.finish();
+    Optional<Path> result = videoRecorder.finish();
     log.info("finish third test");
     Path videoFile = getRecordedVideo(currentThread().getId())
       .orElseThrow(() -> new AssertionError("video file not found in thread " + currentThread()));
+
+    assertThat(result).contains(videoFile);
     assertThat(videoFile).as(() -> "video file not found in thread " + currentThread()).exists();
     assertThat(videoFile).hasExtension("mp4");
     assertThat(videoFile.toFile().length())


### PR DESCRIPTION
Make it possible to use Video Recorder in projects that are not using Selenide.

This PR adds an optional parameter `webDriverSupplier` to method `VideoRecorder.start()`.

## Usage

```java
import org.selenide.videorecorder.core.VideoRecorder;
import java.nio.file.Path;
import java.util.Optional;

public class BaseTest {
  private final VideoRecorder videoRecorder = new VideoRecorder();

  @Before
  void setUp() {
    WebDriver driver = < ... any webdriver creation logic ... >;
    videoRecorder.start(() -> Optional.of(driver));
  }

  @After
  void tearDown() {
    Optional<Path> videoFile = videoRecorder.finish();
    System.out.printf("[[ATTACHMENT|%s]]", videoFile.get().toAbsolutePath());
  }
}
```