### PR TITLE
#3251 limit execution time of all Selenide commands

### DIFF
--- a/src/main/java/com/codeborne/selenide/Stopwatch.java
+++ b/src/main/java/com/codeborne/selenide/Stopwatch.java
@@ -55,7 +55,7 @@ public class Stopwatch {
   public static void sleepAtLeast(long milliseconds) {
     Stopwatch stopwatch = new Stopwatch(milliseconds);
     do {
-      stopwatch.sleep(milliseconds);
+      stopwatch.sleep(milliseconds - stopwatch.getElapsedTimeMs());
     }
     while (!stopwatch.isTimeoutReached());
   }

--- a/src/main/java/com/codeborne/selenide/impl/CommandGuard.java
+++ b/src/main/java/com/codeborne/selenide/impl/CommandGuard.java
@@ -1,0 +1,77 @@
+package com.codeborne.selenide.impl;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import static com.codeborne.selenide.impl.DurationFormat.formatMs;
+import static java.lang.System.nanoTime;
+import static java.lang.Thread.currentThread;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+class CommandGuard {
+  private static final Logger log = LoggerFactory.getLogger(CommandGuard.class);
+  private static final AtomicLong id = new AtomicLong();
+
+  @Nullable
+  static <T> T executeWithTimeout(long timeoutMs, Supplier<@Nullable T> command) {
+    final AtomicBoolean completed = new AtomicBoolean(false);
+    final Thread worker = currentThread();
+
+    Thread guard = new Thread(() -> {
+      long start = nanoTime();
+      try {
+        sleep(timeoutMs);
+        if (!completed.get()) {
+          log.info("Command hasn't been completed in {} (timeout: {}) - let's interrupt its thread {}.",
+            formatMs(elapsedTimeMs(start)), formatMs(timeoutMs), worker);
+          worker.interrupt();
+          log.info("Command thread interrupted: {}", worker);
+        }
+        else if (log.isDebugEnabled()) {
+          log.debug("Command has been completed in less than {} (timeout: {})", formatMs(elapsedTimeMs(start)), formatMs(timeoutMs));
+        }
+      }
+      catch (InterruptedException e) {
+        if (log.isDebugEnabled()) {
+          log.debug("All good, guard interrupted after {} (timeout: {}): {}",
+            formatMs(elapsedTimeMs(start)), formatMs(timeoutMs), e.toString());
+        }
+        currentThread().interrupt();
+      }
+    });
+    guard.setDaemon(true);
+    guard.setName("Command guard #%s (timeout: %s)".formatted(id.incrementAndGet(), formatMs(timeoutMs)));
+    guard.start();
+
+    try {
+      return command.get();
+    }
+    finally {
+      completed.set(true);
+      guard.interrupt();
+    }
+  }
+
+  private static long elapsedTimeMs(long start) {
+    return NANOSECONDS.toMillis(nanoTime() - start);
+  }
+
+  @SuppressWarnings("BusyWait")
+  static void sleep(long durationMs) throws InterruptedException {
+    long duration = TimeUnit.MILLISECONDS.toNanos(durationMs);
+    long start = nanoTime();
+    while (true) {
+      long elapsedTime = nanoTime() - start;
+      if (elapsedTime >= duration) break;
+
+      long timeToSleep = Math.max(1L, NANOSECONDS.toMillis(duration - elapsedTime));
+      Thread.sleep(timeToSleep);
+    }
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/DurationFormat.java
+++ b/src/main/java/com/codeborne/selenide/impl/DurationFormat.java
@@ -14,6 +14,10 @@ public class DurationFormat {
   }
 
   public String format(long milliseconds) {
+    return formatMs(milliseconds);
+  }
+
+  public static String formatMs(long milliseconds) {
     if (milliseconds < 1000) {
       return String.format("%dms", milliseconds);
     }

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementProxy.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.codeborne.selenide.AssertionMode.SOFT;
+import static com.codeborne.selenide.impl.CommandGuard.executeWithTimeout;
 import static com.codeborne.selenide.logevents.ErrorsCollector.validateAssertionMode;
 import static com.codeborne.selenide.logevents.LogEvent.EventStatus.PASS;
 import static java.util.Arrays.asList;
@@ -135,7 +136,8 @@ class SelenideElementProxy<T extends SelenideElement> implements InvocationHandl
     do {
       try {
         if (isSelenideElementMethod(method)) {
-          return Commands.getInstance().execute(proxy, webElementSource, method.getName(), args);
+          return executeWithTimeout(timeoutMs + 5000, // just in case, give +5 seconds to avoid concurrent corner cases
+            () -> Commands.getInstance().execute(proxy, webElementSource, method.getName(), args));
         }
 
         return method.invoke(webElementSource.getWebElement(), args);

--- a/src/test/java/com/codeborne/selenide/impl/CommandGuardTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/CommandGuardTest.java
@@ -1,0 +1,35 @@
+package com.codeborne.selenide.impl;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.TimeoutException;
+
+import static com.codeborne.selenide.impl.CommandGuard.sleep;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CommandGuardTest {
+  @Test
+  void commandCompletesInTime() {
+    String result = CommandGuard.executeWithTimeout(100, () -> "File loaded");
+    assertThat(result).isEqualTo("File loaded");
+  }
+
+  @Test
+  void commandIsRunningLongerThanTimeout() {
+    assertThatThrownBy(() -> CommandGuard.executeWithTimeout(100, () -> loadFileSlowly(200)))
+      .isInstanceOf(TimeoutException.class)
+      .hasMessageStartingWith("Interrupted while loading the file")
+      .cause()
+      .isInstanceOf(InterruptedException.class);
+  }
+
+  private String loadFileSlowly(long durationMs) {
+    try {
+      sleep(durationMs);
+    }
+    catch (InterruptedException e) {
+      throw new TimeoutException("Interrupted while loading the file", e);
+    }
+    return "File loaded";
+  }
+}


### PR DESCRIPTION
Until now, all commands had a timeout, BUT
Selenide only stopped re-trying after this timeout has been reached.

Now Selenide will also interrupt the command execution even if the very first execution of the command lasts longer than N milliseconds.

The use case: method `$.download()` tried to copy the downloaded file from Grid to local machine and froze dur to some networking issues. In such cases, we don't want Selenide to hand indefinitely.
