### PR TITLE
shorten format of timeouts shown in error messages

### DIFF
--- a/modules/error-message-customizer/src/test/java/integration/CustomErrorMessageTest.java
+++ b/modules/error-message-customizer/src/test/java/integration/CustomErrorMessageTest.java
@@ -20,7 +20,7 @@ public class CustomErrorMessageTest extends IntegrationTest {
       .hasMessageContaining("Actual value: text=\"\"")
       .hasMessageContaining("Screenshot: file:/")
       .hasMessageContaining("Page source: file:/")
-      .hasMessageContaining("Timeout: 2 ms.")
+      .hasMessageContaining("Timeout: 2ms")
       .hasMessageContaining("Page url: about:blank");
   }
 }

--- a/modules/grid/src/test/java/integration/DownloadFileFromGridToFolderTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridToFolderTest.java
@@ -91,17 +91,20 @@ final class DownloadFileFromGridToFolderTest extends AbstractGridTest {
     long start = currentTimeMillis();
 
     DownloadOptions downloadOptions = DownloadOptions.using(FOLDER)
-      .withIncrementTimeout(Duration.ofSeconds(5L))
+      .withIncrementTimeout(Duration.ofMillis(1002L))
       .withFilter(withName("foo.bar"))
-      .withTimeout(Duration.ofMinutes(2L));
+      .withTimeout(Duration.ofSeconds(20));
 
     assertThatThrownBy(() -> $(byText("Download me")).download(downloadOptions))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with name \"foo.bar\" in 120000 ms")
-      .hasMessageFindingMatch("haven't been modified for 50\\d{2}");
+      .hasMessageStartingWith("Failed to download file with name \"foo.bar\" in 20s")
+      .hasMessageFindingMatch("haven't been modified for 1(\\.\\d{1,3})?s")
+      .hasMessageContaining("incrementTimeout: 1.002s");
 
     long end = currentTimeMillis();
-    assertThat(end - start).isLessThan(120_000L);
+    assertThat(end - start)
+      .as("Less than timeout (but greater than increment timeout)")
+      .isBetween(1002L, 10_000L);
   }
 
   @Test
@@ -109,7 +112,7 @@ final class DownloadFileFromGridToFolderTest extends AbstractGridTest {
     timeout = 11;
     assertThatThrownBy(() -> $(byText("Download missing file")).download(withExtension("txt")))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with extension \"txt\" in 11 ms");
+      .hasMessageStartingWith("Failed to download file with extension \"txt\" in 11ms");
   }
 
   @Test

--- a/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
@@ -99,7 +99,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
     timeout = 11;
     assertThatThrownBy(() -> $(byText("Download missing file")).download(withExtension("png")))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with extension \"png\" in 11 ms");
+      .hasMessageStartingWith("Failed to download file with extension \"png\" in 11ms");
   }
 
   @Test

--- a/modules/proxy/src/test/java/integration/FileDownloadViaProxyTest.java
+++ b/modules/proxy/src/test/java/integration/FileDownloadViaProxyTest.java
@@ -99,7 +99,7 @@ final class FileDownloadViaProxyTest extends ProxyIntegrationTest {
     timeout = 10;
     assertThatThrownBy(() -> $(byText("Download missing file")).download(withExtension("pdf")))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with extension \"pdf\" in 10 ms");
+      .hasMessageStartingWith("Failed to download file with extension \"pdf\" in 10ms");
   }
 
   @Test

--- a/src/main/java/com/codeborne/selenide/ClickOptions.java
+++ b/src/main/java/com/codeborne/selenide/ClickOptions.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.impl.DurationFormat;
 import com.codeborne.selenide.impl.HasTimeout;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Keys;
@@ -13,6 +14,8 @@ import static com.codeborne.selenide.commands.Util.merge;
 import static java.util.Collections.emptyList;
 
 public class ClickOptions implements HasTimeout {
+  private static final DurationFormat df = new DurationFormat();
+
   private final int offsetX;
   private final int offsetY;
   private final ClickMethod clickMethod;
@@ -124,7 +127,7 @@ public class ClickOptions implements HasTimeout {
         clickMethod, offsetX, offsetY, force, keysToString());
     else
       return String.format("method: %s, offsetX: %s, offsetY: %s, timeout: %s, force: %s, keys: %s",
-        clickMethod, offsetX, offsetY, timeout, force, keysToString());
+        clickMethod, offsetX, offsetY, df.format(timeout), force, keysToString());
   }
 
   private boolean hasDefaultParameters() {

--- a/src/main/java/com/codeborne/selenide/DownloadOptions.java
+++ b/src/main/java/com/codeborne/selenide/DownloadOptions.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide;
 import com.codeborne.selenide.files.DownloadAction;
 import com.codeborne.selenide.files.FileFilter;
 import com.codeborne.selenide.files.FileFilters;
+import com.codeborne.selenide.impl.DurationFormat;
 import com.codeborne.selenide.impl.HasTimeout;
 import org.jspecify.annotations.Nullable;
 
@@ -14,6 +15,8 @@ import static com.codeborne.selenide.files.FileFilters.none;
 import static java.util.stream.Collectors.joining;
 
 public class DownloadOptions implements HasTimeout {
+  private static final DurationFormat df = new DurationFormat();
+
   @Nullable
   private final FileDownloadMode method;
   @Nullable
@@ -119,8 +122,8 @@ public class DownloadOptions implements HasTimeout {
   public String toString() {
     return Stream.of(
         method == null ? null : "method: %s".formatted(method.name()),
-        timeout == null ? null : "timeout: %s ms".formatted(timeout.toMillis()),
-        incrementTimeout == null ? null : "incrementTimeout: %s ms".formatted(incrementTimeout.toMillis()),
+        timeout == null ? null : "timeout: %s".formatted(df.format(timeout)),
+        incrementTimeout == null ? null : "incrementTimeout: %s".formatted(df.format(incrementTimeout)),
         filter.isEmpty() ? null : filter.toString()
       ).filter(p -> p != null)
       .collect(joining(", "));

--- a/src/main/java/com/codeborne/selenide/ModalOptions.java
+++ b/src/main/java/com/codeborne/selenide/ModalOptions.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.impl.DurationFormat;
 import com.codeborne.selenide.impl.HasTimeout;
 import org.jspecify.annotations.Nullable;
 
@@ -9,6 +10,7 @@ public record ModalOptions(
   @Nullable String expectedText,
   @Nullable Duration timeout
 ) implements HasTimeout {
+  private static final DurationFormat df = new DurationFormat();
 
   public static ModalOptions none() {
     return new ModalOptions(null, null);
@@ -31,10 +33,10 @@ public record ModalOptions(
     if (expectedText == null && timeout == null)
       return "";
     else if (expectedText == null)
-      return String.format("timeout: %s", timeout);
+      return String.format("timeout: %s", df.format(timeout));
     else if (timeout == null)
       return String.format("expected text: \"%s\"", expectedText);
     else
-      return String.format("expected text: \"%s\", timeout: %s ms", expectedText, timeout.toMillis());
+      return String.format("expected text: \"%s\", timeout: %s", expectedText, df.format(timeout));
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
@@ -26,6 +26,7 @@ public class DownloadFileToFolder {
   private static final Logger log = LoggerFactory.getLogger(DownloadFileToFolder.class);
   private static final Set<String> CHROMIUM_TEMPORARY_FILES = Set.of("crdownload", "tmp");
   private static final Set<String> FIREFOX_TEMPORARY_FILES = Set.of("part");
+  private static final DurationFormat df = new DurationFormat();
 
   private final Downloader downloader;
 
@@ -109,7 +110,7 @@ public class DownloadFileToFolder {
 
     if (folder.hasFiles(extension, filter)) {
       String message = String.format("Folder %s still contains files %s after %s ms. " +
-                                     "Apparently, the downloading hasn't completed in time.", folder, extension, timeout);
+                                     "Apparently, the downloading hasn't completed in time.", folder, extension, df.format(timeout));
       throw new FileNotDownloadedError(message, timeout);
     }
   }
@@ -156,7 +157,7 @@ public class DownloadFileToFolder {
     }
 
     log.debug("Matching files still not found -> stop waiting for new files after {} ms. (timeout: {} ms.)",
-      currentTimeMillis() - start, timeout);
+      currentTimeMillis() - start, df.format(timeout));
   }
 
   protected void failFastIfNoChanges(Driver driver, DownloadsFolder folder, FileFilter filter,
@@ -166,11 +167,11 @@ public class DownloadFileToFolder {
     long filesHasNotBeenUpdatedForMs = filesHasNotBeenUpdatedForMs(start, now, lastFileUpdate);
     if (filesHasNotBeenUpdatedForMs > incrementTimeout) {
       String message = String.format(
-        "Failed to download file%s in %d ms: files in %s haven't been modified for %s ms. " +
+        "Failed to download file%s in %s: files in %s haven't been modified for %s " +
         "(started at: %s, lastFileUpdate: %s, now: %s, incrementTimeout: %s)" +
         "%nModification times: %s",
-        filter.description(), timeout, folder, filesHasNotBeenUpdatedForMs,
-        start, lastFileUpdate, now, incrementTimeout,
+        filter.description(), df.format(timeout), folder, df.format(filesHasNotBeenUpdatedForMs),
+        start, lastFileUpdate, now, df.format(incrementTimeout),
         folder.modificationTimes());
       throw new FileNotDownloadedError(message, timeout);
     }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
@@ -36,6 +36,7 @@ import static org.openqa.selenium.devtools.v143.browser.Browser.downloadWillBegi
 
 public class DownloadFileWithCdp {
   private static final Logger log = LoggerFactory.getLogger(DownloadFileWithCdp.class);
+  private static final DurationFormat df = new DurationFormat();
   private static final AtomicLong SEQUENCE = new AtomicLong();
 
   protected final Downloader downloader;
@@ -73,8 +74,8 @@ public class DownloadFileWithCdp {
       CdpDownload download = waitUntilDownloadsCompleted(driver, fileFilter, timeout, incrementTimeout, downloads);
 
       if (!fileFilter.match(new DownloadedFile(download.file(), download.lastModifiedAt, download.fileSize, emptyMap()))) {
-        String message = String.format("Failed to download file%s in %d ms.%s;%n actually downloaded: %s",
-          fileFilter.description(), timeout, fileFilter.description(), download.file().getAbsolutePath());
+        String message = String.format("Failed to download file%s in %s%s;%n actually downloaded: %s",
+          fileFilter.description(), df.format(timeout), fileFilter.description(), download.file().getAbsolutePath());
         throw new FileNotDownloadedError(message, timeout);
       }
 
@@ -112,8 +113,8 @@ public class DownloadFileWithCdp {
     }
     while (!stopwatch.isTimeoutReached());
 
-    String message = "Failed to download file%s in %d ms., found files: %s".formatted(
-      fileFilter.description(), timeout, downloads.folder().files());
+    String message = "Failed to download file%s in %s, found files: %s".formatted(
+      fileFilter.description(), df.format(timeout), downloads.folder().files());
     throw new FileNotDownloadedError(message, timeout);
   }
 
@@ -266,10 +267,10 @@ public class DownloadFileWithCdp {
     long filesHasNotBeenUpdatedForMs = now - lastModifiedAt;
     if (filesHasNotBeenUpdatedForMs > incrementTimeout) {
       String message = String.format(
-        "Failed to download file%s in %d ms: files in %s haven't been modified for %s ms. " +
+        "Failed to download file%s in %s: files in %s haven't been modified for %s " +
         "(lastUpdate: %s, now: %s, incrementTimeout: %s)",
-        filter.description(), timeout, downloads.folder, filesHasNotBeenUpdatedForMs,
-        lastModifiedAt, now, incrementTimeout);
+        filter.description(), df.format(timeout), downloads.folder, df.format(filesHasNotBeenUpdatedForMs),
+        lastModifiedAt, now, df.format(incrementTimeout));
       throw new FileNotDownloadedError(message, timeout);
     }
   }

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
@@ -57,6 +57,7 @@ import static org.apache.hc.client5.http.protocol.HttpClientContext.COOKIE_STORE
 
 public class DownloadFileWithHttpRequest {
   private static final Logger log = LoggerFactory.getLogger(DownloadFileWithHttpRequest.class);
+  private static final DurationFormat df = new DurationFormat();
   private final ElementDescriber describe = inject(ElementDescriber.class);
 
   protected boolean ignoreSelfSignedCerts = true;
@@ -128,8 +129,8 @@ public class DownloadFileWithHttpRequest {
     saveContentToFile(response, downloadedFile);
 
     if (!fileFilter.match(localFile(downloadedFile))) {
-      String message = String.format("Failed to download file from %s in %d ms.%s;%n actually downloaded: %s",
-        url, timeout, fileFilter.description(), downloadedFile.getAbsolutePath());
+      String message = String.format("Failed to download file from %s in %s%s;%n actually downloaded: %s",
+        url, df.format(timeout), fileFilter.description(), downloadedFile.getAbsolutePath());
       throw new FileNotDownloadedError(message, timeout);
     }
     return downloadedFile;

--- a/src/main/java/com/codeborne/selenide/impl/Downloads.java
+++ b/src/main/java/com/codeborne/selenide/impl/Downloads.java
@@ -13,6 +13,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.stream.Collectors.toList;
 
 public class Downloads {
+  private static final DurationFormat df = new DurationFormat();
   private final List<DownloadedFile> files = new CopyOnWriteArrayList<>();
 
   public Downloads() {
@@ -66,7 +67,7 @@ public class Downloads {
   public File firstDownloadedFile(long timeout, FileFilter fileFilter) {
     return firstMatchingFile(fileFilter)
       .orElseThrow(() -> {
-        String message = String.format("Failed to download file%s in %d ms.", fileFilter.description(), timeout);
+        String message = String.format("Failed to download file%s in %s", fileFilter.description(), df.format(timeout));
           return new FileNotDownloadedError(message.trim(), timeout);
         }
       ).getFile();

--- a/src/main/java/com/codeborne/selenide/impl/DurationFormat.java
+++ b/src/main/java/com/codeborne/selenide/impl/DurationFormat.java
@@ -1,22 +1,26 @@
 package com.codeborne.selenide.impl;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.time.Duration;
 
 import static java.util.Locale.ROOT;
 
 public class DurationFormat {
+  private static final DecimalFormat SECONDS = new DecimalFormat("0.###", DecimalFormatSymbols.getInstance(ROOT));
+
   public String format(Duration duration) {
     return format(duration.toMillis());
   }
 
   public String format(long milliseconds) {
     if (milliseconds < 1000) {
-      return String.format("%d ms.", milliseconds);
+      return String.format("%dms", milliseconds);
     }
     if (milliseconds % 1000 == 0) {
-      return String.format("%d s.", milliseconds / 1000);
+      return String.format("%ds", milliseconds / 1000);
     }
 
-    return String.format(ROOT, "%.3f s.", milliseconds / 1000.0);
+    return SECONDS.format(milliseconds / 1000.0) + "s";
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -34,6 +34,7 @@ import static java.util.Arrays.asList;
 
 class SelenideElementProxy<T extends SelenideElement> implements InvocationHandler {
   private static final Logger log = LoggerFactory.getLogger(SelenideElementProxy.class);
+  private static final DurationFormat df = new DurationFormat();
 
   private static final Set<String> methodsToSkipLogging = new HashSet<>(asList(
     "as",
@@ -160,14 +161,14 @@ class SelenideElementProxy<T extends SelenideElement> implements InvocationHandl
         log.debug("Method {} execution failed; stop re-trying. Last error: ", method.getName(), lastError);
         throw lastError;
       }
-      log.debug("Method {} execution failed; will re-try after {} ms (timeout: {} ms). Last error: ",
-        method.getName(), pollingIntervalMs, timeoutMs, lastError);
+      log.debug("Method {} execution failed; will re-try after {} (timeout: {}). Last error: ",
+        method.getName(), df.format(pollingIntervalMs), df.format(timeoutMs), lastError);
       stopwatch.sleep(pollingIntervalMs);
     }
     while (!stopwatch.isTimeoutReached());
 
-    log.debug("Method {} execution failed after re-trying {} ms. with interval {} ms. Last error: ",
-      method.getName(), timeoutMs, pollingIntervalMs, lastError);
+    log.debug("Method {} execution failed after re-trying {} with interval {}. Last error: ",
+      method.getName(), df.format(timeoutMs), df.format(pollingIntervalMs), lastError);
     throw exceptionWrapper.wrap(lastError, webElementSource);
   }
 

--- a/src/test/java/com/codeborne/selenide/DownloadOptionsTest.java
+++ b/src/test/java/com/codeborne/selenide/DownloadOptionsTest.java
@@ -56,10 +56,10 @@ final class DownloadOptionsTest {
       .hasToString("method: PROXY");
 
     assertThat(using(PROXY).withTimeout(9999))
-      .hasToString("method: PROXY, timeout: 9999 ms");
+      .hasToString("method: PROXY, timeout: 9.999s");
 
     assertThat(using(HTTPGET).withTimeout(9999).withExtension("ppt"))
-      .hasToString("method: HTTPGET, timeout: 9999 ms, with extension \"ppt\"");
+      .hasToString("method: HTTPGET, timeout: 9.999s, with extension \"ppt\"");
 
     assertThat(using(FOLDER).withFilter(withExtension("exe")))
       .hasToString("method: FOLDER, with extension \"exe\"");

--- a/src/test/java/com/codeborne/selenide/ModalOptionsTest.java
+++ b/src/test/java/com/codeborne/selenide/ModalOptionsTest.java
@@ -1,0 +1,34 @@
+package com.codeborne.selenide;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static com.codeborne.selenide.ModalOptions.withExpectedText;
+import static com.codeborne.selenide.ModalOptions.withTimeout;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ModalOptionsTest {
+  @Test
+  void toString_none() {
+    assertThat(ModalOptions.none()).hasToString("");
+  }
+
+  @Test
+  void toString_withText() {
+    assertThat(withExpectedText("Are you sure?"))
+      .hasToString("expected text: \"Are you sure?\"");
+  }
+
+  @Test
+  void toString_withTimeout() {
+    assertThat(withTimeout(Duration.ofMillis(1234)))
+      .hasToString("timeout: 1.234s");
+  }
+
+  @Test
+  void toString_withTextAndTimeout() {
+    assertThat(withExpectedText("Are you sure?").timeout(Duration.ofMillis(1234)))
+      .hasToString("expected text: \"Are you sure?\", timeout: 1.234s");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/ex/SelenideErrorFormatterTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/SelenideErrorFormatterTest.java
@@ -29,18 +29,18 @@ final class SelenideErrorFormatterTest {
   @Test
   void formatsTimeoutToReadable() {
     assertThat(errorFormatter.timeout(0))
-      .isEqualToIgnoringNewLines("Timeout: 0 ms.");
+      .isEqualToIgnoringNewLines("Timeout: 0ms");
     assertThat(errorFormatter.timeout(1))
-      .isEqualToIgnoringNewLines("Timeout: 1 ms.");
+      .isEqualToIgnoringNewLines("Timeout: 1ms");
     assertThat(errorFormatter.timeout(999))
-      .isEqualToIgnoringNewLines("Timeout: 999 ms.");
+      .isEqualToIgnoringNewLines("Timeout: 999ms");
     assertThat(errorFormatter.timeout(1000))
-      .isEqualToIgnoringNewLines("Timeout: 1 s.");
+      .isEqualToIgnoringNewLines("Timeout: 1s");
     assertThat(errorFormatter.timeout(1001))
-      .isEqualToIgnoringNewLines("Timeout: 1.001 s.");
+      .isEqualToIgnoringNewLines("Timeout: 1.001s");
     assertThat(errorFormatter.timeout(1500))
-      .isEqualToIgnoringNewLines("Timeout: 1.500 s.");
+      .isEqualToIgnoringNewLines("Timeout: 1.5s");
     assertThat(errorFormatter.timeout(4000))
-      .isEqualToIgnoringNewLines("Timeout: 4 s.");
+      .isEqualToIgnoringNewLines("Timeout: 4s");
   }
 }

--- a/src/test/java/com/codeborne/selenide/ex/TextsSizeMismatchTest.java
+++ b/src/test/java/com/codeborne/selenide/ex/TextsSizeMismatchTest.java
@@ -21,7 +21,7 @@ final class TextsSizeMismatchTest {
       "List size mismatch",
       "expected: = 3, actual: 3",
       "Collection: .characters",
-      "Timeout: 9 s."
+      "Timeout: 9s"
     );
   }
 
@@ -35,7 +35,7 @@ final class TextsSizeMismatchTest {
       "expected: = 3, actual: 3",
       "Because: we expect favorite characters",
       "Collection: .characters",
-      "Timeout: 9 s."
+      "Timeout: 9s"
     );
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
@@ -75,7 +75,7 @@ final class DownloadFileWithProxyServerTest {
 
     assertThatThrownBy(() -> command.download(linkWithHref, link, 3000, none(), click()))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file in 3000 ms");
+      .hasMessageStartingWith("Failed to download file in 3s");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/DurationFormatTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DurationFormatTest.java
@@ -16,32 +16,36 @@ final class DurationFormatTest {
 
   @Test
   void zero() {
-    assertThat(df.format(0)).isEqualTo("0 ms.");
+    assertThat(df.format(0)).isEqualTo("0ms");
   }
 
   @Test
   void lessThanSecond() {
-    assertThat(df.format(1)).isEqualTo("1 ms.");
-    assertThat(df.format(999)).isEqualTo("999 ms.");
+    assertThat(df.format(1)).isEqualTo("1ms");
+    assertThat(df.format(999)).isEqualTo("999ms");
   }
 
   @Test
   void integerSeconds() {
-    assertThat(df.format(1000)).isEqualTo("1 s.");
-    assertThat(df.format(2000)).isEqualTo("2 s.");
+    assertThat(df.format(1000)).isEqualTo("1s");
+    assertThat(df.format(2000)).isEqualTo("2s");
   }
 
   @Test
   void greaterThanSecond() {
-    assertThat(df.format(1500)).isEqualTo("1.500 s.");
-    assertThat(df.format(1567)).isEqualTo("1.567 s.");
-    assertThat(df.format(2001)).isEqualTo("2.001 s.");
+    assertThat(df.format(1500)).isEqualTo("1.5s");
+    assertThat(df.format(1567)).isEqualTo("1.567s");
+    assertThat(df.format(2001)).isEqualTo("2.001s");
   }
 
   @Test
   void greaterThanMinute() {
-    assertThat(df.format(Duration.ofMinutes(1))).isEqualTo("60 s.");
-    assertThat(df.format(Duration.ofMinutes(2).plusSeconds(2))).isEqualTo("122 s.");
-    assertThat(df.format(Duration.ofMinutes(3).plusMillis(300))).isEqualTo("180.300 s.");
+    assertThat(df.format(Duration.ofMinutes(1))).isEqualTo("60s");
+    assertThat(df.format(Duration.ofMinutes(2).plusSeconds(2))).isEqualTo("122s");
+    assertThat(df.format(Duration.ofMinutes(3).plusMillis(300))).isEqualTo("180.3s");
+    assertThat(df.format(Duration.ofMinutes(3).plusMillis(330))).isEqualTo("180.33s");
+    assertThat(df.format(Duration.ofMinutes(3).plusMillis(333))).isEqualTo("180.333s");
+    assertThat(df.format(Duration.ofMinutes(3).plusNanos(333_333_333))).isEqualTo("180.333s");
+    assertThat(df.format(Duration.ofMinutes(3).plusNanos(333_999_999))).isEqualTo("180.333s");
   }
 }

--- a/src/test/java/com/codeborne/selenide/logevents/ArgumentsPrinterTest.java
+++ b/src/test/java/com/codeborne/selenide/logevents/ArgumentsPrinterTest.java
@@ -27,11 +27,11 @@ class ArgumentsPrinterTest {
 
   @Test
   void printsDurationAmongArguments() {
-    assertThat(readableArguments(Duration.ofMillis(900))).isEqualTo("900 ms.");
-    assertThat(readableArguments(visible, Duration.ofSeconds(42))).isEqualTo("[visible, 42 s.]");
-    assertThat(readableArguments(visible, Duration.ofMillis(8500))).isEqualTo("[visible, 8.500 s.]");
-    assertThat(readableArguments(visible, Duration.ofMillis(900))).isEqualTo("[visible, 900 ms.]");
-    assertThat(readableArguments(visible, Duration.ofNanos(0))).isEqualTo("[visible, 0 ms.]");
+    assertThat(readableArguments(Duration.ofMillis(900))).isEqualTo("900ms");
+    assertThat(readableArguments(visible, Duration.ofSeconds(42))).isEqualTo("[visible, 42s]");
+    assertThat(readableArguments(visible, Duration.ofMillis(8500))).isEqualTo("[visible, 8.5s]");
+    assertThat(readableArguments(visible, Duration.ofMillis(900))).isEqualTo("[visible, 900ms]");
+    assertThat(readableArguments(visible, Duration.ofNanos(0))).isEqualTo("[visible, 0ms]");
   }
 
   @Test

--- a/src/test/java/integration/ExecuteMethodTest.java
+++ b/src/test/java/integration/ExecuteMethodTest.java
@@ -52,7 +52,7 @@ final class ExecuteMethodTest extends ITest {
     long startMs = System.currentTimeMillis();
     assertThatCode(() -> $("#non-existing-element").execute(new TripleClick(), Duration.ofMillis(timeout)))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("Timeout: 1.100 s.");
+      .hasMessageContaining("Timeout: 1.1s");
     long elapsedTimeMs = System.currentTimeMillis() - startMs;
     assertThat(elapsedTimeMs).isBetween(timeout, timeout * 5);
   }

--- a/src/test/java/integration/LogicalOperationsWithConditions.java
+++ b/src/test/java/integration/LogicalOperationsWithConditions.java
@@ -83,7 +83,7 @@ final class LogicalOperationsWithConditions extends ITest {
       .hasMessageStartingWith("Element should be text \"Add me\" OR text \"Update me\" {#remove}")
       .hasMessageContaining("Actual value: text=\"Remove me\"")
       .hasMessageContaining("Screenshot: ")
-      .hasMessageContaining("Timeout: 3 ms.");
+      .hasMessageContaining("Timeout: 3ms");
   }
 
   @Test

--- a/src/test/java/integration/TimeoutTest.java
+++ b/src/test/java/integration/TimeoutTest.java
@@ -40,20 +40,20 @@ final class TimeoutTest extends ITest {
   void timeoutShouldBeInMilliseconds() {
     assertThatThrownBy(() -> $(xpath("//h16")).shouldBe(visible, ofMillis(15)))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("15 ms");
+      .hasMessageContaining("15ms");
   }
 
   @Test
   void timeoutShouldBeFormattedInErrorMessage() {
     assertThatThrownBy(() -> $(xpath("//h19")).shouldBe(visible, ofMillis(1500)))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("1.500 s");
+      .hasMessageContaining("1.5s");
   }
 
   @Test
   void timeoutLessThanSecond() {
     assertThatThrownBy(() -> $(xpath("//h18")).shouldBe(visible, ofMillis(800)))
       .isInstanceOf(ElementNotFound.class)
-      .hasMessageContaining("800 ms");
+      .hasMessageContaining("800ms");
   }
 }

--- a/src/test/java/integration/collections/AttributesTest.java
+++ b/src/test/java/integration/collections/AttributesTest.java
@@ -55,7 +55,7 @@ public class AttributesTest extends ITest {
       .hasMessageContaining("Actual (3): [1 uno, 2 duo, 3 trio]")
       .hasMessageContaining("Expected (3): [1  uno, 2  duo, 3  trio]")
       .hasMessageContaining("Collection: .element")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -66,7 +66,7 @@ public class AttributesTest extends ITest {
       .hasMessageContaining("Expected: Attribute: 'data-value' values [1 uno, 2 duo, 3 trio]")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test

--- a/src/test/java/integration/collections/CollectionMethodsTest.java
+++ b/src/test/java/integration/collections/CollectionMethodsTest.java
@@ -184,7 +184,7 @@ final class CollectionMethodsTest extends ITest {
       .shouldHave(texts("foo bar")))
       .isInstanceOf(ElementNotFound.class)
       .hasMessageContaining("Element not found {#multirowTable.findBy(text \"INVALID-TEXT\")/valid-selector}")
-      .hasMessageContaining("Timeout: 1 ms.")
+      .hasMessageContaining("Timeout: 1ms")
       .hasCauseInstanceOf(NoSuchElementException.class)
       .cause()
       .hasMessageStartingWith("Cannot locate an element #multirowTable.findBy(text \"INVALID-TEXT\")");

--- a/src/test/java/integration/collections/CollectionWaitTest.java
+++ b/src/test/java/integration/collections/CollectionWaitTest.java
@@ -46,7 +46,7 @@ final class CollectionWaitTest extends ITest {
       .isInstanceOf(AssertionError.class)
       .hasMessageContaining("expected: = -1, actual: ")
       .hasMessageContaining("collection: #collection li")
-      .hasMessageContaining("Timeout: 3 ms.");
+      .hasMessageContaining("Timeout: 3ms");
     assertTestTookLessThan(500, MILLISECONDS);
   }
 
@@ -74,7 +74,7 @@ final class CollectionWaitTest extends ITest {
                       "Actual (2): [Element #0, Element #1]%n" +
                       "Expected (2): [Element, #wrong]%n" +
                       "Collection: #collection li:first(2)"))
-      .hasMessageContaining("Timeout: 1 s.");
+      .hasMessageContaining("Timeout: 1s");
     assertTestTookMoreThan(1, SECONDS);
   }
 
@@ -96,7 +96,7 @@ final class CollectionWaitTest extends ITest {
       .hasMessageContaining(String.format("Actual (2): [Element #18, Element #19]%n" +
         "Expected (2): [Element, #wrong]%n" +
         "Collection: #collection li:last(2)"))
-        .hasMessageContaining("Timeout: 1 s.");
+        .hasMessageContaining("Timeout: 1s");
     assertTestTookMoreThan(1, SECONDS);
   }
 
@@ -117,7 +117,7 @@ final class CollectionWaitTest extends ITest {
       .hasMessageContaining("Text #0 mismatch (expected: \"Element #88888\", actual: \"Element #18\")")
       .hasMessageContaining("Actual (2): [Element #18, Element #19]")
       .hasMessageContaining("Expected (2): [Element #88888, Element #99999]")
-      .hasMessageContaining("Timeout: 999 ms.");
+      .hasMessageContaining("Timeout: 999ms");
     assertTestTookMoreThan(999, MILLISECONDS);
   }
 

--- a/src/test/java/integration/collections/ExactTextsCaseSensitiveInAnyOrderTest.java
+++ b/src/test/java/integration/collections/ExactTextsCaseSensitiveInAnyOrderTest.java
@@ -73,7 +73,7 @@ class ExactTextsCaseSensitiveInAnyOrderTest extends ITest {
       .hasMessageContaining("Expected: Exact texts case sensitive in any order [content1, content2]")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test

--- a/src/test/java/integration/collections/OrTest.java
+++ b/src/test/java/integration/collections/OrTest.java
@@ -29,6 +29,6 @@ public class OrTest extends ITest {
       .hasMessageContaining("Expected: texts [A, B, C] OR texts [1, 2, 3]")
       .hasMessageContaining("Collection: .element")
       .hasMessageContaining("Screenshot:")
-      .hasMessageContaining("Timeout: 2 ms.");
+      .hasMessageContaining("Timeout: 2ms");
   }
 }

--- a/statics/src/test/java/integration/ClickRelativeTest.java
+++ b/statics/src/test/java/integration/ClickRelativeTest.java
@@ -80,7 +80,7 @@ final class ClickRelativeTest extends IntegrationTest {
       .hasMessageContaining("out of bounds")
       .hasMessageContaining("Screenshot:")
       .hasMessageContaining("Page source:")
-      .hasMessageContaining("Timeout: 123 ms.")
+      .hasMessageContaining("Timeout: 123ms")
       .hasCauseInstanceOf(MoveTargetOutOfBoundsException.class);
   }
 

--- a/statics/src/test/java/integration/ConfirmTest.java
+++ b/statics/src/test/java/integration/ConfirmTest.java
@@ -116,7 +116,7 @@ final class ConfirmTest extends IntegrationTest {
       .hasMessageContaining("Actual: Get out of this page, %s?".formatted(USER_NAME))
       .hasMessageContaining("Expected: Get out of this page, Maria?")
       .hasMessageMatching("(?s).*Page source: file:.+\\.html.*")
-      .hasMessageMatching("(?s).*Timeout: .+ m?s\\..*");
+      .hasMessageMatching("(?s).*Timeout: .+m?s.*");
   }
 
   @Test

--- a/statics/src/test/java/integration/DefaultClipboardTest.java
+++ b/statics/src/test/java/integration/DefaultClipboardTest.java
@@ -47,7 +47,7 @@ public class DefaultClipboardTest extends IntegrationTest {
       .isInstanceOf(ConditionNotMetError.class)
       .hasMessageStartingWith("clipboard should have content 'Goodbye World'")
       .hasMessageContaining("Actual value: Hello World")
-      .hasMessageContaining("Timeout: 22 ms.");
+      .hasMessageContaining("Timeout: 22ms");
   }
 
   @Test
@@ -59,7 +59,7 @@ public class DefaultClipboardTest extends IntegrationTest {
       .isInstanceOf(ConditionMetError.class)
       .hasMessageStartingWith("clipboard should not have content 'Hello World'")
       .hasMessageContaining("Actual value: Hello World")
-      .hasMessageContaining("Timeout: 300 ms.");
+      .hasMessageContaining("Timeout: 300ms");
   }
 
   @Test

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -115,7 +115,7 @@ final class FileDownloadToFolderTest extends IntegrationTest {
     timeout = 111;
     assertThatThrownBy(() -> $(byText("Download missing file")).download(withExtension("txt")))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with extension \"txt\" in 111 ms");
+      .hasMessageStartingWith("Failed to download file with extension \"txt\" in 111ms");
   }
 
   @Test
@@ -131,7 +131,7 @@ final class FileDownloadToFolderTest extends IntegrationTest {
       .hasMessageStartingWith("Element not found {#imaginary-button}")
       .hasMessageContaining("Screenshot:")
       .hasMessageContaining("Page source:")
-      .hasMessageContaining("Timeout: 300 ms.")
+      .hasMessageContaining("Timeout: 300ms")
       .cause()
       .isInstanceOf(NoSuchElementException.class);
 
@@ -255,9 +255,9 @@ final class FileDownloadToFolderTest extends IntegrationTest {
     assertThatThrownBy(() -> $("h1")
       .download(shortIncrementTimeout))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with name \"hello_world.txt\" in 10000 ms")
-      .hasMessageMatching(Pattern.compile("(?s).+files in .+ haven't been modified for \\d+ ms\\. +" +
-        "\\(started at: \\d+, lastFileUpdate: -?\\d+, now: \\d+, incrementTimeout: 1001\\)\\s*" +
+      .hasMessageStartingWith("Failed to download file with name \"hello_world.txt\" in 10s")
+      .hasMessageMatching(Pattern.compile("(?s).+files in .+ haven't been modified for [\\d.]+s +" +
+        "\\(started at: \\d+, lastFileUpdate: -?\\d+, now: \\d+, incrementTimeout: 1\\.001s\\)\\s*" +
         "Modification times: \\{.*}.*", DOTALL));
 
     closeWebDriver();
@@ -285,13 +285,15 @@ final class FileDownloadToFolderTest extends IntegrationTest {
       assertThat(file).content(UTF_8).isEqualToIgnoringNewLines("Hello, WinRar!");
     })
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with name \"hello_world.txt\" in 10000 ms")
-      .hasMessageMatching(Pattern.compile("(?s).+files in .+ haven't been modified for \\d+ ms\\..*", DOTALL));
+      .hasMessageStartingWith("Failed to download file with name \"hello_world.txt\" in 10s")
+      .hasMessageContaining("incrementTimeout: 1s")
+      .hasMessageMatching(Pattern.compile("(?s).+files in .+ haven't been modified for [\\d.]+s.*", DOTALL));
 
     closeWebDriver();
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void download_slowly() {
     File downloadedFile = $(byText("Download me slowly"))
       .download(4000, withName("hello_world.txt"));

--- a/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
@@ -107,7 +107,7 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
     timeout = 111;
     assertThatThrownBy(() -> $(byText("Download missing file")).download(withExtension("png")))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with extension \"png\" in 111 ms");
+      .hasMessageStartingWith("Failed to download file with extension \"png\" in 111ms");
   }
 
   @Test
@@ -115,7 +115,7 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
     timeout = 111;
     assertThatThrownBy(() -> $(byText("Download me")).download(withExtension("pdf")))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download file with extension \"pdf\" in 111 ms");
+      .hasMessageStartingWith("Failed to download file with extension \"pdf\" in 111ms");
   }
 
   @Test
@@ -242,9 +242,9 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
       .download(shortIncrementTimeout))
       .isInstanceOf(FileNotDownloadedError.class)
       .hasMessageStartingWith("""
-        Failed to download file with name "hello_world.txt" in 10000 ms""")
+        Failed to download file with name "hello_world.txt" in 10s""")
       .hasMessageMatching(Pattern.compile("""
-        (?s).+: files in .+ haven't been modified for \\d+ ms\\. +\\(lastUpdate: -?\\d+, now: \\d+, incrementTimeout: 201\\).*
+        (?s).+: files in .+ haven't been modified for \\d+ms +\\(lastUpdate: -?\\d+, now: \\d+, incrementTimeout: 201ms\\).*
         """.trim(), DOTALL));
 
     closeWebDriver();

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -144,7 +144,7 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
     assertThatThrownBy(() -> $(byText("Download me")).download(withName("good_bye_world.txt")))
       .isInstanceOf(FileNotDownloadedError.class)
       .hasMessageMatching(Pattern.compile("""
-        Failed to download file from http.+/files/hello_world\\.txt in 1000 ms\\. with name "good_bye_world\\.txt";.*""", DOTALL))
+        Failed to download file from http.+/files/hello_world\\.txt in 1s with name "good_bye_world\\.txt";.*""", DOTALL))
       .hasMessageMatching(Pattern.compile("""
         .*actually downloaded: .+hello_world\\.txt.*""", DOTALL));
 

--- a/statics/src/test/java/integration/LocalStorageTest.java
+++ b/statics/src/test/java/integration/LocalStorageTest.java
@@ -91,7 +91,7 @@ final class LocalStorageTest extends IntegrationTest {
       .hasMessageStartingWith("localStorage should have item 'foo'")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 10 ms.");
+      .hasMessageContaining("Timeout: 10ms");
   }
 
   @Test
@@ -105,7 +105,7 @@ final class LocalStorageTest extends IntegrationTest {
       .hasMessageStartingWith("localStorage should have item 'it' with value 'wrong'")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -138,7 +138,7 @@ final class LocalStorageTest extends IntegrationTest {
       .hasMessageStartingWith("localStorage should not have item 'cat'")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -152,7 +152,7 @@ final class LocalStorageTest extends IntegrationTest {
       .hasMessageStartingWith("localStorage should not have item 'cat' with value 'Tom'")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test

--- a/statics/src/test/java/integration/SelenideMethodsTest.java
+++ b/statics/src/test/java/integration/SelenideMethodsTest.java
@@ -276,7 +276,7 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isInstanceOf(ElementShould.class)
       .hasMessageContaining("Element should have text \"wrong-text\" {#username-blur-counter}")
       .hasMessageContaining("Actual value: text=\"___\"")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -341,7 +341,7 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageContaining("Element should not have css class \"firstname\" {by text: Bob}")
       .hasMessageContaining("Actual value: class=\"firstname\"")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -462,7 +462,7 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isInstanceOf(ElementShould.class)
       .hasMessageContaining("Element should have text \"Some wrong test\" (because it's wrong text) {h1}")
       .hasMessageContaining("Actual value: text=\"Page with selects\"")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -471,7 +471,7 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isInstanceOf(ElementShould.class)
       .hasMessageContaining("Element should have text \"Some wrong test\" (because it's wrong text) {h1}")
       .hasMessageContaining("Actual value: text=\"Page with selects\"")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -480,7 +480,7 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isInstanceOf(ElementShould.class)
       .hasMessageContaining("Element should have text \"Some wrong test\" (because it's wrong text) {h1}")
       .hasMessageContaining("Actual value: text=\"Page with selects\"")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -489,7 +489,7 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageStartingWith("Element should not have text \"Page with selects\" (because it's wrong text) {h1}")
       .hasMessageContaining("Actual value: text=\"Page with selects\"")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -500,7 +500,7 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageStartingWith("Element should not be visible (because we expect it do disappear) {h1}")
       .hasMessageContaining("Actual value: visible")
-      .hasMessageContaining("Timeout: 200 ms.");
+      .hasMessageContaining("Timeout: 200ms");
   }
 
   @Test
@@ -511,7 +511,7 @@ final class SelenideMethodsTest extends IntegrationTest {
       .isInstanceOf(ElementShould.class)
       .hasMessageStartingWith("Element should be hidden (because it's sensitive information) {h1}")
       .hasMessageContaining("Actual value: visible")
-      .hasMessageContaining("Timeout: 100 ms.");
+      .hasMessageContaining("Timeout: 100ms");
   }
 
   @Test

--- a/statics/src/test/java/integration/SessionStorageTest.java
+++ b/statics/src/test/java/integration/SessionStorageTest.java
@@ -73,7 +73,7 @@ final class SessionStorageTest extends IntegrationTest {
       .hasMessageStartingWith("sessionStorage should have item 'foo'")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 10 ms.");
+      .hasMessageContaining("Timeout: 10ms");
   }
 
   @Test
@@ -87,7 +87,7 @@ final class SessionStorageTest extends IntegrationTest {
       .hasMessageStartingWith("sessionStorage should have item 'it' with value 'wrong'")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -121,7 +121,7 @@ final class SessionStorageTest extends IntegrationTest {
       .hasMessageStartingWith("sessionStorage should not have item 'cat'")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -135,6 +135,6 @@ final class SessionStorageTest extends IntegrationTest {
       .hasMessageStartingWith("sessionStorage should not have item 'cat' with value 'Tom'")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 }

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -52,7 +52,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
       .hasMessageStartingWith("webdriver should have url page_with_frames.html")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 10 ms.");
+      .hasMessageContaining("Timeout: 10ms");
   }
 
   @Test
@@ -64,7 +64,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
       .hasMessageStartingWith("webdriver should have url page_with_frames.html (because wrong url)")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 10 ms.");
+      .hasMessageContaining("Timeout: 10ms");
   }
 
   @Test
@@ -76,7 +76,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
       .hasMessageStartingWith("webdriver should not have url " + baseUrl + "/page_with_frames_with_delays.html (because wrong url)")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 10 ms.");
+      .hasMessageContaining("Timeout: 10ms");
   }
 
   @Test
@@ -92,7 +92,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
       .hasMessageContaining("Actual value: " + url)
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 11 ms.");
+      .hasMessageContaining("Timeout: 11ms");
   }
 
   @Test
@@ -115,7 +115,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
       .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 10 ms.");
+      .hasMessageContaining("Timeout: 10ms");
   }
 
   @Test
@@ -133,7 +133,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
       .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 20 ms.");
+      .hasMessageContaining("Timeout: 20ms");
   }
 
   @Test
@@ -156,7 +156,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
       .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 5 ms.");
+      .hasMessageContaining("Timeout: 5ms");
   }
 
   @Test
@@ -276,7 +276,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
       .hasMessageContaining("Actual value: Available cookies: [TEST_COOKIE=AF33892F98ABC39A")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test

--- a/statics/src/test/java/integration/errormessages/MethodCalledOnElementWithInvalidOperationFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/MethodCalledOnElementWithInvalidOperationFailsOnTest.java
@@ -29,6 +29,6 @@ final class MethodCalledOnElementWithInvalidOperationFailsOnTest extends Integra
       $("[name=username]").sendKeys("\uD83D\uDE06"))
       .isInstanceOf(UIAssertionError.class)
       .hasMessageContaining("WebDriverException: unknown error: ChromeDriver only supports characters in the BMP")
-      .hasMessageContaining("Timeout: 300 ms.");
+      .hasMessageContaining("Timeout: 300ms");
   }
 }

--- a/statics/src/test/java/integration/errormessages/MissingElementTest.java
+++ b/statics/src/test/java/integration/errormessages/MissingElementTest.java
@@ -68,7 +68,7 @@ final class MissingElementTest extends IntegrationTest {
         "Expected: text \"expected text\"%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.%n" +
+        "Timeout: 15ms%n" +
         "Caused by: NoSuchElementException:.*", path, png(), path, html()))
       .has(screenshot(path("elementNotFound")))
       .cause()
@@ -91,7 +91,7 @@ final class MissingElementTest extends IntegrationTest {
         "Actual value: text=\"Dropdown list\"%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.", path, png(), path, html()));
+        "Timeout: 15ms", path, png(), path, html()));
     assertThat(e.getActual().getStringRepresentation()).isEqualTo("text=\"Dropdown list\"");
     assertThat(e.getExpected().getStringRepresentation()).isEqualTo("text \"expected text\"");
   }
@@ -109,7 +109,7 @@ final class MissingElementTest extends IntegrationTest {
         "Actual value: name=\"\"%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.", path, png(), path, html()));
+        "Timeout: 15ms", path, png(), path, html()));
     assertThat(e.getActual().getStringRepresentation()).isEqualTo("name=\"\"");
     assertThat(e.getExpected().getStringRepresentation()).isEqualTo("attribute name=\"header\"");
   }
@@ -127,7 +127,7 @@ final class MissingElementTest extends IntegrationTest {
         "Actual value: text=\"Dropdown list\"%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.", path, png(), path, html()));
+        "Timeout: 15ms", path, png(), path, html()));
     assertThat(e.getActual().getStringRepresentation()).isEqualTo("text=\"Dropdown list\"");
     assertThat(e.getExpected().getStringRepresentation()).isEqualTo("text \"expected text\"");
   }
@@ -146,7 +146,7 @@ final class MissingElementTest extends IntegrationTest {
           "Actual value: hidden, opacity=1%n" +
           "Screenshot: %s%s%n" +
           "Page source: %s%s%n" +
-          "Timeout: 15 ms.", path, png(), path, html()));
+          "Timeout: 15ms", path, png(), path, html()));
     assertThat(e.getActual().getStringRepresentation()).isEqualTo("hidden, opacity=1");
     assertThat(e.getExpected().getStringRepresentation()).isEqualTo("clickable: interactable and enabled");
   }
@@ -164,7 +164,7 @@ final class MissingElementTest extends IntegrationTest {
         "Actual value: text=\"Dropdown list\"%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.", path, png(), path, html()));
+        "Timeout: 15ms", path, png(), path, html()));
     assertThat(e.getActual().getStringRepresentation()).isEqualTo("text=\"Dropdown list\"");
     assertThat(e.getExpected().getStringRepresentation()).isEqualTo("text \"expected text\"");
   }
@@ -182,7 +182,7 @@ final class MissingElementTest extends IntegrationTest {
         "Actual value: text=\"Dropdown list\"%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.", path, png(), path, html()));
+        "Timeout: 15ms", path, png(), path, html()));
     assertThat(e.getActual().getStringRepresentation()).isEqualTo("text=\"Dropdown list\"");
     assertThat(e.getExpected().getStringRepresentation()).isEqualTo("text \"expected text\"");
   }
@@ -211,7 +211,7 @@ final class MissingElementTest extends IntegrationTest {
         "Expected: clickable: interactable and enabled%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.%n" +
+        "Timeout: 15ms%n" +
         "Caused by: NoSuchElementException:.*", path, png(), path, html()));
     assertThat(e.getActual()).isNull();
     assertThat(e.getExpected()).isNull();
@@ -230,7 +230,7 @@ final class MissingElementTest extends IntegrationTest {
         "Actual value: exists%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.", path, png(), path, html()));
+        "Timeout: 15ms", path, png(), path, html()));
     assertThat(e.getActual().getStringRepresentation()).isEqualTo("exists");
     assertThat(e.getExpected().getStringRepresentation()).isEqualTo("not exist");
   }
@@ -247,7 +247,7 @@ final class MissingElementTest extends IntegrationTest {
         "Expected: not hidden%n" +
         "Screenshot: %s%s%n" +
         "Page source: %s%s%n" +
-        "Timeout: 15 ms.%n" +
+        "Timeout: 15ms%n" +
         "Caused by: NoSuchElementException:.*", path, png(), path, html()));
 
     assertThat(e.getActual()).isNull();

--- a/statics/src/test/java/integration/errormessages/ShouldMethodWithTimeoutFailsOnTest.java
+++ b/statics/src/test/java/integration/errormessages/ShouldMethodWithTimeoutFailsOnTest.java
@@ -37,7 +37,7 @@ final class ShouldMethodWithTimeoutFailsOnTest extends IntegrationTest {
     assertThatThrownBy(() -> element.shouldHave(text("Müller"), Duration.ofMillis(43)))
       .isInstanceOf(ElementShould.class)
       .hasMessageStartingWith("Element should have text \"Müller\" {.detective}")
-      .hasMessageContaining("Timeout: 43 ms.");
+      .hasMessageContaining("Timeout: 43ms");
   }
 
   @Test
@@ -48,7 +48,7 @@ final class ShouldMethodWithTimeoutFailsOnTest extends IntegrationTest {
       .isInstanceOf(ElementNotFound.class)
       .hasMessageStartingWith("Element not found {ul .nonexistent[1]}")
       .hasMessageContaining("Expected: visible")
-      .hasMessageContaining("Timeout: 1 ms.");
+      .hasMessageContaining("Timeout: 1ms");
   }
 
   @Test
@@ -59,7 +59,7 @@ final class ShouldMethodWithTimeoutFailsOnTest extends IntegrationTest {
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageStartingWith("Element should not be visible {.detective}")
       .hasMessageContaining("Actual value: visible")
-      .hasMessageContaining("Timeout: 46 ms.");
+      .hasMessageContaining("Timeout: 46ms");
   }
 
   @Test
@@ -69,6 +69,6 @@ final class ShouldMethodWithTimeoutFailsOnTest extends IntegrationTest {
     assertThatThrownBy(() -> element.shouldNotHave(text("Miller detective"), Duration.ofNanos(20001000)))
       .isInstanceOf(ElementShouldNot.class)
       .hasMessageStartingWith("Element should not have text \"Miller detective\" {.detective}")
-      .hasMessageContaining("Timeout: 20 ms.");
+      .hasMessageContaining("Timeout: 20ms");
   }
 }

--- a/statics/src/test/java/integration/pageobjects/LazyPageObjectTest.java
+++ b/statics/src/test/java/integration/pageobjects/LazyPageObjectTest.java
@@ -62,7 +62,7 @@ public class LazyPageObjectTest extends IntegrationTest {
     assertThatThrownBy(thisLineShouldNotFail::size)
       .isInstanceOf(ElementNotFound.class)
       .hasMessageStartingWith("Element not found {By.className: wrong-content/form}")
-      .hasMessageContaining("Timeout: 0 ms.")
+      .hasMessageContaining("Timeout: 0ms")
       .cause()
       .isInstanceOf(NoSuchElementException.class);
   }


### PR DESCRIPTION
"100 ms." -> "100ms"

I've removed space and dot. It's readable, compact and resistant to punctuation edge cases.
