### PR TITLE
#3243 Take screenshot in remote Chrome even if CDP port not available

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/BiDiUti.java
+++ b/src/main/java/com/codeborne/selenide/impl/BiDiUti.java
@@ -25,10 +25,16 @@ public class BiDiUti {
   private static final Logger log = LoggerFactory.getLogger(BiDiUti.class);
 
   public static boolean isBiDiEnabled(WebDriver webDriver) {
+    if (!(webDriver instanceof HasBiDi hasBiDi)) {
+      return false;
+    }
+
     try {
-      return webDriver instanceof HasBiDi hasBiDi && hasBiDi.getBiDi() != null;
+      hasBiDi.getBiDi();
+      return true;
     }
     catch (BiDiException notEnabled) {
+      log.warn("Failed to establish BiDi connection: {}", notEnabled.toString());
       return false;
     }
   }


### PR DESCRIPTION
Starting from Chrome 144, CDP is not enabled by default. Users have to enable it explicitly with `--remote-debugging-port=9222` option.

See https://developer.chrome.com/blog/chrome-devtools-mcp-debug-your-browser-session?utm_source=chatgpt.com

## Proposed changes
Even if CDP is disabled, Selenide will write a warning and take the screenshot using the standard WebDriver method. 
It will be slowed than CDP, but work. 
