### PR TITLE
Selenide MCP: added more configuration parameters

### DIFF
--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -1,0 +1,117 @@
+# Selenide MCP Server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that lets AI assistants control a real browser via [Selenide](https://selenide.org).
+
+## Requirements
+
+- Java 17+
+- A browser installed (Chrome, Firefox, Edge, or Safari)
+
+## Connecting to Claude Code
+
+### Using `claude mcp add`
+
+```bash
+claude mcp add selenide-mcp 
+```
+
+With options:
+
+```bash
+claude mcp add selenide-mcp  \
+  --browser=chrome --base-url=https://app.example.com --remote=http://selenium-hub:4444/wd/hub
+```
+
+
+### Using JSON config
+
+Add to `.claude/settings.json` (project) or `~/.claude/settings.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "selenide-mcp": {
+      "command": "npx",
+      "args": ["selenide-mcp", "--browser=chrome", "--remote=http://selenium-hub:4444/wd/hub"]
+    }
+  }
+}
+```
+
+## Configuration Parameters
+
+### Browser
+
+| Parameter | Description | Default |
+|---|---|---|
+| `--browser=<name>` | Browser to use: `chrome`, `firefox`, `edge`, `safari` | `chrome` |
+| `--browser-version=<ver>` | Browser version to use | latest installed |
+| `--browser-size=<WxH>` | Browser window size, e.g. `1920x1080` | `1366x768` |
+| `--browser-binary=<path>` | Path to browser executable | from PATH |
+| `--browser-position=<XxY>` | Browser window position, e.g. `0x0` | none |
+| `--headless` | Run browser in headless mode | `false` |
+
+### Timeouts
+
+| Parameter | Description | Default |
+|---|---|---|
+| `--timeout=<ms>` | Default element wait timeout (ms) | `4000` |
+| `--polling-interval=<ms>` | Polling interval for conditions (ms) | `200` |
+| `--page-load-timeout=<ms>` | Page load timeout (ms) | `30000` |
+| `--page-load-strategy=<s>` | Page load strategy: `normal`, `eager`, `none` | `normal` |
+
+### Navigation
+
+| Parameter | Description | Default |
+|---|---|---|
+| `--base-url=<url>` | Base URL prepended to relative paths | `http://localhost:8080` |
+
+### Remote WebDriver
+
+| Parameter | Description | Default |
+|---|---|---|
+| `--remote=<url>` | Remote WebDriver URL, e.g. `http://selenium-hub:4444/wd/hub` | none |
+| `--remote-read-timeout=<ms>` | Read timeout for remote connections (ms) | `90000` |
+| `--remote-connection-timeout=<ms>` | Connection timeout for remote connections (ms) | `10000` |
+
+### Proxy
+
+| Parameter | Description | Default |
+|---|---|---|
+| `--proxy-enabled` | Enable built-in proxy | `false` |
+| `--proxy-host=<host>` | Proxy host | none |
+| `--proxy-port=<port>` | Proxy port | `0` |
+
+### File Handling
+
+| Parameter | Description | Default |
+|---|---|---|
+| `--downloads-folder=<path>` | Folder for downloaded files | `build/downloads` |
+| `--reports-folder=<path>` | Folder for screenshots and reports | `build/reports/tests` |
+| `--file-download=<mode>` | Download mode: `HTTPGET`, `PROXY`, `FOLDER`, `CDP` | `HTTPGET` |
+| `--no-screenshots` | Disable screenshot capture on failure | screenshots enabled |
+| `--no-save-page-source` | Disable page source saving on failure | saving enabled |
+
+### Behavior
+
+| Parameter | Description | Default |
+|---|---|---|
+| `--fast-set-value` | Set input values directly via JS (faster) | `false` |
+| `--click-via-js` | Perform clicks via JS | `false` |
+| `--webdriver-logs` | Enable WebDriver logs collection | `false` |
+| `--no-reopen-browser-on-fail` | Do not reopen browser on failure | reopens on fail |
+| `--text-check=<mode>` | Text assertion mode: `PARTIAL_TEXT`, `FULL_TEXT` | `PARTIAL_TEXT` |
+| `--selector-mode=<mode>` | Selector mode: `CSS`, `Sizzle` | `CSS` |
+| `--assertion-mode=<mode>` | Assertion mode: `STRICT`, `SOFT` | `STRICT` |
+
+### Capabilities
+
+| Parameter | Description |
+|---|---|
+| `--caps=<list>` | Comma-separated list of capabilities to enable |
+
+Available capabilities:
+
+- `codegen` — enables test code generation tools
+
+Example: `--caps=codegen`

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
@@ -18,13 +18,28 @@ import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 
+/**
+ * MCP (Model Context Protocol) server that exposes Selenide browser automation
+ * as tools consumable by AI assistants such as Claude.
+ *
+ * <p>Start via {@link #main(String[])} passing CLI arguments to configure the browser session.
+ * See the module README for the full list of supported parameters.
+ */
 public class SelenideMcpServer {
   private final BrowserSession session;
 
+  /**
+   * Creates a server backed by a browser session configured with the given {@code config}.
+   */
   public SelenideMcpServer(SelenideConfig config) {
     this.session = new BrowserSession(config);
   }
 
+  /**
+   * Starts the MCP server over stdio and blocks until the JVM shuts down.
+   *
+   * @param args command-line arguments; {@code --caps=codegen} enables the codegen toolset
+   */
   @SuppressWarnings("unchecked") // MCP SDK's tools() uses generic varargs
   public void start(String[] args) {
     StdioServerTransportProvider transport = new StdioServerTransportProvider(McpJsonDefaults.getMapper());

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
@@ -1,6 +1,10 @@
 package com.codeborne.selenide.mcp;
 
+import com.codeborne.selenide.AssertionMode;
+import com.codeborne.selenide.FileDownloadMode;
 import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.SelectorMode;
+import com.codeborne.selenide.TextCheck;
 import com.codeborne.selenide.mcp.tools.AdvancedInteractionTools;
 import com.codeborne.selenide.mcp.tools.CodegenTools;
 import com.codeborne.selenide.mcp.tools.ElementInteractionTools;
@@ -79,19 +83,114 @@ public class SelenideMcpServer {
   static SelenideConfig parseConfig(String[] args) {
     SelenideConfig config = new SelenideConfig();
     for (String arg : args) {
-      if (arg.startsWith("--browser=")) {
-        config.browser(arg.substring("--browser=".length()));
-      }
-      else if (arg.equals("--headless")) {
-        config.headless(true);
-      }
-      else if (arg.startsWith("--base-url=")) {
-        config.baseUrl(arg.substring("--base-url=".length()));
-      }
-      else if (arg.startsWith("--timeout=")) {
-        config.timeout(Long.parseLong(arg.substring("--timeout=".length())));
-      }
+      applyBrowserArg(config, arg);
+      applyConnectionArg(config, arg);
+      applyProxyArg(config, arg);
+      applyBehaviorArg(config, arg);
+      applyModeArg(config, arg);
     }
     return config;
+  }
+
+  private static void applyBrowserArg(SelenideConfig config, String arg) {
+    if (arg.startsWith("--browser=")) {
+      config.browser(arg.substring("--browser=".length()));
+    }
+    else if (arg.startsWith("--browser-version=")) {
+      config.browserVersion(arg.substring("--browser-version=".length()));
+    }
+    else if (arg.startsWith("--browser-size=")) {
+      config.browserSize(arg.substring("--browser-size=".length()));
+    }
+    else if (arg.startsWith("--browser-binary=")) {
+      config.browserBinary(arg.substring("--browser-binary=".length()));
+    }
+    else if (arg.startsWith("--browser-position=")) {
+      config.browserPosition(arg.substring("--browser-position=".length()));
+    }
+    else if (arg.equals("--headless")) {
+      config.headless(true);
+    }
+  }
+
+  private static void applyConnectionArg(SelenideConfig config, String arg) {
+    if (arg.startsWith("--base-url=")) {
+      config.baseUrl(arg.substring("--base-url=".length()));
+    }
+    else if (arg.startsWith("--timeout=")) {
+      config.timeout(Long.parseLong(arg.substring("--timeout=".length())));
+    }
+    else if (arg.startsWith("--polling-interval=")) {
+      config.pollingInterval(Long.parseLong(arg.substring("--polling-interval=".length())));
+    }
+    else if (arg.startsWith("--remote=")) {
+      config.remote(arg.substring("--remote=".length()));
+    }
+    else if (arg.startsWith("--remote-read-timeout=")) {
+      config.remoteReadTimeout(Long.parseLong(arg.substring("--remote-read-timeout=".length())));
+    }
+    else if (arg.startsWith("--remote-connection-timeout=")) {
+      config.remoteConnectionTimeout(Long.parseLong(arg.substring("--remote-connection-timeout=".length())));
+    }
+    else if (arg.startsWith("--page-load-strategy=")) {
+      config.pageLoadStrategy(arg.substring("--page-load-strategy=".length()));
+    }
+    else if (arg.startsWith("--page-load-timeout=")) {
+      config.pageLoadTimeout(Long.parseLong(arg.substring("--page-load-timeout=".length())));
+    }
+    else if (arg.startsWith("--downloads-folder=")) {
+      config.downloadsFolder(arg.substring("--downloads-folder=".length()));
+    }
+  }
+
+  private static void applyProxyArg(SelenideConfig config, String arg) {
+    if (arg.equals("--proxy-enabled")) {
+      config.proxyEnabled(true);
+    }
+    else if (arg.startsWith("--proxy-host=")) {
+      config.proxyHost(arg.substring("--proxy-host=".length()));
+    }
+    else if (arg.startsWith("--proxy-port=")) {
+      config.proxyPort(Integer.parseInt(arg.substring("--proxy-port=".length())));
+    }
+  }
+
+  private static void applyBehaviorArg(SelenideConfig config, String arg) {
+    if (arg.equals("--fast-set-value")) {
+      config.fastSetValue(true);
+    }
+    else if (arg.equals("--click-via-js")) {
+      config.clickViaJs(true);
+    }
+    else if (arg.equals("--webdriver-logs")) {
+      config.webdriverLogsEnabled(true);
+    }
+    else if (arg.equals("--no-screenshots")) {
+      config.screenshots(false);
+    }
+    else if (arg.equals("--no-save-page-source")) {
+      config.savePageSource(false);
+    }
+    else if (arg.equals("--no-reopen-browser-on-fail")) {
+      config.reopenBrowserOnFail(false);
+    }
+    else if (arg.startsWith("--reports-folder=")) {
+      config.reportsFolder(arg.substring("--reports-folder=".length()));
+    }
+  }
+
+  private static void applyModeArg(SelenideConfig config, String arg) {
+    if (arg.startsWith("--text-check=")) {
+      config.textCheck(TextCheck.valueOf(arg.substring("--text-check=".length())));
+    }
+    else if (arg.startsWith("--selector-mode=")) {
+      config.selectorMode(SelectorMode.valueOf(arg.substring("--selector-mode=".length())));
+    }
+    else if (arg.startsWith("--assertion-mode=")) {
+      config.assertionMode(AssertionMode.valueOf(arg.substring("--assertion-mode=".length())));
+    }
+    else if (arg.startsWith("--file-download=")) {
+      config.fileDownload(FileDownloadMode.valueOf(arg.substring("--file-download=".length())));
+    }
   }
 }

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/SelenideMcpServerTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/SelenideMcpServerTest.java
@@ -1,6 +1,10 @@
 package com.codeborne.selenide.mcp;
 
+import com.codeborne.selenide.AssertionMode;
+import com.codeborne.selenide.FileDownloadMode;
 import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.SelectorMode;
+import com.codeborne.selenide.TextCheck;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,6 +61,181 @@ class SelenideMcpServerTest {
     assertThat(config.browser()).isEqualTo("chrome");
     assertThat(config.headless()).isTrue();
     assertThat(config.timeout()).isEqualTo(5000);
+  }
+
+  @Test
+  void parseConfigBrowserVersion() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--browser-version=120"});
+    assertThat(config.browserVersion()).isEqualTo("120");
+  }
+
+  @Test
+  void parseConfigBrowserSize() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--browser-size=1920x1080"});
+    assertThat(config.browserSize()).isEqualTo("1920x1080");
+  }
+
+  @Test
+  void parseConfigBrowserBinary() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--browser-binary=/usr/bin/chromium"});
+    assertThat(config.browserBinary()).isEqualTo("/usr/bin/chromium");
+  }
+
+  @Test
+  void parseConfigBrowserPosition() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--browser-position=100x200"});
+    assertThat(config.browserPosition()).isEqualTo("100x200");
+  }
+
+  @Test
+  void parseConfigRemote() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--remote=http://selenium-hub:4444/wd/hub"});
+    assertThat(config.remote()).isEqualTo("http://selenium-hub:4444/wd/hub");
+  }
+
+  @Test
+  void parseConfigPollingInterval() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--polling-interval=500"});
+    assertThat(config.pollingInterval()).isEqualTo(500);
+  }
+
+  @Test
+  void parseConfigRemoteReadTimeout() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--remote-read-timeout=120000"});
+    assertThat(config.remoteReadTimeout()).isEqualTo(120000);
+  }
+
+  @Test
+  void parseConfigRemoteConnectionTimeout() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--remote-connection-timeout=15000"});
+    assertThat(config.remoteConnectionTimeout()).isEqualTo(15000);
+  }
+
+  @Test
+  void parseConfigPageLoadStrategy() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--page-load-strategy=eager"});
+    assertThat(config.pageLoadStrategy()).isEqualTo("eager");
+  }
+
+  @Test
+  void parseConfigPageLoadTimeout() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--page-load-timeout=60000"});
+    assertThat(config.pageLoadTimeout()).isEqualTo(60000);
+  }
+
+  @Test
+  void parseConfigDownloadsFolder() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--downloads-folder=/tmp/downloads"});
+    assertThat(config.downloadsFolder()).isEqualTo("/tmp/downloads");
+  }
+
+  @Test
+  void parseConfigProxyEnabled() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--proxy-enabled"});
+    assertThat(config.proxyEnabled()).isTrue();
+  }
+
+  @Test
+  void parseConfigProxyHost() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--proxy-host=proxy.internal"});
+    assertThat(config.proxyHost()).isEqualTo("proxy.internal");
+  }
+
+  @Test
+  void parseConfigProxyPort() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--proxy-port=8080"});
+    assertThat(config.proxyPort()).isEqualTo(8080);
+  }
+
+  @Test
+  void parseConfigFastSetValue() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--fast-set-value"});
+    assertThat(config.fastSetValue()).isTrue();
+  }
+
+  @Test
+  void parseConfigClickViaJs() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--click-via-js"});
+    assertThat(config.clickViaJs()).isTrue();
+  }
+
+  @Test
+  void parseConfigWebdriverLogs() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--webdriver-logs"});
+    assertThat(config.webdriverLogsEnabled()).isTrue();
+  }
+
+  @Test
+  void parseConfigNoScreenshots() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--no-screenshots"});
+    assertThat(config.screenshots()).isFalse();
+  }
+
+  @Test
+  void parseConfigNoSavePageSource() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--no-save-page-source"});
+    assertThat(config.savePageSource()).isFalse();
+  }
+
+  @Test
+  void parseConfigNoReopenBrowserOnFail() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--no-reopen-browser-on-fail"});
+    assertThat(config.reopenBrowserOnFail()).isFalse();
+  }
+
+  @Test
+  void parseConfigReportsFolder() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--reports-folder=/tmp/reports"});
+    assertThat(config.reportsFolder()).isEqualTo("/tmp/reports");
+  }
+
+  @Test
+  void parseConfigTextCheck() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--text-check=FULL_TEXT"});
+    assertThat(config.textCheck()).isEqualTo(TextCheck.FULL_TEXT);
+  }
+
+  @Test
+  void parseConfigSelectorMode() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--selector-mode=Sizzle"});
+    assertThat(config.selectorMode()).isEqualTo(SelectorMode.Sizzle);
+  }
+
+  @Test
+  void parseConfigAssertionMode() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--assertion-mode=SOFT"});
+    assertThat(config.assertionMode()).isEqualTo(AssertionMode.SOFT);
+  }
+
+  @Test
+  void parseConfigFileDownload() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--file-download=PROXY"});
+    assertThat(config.fileDownload()).isEqualTo(FileDownloadMode.PROXY);
   }
 
   @Test


### PR DESCRIPTION
- added more configuration parameters
- added readme for Selenide MCP

## Proposed changes
In previous version of selenide mcp - there were only 5 parameters to pass to configuration. In this PR I added all parameters from SelenideConfig to make an ability to use all of them in mcp.
 
## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a complete Selenide MCP Server guide covering purpose, requirements, integration methods, and full CLI configuration for browser, timeouts, proxy, file handling, and assertion/selector modes.

* **Improvements**
  * Improved CLI configuration handling and expanded available runtime options and behavior flags.

* **Tests**
  * Expanded test coverage to validate the wider set of configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selenide/selenide/pull/3323)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->