### PR TITLE
prefer the latest file when browser occasionally downloaded multiple files

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/DownloadDetector.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadDetector.java
@@ -34,7 +34,7 @@ public class DownloadDetector implements Comparator<DownloadedFile>, Serializabl
       result = Boolean.compare(isHtmlOrCss1, isHtmlOrCss2);
 
       if (result == 0) {
-        result = Long.compare(file1.getFile().lastModified(), file2.getFile().lastModified());
+        result = Long.compare(file2.lastModifiedTime(), file1.lastModifiedTime());
         if (result == 0) {
           result = file1.getName().compareTo(file2.getName());
         }

--- a/src/test/java/com/codeborne/selenide/impl/DownloadDetectorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadDetectorTest.java
@@ -4,7 +4,9 @@ import com.codeborne.selenide.files.DownloadedFile;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,38 +19,49 @@ final class DownloadDetectorTest {
 
   @Test
   void responseWithContentDispositionHeaderHasHighRank() {
-    DownloadedFile response1 = new DownloadedFile(new File("cv.pdf"), 0, 0, withContentDisposition("attachment; filename=cv.pdf"));
-    DownloadedFile response2 = new DownloadedFile(new File("script.js"), 0, 0, withContentType("application/javascript"));
+    DownloadedFile withHeader = new DownloadedFile(new File("cv.pdf"), 0, 0, withContentDisposition("attachment; filename=cv.pdf"));
+    DownloadedFile withoutHeader = new DownloadedFile(new File("script.js"), 0, 0, withContentType("application/javascript"));
 
-    assertThat(detector.compare(response1, response2)).isEqualTo(-1);
-    assertThat(detector.compare(response2, response1)).isEqualTo(1);
+    assertThat(sort(withHeader, withoutHeader)).containsExactly(withHeader, withoutHeader);
+    assertThat(sort(withoutHeader, withHeader)).containsExactly(withHeader, withoutHeader);
   }
 
   @Test
-  void htmlResponseHasLowRank() {
-    DownloadedFile response1 = new DownloadedFile(new File("some-file.txt"), 0, 0, withContentType("application/octet-stream"));
-    DownloadedFile response2 = new DownloadedFile(new File("event.json"), 0, 0, withContentType("application/json"));
+  void technicalWebFilesHaveLowRank() {
+    DownloadedFile textFile = new DownloadedFile(new File("some-file.txt"), 0, 0, withContentType("application/octet-stream"));
+    DownloadedFile htmlFile = new DownloadedFile(new File("index.html"), 0, 0, withContentType("text/html"));
+    DownloadedFile jsonFile = new DownloadedFile(new File("event.json"), 0, 0, withContentType("application/json"));
 
-    assertThat(detector.compare(response1, response2)).isEqualTo(-1);
-    assertThat(detector.compare(response2, response1)).isEqualTo(1);
+    assertThat(sort(textFile, htmlFile, jsonFile)).containsExactly(textFile, jsonFile, htmlFile);
+    assertThat(sort(htmlFile, textFile, jsonFile)).containsExactly(textFile, jsonFile, htmlFile);
+    assertThat(sort(htmlFile, jsonFile, textFile)).containsExactly(textFile, jsonFile, htmlFile);
   }
 
   @Test
   void latestFileWins() {
-    DownloadedFile response1 = new DownloadedFile(fileCreatedSecondsAgo("earlier-file.txt", 60), 0, 0, emptyMap());
-    DownloadedFile response2 = new DownloadedFile(fileCreatedSecondsAgo("latest-file.txt", 10), 0, 0, emptyMap());
+    DownloadedFile oldest = fileCreatedSecondsAgo("oldest-file.txt", 90);
+    DownloadedFile older = fileCreatedSecondsAgo("older-file.txt", 60);
+    DownloadedFile younger = fileCreatedSecondsAgo("younger-file.txt", 10);
+    DownloadedFile youngest = fileCreatedSecondsAgo("youngest-file.txt", 5);
 
-    assertThat(detector.compare(response1, response2)).isEqualTo(-1);
-    assertThat(detector.compare(response2, response1)).isEqualTo(1);
+    assertThat(sort(oldest, older, younger, youngest)).containsExactly(youngest, younger, older, oldest);
+    assertThat(sort(older, oldest, younger, youngest)).containsExactly(youngest, younger, older, oldest);
+    assertThat(sort(older, younger, oldest, youngest)).containsExactly(youngest, younger, older, oldest);
+    assertThat(sort(older, younger, youngest, oldest)).containsExactly(youngest, younger, older, oldest);
+    assertThat(sort(youngest, older, younger, oldest)).containsExactly(youngest, younger, older, oldest);
+    assertThat(sort(youngest, younger, older, oldest)).containsExactly(youngest, younger, older, oldest);
   }
 
   @Test
   void finallyJustTakeFirstFileAlphabetically() {
-    DownloadedFile response1 = new DownloadedFile(fileCreatedSecondsAgo("a.txt", 42), 0, 0, emptyMap());
-    DownloadedFile response2 = new DownloadedFile(fileCreatedSecondsAgo("b.txt", 42), 0, 0, emptyMap());
+    DownloadedFile first = fileCreatedSecondsAgo("a.txt", 42);
+    DownloadedFile second = fileCreatedSecondsAgo("b.txt", 42);
+    DownloadedFile third = fileCreatedSecondsAgo("c.txt", 42);
 
-    assertThat(detector.compare(response1, response2)).isEqualTo(-1);
-    assertThat(detector.compare(response2, response1)).isEqualTo(1);
+    assertThat(sort(first, second, third)).containsExactly(first, second, third);
+    assertThat(sort(second, first, third)).containsExactly(first, second, third);
+    assertThat(sort(second, third, first)).containsExactly(first, second, third);
+    assertThat(sort(third, second, first)).containsExactly(first, second, third);
   }
 
   private Map<String, String> withContentDisposition(String contentType) {
@@ -59,10 +72,15 @@ final class DownloadDetectorTest {
     return Map.of("content-type", contentType);
   }
 
-  private File fileCreatedSecondsAgo(String name, int secondsAgo) {
+  private DownloadedFile fileCreatedSecondsAgo(String name, int secondsAgo) {
+    long lastModified = now - 1000L * secondsAgo;
     File file = mock();
     when(file.getName()).thenReturn(name);
-    when(file.lastModified()).thenReturn(now - 1000L * secondsAgo);
-    return file;
+    when(file.lastModified()).thenReturn(lastModified);
+    return new DownloadedFile(file, lastModified, 0, emptyMap());
+  }
+
+  private List<DownloadedFile> sort(DownloadedFile... files) {
+    return Stream.of(files).sorted(detector).toList();
   }
 }


### PR DESCRIPTION
What a shame! Though the test claims "latest file wins", Selenide preferred the oldest file. :)

This is a brilliant illustration why we should always verify the (high-level) end result in tests instead of (low-level) implementation details. In this case, we should verify the sorted list of files instead of just (-1, 1) returned by Comparator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ordering logic for downloaded files when multiple files have equal priority rankings. The system now consistently determines the most recent download using a more reliable timestamp comparison method.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/selenide/selenide/pull/3333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->