### PR TITLE
Fix disposables registry leak

### DIFF
--- a/docs/superpowers/specs/2026-05-03-disposables-registry-leak-fix-design.md
+++ b/docs/superpowers/specs/2026-05-03-disposables-registry-leak-fix-design.md
@@ -1,0 +1,97 @@
+# DisposablesRegistry: prevent webdriver leak on overwrite
+
+## Problem
+
+`DisposablesRegistry<K, T extends Disposable>` (`src/main/java/com/codeborne/selenide/drivercommands/DisposablesRegistry.java`) holds disposables in a `Map<K, T>` keyed by, in practice, the thread ID. The Map was introduced in commit `8eda33eb3` to give the screenshooter O(1) lookup of the current thread's webdriver.
+
+When `register(key, newDriver)` is called and `key` already has an entry, the `Map.put` silently overwrites the previous entry. The previous `WebDriverInstance` becomes unreachable through the registry and is never disposed — neither during normal flow nor at JVM shutdown. The `log.warn("Unclosed webdriver detected ...")` added to `register` reports the situation but does not fix the leak.
+
+## Goal
+
+Guarantee that every `Disposable` ever registered is disposed at the latest by JVM shutdown, even when a caller registers a new disposable under an existing key without first calling `unregister` (i.e., a "defensive safety net" — the registry is the last line of defense, not a tool for diagnosing buggy callers).
+
+The fast O(1) lookup behavior (`get(K)`) must be preserved.
+
+## Non-goals
+
+- Diagnosing or fixing the upstream callers that double-register. The local diff already adds a `source` (thread name) field to `WebDriverInstance` for diagnostic logging; that work is complementary and stays outside this refactor.
+- Eager disposal of an orphan at the moment a double-register is detected. We accept that an orphaned browser process may live until JVM shutdown.
+- Making `Disposable.dispose()` idempotent. `disposeAllItems()` will swallow exceptions (see below) so a misbehaving disposable cannot block the rest, but `dispose()` itself is not changed.
+
+## Design
+
+### Data structure
+
+```java
+class DisposablesRegistry<K, T extends Disposable> {
+  private final Map<K, T> byKey = new ConcurrentHashMap<>();
+  private final List<T> all = new ArrayList<>();
+  // shutdownHook unchanged
+}
+```
+
+- `byKey` keeps O(1) lookup by key (preserves the optimization from `8eda33eb3`).
+- `all` is the authoritative list of every disposable the registry has promised to dispose. It is the single source of truth used by `disposeAllItems()`.
+
+`ArrayList` is acceptable because all mutations happen inside the existing `synchronized` methods (`register`, `unregister`, `cancel`). No additional concurrency primitives are needed.
+
+### Behavior
+
+**`register(key, disposable)`** (synchronized)
+1. If `byKey.get(key)` returns a non-null `previous`: keep the existing `log.warn("Unclosed webdriver detected ...")`. Do **not** remove `previous` from `all` — leaving it in `all` is what makes the shutdown hook eventually dispose it.
+2. `byKey.put(key, disposable)`
+3. `all.add(disposable)`
+4. Existing shutdown-hook-installation logic stays unchanged.
+
+**`unregister(key)`** (synchronized)
+1. `T removed = byKey.remove(key)`
+2. If `removed != null`: `all.remove(removed)`. `unregister` is the caller's signal that they are taking ownership and have disposed (or will dispose) it themselves; we don't want to dispose it again at shutdown.
+
+   *Implication:* an entry that was overwritten by `register` and never unregistered is never removed from `all`, so the shutdown hook always sees it.
+
+**`disposeAllItems()`**
+1. Iterate `all` and call `dispose()` on each.
+2. Swallow exceptions per-element (log at `warn` level) so a single broken disposable cannot block the rest of the cleanup.
+
+   ```java
+   for (T item : all) {
+     try {
+       item.dispose();
+     } catch (RuntimeException e) {
+       log.warn("Failed to dispose {}", item, e);
+     }
+   }
+   ```
+
+**`size()`**
+- Returns `all.size()` (count of undisposed instances, including orphans). This makes the test assertions and the existing `[size=...]` log lines reflect the true number of disposables the registry is still responsible for.
+
+**`get(K key)`, `cancel()`, `isShutdownHookRegistered()`**
+- Unchanged.
+
+### Public API impact
+
+`WebdriversRegistry` (the only production caller) is unchanged. The leak-fix itself does not require changes to `WebdriversRegistryTest`; the test is, however, modified in the same working tree by the parallel `WebDriverInstance.source` diagnostic work (constructor signature gained an argument), which is out of scope for this design.
+
+### Concurrency
+
+`register`, `unregister`, `cancel` remain `synchronized` on the registry instance, which protects all mutations to both `byKey` and `all`. `get(K)` reads `byKey` without locking — same as today. `disposeAllItems()` will also be `synchronized` on the registry instance: shutdown can race with a thread that is still mid-test, so iterating `all` under the monitor avoids `ConcurrentModificationException` and ensures we see a consistent snapshot.
+
+## Tests
+
+Add to `src/test/java/com/codeborne/selenide/drivercommands/DisposablesRegistryTest.java`:
+
+1. **Overwrite preserves orphan for shutdown.** Register `a` under key `1`. Register `b` under key `1` (no `unregister` between). Call `disposeAllItems()`. Both `a` and `b` are disposed.
+2. **Unregister removes from shutdown set.** Register `a` under key `1`. Unregister key `1`. Call `disposeAllItems()`. `a` is **not** disposed.
+3. **Mixed orphan + clean unregister.** Register `a` under key `1`. Register `b` under key `1` (overwrites). Unregister key `1` (removes `b`). Call `disposeAllItems()`. Only `a` is disposed.
+4. **Exception in dispose does not block others.** Register `a`, `b`, `c` (different keys). `b.dispose()` throws. Call `disposeAllItems()`. `a` and `c` are still disposed.
+5. **`size()` reflects `all`, not `byKey`.** After registering `a`, registering `b` under the same key, and unregistering one of them, `size()` returns the expected count of still-tracked disposables.
+
+`WebdriversRegistryTest` does not need new assertions for this design — public behavior of `WebdriversRegistry` is unchanged.
+
+## Files touched
+
+- `src/main/java/com/codeborne/selenide/drivercommands/DisposablesRegistry.java` — implementation change.
+- `src/test/java/com/codeborne/selenide/drivercommands/DisposablesRegistryTest.java` — new test cases.
+
+No changes to `WebdriversRegistry`, `WebDriverInstance`, or any caller from the leak-fix itself. (Other files in the working tree — `WebDriverInstance.java`, `WebdriversRegistryTest.java`, several integration tests — are modified by the parallel `source` diagnostic work, which is out of scope here.)

--- a/src/main/java/com/codeborne/selenide/drivercommands/DisposablesRegistry.java
+++ b/src/main/java/com/codeborne/selenide/drivercommands/DisposablesRegistry.java
@@ -5,6 +5,8 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,10 +22,16 @@ class DisposablesRegistry<K, T extends Disposable> {
 
   @Nullable
   private SelenideCleanupShutdownHook shutdownHook;
-  private final Map<K, T> disposables = new ConcurrentHashMap<>();
+  private final Map<K, T> index = new ConcurrentHashMap<>();
+  private final List<T> disposables = new ArrayList<>();
 
   public synchronized void register(K key, T disposable) {
-    disposables.put(key, disposable);
+    T previous = index.get(key);
+    if (previous != null) {
+      log.warn("Unclosed webdriver detected {}:{} [size={}]", key, previous, disposables.size());
+    }
+    index.put(key, disposable);
+    disposables.add(disposable);
     log.debug("Register {}:{} [size={}]", key, disposable, disposables.size());
     if (shutdownHook == null) {
       log.debug("Add shutdown hook in {} [size={}]", currentThread().getId(), disposables.size());
@@ -33,7 +41,8 @@ class DisposablesRegistry<K, T extends Disposable> {
   }
 
   public synchronized void unregister(K key) {
-    T removed = disposables.remove(key);
+    T removed = index.remove(key);
+    disposables.remove(removed);
     log.debug("Unregister {}:{} [size={}]", key, removed, disposables.size());
   }
 
@@ -53,12 +62,19 @@ class DisposablesRegistry<K, T extends Disposable> {
     return shutdownHook != null;
   }
 
-  void disposeAllItems() {
-    disposables.values().forEach(Disposable::dispose);
+  synchronized void disposeAllItems() {
+    for (T item : disposables) {
+      try {
+        item.dispose();
+      }
+      catch (RuntimeException e) {
+        log.warn("Failed to dispose {}", item, e);
+      }
+    }
   }
 
   public Optional<T> get(K key) {
-    return Optional.ofNullable(disposables.get(key));
+    return Optional.ofNullable(index.get(key));
   }
 
   private class SelenideCleanupShutdownHook extends Thread {

--- a/src/main/java/com/codeborne/selenide/impl/WebDriverInstance.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebDriverInstance.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.logging.LogEntry;
 import java.util.List;
 
 import static com.codeborne.selenide.impl.BiDiUti.collectBrowserLogs;
+import static java.lang.Thread.currentThread;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -22,7 +23,8 @@ public record WebDriverInstance(
   WebDriver webDriver,
   @Nullable SelenideProxyServer proxy,
   @Nullable DownloadsFolder downloadsFolder,
-  List<LogEntry> browserLogs
+  List<LogEntry> browserLogs,
+  String source
 ) implements Disposable {
 
   private static final String NOTICE = "Be sure to enable proxy BEFORE you open the browser.";
@@ -34,7 +36,7 @@ public record WebDriverInstance(
     @Nullable SelenideProxyServer proxy,
     @Nullable DownloadsFolder downloadsFolder
   ) {
-    this(Thread.currentThread().getId(), config, webDriver, proxy, downloadsFolder, collectBrowserLogs(webDriver));
+    this(currentThread().getId(), config, webDriver, proxy, downloadsFolder, collectBrowserLogs(webDriver), currentThread().getName());
   }
 
   public WebDriverInstance {

--- a/src/test/java/com/codeborne/selenide/drivercommands/DisposablesRegistryTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/DisposablesRegistryTest.java
@@ -59,16 +59,89 @@ class DisposablesRegistryTest {
     assertThat(disposed.get()).isEqualTo(2);
   }
 
+  @Test
+  void overwritingKey_keepsOrphanForShutdownDisposal() {
+    CovidTest test1 = new CovidTest();
+    CovidTest test2 = new CovidTest();
+    registry.register(99, test1);
+    registry.register(99, test2);
+
+    assertThat(registry.size()).isEqualTo(2);
+
+    registry.disposeAllItems();
+
+    assertThat(test1.disposed).isTrue();
+    assertThat(test2.disposed).isTrue();
+    assertThat(disposed.get()).isEqualTo(2);
+  }
+
+  @Test
+  void unregister_removesItemFromShutdownDisposalSet() {
+    CovidTest test = new CovidTest();
+    registry.register(test.id, test);
+    registry.unregister(test.id);
+
+    assertThat(registry.size()).isEqualTo(0);
+
+    registry.disposeAllItems();
+
+    assertThat(test.disposed).isFalse();
+    assertThat(disposed.get()).isEqualTo(0);
+  }
+
+  @Test
+  void unregisterAfterOverwrite_disposesOnlyTheOrphan() {
+    CovidTest orphan = new CovidTest();
+    CovidTest current = new CovidTest();
+    registry.register(99, orphan);
+    registry.register(99, current);
+    registry.unregister(99);
+
+    assertThat(registry.size()).isEqualTo(1);
+
+    registry.disposeAllItems();
+
+    assertThat(orphan.disposed).isTrue();
+    assertThat(current.disposed).isFalse();
+    assertThat(disposed.get()).isEqualTo(1);
+  }
+
+  @Test
+  void disposeAllItems_swallowsExceptions_andDisposesRemaining() {
+    CovidTest before = new CovidTest();
+    CovidTest broken = new CovidTest().failOnDispose();
+    CovidTest after = new CovidTest();
+    registry.register(before.id, before);
+    registry.register(broken.id, broken);
+    registry.register(after.id, after);
+
+    registry.disposeAllItems();
+
+    assertThat(before.disposed).isTrue();
+    assertThat(after.disposed).isTrue();
+  }
+
   private class CovidTest implements Disposable {
     private final int id;
+    private boolean disposed;
+    private boolean failOnDispose;
 
     CovidTest() {
       id = created.incrementAndGet();
     }
 
+    CovidTest failOnDispose() {
+      failOnDispose = true;
+      return this;
+    }
+
     @Override
     public void dispose() {
-      disposed.incrementAndGet();
+      if (failOnDispose) {
+        throw new IllegalStateException("boom");
+      }
+      disposed = true;
+      DisposablesRegistryTest.this.disposed.incrementAndGet();
     }
   }
 }

--- a/src/test/java/com/codeborne/selenide/drivercommands/WebdriversRegistryTest.java
+++ b/src/test/java/com/codeborne/selenide/drivercommands/WebdriversRegistryTest.java
@@ -17,8 +17,8 @@ class WebdriversRegistryTest {
   void register_unregister() {
     RemoteWebDriver wd1 = mock();
     RemoteWebDriver wd2 = mock();
-    WebDriverInstance driver1 = new WebDriverInstance(-1L, new SelenideConfig(), wd1, null, from(new File("/tmp/t1")), emptyList());
-    WebDriverInstance driver2 = new WebDriverInstance(-2L, new SelenideConfig(), wd2, null, from(new File("/tmp/t2")), emptyList());
+    WebDriverInstance driver1 = new WebDriverInstance(-1L, new SelenideConfig(), wd1, null, from(new File("/tmp/1")), emptyList(), "1");
+    WebDriverInstance driver2 = new WebDriverInstance(-2L, new SelenideConfig(), wd2, null, from(new File("/tmp/2")), emptyList(), "2");
     WebdriversRegistry.register(driver1);
     WebdriversRegistry.register(driver2);
 

--- a/src/test/java/integration/LogTestNameExtension.java
+++ b/src/test/java/integration/LogTestNameExtension.java
@@ -5,31 +5,55 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
 import org.opentest4j.TestAbortedException;
 
 import static integration.BaseIntegrationTest.browser;
+import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNullElseGet;
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
 import static org.slf4j.LoggerFactory.getLogger;
 
 public final class LogTestNameExtension implements BeforeAllCallback, AfterAllCallback, BeforeEachCallback, AfterEachCallback {
+  private static final Namespace namespace = create(LogTestNameExtension.class);
+  private static final String CLASS_THREAD_NAME = "class-thread-name";
+  private static final String METHOD_THREAD_NAME = "method-thread-name";
+
   @Override
   public void beforeAll(ExtensionContext context) {
     getLogger(context.getDisplayName()).info("Starting tests @ {} ({})", browser, memory());
+    context.getStore(namespace).put(CLASS_THREAD_NAME, currentThread().getName());
+    currentThread().setName("%s:%s".formatted(currentThread().getName(), context.getDisplayName()));
   }
 
   @Override
   public void afterAll(ExtensionContext context) {
     getLogger(context.getDisplayName()).info("Finished tests @ {} - {} ({})", browser, verdict(context), memory());
+
+    restoreThreadName(context, CLASS_THREAD_NAME);
   }
 
   @Override
   public void beforeEach(ExtensionContext context) {
     getLogger(context.getRequiredTestClass().getName()).info("starting {} ({})...", context.getDisplayName(), memory());
+    Store store = context.getStore(namespace);
+    store.put(METHOD_THREAD_NAME, currentThread().getName());
+    currentThread().setName("%s:%s.%s".formatted(store.get(CLASS_THREAD_NAME),
+      context.getRequiredTestClass().getName(), context.getDisplayName()));
   }
 
   @Override
   public void afterEach(ExtensionContext context) {
     getLogger(context.getRequiredTestClass().getName())
       .info("finished {} - {} ({})", context.getDisplayName(), verdict(context), memory());
+
+    restoreThreadName(context, METHOD_THREAD_NAME);
+  }
+
+  private void restoreThreadName(ExtensionContext context, String name) {
+    String originalThreadName = context.getStore(namespace).remove(name, String.class);
+    currentThread().setName(requireNonNullElseGet(originalThreadName, () -> context.getDisplayName()));
   }
 
   private String verdict(ExtensionContext context) {

--- a/src/test/java/integration/ReportForChainedElementsTest.java
+++ b/src/test/java/integration/ReportForChainedElementsTest.java
@@ -3,6 +3,7 @@ package integration;
 import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.SelenideDriver;
 import com.codeborne.selenide.ex.ElementNotFound;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,13 @@ final class ReportForChainedElementsTest extends BaseIntegrationTest {
 
     driver.open("/page_with_absence.html?browser=" + browser);
     previousScreenshots = screenshots();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (driver != null) {
+      driver.close();
+    }
   }
 
   @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebDriver shutdown leak so overwritten/orphaned disposables are reliably cleaned and not double-disposed; disposal continues if one item throws.

* **New Features**
  * Added per-thread source/name tracking for WebDriver instances to aid debugging.

* **Tests**
  * Added tests for overwrite/orphan disposal, unregister behavior, exception isolation, and size semantics.

* **Documentation**
  * Added design spec detailing shutdown disposal behavior and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->