### PR TITLE
Add an ability to pass proxy filters via config, and add them as global, even before open() method call

### DIFF
--- a/modules/proxy/src/test/java/integration/ProxyFiltersFromConfigurationTest.java
+++ b/modules/proxy/src/test/java/integration/ProxyFiltersFromConfigurationTest.java
@@ -1,0 +1,32 @@
+package integration;
+
+import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.RequestFilters;
+import com.codeborne.selenide.ResponseFilters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.codeborne.selenide.WebDriverRunner.getSelenideProxy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class ProxyFiltersFromConfigurationTest extends ProxyIntegrationTest {
+  @BeforeEach
+  void setUp() {
+    Configuration.requestFilters = RequestFilters.from("foo-filter.request", (request, contents, messageInfo) -> null);
+    Configuration.responseFilters = ResponseFilters.from("bar-filter.response", (response, contents, messageInfo) -> {
+    });
+
+    openFile("page_with_uploads.html");
+  }
+
+  @Test
+  public void canConfigureProxyFilters() {
+    List<String> requestFilterNames = getSelenideProxy().requestFilterNames();
+    assertThat(requestFilterNames).contains("config.proxy.filter.foo-filter.request");
+
+    List<String> responseFilterNames = getSelenideProxy().responseFilterNames();
+    assertThat(responseFilterNames).contains("config.proxy.filter.bar-filter.response");
+  }
+}

--- a/src/main/java/com/codeborne/selenide/Config.java
+++ b/src/main/java/com/codeborne/selenide/Config.java
@@ -48,4 +48,7 @@ public interface Config {
 
   long remoteReadTimeout();
   long remoteConnectionTimeout();
+
+  RequestFilters requestFilters();
+  ResponseFilters responseFilters();
 }

--- a/src/main/java/com/codeborne/selenide/RequestFilters.java
+++ b/src/main/java/com/codeborne/selenide/RequestFilters.java
@@ -1,0 +1,13 @@
+package com.codeborne.selenide;
+
+import com.browserup.bup.filters.RequestFilter;
+
+import java.util.LinkedHashMap;
+
+public class RequestFilters extends LinkedHashMap<String, RequestFilter> {
+  public static RequestFilters from(final String name, final RequestFilter requestFilter) {
+    final RequestFilters requestFilters = new RequestFilters();
+    requestFilters.put(name, requestFilter);
+    return requestFilters;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/ResponseFilters.java
+++ b/src/main/java/com/codeborne/selenide/ResponseFilters.java
@@ -1,0 +1,14 @@
+package com.codeborne.selenide;
+
+import com.browserup.bup.filters.ResponseFilter;
+
+import java.util.LinkedHashMap;
+
+public class ResponseFilters extends LinkedHashMap<String, ResponseFilter> {
+
+  public static ResponseFilters from(final String name, final ResponseFilter responseFilter) {
+    final ResponseFilters responseFilters = new ResponseFilters();
+    responseFilters.put(name, responseFilter);
+    return responseFilters;
+  }
+}

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -60,6 +60,8 @@ public class SelenideConfig implements Config {
   private int proxyPort = Integer.parseInt(getProperty("selenide.proxyPort", "0"));
   private long remoteReadTimeout = Long.parseLong(getProperty("selenide.remoteReadTimeout", "90000"));
   private long remoteConnectionTimeout = Long.parseLong(getProperty("selenide.remoteConnectionTimeout", "10000"));
+  private RequestFilters requestFilters = new RequestFilters();
+  private ResponseFilters responseFilters = new ResponseFilters();
 
   @Override
   public String baseUrl() {
@@ -434,5 +436,27 @@ public class SelenideConfig implements Config {
   @Override
   public String toString() {
     return getClass().getSimpleName();
+  }
+
+  @Override
+  public RequestFilters requestFilters() {
+    return requestFilters;
+  }
+
+  @CanIgnoreReturnValue
+  public SelenideConfig requestFilters(RequestFilters requestFilters) {
+    this.requestFilters = requestFilters;
+    return this;
+  }
+
+  @Override
+  public ResponseFilters responseFilters() {
+    return responseFilters;
+  }
+
+  @CanIgnoreReturnValue
+  public SelenideConfig responseFilters(ResponseFilters responseFilters) {
+    this.responseFilters = responseFilters;
+    return this;
   }
 }

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -357,6 +357,22 @@ public class Configuration {
   public static long remoteReadTimeout = defaults.remoteReadTimeout();
 
   /**
+   * Proxy request filters.
+   * Warning: this request filters will added only once on proxy start (first open() method call)
+   * <br>
+   * Default value: new RequestFilters()
+   */
+  public static RequestFilters requestFilters = defaults.requestFilters();
+
+  /**
+   * Proxy response filters.
+   * Warning: this response filters will added only once on proxy start (first open() method call)
+   * <br>
+   * Default value: new ResponseFilters()
+   */
+  public static ResponseFilters responseFilters = defaults.responseFilters();
+
+  /**
    * Sets connection timeout in milliseconds for remote browser connections.
    * Applies only when remote is specified.
    * Can be configured either programmatically, via selenide.properties file
@@ -404,6 +420,8 @@ public class Configuration {
       .headless(headless)
       .browserBinary(browserBinary)
       .remoteReadTimeout(remoteReadTimeout)
-      .remoteConnectionTimeout(remoteConnectionTimeout);
+      .remoteConnectionTimeout(remoteConnectionTimeout)
+      .requestFilters(requestFilters)
+      .responseFilters(responseFilters);
   }
 }

--- a/statics/src/main/java/com/codeborne/selenide/StaticConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/StaticConfig.java
@@ -181,6 +181,16 @@ final class StaticConfig implements Config {
   }
 
   @Override
+  public RequestFilters requestFilters() {
+    return Configuration.requestFilters;
+  }
+
+  @Override
+  public ResponseFilters responseFilters() {
+    return Configuration.responseFilters;
+  }
+
+  @Override
   public String toString() {
     return getClass().getSimpleName();
   }

--- a/statics/src/main/java/com/codeborne/selenide/ThreadLocalSelenideConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/ThreadLocalSelenideConfig.java
@@ -187,4 +187,14 @@ final class ThreadLocalSelenideConfig implements Config {
   public long remoteConnectionTimeout() {
     return config.get().remoteConnectionTimeout();
   }
+
+  @Override
+  public RequestFilters requestFilters() {
+    return config.get().requestFilters();
+  }
+
+  @Override
+  public ResponseFilters responseFilters() {
+    return config.get().responseFilters();
+  }
 }

--- a/statics/src/test/java/com/codeborne/selenide/ConfigurationTest.java
+++ b/statics/src/test/java/com/codeborne/selenide/ConfigurationTest.java
@@ -45,8 +45,7 @@ final class ConfigurationTest {
   private Object getSetting(SelenideConfig config, String name) {
     try {
       return SelenideConfig.class.getMethod(name).invoke(config);
-    }
-    catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       throw new RuntimeException(e);
     }
   }
@@ -84,14 +83,20 @@ final class ConfigurationTest {
     if (type.isEnum()) {
       return type.getEnumConstants()[random.nextInt(0, type.getEnumConstants().length)];
     }
+    if (type == RequestFilters.class) {
+      return RequestFilters.from(random.nextDouble() + ".request", (request, contents, messageInfo) -> null);
+    }
+    if (type == ResponseFilters.class) {
+      return ResponseFilters.from(random.nextDouble() + ".response", (response, contents, messageInfo) -> {
+      });
+    }
     return "Tere#" + random.nextDouble();
   }
 
   private static Value getStaticFieldValue(Field field) {
     try {
       return new Value(field.get(null));
-    }
-    catch (IllegalAccessException e) {
+    } catch (IllegalAccessException e) {
       throw new RuntimeException(e);
     }
   }
@@ -99,8 +104,7 @@ final class ConfigurationTest {
   private void setStaticFieldValue(Field field, Value value) {
     try {
       field.set(null, value.value);
-    }
-    catch (IllegalAccessException e) {
+    } catch (IllegalAccessException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
## Proposed changes
Possible solution to resolve #2616

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
