### PR TITLE
fix VideoMerger edge case when only one screenshot

### DIFF
--- a/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/VideoMerger.java
+++ b/modules/video-recorder/src/main/java/org/selenide/videorecorder/core/VideoMerger.java
@@ -74,9 +74,13 @@ class VideoMerger {
   }
 
   static float frameRate(List<Screenshot> screenshots) {
+    if (screenshots.size() == 1)
+      return 1f;
+
     Screenshot first = screenshots.get(0);
     Screenshot last = screenshots.get(screenshots.size() - 1);
     long duration = NANOSECONDS.toMillis(last.timestampNano - first.timestampNano);
+
     return (screenshots.size() - 1) * 1000.0f / duration;
   }
 

--- a/modules/video-recorder/src/test/java/org/selenide/videorecorder/core/VideoMergerTest.java
+++ b/modules/video-recorder/src/test/java/org/selenide/videorecorder/core/VideoMergerTest.java
@@ -22,6 +22,7 @@ class VideoMergerTest {
     assertThat(VideoMerger.frameRate(List.of(s1, s2, s3))).isEqualTo(2 / 1.0f);
     assertThat(VideoMerger.frameRate(List.of(s1, s3))).isEqualTo(1 / 1.0f);
     assertThat(VideoMerger.frameRate(List.of(s2, s4))).isEqualTo(1 / 1.5f);
+    assertThat(VideoMerger.frameRate(List.of(s1))).isEqualTo(1);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary
Fixed a bug in the frameRate calculation that resulted in NaN (Not a Number) when a video contained only one screenshot. This prevented FFmpeg from processing the video, as it cannot parse NaN as a valid input for the -framerate flag.

## Proposed Changes
`VideoMerger.java`
- Added a guard clause: If the list of screenshots contains only one item, the method now returns a default value of 1.0f.
- Logic: Previously, a single screenshot resulted in a numerator of (1 - 1) and a duration of 0, causing a 0/0 floating-point operation. By returning 1f, we ensure FFmpeg receives a valid numeric value to create a 1-second still video.

`VideoMergerTest.java`
- Updated Unit Tests: Added an assertion to verify that a list with a single screenshot correctly returns 1.0f instead of triggering an arithmetic error.

## Why this is important
When running automated tests that finish extremely quickly (or fail immediately), the video recorder might only capture a single frame. Without this fix, the underlying FFmpeg process fails with the following error:
`[image2 demuxer] Unable to parse option value "NaN" as video rate`

This change ensures that videos are still generated correctly even for very short test executions.
