### PR TITLE
fix downloading files that have space in name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 allprojects {
   group = 'com.codeborne'
-  version = '7.13.0'
+  version = '7.14.0-SNAPSHOT'
 }
 
 subprojects {

--- a/modules/grid/src/test/java/integration/DownloadFileFromGridToFolderTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridToFolderTest.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.ex.FileNotDownloadedError;
 import com.codeborne.selenide.impl.FileContent;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -69,6 +70,16 @@ final class DownloadFileFromGridToFolderTest extends AbstractGridTest {
 
     assertThat(downloadedFile.getName()).isEqualTo("файл-с-русским-названием.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Превед медвед!");
+    assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());
+  }
+
+  @Test
+  @Disabled("Broken in Selenium 4.39.0; will be fixed in 4.40.0")
+  void downloadsFileWithSpaceInName() {
+    File downloadedFile = $(byText("Download file with space in name")).download(withExtension("txt"));
+
+    assertThat(downloadedFile.getName()).isEqualTo("file 0 & _ ' `backticks`.txt");
+    assertThat(downloadedFile).content().isEqualToIgnoringNewLines("File with space in name\n");
     assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());
   }
 

--- a/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
@@ -8,6 +8,7 @@ import com.codeborne.selenide.impl.FileContent;
 import com.codeborne.selenide.webdriver.ChromeDriverFactory;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -80,6 +81,16 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
 
     assertThat(downloadedFile.getName()).isEqualTo("файл-с-русским-названием.txt");
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Превед медвед!");
+    assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());
+  }
+
+  @Test
+  @Disabled("Broken in Selenium 4.39.0; will be fixed in 4.40.0")
+  void downloadsFileWithSpaceInName() {
+    File downloadedFile = $(byText("Download file with space in name")).download(withExtension("txt"));
+
+    assertThat(downloadedFile.getName()).isEqualTo("file 0 & _ ' `backticks`.txt");
+    assertThat(downloadedFile).content().isEqualToIgnoringNewLines("File with space in name\n");
     assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());
   }
 

--- a/modules/proxy/src/test/java/integration/FileDownloadViaProxyTest.java
+++ b/modules/proxy/src/test/java/integration/FileDownloadViaProxyTest.java
@@ -86,9 +86,9 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
     File downloadedFile = $(byText("Download file with \"forbidden\" characters in name"))
       .download(withNameMatching("имя.*\\.txt"));
 
-    assertThat(downloadedFile).hasName("имя+с+_pound,_percent,_ampersand,_left,_right,_backslash," +
-      "_left,_right,_asterisk,_question,_dollar,_exclamation,_quote,_quotes," +
-      "_colon,_at,_plus,_backtick,_pipe,_equal.txt");
+    assertThat(downloadedFile).hasName("имя с _pound,_percent,&ampersand,_left,_right,_backslash," +
+      "_left,_right,_asterisk,_question,_dollar,_exclamation,'quote,_quotes," +
+      "_colon,_at,_plus,`backtick,_pipe,_equal.txt");
 
     assertThat(downloadedFile).content().isEqualToIgnoringNewLines("Превед \"короед\"! Амперсанды &everywhere&&;$#`");
     assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());

--- a/src/main/java/com/codeborne/selenide/impl/HttpHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/HttpHelper.java
@@ -22,7 +22,7 @@ public class HttpHelper {
   private static final Pattern FILENAME_IN_CONTENT_DISPOSITION_HEADER =
     Pattern.compile(".*filename\\*? *= *\"?((.+)'')?([^\";?]*)\"?(;charset=(.*))?.*", CASE_INSENSITIVE);
 
-  private static final Pattern FILENAME_FORBIDDEN_CHARACTERS = Pattern.compile("[#%&{}/\\\\<>*?$!'\":@+`|=]");
+  private static final Pattern FILENAME_FORBIDDEN_CHARACTERS = Pattern.compile("[#%{}/\\\\<>*?$!\":@+|=]");
   private static final Pattern RE_URL_WITH_CREDENTIALS = Pattern.compile("(.+//).*:.*@(.+)");
 
   public Optional<String> getFileNameFromContentDisposition(Map<String, String> headers) {
@@ -77,7 +77,7 @@ public class HttpHelper {
   }
 
   public String normalize(String fileName) {
-    return FILENAME_FORBIDDEN_CHARACTERS.matcher(fileName).replaceAll("_").replace(' ', '+');
+    return FILENAME_FORBIDDEN_CHARACTERS.matcher(fileName).replaceAll("_");
   }
 
   @Nullable

--- a/src/test/java/com/codeborne/selenide/impl/HttpHelperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/HttpHelperTest.java
@@ -129,7 +129,7 @@ final class HttpHelperTest {
     assertThat(helper.getFileName("/blah.jpg?foo")).isEqualTo("blah.jpg");
     assertThat(helper.getFileName("https://blah.org/blah.jpg")).isEqualTo("blah.jpg");
     assertThat(helper.getFileName("https://blah.org/with spaces`and'forbidden\"characters+&.jpg"))
-      .isEqualTo("with+spaces_and_forbidden_characters__.jpg");
+      .isEqualTo("with spaces`and'forbidden_characters_&.jpg");
 
     assertThat(helper.getFileName("https://some.com/foo/bar/")).isEqualTo("");
   }
@@ -139,15 +139,15 @@ final class HttpHelperTest {
     assertThat(helper.normalize("имя с #pound,%percent,&ampersand,{left,}right,/slash,\\backslash," +
       "<left,>right,*asterisk,?question,$dollar,!exclamation,'quote,\"quotes," +
       ":colon,@at,+plus,`backtick,|pipe,=equal.winrar"))
-      .isEqualTo("имя+с+_pound,_percent,_ampersand,_left,_right,_slash,_backslash," +
-        "_left,_right,_asterisk,_question,_dollar,_exclamation,_quote,_quotes," +
-        "_colon,_at,_plus,_backtick,_pipe,_equal.winrar");
+      .isEqualTo("имя с _pound,_percent,&ampersand,_left,_right,_slash,_backslash," +
+        "_left,_right,_asterisk,_question,_dollar,_exclamation,'quote,_quotes," +
+        "_colon,_at,_plus,`backtick,_pipe,_equal.winrar");
   }
 
   @Test
   void slashIsAlsoReplacedByUnderscore() {
     assertThat(helper.normalize("имя с /slash.winzip"))
-      .isEqualTo("имя+с+_slash.winzip");
+      .isEqualTo("имя с _slash.winzip");
   }
 
   @Test

--- a/src/test/java/integration/server/FileDownloadHandler.java
+++ b/src/test/java/integration/server/FileDownloadHandler.java
@@ -58,7 +58,7 @@ class FileDownloadHandler extends BaseHandler {
 
   private Map<String, String> headers(String fileName, boolean exposeFileName) throws UnsupportedEncodingException {
     return Map.of(
-      "content-disposition", exposeFileName ? "attachment; filename=" + encode(fileName, "UTF-8") : "attachment;",
+      "content-disposition", exposeFileName ? "attachment; filename=" + encode(fileName, "UTF-8").replace("+", "%20") : "attachment;",
       "content-type", contentType(fileName)
     );
   }

--- a/src/test/resources/file 0 & _ ' `backticks`.txt
+++ b/src/test/resources/file 0 & _ ' `backticks`.txt
@@ -1,0 +1,1 @@
+File with space in name

--- a/src/test/resources/page_with_uploads.html
+++ b/src/test/resources/page_with_uploads.html
@@ -14,6 +14,7 @@
     <div><a href="/files/hello_world.txt?duration=1000">Download me slowly</a></div>
     <div><a href="/files/hello_world.txt?duration=2000" id="download-after-delay">Download me super slowly</a></div>
 
+    <div><a href="/files/file%200%20%26%20_%20%27%20%60backticks%60.txt">Download file with space in name</a></div>
     <div><a href="/files/файл-с-русским-названием.txt">Download file with cyrillic name</a></div>
     <div><a href="/files/файл-с-запрещёнными-символами.txt">Download file with "forbidden" characters in name</a></div>
     <div><a href="/files/ø-report.txt">Download file with "ø" in name</a></div>

--- a/statics/src/test/java/integration/DirectFileDownloadTest.java
+++ b/statics/src/test/java/integration/DirectFileDownloadTest.java
@@ -17,12 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 final class DirectFileDownloadTest extends IntegrationTest {
   @BeforeEach
   void setUp() {
+    Configuration.timeout = 4000;
     openFile("page_with_big_divs.html");
   }
 
   @Test
   void downloadFileByDirectLink() throws IOException, URISyntaxException {
-    Configuration.timeout = 4000;
     File file = download("/files/hello_world.txt");
     assertThat(file.getName()).isEqualTo("hello_world.txt");
     assertThat(readFileToString(file, UTF_8)).isEqualTo("Hello, WinRar!");
@@ -30,10 +30,16 @@ final class DirectFileDownloadTest extends IntegrationTest {
 
   @Test
   void downloadFileWithCyrillicName() throws IOException, URISyntaxException {
-    Configuration.timeout = 4000;
     File file = download(new URI("/files/файл-с-русским-названием.txt"));
     assertThat(file.getName()).isEqualTo("файл-с-русским-названием.txt");
     assertThat(readFileToString(file, UTF_8)).isEqualTo("Превед медвед!");
+  }
+
+  @Test
+  void downloadsFileWithSpaceInName() throws URISyntaxException {
+    File file = download("/files/file%200%20%26%20_%20%27%20%60backticks%60.txt");
+    assertThat(file.getName()).isEqualTo("file 0 & _ ' `backticks`.txt");
+    assertThat(file).content().isEqualToIgnoringNewLines("File with space in name\n");
   }
 
   @Test

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -102,6 +102,15 @@ final class FileDownloadToFolderTest extends IntegrationTest {
   }
 
   @Test
+  void downloadsFileWithSpaceInName() {
+    File downloadedFile = $(byText("Download file with space in name")).download(withExtension("txt"));
+
+    assertThat(downloadedFile.getName()).isEqualTo("file 0 & _ ' `backticks`.txt");
+    assertThat(downloadedFile).content().isEqualToIgnoringNewLines("File with space in name");
+    assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());
+  }
+
+  @Test
   void downloadMissingFile() {
     timeout = 111;
     assertThatThrownBy(() -> $(byText("Download missing file")).download(withExtension("txt")))

--- a/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
@@ -94,6 +94,15 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
   }
 
   @Test
+  void downloadsFileWithSpaceInName() {
+    File downloadedFile = $(byText("Download file with space in name")).download(withExtension("txt"));
+
+    assertThat(downloadedFile.getName()).isEqualTo("file 0 & _ ' `backticks`.txt");
+    assertThat(downloadedFile).content().isEqualToIgnoringNewLines("File with space in name");
+    assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());
+  }
+
+  @Test
   void downloadMissingFile() {
     timeout = 111;
     assertThatThrownBy(() -> $(byText("Download missing file")).download(withExtension("png")))

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -99,14 +99,23 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
   }
 
   @Test
+  void downloadsFileWithSpaceInName() {
+    File downloadedFile = $(byText("Download file with space in name")).download(withExtension("txt"));
+
+    assertThat(downloadedFile.getName()).isEqualTo("file 0 & _ ' `backticks`.txt");
+    assertThat(downloadedFile).content().isEqualToIgnoringNewLines("File with space in name");
+    assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());
+  }
+
+  @Test
   void downloadsFileWithForbiddenCharactersInName() {
     File downloadedFile = $(byText("Download file with \"forbidden\" characters in name"))
       .download(withNameMatching("имя.*\\.txt"));
 
     assertThat(downloadedFile.getName())
-      .isEqualTo("имя+с+_pound,_percent,_ampersand,_left,_right,_backslash," +
-        "_left,_right,_asterisk,_question,_dollar,_exclamation,_quote,_quotes," +
-        "_colon,_at,_plus,_backtick,_pipe,_equal.txt");
+      .isEqualTo("имя с _pound,_percent,&ampersand,_left,_right,_backslash," +
+        "_left,_right,_asterisk,_question,_dollar,_exclamation,'quote,_quotes," +
+        "_colon,_at,_plus,`backtick,_pipe,_equal.txt");
     assertThat(downloadedFile).content()
       .isEqualToIgnoringNewLines("Превед \"короед\"! Амперсанды &everywhere&&;$#`");
     assertThat(downloadedFile.getAbsolutePath())

--- a/statics/src/test/java/integration/HrefTest.java
+++ b/statics/src/test/java/integration/HrefTest.java
@@ -32,8 +32,9 @@ final class HrefTest extends IntegrationTest {
     $("a", 0).shouldHave(href("/files/hello_world.txt"));
     $("a", 1).shouldHave(href("/files/hello_world.txt"));
     $("a", 2).shouldHave(href("/files/hello_world.txt?pause=2000"));
-    $("a", 5).shouldHave(href("/files/файл-с-русским-названием.txt"));
-    $("a", 6).shouldHave(href("/files/файл-с-запрещёнными-символами.txt"));
+    $("a", 5).shouldHave(href("/files/file%200%20%26%20_%20%27%20%60backticks%60.txt"));
+    $("a", 6).shouldHave(href("/files/файл-с-русским-названием.txt"));
+    $("a", 7).shouldHave(href("/files/файл-с-запрещёнными-символами.txt"));
     $(byText("Check href value")).shouldHave(href("unexisting%20file%20encoded.png"));
   }
 }


### PR DESCRIPTION
Also, I realized that some symbols (& ' `) are allowed in file name. Browser doesn't replace them with _ when downloading.

For Grid, we are waiting for release 4.40.0 with fix https://github.com/SeleniumHQ/selenium/pull/16844

