### PR TITLE
Fix video size in situation when browser size has been changing

### DIFF
--- a/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/Images.java
+++ b/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/Images.java
@@ -1,0 +1,49 @@
+package org.selenide.videorecorder.core;
+
+import org.openqa.selenium.Dimension;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+class Images {
+  /**
+   * Find the maximum width and the maximum height among all images in the given directory
+   */
+  static Dimension findMaxSize(Path dir, String prefix, String suffix) {
+    int maxWidth = 0;
+    int maxHeight = 0;
+
+    try (Stream<Path> paths = Files.walk(dir, 2)) {
+      for (Path path : (Iterable<Path>) () -> paths.iterator()) {
+        String fileName = path.toFile().getName();
+        if (!fileName.startsWith(prefix) || !fileName.endsWith(suffix)) continue;
+
+        try (ImageInputStream iis = ImageIO.createImageInputStream(path.toFile())) {
+          Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
+          if (!readers.hasNext()) continue;
+
+          ImageReader reader = readers.next();
+          try {
+            reader.setInput(iis, true, true);
+            maxWidth = Math.max(maxWidth, reader.getWidth(0));
+            maxHeight = Math.max(maxHeight, reader.getHeight(0));
+          }
+          finally {
+            reader.dispose();
+          }
+        }
+      }
+    }
+    catch (IOException e) {
+      throw new RuntimeException("Failed to read image sizes from directory " + dir.toAbsolutePath(), e);
+    }
+
+    return new Dimension(maxWidth, maxHeight);
+  }
+}

--- a/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/ScreenShooter.java
+++ b/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/ScreenShooter.java
@@ -90,7 +90,7 @@ class ScreenShooter implements Runnable {
   }
 
   private File saveScreenshot(InputStream screenshot) {
-    File file = new File(screenshotsFolder, "screenshot.%s.png".formatted(screenshotCounter.incrementAndGet()));
+    File file = new File(screenshotsFolder, "screenshot.%d.png".formatted(screenshotCounter.incrementAndGet()));
     try {
       copyInputStreamToFile(screenshot, file);
       return file;

--- a/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/VideoMerger.java
+++ b/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/VideoMerger.java
@@ -3,6 +3,7 @@ package org.selenide.videorecorder.core;
 import net.bramp.ffmpeg.FFmpeg;
 import net.bramp.ffmpeg.FFmpegExecutor;
 import net.bramp.ffmpeg.builder.FFmpegBuilder;
+import org.openqa.selenium.Dimension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,10 +49,11 @@ class VideoMerger {
   }
 
   private void generateVideo() throws IOException {
+    Dimension size = videoSize();
     FFmpegBuilder builder = new FFmpegBuilder()
       .addExtraArgs("-framerate", String.valueOf(frameRate(screenshots)))
       .addInput(screenshotsFolder.getAbsolutePath() + "/screenshot.%d.png")
-      .setVideoFilter("pad=iw+mod(iw\\,2):ih+mod(ih\\,2)")
+      .setVideoFilter("pad=%d:%d:0:0:color=black".formatted(even(size.getWidth()), even(size.getHeight())))
       .addOutput(videoFile.toAbsolutePath().toString())
       .setVideoFrameRate(config.fps(), 1)
       .setVideoCodec("h264")
@@ -66,11 +68,23 @@ class VideoMerger {
     executor.createJob(builder).run();
   }
 
+  static int even(int n) {
+    return n + n % 2;
+  }
+
   static float frameRate(List<Screenshot> screenshots) {
     Screenshot first = screenshots.get(0);
     Screenshot last = screenshots.get(screenshots.size() - 1);
     long duration = NANOSECONDS.toMillis(last.timestampNano - first.timestampNano);
     return (screenshots.size() - 1) * 1000.0f / duration;
+  }
+
+  private Dimension videoSize() {
+    long start = nanoTime();
+    Dimension result = Images.findMaxSize(screenshotsFolder.toPath(), "screenshot", ".png");
+    long duration = NANOSECONDS.toMillis(nanoTime() - start);
+    log.debug("Read max width and height {} from {} screenshots in {} ms.", result, screenshots.size(), duration);
+    return result;
   }
 
   private static Path prepareVideoFolder(Path videoFile) {

--- a/modules/video-recorder/src/test/java/integration/videorecorder/core/VideoRecorder1Test.java
+++ b/modules/video-recorder/src/test/java/integration/videorecorder/core/VideoRecorder1Test.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.WebDriver;
 import org.selenide.videorecorder.core.VideoRecorder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +21,7 @@ import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.closeWebDriver;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.TypeOptions.text;
+import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static java.lang.Thread.currentThread;
 import static java.time.Duration.ofMillis;
 import static java.util.Objects.requireNonNull;
@@ -43,8 +46,13 @@ public class VideoRecorder1Test {
   @Test
   public void firstTest() {
     open(config);
+    WebDriver webDriver = getWebDriver();
+    Dimension size = webDriver.manage().window().getSize();
+
     for (int i = 0; i < 3; i++) {
       open(requireNonNull(getClass().getClassLoader().getResource("search.html")));
+      webDriver.manage().window().setSize(new Dimension(size.width + i * 140, size.height + i * 60));
+
       $("[name=q]").type(text("#1 JUnit JUnit JUnit JUnit JUnit JUnit JUnit JUnit JUnit #111")
         .withDelay(ofMillis(5)));
     }

--- a/modules/video-recorder/src/test/java/org/selenide/videorecorder/core/ImagesTest.java
+++ b/modules/video-recorder/src/test/java/org/selenide/videorecorder/core/ImagesTest.java
@@ -1,0 +1,39 @@
+package org.selenide.videorecorder.core;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Dimension;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.awt.image.BufferedImage.TYPE_INT_RGB;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImagesTest {
+  private Path dir;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    dir = Files.createTempDirectory("selenide-test-");
+    dir.toFile().deleteOnExit();
+  }
+
+  @Test
+  void findsBiggestWidthAndBiggestHeight() throws IOException {
+    createImage("image-1.png", 200, 100);
+    createImage("image-2.png", 300, 110);
+    createImage("image-3.png", 10, 220);
+
+    assertThat(Images.findMaxSize(dir, "image", "png")).isEqualTo(new Dimension(300, 220));
+  }
+
+  private void createImage(String name, int width, int height) throws IOException {
+    BufferedImage img = new BufferedImage(width, height, TYPE_INT_RGB);
+    assertThat(ImageIO.write(img, "png", new File(dir.toFile(), name))).isTrue();
+  }
+}

--- a/modules/video-recorder/src/test/java/org/selenide/videorecorder/core/VideoMergerTest.java
+++ b/modules/video-recorder/src/test/java/org/selenide/videorecorder/core/VideoMergerTest.java
@@ -1,6 +1,8 @@
 package org.selenide.videorecorder.core;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.util.List;
@@ -20,5 +22,17 @@ class VideoMergerTest {
     assertThat(VideoMerger.frameRate(List.of(s1, s2, s3))).isEqualTo(2 / 1.0f);
     assertThat(VideoMerger.frameRate(List.of(s1, s3))).isEqualTo(1 / 1.0f);
     assertThat(VideoMerger.frameRate(List.of(s2, s4))).isEqualTo(1 / 1.5f);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints =  {0, 2, 4, 6, 8, 10, 600, 800, 1024, 2048, 4096})
+  void even_keepsEvenNumberUntouched(int height) {
+    assertThat(VideoMerger.even(height)).isEqualTo(height);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints =  {1, 3, 5, 7, 9, 11, 67, 111, 777, 1037})
+  void even_ceilOddNumberToMakeEvenResult(int height) {
+    assertThat(VideoMerger.even(height)).isEqualTo(height + 1);
   }
 }


### PR DESCRIPTION
* Previously, the recorded video had a size of very first screenshot.
* Now, Selenide generates a video of size that fits all takes screenshots (the rest space is filled with black color). In other words, Selenide finds the biggest width and biggest height among all taken screenshots.

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
