### PR TITLE
fix flaky InvisibleElementTest

### DIFF
--- a/.github/workflows/test-with-selenium-nightly-build.yml
+++ b/.github/workflows/test-with-selenium-nightly-build.yml
@@ -20,6 +20,11 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
           java-version: '17'
+      - name: Setup Chrome
+        if: ${{ matrix.gradle-task == 'chrome_headless_smoke' }}
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: stable
       - uses: gradle/actions/setup-gradle@v6
       - name: Build with Gradle
         run: ./gradlew ${{ matrix.gradle-task }} -PseleniumVersionNightlyBuild=4.44.0-SNAPSHOT --no-parallel --no-daemon --console=plain

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,11 @@ jobs:
       - name: Setup Firefox
         if: ${{ matrix.gradle-task != 'check' && matrix.gradle-task != 'javadocForSite' }}
         uses: browser-actions/setup-firefox@latest
+      - name: Setup Chrome
+        if: ${{ matrix.gradle-task == 'chrome_headless' }}
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: stable
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Run the tests

--- a/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
@@ -3,9 +3,11 @@ package integration;
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Config;
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.ex.FileNotDownloadedError;
 import com.codeborne.selenide.impl.FileContent;
 import com.codeborne.selenide.webdriver.ChromeDriverFactory;
+import com.codeborne.selenide.webdriver.EdgeDriverFactory;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -206,7 +208,7 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
   void downloadFileWithCustomBrowser() {
     closeWebDriver();
     try {
-      Configuration.browser = CustomWebDriverProvider.class.getName();
+      Configuration.browser = WebDriverRunner.isEdge() ? CustomEdgeProvider.class.getName() : CustomChromeProvider.class.getName();
       openFile("page_with_uploads.html");
       File downloadedFile = $(byText("Download me")).download(withNameMatching("hello.*\\.txt"));
 
@@ -228,7 +230,15 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
     assertThat(downloadedFile.getAbsolutePath()).startsWith(folder.getAbsolutePath());
   }
 
-  private static class CustomWebDriverProvider extends ChromeDriverFactory {
+  private static class CustomChromeProvider extends ChromeDriverFactory {
+    @Override
+    public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy,
+                            @Nullable File browserDownloadsFolder) {
+      return super.create(config, browser, proxy, browserDownloadsFolder);
+    }
+  }
+
+  private static class CustomEdgeProvider extends EdgeDriverFactory {
     @Override
     public WebDriver create(Config config, Browser browser, @Nullable Proxy proxy,
                             @Nullable File browserDownloadsFolder) {

--- a/src/test/java/integration/BaseIntegrationTest.java
+++ b/src/test/java/integration/BaseIntegrationTest.java
@@ -7,6 +7,9 @@ import integration.server.LocalHttpServer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +19,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static com.codeborne.selenide.Browsers.CHROME;
+import static com.codeborne.selenide.Browsers.EDGE;
 import static com.codeborne.selenide.Browsers.SAFARI;
 import static integration.server.LocalHttpServer.startWithRetry;
 import static java.lang.Boolean.parseBoolean;
@@ -87,5 +91,13 @@ public abstract class BaseIntegrationTest {
 
   protected static Browser browser() {
     return new Browser(browser, headless);
+  }
+
+  protected static MutableCapabilities defaultBrowserCapabilities() {
+    return switch (browser) {
+      case CHROME -> new ChromeOptions().addArguments("--no-sandbox", "--disable-gpu");
+      case EDGE ->  new EdgeOptions().addArguments("--no-sandbox", "--disable-gpu");
+      default -> new MutableCapabilities();
+    };
   }
 }

--- a/src/test/java/integration/ElementHiddenTest.java
+++ b/src/test/java/integration/ElementHiddenTest.java
@@ -7,6 +7,7 @@ import static com.codeborne.selenide.Condition.appear;
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.hidden;
+import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 
 final class ElementHiddenTest extends ITest {
@@ -14,7 +15,9 @@ final class ElementHiddenTest extends ITest {
   void clickRemovesElement() {
     setTimeout(4000);
     openFile("elements_disappear_on_click.html");
-    $("#hide").click();
+    $("#hide")
+      .shouldBe(visible, text("Hide me"))
+      .click();
   }
 
   @Test

--- a/src/test/java/integration/ElementRemovedTest.java
+++ b/src/test/java/integration/ElementRemovedTest.java
@@ -7,6 +7,7 @@ import static com.codeborne.selenide.Condition.appear;
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.exist;
 import static com.codeborne.selenide.Condition.hidden;
+import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 
 /**
@@ -17,7 +18,9 @@ final class ElementRemovedTest extends ITest {
   void clickRemovesElement() {
     openFile("elements_disappear_on_click.html");
     setTimeout(2000);
-    $("#remove").click();
+    $("#remove")
+      .shouldBe(visible, text("Remove me"))
+      .click();
   }
 
   @Test

--- a/src/test/java/integration/ITest.java
+++ b/src/test/java/integration/ITest.java
@@ -21,7 +21,13 @@ public abstract class ITest extends BaseIntegrationTest {
   private final long longTimeout = Long.parseLong(System.getProperty("selenide.timeout", "4000"));
 
   private static final ThreadLocal<SelenideConfig> config = withInitial(() ->
-    new SelenideConfig().browser(browser).baseUrl(getBaseUrl()).timeout(100));
+    new SelenideConfig()
+      .browser(browser)
+      .baseUrl(getBaseUrl())
+      .timeout(100)
+      .pollingInterval(1)
+      .browserCapabilities(defaultBrowserCapabilities())
+  );
 
   private static final ThreadLocal<SelenideDriver> driver = withInitial(() ->
     new SelenideDriver(config()));

--- a/src/test/java/integration/InvisibleElementTest.java
+++ b/src/test/java/integration/InvisibleElementTest.java
@@ -15,7 +15,9 @@ final class InvisibleElementTest extends ITest {
   @BeforeEach
   void clickHidesElement() {
     openFile("elements_disappear_on_click.html");
-    $("#hide").click();
+    $("#hide")
+      .shouldBe(visible, text("Hide me"))
+      .click();
     $("#hide").shouldBe(hidden, Duration.ofMillis(2000));
   }
 

--- a/src/test/resources/elements_disappear_on_click.html
+++ b/src/test/resources/elements_disappear_on_click.html
@@ -4,21 +4,29 @@
   <title>Elements disappear</title>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-  <script type="text/javascript" src="jquery.min.js"></script>
   <script type="text/javascript">
-        function removeButton() {
-            $("#remove").remove();
-        }
-        function hideButton() {
-            $("#hide").css("display", "none");
-        }
+    window.addEventListener('DOMContentLoaded', () => {
+      const remove = document.getElementById('remove');
+      const hide = document.getElementById('hide');
 
+      remove.addEventListener('click', () => {
+        setTimeout(() => {
+          remove.remove();
+        }, 100);
+      });
+
+      hide.addEventListener('click', () => {
+        setTimeout(() => {
+          hide.style.display = 'none';
+        }, 100);
+      });
+    });
   </script>
 </head>
 <body>
 <h1>Element removed from DOM</h1>
-<button id="remove" class="someclass" onclick="setTimeout(removeButton, 100)">Remove me</button>
+<button id="remove" class="someclass">Remove me</button>
 <h1>Element hidden</h1>
-<button id="hide" class="someclass" onclick="setTimeout(hideButton, 100)">Hide me</button>
+<button id="hide" class="someclass">Hide me</button>
 </body>
 </html>

--- a/statics/src/test/java/integration/ChromeProfileByFactoryTest.java
+++ b/statics/src/test/java/integration/ChromeProfileByFactoryTest.java
@@ -57,7 +57,7 @@ final class ChromeProfileByFactoryTest extends IntegrationTest {
     assertThat(log).contains("\"profile.password_manager_enabled\": false");
     assertThat(log).contains("\"download.default_directory\": \"" + downloadsFolder.getAbsolutePath().replaceAll("\\\\", "\\\\\\\\"));
 
-    String args = "\"--proxy-bypass-list=\\u003C-loopback>\", \"--no-sandbox\", \"--disable-3d-apis\"";
+    String args = "\"--proxy-bypass-list=\\u003C-loopback>\", \"--no-sandbox\", \"--disable-3d-apis\", \"--disable-gpu\"";
     if (Configuration.headless) {
       assertThat(log).contains("\"args\": [ \"--headless=new\", " + args + " ]");
     }

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -3,12 +3,12 @@ package integration;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.junit5.ScreenShooterExtension;
 import com.codeborne.selenide.proxy.SelenideProxyServer;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -16,7 +16,6 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.opentest4j.TestAbortedException;
 
-import org.jspecify.annotations.Nullable;
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
@@ -87,7 +86,7 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     Configuration.fileDownload = HTTPGET;
     Configuration.reopenBrowserOnFail = Boolean.parseBoolean(System.getProperty("selenide.reopenBrowserOnFail", "false"));
     Configuration.textCheck = FULL_TEXT;
-    Configuration.browserCapabilities = new MutableCapabilities();
+    Configuration.browserCapabilities = defaultBrowserCapabilities();
     Configuration.remoteConnectionTimeout = Duration.ofSeconds(10).toMillis();
     Configuration.remoteReadTimeout = Duration.ofSeconds(90).toMillis();
   }


### PR DESCRIPTION
Example of failed test:
https://github.com/selenide/selenide/actions/runs/24524511243

```java
Element not found {#hide}
Expected: clickable: interactable and enabled
Screenshot: file:/home/runner/work/selenide/selenide/modules/core/build/reports/tests/chrome_headless/1776361035057.60.png
Page source: file:/home/runner/work/selenide/selenide/modules/core/build/reports/tests/chrome_headless/1776361035057.60.html
Timeout: 100ms
Caused by: NoSuchElementException: no such element: Unable to locate element: {"method":"css selector","selector":"#hide"}
	at app//com.codeborne.selenide.impl.WebElementSource.createElementNotFoundError(WebElementSource.java:89)
	at app//com.codeborne.selenide.impl.ElementFinder.createElementNotFoundError(ElementFinder.java:129)
	at app//com.codeborne.selenide.impl.WebElementSource.handleError(WebElementSource.java:140)
	at app//com.codeborne.selenide.impl.WebElementSource.checkConditionAndReturnElement(WebElementSource.java:123)
	at app//com.codeborne.selenide.impl.WebElementSource.findAndAssertElementIsClickable(WebElementSource.java:169)
	at app//com.codeborne.selenide.commands.Click.findElement(Click.java:53)
	at app//com.codeborne.selenide.commands.Click.execute(Click.java:39)
	at app//com.codeborne.selenide.FluentCommand.execute(FluentCommand.java:27)
	at app//com.codeborne.selenide.FluentCommand.execute(FluentCommand.java:19)
	at app//com.codeborne.selenide.commands.Commands.execute(Commands.java:161)
	at app//com.codeborne.selenide.impl.SelenideElementProxy.dispatchAndRetry(SelenideElementProxy.java:138)
	at app//com.codeborne.selenide.impl.SelenideElementProxy.invoke(SelenideElementProxy.java:90)
	at app/jdk.proxy3/jdk.proxy3.$Proxy48.click(Unknown Source)
	at app//integration.InvisibleElementTest.clickHidesElement(InvisibleElementTest.java:18)
Caused by: org.openqa.selenium.NoSuchElementException: no such element: Unable to locate element: {"method":"css selector","selector":"#hide"}
  (Session info: chrome=146.0.7680.177)
For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#nosuchelementexception
Build info: version: '4.43.0', revision: 'dd0f534'
System info: os.name: 'Linux', os.arch: 'amd64', os.version: '6.17.0-1010-azure', java.version: '17.0.18'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Command: [ac854c729b1e203ac00da0924fca1eaf, findElement {using=css selector, value=#hide}]
Capabilities {acceptInsecureCerts: true, browserName: chrome, browserVersion: 146.0.7680.177, chrome: {chromedriverVersion: 146.0.7680.165 (4b989da09e1..., userDataDir: /tmp/org.chromium.Chromium....}, fedcm:accounts: true, goog:chromeOptions: {debuggerAddress: localhost:35847}, goog:processID: 31644, networkConnectionEnabled: false, pageLoadStrategy: normal, platformName: linux, proxy: Proxy(), se:cdp: ws://localhost:35847/devtoo..., se:cdpVersion: 146.0.7680.177, setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: ignore, webauthn:extension:credBlob: true, webauthn:extension:largeBlob: true, webauthn:extension:minPinLength: true, webauthn:extension:prf: true, webauthn:virtualAuthenticators: true}
Session ID: ac854c729b1e203ac00da0924fca1eaf
	at app//org.openqa.selenium.remote.ErrorCodec.decode(ErrorCodec.java:169)
	at app//org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:142)
	at app//org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
	at app//org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:223)
	at app//org.openqa.selenium.remote.service.DriverCommandExecutor.invokeExecute(DriverCommandExecutor.java:216)
	at app//org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:174)
	at app//org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:606)
	at app//org.openqa.selenium.remote.ElementLocation$ElementFinder$2.findElement(ElementLocation.java:166)
	at app//org.openqa.selenium.remote.ElementLocation.findElement(ElementLocation.java:60)
	at app//org.openqa.selenium.remote.RemoteWebDriver.findElement(RemoteWebDriver.java:429)
	at app//org.openqa.selenium.remote.RemoteWebDriver.findElement(RemoteWebDriver.java:423)
	at app//com.codeborne.selenide.impl.WebElementSelector.findElement(WebElementSelector.java:67)
	at app//com.codeborne.selenide.impl.WebElementSelector.findElement(WebElementSelector.java:38)
	at app//com.codeborne.selenide.impl.WebElementSelector.findElement(WebElementSelector.java:29)
	at app//com.codeborne.selenide.impl.ElementFinder.getWebElement(ElementFinder.java:113)
	at app//com.codeborne.selenide.impl.WebElementSource.checkConditionAndReturnElement(WebElementSource.java:112)
	... 10 more
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened test setup with pre-condition assertions verifying element visibility and exact text before actions.
  * Improved test configuration: finer polling and enhanced browser capability handling for Chrome and Edge.
  * Updated cross-browser test providers to select appropriate Chrome/Edge providers at runtime.

* **Chores**
  * Removed external JS dependency in test fixtures, replacing with native event handlers.
  * CI now installs Chrome for specific browser test jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->