### PR TITLE
Enable fail fast mechanism in download method for selenium grid

### DIFF
--- a/modules/grid/src/main/java/org/selenide/grid/DownloadFileFromGridToFolder.java
+++ b/modules/grid/src/main/java/org/selenide/grid/DownloadFileFromGridToFolder.java
@@ -2,7 +2,6 @@ package org.selenide.grid;
 
 import com.codeborne.selenide.DownloadsFolder;
 import com.codeborne.selenide.Driver;
-import com.codeborne.selenide.files.FileFilter;
 import com.codeborne.selenide.impl.Downloader;
 import org.jspecify.annotations.Nullable;
 
@@ -25,23 +24,6 @@ public class DownloadFileFromGridToFolder extends com.codeborne.selenide.impl.Do
     return driver.isLocalBrowser() ?
       super.getDownloadsFolder(driver) :
       new GridDownloadsFolder(driver);
-  }
-
-  @Override
-  protected void waitWhileFilesAreBeingModified(Driver driver, DownloadsFolder folder, long timeout, long pollingInterval) {
-    if (driver.isLocalBrowser()) {
-      super.waitWhileFilesAreBeingModified(driver, folder, timeout, pollingInterval);
-    }
-    // In Selenium Grid, we don't know files' modification time :(
-  }
-
-  @Override
-  protected void failFastIfNoChanges(Driver driver, DownloadsFolder folder, FileFilter filter,
-                                     long start, long timeout, long incrementTimeout) {
-    if (driver.isLocalBrowser()) {
-      super.failFastIfNoChanges(driver, folder, filter, start, timeout, incrementTimeout);
-    }
-    // In Selenium Grid, we don't know files' modification time :(
   }
 
   @Override

--- a/modules/moon/src/main/java/org/selenide/moon/DownloadFileFromMoonToFolder.java
+++ b/modules/moon/src/main/java/org/selenide/moon/DownloadFileFromMoonToFolder.java
@@ -6,10 +6,14 @@ import com.codeborne.selenide.files.FileFilter;
 import com.codeborne.selenide.impl.DownloadFileToFolder;
 import com.codeborne.selenide.impl.Downloader;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
 public class DownloadFileFromMoonToFolder extends DownloadFileToFolder {
+  private static final Logger log = LoggerFactory.getLogger(DownloadFileFromMoonToFolder.class);
+
   private final Downloader downloader;
 
   public DownloadFileFromMoonToFolder() {
@@ -33,7 +37,7 @@ public class DownloadFileFromMoonToFolder extends DownloadFileToFolder {
     if (driver.isLocalBrowser()) {
       super.waitWhileFilesAreBeingModified(driver, folder, timeout, pollingInterval);
     }
-    // In Moon, we don't know files' modification time :(
+    log.warn("Unable to fail fast if no changes in Moon, we don't know files' modification time");
   }
 
   @Override
@@ -42,7 +46,7 @@ public class DownloadFileFromMoonToFolder extends DownloadFileToFolder {
     if (driver.isLocalBrowser()) {
       super.failFastIfNoChanges(driver, folder, filter, start, timeout, incrementTimeout);
     }
-    // In Moon, we don't know files' modification time :(
+    log.warn("Unable to fail fast if no changes in Moon, we don't know files' modification time");
   }
 
   @Override

--- a/modules/selenoid/src/main/java/org/selenide/selenoid/DownloadFileFromSelenoidToFolder.java
+++ b/modules/selenoid/src/main/java/org/selenide/selenoid/DownloadFileFromSelenoidToFolder.java
@@ -3,12 +3,17 @@ package org.selenide.selenoid;
 import com.codeborne.selenide.DownloadsFolder;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.files.FileFilter;
+import com.codeborne.selenide.impl.DownloadFileToFolder;
 import com.codeborne.selenide.impl.Downloader;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
-public class DownloadFileFromSelenoidToFolder extends com.codeborne.selenide.impl.DownloadFileToFolder {
+public class DownloadFileFromSelenoidToFolder extends DownloadFileToFolder {
+  private static final Logger log = LoggerFactory.getLogger(DownloadFileFromSelenoidToFolder.class);
+
   private final Downloader downloader;
 
   public DownloadFileFromSelenoidToFolder() {
@@ -32,7 +37,7 @@ public class DownloadFileFromSelenoidToFolder extends com.codeborne.selenide.imp
     if (driver.isLocalBrowser()) {
       super.waitWhileFilesAreBeingModified(driver, folder, timeout, pollingInterval);
     }
-    // In Selenoid, we don't know files' modification time :(
+    log.warn("Unable to fail fast if no changes in Selenoid, we don't know files' modification time");
   }
 
   @Override
@@ -41,7 +46,7 @@ public class DownloadFileFromSelenoidToFolder extends com.codeborne.selenide.imp
     if (driver.isLocalBrowser()) {
       super.failFastIfNoChanges(driver, folder, filter, start, timeout, incrementTimeout);
     }
-    // In Selenoid, we don't know files' modification time :(
+    log.warn("Unable to fail fast if no changes in Selenoid, we don't know files' modification time");
   }
 
   @Override


### PR DESCRIPTION
## Proposed changes
Enable fail fast mechanism in download method for selenium grid
Fix issue #3233

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
