### PR TITLE
#3300 fix downloading files in Selenoid and Moon

### DIFF
--- a/modules/moon/src/main/java/org/selenide/moon/MoonDownloader.java
+++ b/modules/moon/src/main/java/org/selenide/moon/MoonDownloader.java
@@ -4,12 +4,12 @@ import com.codeborne.selenide.Config;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Downloader;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
+import static com.codeborne.selenide.impl.WebdriverUnwrapper.unwrapRemoteWebDriver;
 import static java.util.Objects.requireNonNull;
 
 public class MoonDownloader {
@@ -22,7 +22,7 @@ public class MoonDownloader {
 
   static File archiveFile(Downloader downloader, Config config, WebDriver driver, File downloadedFile) {
     String hubUrl = requireNonNull(config.remote(), "Remote browser URL is not configured");
-    MoonClient moonClient = new MoonClient(hubUrl, ((RemoteWebDriver) driver).getSessionId());
+    MoonClient moonClient = new MoonClient(hubUrl, unwrapRemoteWebDriver(driver).getSessionId());
     File uniqueFolder = downloader.prepareTargetFolder(config);
     File localFile = moonClient.download(downloadedFile.getName(), uniqueFolder);
     log.debug("Copied the downloaded file {} from Moon to {}", downloadedFile, localFile);

--- a/modules/selenoid/src/main/java/org/selenide/selenoid/SelenoidDownloader.java
+++ b/modules/selenoid/src/main/java/org/selenide/selenoid/SelenoidDownloader.java
@@ -4,12 +4,12 @@ import com.codeborne.selenide.Config;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.impl.Downloader;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
+import static com.codeborne.selenide.impl.WebdriverUnwrapper.unwrapRemoteWebDriver;
 import static java.util.Objects.requireNonNull;
 
 public class SelenoidDownloader {
@@ -22,7 +22,7 @@ public class SelenoidDownloader {
 
   static File archiveFile(Downloader downloader, Config config, WebDriver driver, File downloadedFile) {
     String hubUrl = requireNonNull(config.remote(), "Remote browser URL is not configured");
-    SelenoidClient selenoidClient = new SelenoidClient(hubUrl, ((RemoteWebDriver) driver).getSessionId());
+    SelenoidClient selenoidClient = new SelenoidClient(hubUrl, unwrapRemoteWebDriver(driver).getSessionId());
     File uniqueFolder = downloader.prepareTargetFolder(config);
     File localFile = selenoidClient.download(downloadedFile.getName(), uniqueFolder);
     log.debug("Copied the downloaded file {} from Selenoid to {}", downloadedFile, localFile);


### PR DESCRIPTION
We cannot just cast WebDriver to RemoteWebDriver. It causes ClassCastException if the driver is augmented. We need to call `WrapsDriver.getWrappedDriver()` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated session ID retrieval mechanism in remote WebDriver handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->