### PR TITLE
#3227 fix downloading file from Grid which is few seconds behind the central time

### DIFF
--- a/modules/grid/src/main/java/org/selenide/grid/GridDownloadsFolder.java
+++ b/modules/grid/src/main/java/org/selenide/grid/GridDownloadsFolder.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import static com.codeborne.selenide.impl.WebdriverUnwrapper.unwrapRemoteWebDriver;
 import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toList;
 
 public class GridDownloadsFolder implements DownloadsFolder {
   private final RemoteWebDriver webDriver;
@@ -37,13 +36,6 @@ public class GridDownloadsFolder implements DownloadsFolder {
       .map(fileOnGrid -> new DownloadedFile(
         new File(fileOnGrid.getName()), fileOnGrid.getLastModifiedTime(), fileOnGrid.getSize(), emptyMap()))
       .toList();
-  }
-
-  @Override
-  public List<DownloadedFile> filesNewerThan(long modifiedAfterTs) {
-    return files().stream()
-      .filter(fileInfo -> fileInfo.isFileModifiedLaterThan(modifiedAfterTs))
-      .collect(toList());
   }
 
   @Override

--- a/modules/grid/src/test/java/integration/AbstractGridTest.java
+++ b/modules/grid/src/test/java/integration/AbstractGridTest.java
@@ -58,6 +58,9 @@ abstract class AbstractGridTest extends IntegrationTest {
 
   @BeforeAll
   static synchronized void setUpGrid() throws MalformedURLException {
+//    gridUrl = new URL("http://192.168.105.1:4444/wd/hub");
+//    gridUrl = new URL("http://192.168.0.41:4444/wd/hub"); // home old mac
+//    gridUrl = new URL("http://10.10.10.151:4444/wd/hub"); // office old mac
     if (gridUrl == null) {
       for (int tries = 0; tries < 3; tries++) {
         int port = findFreePort();

--- a/modules/moon/src/main/java/org/selenide/moon/MoonDownloadsFolder.java
+++ b/modules/moon/src/main/java/org/selenide/moon/MoonDownloadsFolder.java
@@ -32,15 +32,6 @@ public class MoonDownloadsFolder implements DownloadsFolder {
     return files.stream().map(name -> fileWithName(name)).collect(toList());
   }
 
-  /**
-   * @param modifiedAfterTs ignored
-   * @return all downloaded files because Moon API doesn't provide info about file modification time :(
-   */
-  @Override
-  public List<DownloadedFile> filesNewerThan(long modifiedAfterTs) {
-    return files();
-  }
-
   @Override
   public String toString() {
     return moonClient.toString();

--- a/modules/selenoid/src/main/java/org/selenide/selenoid/SelenoidDownloadsFolder.java
+++ b/modules/selenoid/src/main/java/org/selenide/selenoid/SelenoidDownloadsFolder.java
@@ -32,15 +32,6 @@ public class SelenoidDownloadsFolder implements DownloadsFolder {
     return files.stream().map(name -> fileWithName(name)).collect(toList());
   }
 
-  /**
-   * @param modifiedAfterTs ignored
-   * @return all downloaded files because Selenoid API doesn't provide info about file modification time :(
-   */
-  @Override
-  public List<DownloadedFile> filesNewerThan(long modifiedAfterTs) {
-    return files();
-  }
-
   @Override
   public String toString() {
     return selenoidClient.toString();

--- a/src/main/java/com/codeborne/selenide/BrowserDownloadsFolder.java
+++ b/src/main/java/com/codeborne/selenide/BrowserDownloadsFolder.java
@@ -43,14 +43,6 @@ public class BrowserDownloadsFolder implements DownloadsFolder {
       .toList();
   }
 
-  @Override
-  public List<DownloadedFile> filesNewerThan(long modifiedAfterTs) {
-    return files().stream()
-      .filter(file -> file.lastModifiedTime() > 0)
-      .filter(file -> file.isFileModifiedLaterThan(modifiedAfterTs))
-      .collect(toList());
-  }
-
   public File file(String fileName) {
     return new File(folder, fileName).getAbsoluteFile();
   }

--- a/src/main/java/com/codeborne/selenide/DownloadsFolder.java
+++ b/src/main/java/com/codeborne/selenide/DownloadsFolder.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide;
 import com.codeborne.selenide.files.DownloadedFile;
 import com.codeborne.selenide.files.FileFilter;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -11,11 +12,18 @@ import java.util.Set;
 import static java.util.Locale.ROOT;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 public interface DownloadsFolder {
   List<DownloadedFile> files();
 
-  List<DownloadedFile> filesNewerThan(long modifiedAfterTs);
+  default List<DownloadedFile> filesExcept(List<DownloadedFile> previousFiles) {
+    Collection<String> previousFilenames = previousFiles.stream().map(DownloadedFile::getName).collect(toSet());
+    List<DownloadedFile> files = files();
+    return files.stream()
+      .filter(file -> !previousFilenames.contains(file.getName()))
+      .toList();
+  }
 
   void cleanupBeforeDownload();
 

--- a/src/main/java/com/codeborne/selenide/impl/DownloadDetector.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadDetector.java
@@ -36,7 +36,7 @@ public class DownloadDetector implements Comparator<DownloadedFile>, Serializabl
       if (result == 0) {
         result = Long.compare(file1.getFile().lastModified(), file2.getFile().lastModified());
         if (result == 0) {
-          result = file1.getFile().getName().compareTo(file2.getFile().getName());
+          result = file1.getName().compareTo(file2.getName());
         }
       }
     }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -152,7 +152,6 @@ class SelenideElementProxy<T extends SelenideElement> implements InvocationHandl
         throw Cleanup.of.wrapInvalidSelectorException(lastError);
       }
       else if (lastError instanceof StopCommandExecutionException stop) {
-        lastError = stop;
         if (stopwatch.getElapsedTimeMs() >= stop.timeoutMs()) {
           throw lastError;
         }

--- a/src/test/java/com/codeborne/selenide/DownloadsFolderTest.java
+++ b/src/test/java/com/codeborne/selenide/DownloadsFolderTest.java
@@ -1,0 +1,57 @@
+package com.codeborne.selenide;
+
+import com.codeborne.selenide.files.DownloadedFile;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.codeborne.selenide.files.DownloadedFile.fileWithName;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@NullMarked
+class DownloadsFolderTest {
+  @Test
+  void filesExcept() {
+    DownloadedFile f1 = fileWithName("hello.txt");
+    DownloadedFile f2 = fileWithName("goodbye.txt");
+    DownloadedFile f3 = fileWithName("report.pdf");
+
+    DummyDownloadsFolder folder = new DummyDownloadsFolder(List.of(f1, f2, f3));
+
+    assertThat(folder.filesExcept(emptyList())).containsExactly(f1, f2, f3);
+    assertThat(folder.filesExcept(List.of(f1))).containsExactly(f2, f3);
+    assertThat(folder.filesExcept(List.of(f2))).containsExactly(f1, f3);
+    assertThat(folder.filesExcept(List.of(f3))).containsExactly(f1, f2);
+    assertThat(folder.filesExcept(List.of(f2, f3))).containsExactly(f1);
+    assertThat(folder.filesExcept(List.of(f1, f2, f3))).isEmpty();
+  }
+
+  @Test
+  void filesExcept_emptyFolder() {
+    DummyDownloadsFolder folder = new DummyDownloadsFolder(emptyList());
+
+    assertThat(folder.filesExcept(emptyList())).isEmpty();
+    assertThat(folder.filesExcept(List.of())).isEmpty();
+    assertThat(folder.filesExcept(List.of(fileWithName("hello.txt")))).isEmpty();
+  }
+
+  private record DummyDownloadsFolder(
+    List<DownloadedFile> files
+  ) implements DownloadsFolder {
+
+    @Override
+    public void cleanupBeforeDownload() {
+    }
+
+    @Override
+    public void deleteIfEmpty() {
+    }
+
+    @Override
+    public String getPath() {
+      return "/tmp";
+    }
+  }
+}

--- a/src/test/java/com/codeborne/selenide/files/DownloadedFileTest.java
+++ b/src/test/java/com/codeborne/selenide/files/DownloadedFileTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyMap;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,12 +49,23 @@ final class DownloadedFileTest {
     assertThat(file(1111111114998L).isFileModifiedLaterThan(1111111115002L)).isTrue();
   }
 
-  private DownloadedFile file(long modifiedAt) throws IOException {
-//    File file = createTempFile("selenide-tests", "new-file");
-//    FileUtils.touch(file);
-//    if (!file.setLastModified(modifiedAt)) {
-//      throw new IllegalStateException("Failed to set last modified time to file " + file.getAbsolutePath());
-//    }
+  @Test
+  void toString_showsFileName() {
+    assertThat(file("hello.txt", 0L)).hasToString("hello.txt");
+    assertThat(file("hello.pdf", 1000L)).hasToString("hello.pdf");
+  }
+
+  @Test
+  void toString_showsModificationTime_whenKnown() {
+    assertThat(file("hello.png", currentTimeMillis() - 100).toString()).matches("hello.png \\(modified 10\\dms ago\\)");
+    assertThat(file("hello.jpg", currentTimeMillis() - 99991).toString()).matches("hello.jpg \\(modified 99.99\\ds ago\\)");
+  }
+
+  private DownloadedFile file(String name, long modifiedAt) {
+    return new DownloadedFile(new File(name), modifiedAt, 0, emptyMap());
+  }
+
+  private DownloadedFile file(long modifiedAt) {
     return new DownloadedFile(new File(randomUUID().toString()), modifiedAt, 0, emptyMap());
   }
 


### PR DESCRIPTION
Do not compare "local time" and "time on grid". They might be different (say, up to few seconds) if something is wrong with their clock synchronization services.
