### PR TITLE
#3265 support running ChromeDriver in "remote debugger" mode

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/ChromeDriverFactory.java
@@ -46,11 +46,18 @@ public class ChromeDriverFactory extends AbstractChromiumDriverFactory {
       options.setBinary(config.browserBinary());
     }
     options.addArguments(createChromeArguments(config, browser));
-    options.setExperimentalOption("excludeSwitches", excludeSwitches(commonCapabilities));
+    if (!isRemoteDebuggingSession(commonCapabilities)) {
+      options.setExperimentalOption("excludeSwitches", excludeSwitches(commonCapabilities));
+    }
     options.setExperimentalOption("prefs", prefs(browserDownloadsFolder, System.getProperty("chromeoptions.prefs", "")));
     setMobileEmulation(options);
 
     return merge(options, commonCapabilities);
+  }
+
+  protected boolean isRemoteDebuggingSession(ChromeOptions capabilities) {
+    Object chromeOptions = capabilities.getCapability("goog:chromeOptions");
+    return chromeOptions instanceof Map<?, ?> map && map.containsKey("debuggerAddress");
   }
 
   protected void addHeadless(ChromeOptions options) {

--- a/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/ChromeDriverFactoryTest.java
@@ -76,6 +76,18 @@ final class ChromeDriverFactoryTest {
   }
 
   @Test
+  void doesNotAddExcludeSwitches_whenConnectingToRunningChrome_withRemoteDebugging() {
+    SelenideConfig debuggerConfig = config.browserCapabilities(
+      new ChromeOptions().setExperimentalOption("debuggerAddress", "127.0.0.1:9222")
+    );
+
+    Capabilities chromeOptions = factory.createCapabilities(debuggerConfig, browser, proxy, browserDownloadsFolder);
+
+    List<String> excludeSwitches = getBrowserLaunchExcludeSwitches(CAPABILITY, chromeOptions);
+    assertThat(excludeSwitches).isNull();
+  }
+
+  @Test
   void shouldNotExcludeExtensionsSwitch_ifChromeIsOpenedWithExtensions() {
     ChromeOptions options = new ChromeOptions();
     options.addExtensions(toFile("firebug-1.11.4.xpi"), toFile("firepath-0.9.7-fx.xpi"));

--- a/src/test/java/com/codeborne/selenide/webdriver/SeleniumCapabilitiesHelper.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/SeleniumCapabilitiesHelper.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide.webdriver;
 
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Capabilities;
 
 import java.util.List;
@@ -32,6 +33,7 @@ class SeleniumCapabilitiesHelper {
     return (Map<String, Object>) arguments.get("prefs");
   }
 
+  @Nullable
   @SuppressWarnings("unchecked")
   static List<String> getBrowserLaunchExcludeSwitches(String capability, Capabilities capabilities) {
     // it depends on internal Selenium capabilities structure
@@ -40,6 +42,7 @@ class SeleniumCapabilitiesHelper {
     if (arguments == null) {
       return emptyList();
     }
-    return asList((String[]) arguments.get("excludeSwitches"));
+    Object excludeSwitches = arguments.get("excludeSwitches");
+    return excludeSwitches == null ? null : asList((String[]) excludeSwitches);
   }
 }


### PR DESCRIPTION
When running Chromium with "debuggerAddress" switch, we are telling ChromeDriver to connect to already running instance of Chrome.

In this case, we shouldn't add "excludeSwitches" option because is a startup instruction. It tells ChromeDriver how to launch a new Chrome process (specifically, telling it to omit the "enable-automation" and "load-extension" flags).

Because the browser is already open and running, ChromeDriver cannot go back in time and change the command-line arguments used to start it. When ChromeDriver sees startup options mixed with a debuggerAddress, it throws an unrecognized chrome option error because those options are invalid in that context.
