### PR TITLE
Download multiple files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ subprojects {
   apply plugin: 'checkstyle'
   apply plugin: 'com.github.spotbugs'
   apply plugin: "org.sonarqube"
+
+  // Run the fast Checkstyle checks before the slower unit tests, so style violations fail the build quickly
+  tasks.withType(Test).configureEach {
+    shouldRunAfter tasks.withType(Checkstyle)
+  }
 }
 
 apply from: 'gradle/compilation.gradle'

--- a/modules/grid/src/main/java/org/selenide/grid/GridDownloadsFolder.java
+++ b/modules/grid/src/main/java/org/selenide/grid/GridDownloadsFolder.java
@@ -5,6 +5,8 @@ import com.codeborne.selenide.DownloadsFolder;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.files.DownloadedFile;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.List;
@@ -13,6 +15,8 @@ import static com.codeborne.selenide.impl.WebdriverUnwrapper.unwrapRemoteWebDriv
 import static java.util.Collections.emptyMap;
 
 public class GridDownloadsFolder implements DownloadsFolder {
+  private static final Logger log = LoggerFactory.getLogger(GridDownloadsFolder.class);
+
   private final RemoteWebDriver webDriver;
   private final Config config;
 
@@ -23,7 +27,15 @@ public class GridDownloadsFolder implements DownloadsFolder {
 
   @Override
   public void cleanupBeforeDownload() {
+    if (log.isDebugEnabled()) {
+      log.debug("Going to clean Grid folder {} - found files: {}", webDriver.getSessionId(), webDriver.getDownloadedFiles());
+    }
+
     webDriver.deleteDownloadableFiles();
+
+    if (log.isDebugEnabled()) {
+      log.debug("After cleaning folder {}: {}", webDriver.getSessionId(), webDriver.getDownloadedFiles());
+    }
   }
 
   @Override

--- a/modules/grid/src/test/java/integration/DownloadFileFromGridToFolderTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridToFolderTest.java
@@ -16,10 +16,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
 
 import static com.codeborne.selenide.Configuration.downloadsFolder;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.DownloadOptions.file;
+import static com.codeborne.selenide.DownloadOptions.files;
 import static com.codeborne.selenide.FileDownloadMode.FOLDER;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
@@ -29,6 +32,8 @@ import static com.codeborne.selenide.files.FileFilters.withExtension;
 import static com.codeborne.selenide.files.FileFilters.withName;
 import static com.codeborne.selenide.files.FileFilters.withNameMatching;
 import static java.lang.System.currentTimeMillis;
+import static java.time.Duration.ofSeconds;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -93,7 +98,7 @@ final class DownloadFileFromGridToFolderTest extends AbstractGridTest {
     DownloadOptions downloadOptions = DownloadOptions.using(FOLDER)
       .withIncrementTimeout(Duration.ofMillis(1002L))
       .withFilter(withName("foo.bar"))
-      .withTimeout(Duration.ofSeconds(20));
+      .withTimeout(ofSeconds(20));
 
     assertThatThrownBy(() -> $(byText("Download me")).download(downloadOptions))
       .isInstanceOf(FileNotDownloadedError.class)
@@ -140,7 +145,8 @@ final class DownloadFileFromGridToFolderTest extends AbstractGridTest {
 
   @Test
   void downloadsPotentiallyHarmfulMacFiles() throws IOException {
-    File downloadedFile = $(byText("Download DMG file")).download(withExtension("dmg"));
+    File downloadedFile = $(byText("Download DMG file")).download(
+      file().withExtension("dmg").withTimeout(ofSeconds(8)));
 
     assertThat(downloadedFile.getName()).isEqualTo("tiny.dmg");
     assertThat(Files.size(downloadedFile.toPath())).isEqualTo(43);
@@ -211,6 +217,34 @@ final class DownloadFileFromGridToFolderTest extends AbstractGridTest {
 
     assertThat(text.getName()).isEqualTo(fileName);
     assertThat(text.length()).isEqualTo(new FileContent(fileName).content().length());
+  }
+
+  @Test
+  void downloadMultipleFilesAtOnce() {
+    openFile("downloadMultipleFiles.html");
+
+    Collection<File> result = $("#multiple-downloads").downloadFiles(files(3));
+
+    Map<String, File> files = result.stream().collect(toMap(File::getName, file -> file));
+    assertThat(files).hasSizeGreaterThanOrEqualTo(3);
+    assertThat(files.keySet()).containsExactlyInAnyOrder("empty.html", "hello_world.txt", "download.html");
+
+    assertThat(files.get("empty.html")).content().isEqualToIgnoringNewLines(new FileContent("empty.html").content());
+    assertThat(files.get("hello_world.txt")).content().isEqualToIgnoringNewLines(new FileContent("hello_world.txt").content());
+    assertThat(files.get("download.html")).content().isEqualToIgnoringNewLines(new FileContent("download.html").content());
+  }
+
+  @Test
+  void downloadMultipleFiles_errorMessage() {
+    openFile("downloadMultipleFiles.html");
+
+    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(22).withTimeout(200)))
+      .isInstanceOf(FileNotDownloadedError.class)
+      .hasMessageStartingWith("Failed to download at least 22 files in 200ms (found 3 files: [")
+      .hasMessageContaining("hello_world.txt")
+      .hasMessageContaining("empty.html")
+      .hasMessageContaining("download.html")
+      .hasMessageContaining("Timeout: 200ms");
   }
 
   @Test

--- a/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
+++ b/modules/grid/src/test/java/integration/DownloadFileFromGridWithCdpTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import static com.codeborne.selenide.Configuration.downloadsFolder;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.DownloadOptions.file;
+import static com.codeborne.selenide.DownloadOptions.files;
 import static com.codeborne.selenide.FileDownloadMode.CDP;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
@@ -197,6 +198,19 @@ final class DownloadFileFromGridWithCdpTest extends AbstractGridTest {
 
     assertThat(text.getName()).isEqualTo(fileName);
     assertThat(text.length()).isEqualTo(new FileContent(fileName).content().length());
+  }
+
+  @Test
+  void downloadMultipleFiles_errorMessage() {
+    openFile("downloadMultipleFiles.html");
+
+    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(22).withTimeout(200)))
+      .isInstanceOf(FileNotDownloadedError.class)
+      .hasMessageStartingWith("Failed to download at least 22 files in 200ms (found 3 files: [")
+      .hasMessageContaining("hello_world.txt")
+      .hasMessageContaining("empty.html")
+      .hasMessageContaining("download.html")
+      .hasMessageContaining("Timeout: 200ms");
   }
 
   @Test

--- a/modules/moon/src/main/java/org/selenide/moon/MoonDownloadsFolder.java
+++ b/modules/moon/src/main/java/org/selenide/moon/MoonDownloadsFolder.java
@@ -3,6 +3,8 @@ package org.selenide.moon;
 import com.codeborne.selenide.DownloadsFolder;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.files.DownloadedFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -11,6 +13,7 @@ import static java.util.stream.Collectors.toList;
 import static org.selenide.moon.MoonClient.clientFor;
 
 public class MoonDownloadsFolder implements DownloadsFolder {
+  private static final Logger log = LoggerFactory.getLogger(MoonDownloadsFolder.class);
   private final MoonClient moonClient;
 
   public MoonDownloadsFolder(Driver driver) {
@@ -19,7 +22,15 @@ public class MoonDownloadsFolder implements DownloadsFolder {
 
   @Override
   public void cleanupBeforeDownload() {
+    if (log.isDebugEnabled()) {
+      log.debug("Going to clean Moon folder {} - found files: {}", moonClient.getSessionId(), moonClient.downloads());
+    }
+
     moonClient.deleteDownloadedFiles();
+
+    if (log.isDebugEnabled()) {
+      log.debug("After clean folder {}: {}", moonClient.getSessionId(), moonClient.downloads());
+    }
   }
 
   @Override

--- a/modules/proxy/src/test/java/integration/proxy/MultipleDownloadsTest.java
+++ b/modules/proxy/src/test/java/integration/proxy/MultipleDownloadsTest.java
@@ -1,26 +1,37 @@
 package integration.proxy;
 
+import com.codeborne.selenide.ex.FileNotDownloadedError;
 import com.codeborne.selenide.impl.FileContent;
 import integration.ProxyIntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Map;
 
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.DownloadOptions.file;
+import static com.codeborne.selenide.DownloadOptions.files;
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
 import static com.codeborne.selenide.Selenide.$;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MultipleDownloadsTest extends ProxyIntegrationTest {
+  @BeforeEach
+  final void setUp() {
+    timeout = 1;
+    openFile("downloadMultipleFiles.html");
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"empty.html", "hello_world.txt", "download.html"})
   void downloadMultipleFiles(String fileName) {
-    timeout = 1;
-    openFile("downloadMultipleFiles.html");
-
     File text = $("#multiple-downloads").download(using(PROXY).withTimeout(4000).withName(fileName));
 
     assertThat(text.getName()).isEqualTo(fileName);
@@ -30,12 +41,34 @@ public class MultipleDownloadsTest extends ProxyIntegrationTest {
   @ParameterizedTest
   @ValueSource(strings = {"empty.html", "hello_world.txt", "download.html"})
   void downloadMultipleFilesWithoutContent(String fileName) {
-    timeout = 1;
-    openFile("downloadMultipleFiles.html");
-
     File text = $("#multiple-downloads").download(file().withMethod(PROXY).withTimeout(4000).withName(fileName).withoutContent());
 
     assertThat(text.getName()).isEqualTo(fileName);
     assertThat(text).content().isEqualTo("Mocked file content");
+  }
+
+  @Test
+  void downloadMultipleFilesAtOnce() {
+    Collection<File> result = $("#multiple-downloads").downloadFiles(
+      files(2).withMethod(PROXY).withExtension("html").withTimeout(4000)
+    );
+
+    Map<String, File> files = result.stream().collect(toMap(File::getName, file -> file));
+    assertThat(files).hasSizeGreaterThanOrEqualTo(2);
+    assertThat(files.keySet()).containsExactlyInAnyOrder("empty.html", "download.html");
+
+    assertThat(files.get("empty.html")).content().isEqualToIgnoringNewLines(new FileContent("empty.html").content());
+    assertThat(files.get("download.html")).content().isEqualToIgnoringNewLines(new FileContent("download.html").content());
+  }
+
+  @Test
+  void downloadMultipleFiles_errorMessage() {
+    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(2).withMethod(PROXY).withExtension("txt").withTimeout(100)))
+      .isInstanceOf(FileNotDownloadedError.class)
+      .hasMessageStartingWith("Failed to download at least 2 files with extension \"txt\" in 100ms (found 3 files: [")
+      .hasMessageContaining("empty.html")
+      .hasMessageContaining("download.html")
+      .hasMessageContaining("hello_world.txt")
+      .hasMessageContaining("Timeout: 100ms");
   }
 }

--- a/modules/selenoid/src/main/java/org/selenide/selenoid/SelenoidDownloadsFolder.java
+++ b/modules/selenoid/src/main/java/org/selenide/selenoid/SelenoidDownloadsFolder.java
@@ -3,6 +3,8 @@ package org.selenide.selenoid;
 import com.codeborne.selenide.DownloadsFolder;
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.files.DownloadedFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -11,6 +13,7 @@ import static java.util.stream.Collectors.toList;
 import static org.selenide.selenoid.SelenoidClient.clientFor;
 
 public class SelenoidDownloadsFolder implements DownloadsFolder {
+  private static final Logger log = LoggerFactory.getLogger(SelenoidDownloadsFolder.class);
   private final SelenoidClient selenoidClient;
 
   public SelenoidDownloadsFolder(Driver driver) {
@@ -19,7 +22,15 @@ public class SelenoidDownloadsFolder implements DownloadsFolder {
 
   @Override
   public void cleanupBeforeDownload() {
+    if (log.isDebugEnabled()) {
+      log.debug("Going to clean Selenoid folder {} - found files: {}", selenoidClient.getSessionId(), selenoidClient.downloads());
+    }
+
     selenoidClient.deleteDownloadedFiles();
+
+    if (log.isDebugEnabled()) {
+      log.debug("After clean folder {}: {}", selenoidClient.getSessionId(), selenoidClient.downloads());
+    }
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/DownloadOptions.java
+++ b/src/main/java/com/codeborne/selenide/DownloadOptions.java
@@ -41,15 +41,17 @@ public class DownloadOptions implements HasTimeout {
   private final FileFilter filter;
   private final DownloadAction action;
   private final ContentStrategy contentStrategy;
+  private final int minimumFileCount;
 
   private DownloadOptions(@Nullable FileDownloadMode method, @Nullable Duration timeout, @Nullable Duration incrementTimeout,
-                          FileFilter filter, DownloadAction action, ContentStrategy contentStrategy) {
+                          FileFilter filter, DownloadAction action, ContentStrategy contentStrategy, int minimumFileCount) {
     this.method = method;
     this.timeout = timeout;
     this.incrementTimeout = incrementTimeout;
     this.filter = filter;
     this.action = action;
     this.contentStrategy = contentStrategy;
+    this.minimumFileCount = minimumFileCount;
   }
 
   @Nullable
@@ -80,16 +82,21 @@ public class DownloadOptions implements HasTimeout {
     return contentStrategy;
   }
 
+  public int minimumFileCount() {
+    return minimumFileCount;
+  }
+
   public DownloadOptions withMethod(FileDownloadMode method) {
-    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy);
+    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy, minimumFileCount);
   }
 
   public DownloadOptions withTimeout(long timeoutMs) {
-    return new DownloadOptions(method, Duration.ofMillis(timeoutMs), incrementTimeout, filter, action, contentStrategy);
+    return new DownloadOptions(method, Duration.ofMillis(timeoutMs),
+      incrementTimeout, filter, action, contentStrategy, minimumFileCount);
   }
 
   public DownloadOptions withTimeout(Duration timeout) {
-    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy);
+    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy, minimumFileCount);
   }
 
   /**
@@ -107,27 +114,30 @@ public class DownloadOptions implements HasTimeout {
    * @param incrementTimeout should be lesser than download timeout
    */
   public DownloadOptions withIncrementTimeout(Duration incrementTimeout) {
-    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy);
+    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy, minimumFileCount);
   }
 
   public DownloadOptions withFilter(FileFilter filter) {
-    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy);
+    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy, minimumFileCount);
   }
 
   public DownloadOptions withExtension(String extension) {
-    return new DownloadOptions(method, timeout, incrementTimeout, FileFilters.withExtension(extension), action, contentStrategy);
+    return new DownloadOptions(method, timeout, incrementTimeout,
+      FileFilters.withExtension(extension), action, contentStrategy, minimumFileCount);
   }
 
   public DownloadOptions withName(String fileName) {
-    return new DownloadOptions(method, timeout, incrementTimeout, FileFilters.withName(fileName), action, contentStrategy);
+    return new DownloadOptions(method, timeout, incrementTimeout,
+      FileFilters.withName(fileName), action, contentStrategy, minimumFileCount);
   }
 
   public DownloadOptions withNameMatching(String fileNameRegex) {
-    return new DownloadOptions(method, timeout, incrementTimeout, FileFilters.withNameMatching(fileNameRegex), action, contentStrategy);
+    return new DownloadOptions(method, timeout, incrementTimeout,
+      FileFilters.withNameMatching(fileNameRegex), action, contentStrategy, minimumFileCount);
   }
 
   public DownloadOptions withoutContent() {
-    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, ContentStrategy.EMPTY_CONTENT);
+    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, ContentStrategy.EMPTY_CONTENT, minimumFileCount);
   }
 
   /**
@@ -140,7 +150,7 @@ public class DownloadOptions implements HasTimeout {
    * @return DownloadOptions
    */
   public DownloadOptions withAction(DownloadAction action) {
-    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy);
+    return new DownloadOptions(method, timeout, incrementTimeout, filter, action, contentStrategy, minimumFileCount);
   }
 
   @Override
@@ -149,13 +159,22 @@ public class DownloadOptions implements HasTimeout {
         method == null ? null : "method: %s".formatted(method.name()),
         timeout == null ? null : "timeout: %s".formatted(df.format(timeout)),
         incrementTimeout == null ? null : "incrementTimeout: %s".formatted(df.format(incrementTimeout)),
+        minimumFileCount == 1 ? null : "minimumFileCount: %s".formatted(minimumFileCount),
         filter.isEmpty() ? null : filter.toString()
       ).filter(p -> p != null)
       .collect(joining(", "));
   }
 
   public static DownloadOptions file() {
-    return new DownloadOptions(null, null, null, none(), click(), ContentStrategy.FULL_CONTENT);
+    return new DownloadOptions(null, null, null, none(), click(), ContentStrategy.FULL_CONTENT, 1);
+  }
+
+  public static DownloadOptions files() {
+    return files(2);
+  }
+
+  public static DownloadOptions files(int minimumFileCount) {
+    return new DownloadOptions(null, null, null, none(), click(), ContentStrategy.FULL_CONTENT, minimumFileCount);
   }
 
   public static DownloadOptions using(FileDownloadMode method) {

--- a/src/main/java/com/codeborne/selenide/SelenideElement.java
+++ b/src/main/java/com/codeborne/selenide/SelenideElement.java
@@ -22,6 +22,7 @@ import org.openqa.selenium.interactions.Locatable;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.time.Duration;
+import java.util.List;
 
 /**
  * Wrapper around {@link WebElement} with additional methods like
@@ -1239,6 +1240,17 @@ public interface SelenideElement extends WebElement, WrapsDriver, WrapsElement, 
    * @see com.codeborne.selenide.commands.DownloadFile
    */
   File download(DownloadOptions options) throws FileNotDownloadedError;
+
+  /**
+   * Download multiple files matching given criterias
+   *
+   * Sample:
+   * <pre>
+   *  {@code $("#distributive").downloadFiles(DownloadOptions.files().withExtension("zip"))}
+   * </pre>
+   * @since 7.17.0
+   */
+  List<File> downloadFiles(DownloadOptions options) throws FileNotDownloadedError;
 
   /**
    * Return criteria by which this element is located

--- a/src/main/java/com/codeborne/selenide/commands/Commands.java
+++ b/src/main/java/com/codeborne/selenide/commands/Commands.java
@@ -133,7 +133,8 @@ public class Commands {
   }
 
   private void addFileCommands() {
-    add("download", new DownloadFile());
+    add("download", new DownloadSingleFile());
+    add("downloadFiles", new DownloadMultipleFiles());
     add("uploadFile", new UploadFile());
     add("uploadFromClasspath", new UploadFileFromClasspath());
   }

--- a/src/main/java/com/codeborne/selenide/commands/DownloadFile.java
+++ b/src/main/java/com/codeborne/selenide/commands/DownloadFile.java
@@ -1,6 +1,5 @@
 package com.codeborne.selenide.commands;
 
-import com.codeborne.selenide.Command;
 import com.codeborne.selenide.Config;
 import com.codeborne.selenide.DownloadOptions;
 import com.codeborne.selenide.Driver;
@@ -22,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.List;
 
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.impl.DurationFormat.formatDuration;
@@ -29,7 +29,7 @@ import static com.codeborne.selenide.impl.Plugins.inject;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Optional.ofNullable;
 
-public class DownloadFile implements Command<File> {
+abstract class DownloadFile {
   private static final Logger log = LoggerFactory.getLogger(DownloadFile.class);
 
   private final DownloadFileWithHttpRequest downloadFileWithHttpRequest;
@@ -37,21 +37,20 @@ public class DownloadFile implements Command<File> {
   private final DownloadFileToFolder downloadFileToFolder;
   private final DownloadFileWithCdp downloadFileWithCdp;
 
-  public DownloadFile() {
+  DownloadFile() {
     this(new DownloadFileWithHttpRequest(), new DownloadFileWithProxyServer(),
       inject(DownloadFileToFolder.class), inject(DownloadFileWithCdp.class));
   }
 
-  DownloadFile(DownloadFileWithHttpRequest httpGet, DownloadFileWithProxyServer proxy,
-               DownloadFileToFolder folder, DownloadFileWithCdp cdp) {
+  protected DownloadFile(DownloadFileWithHttpRequest httpGet, DownloadFileWithProxyServer proxy,
+                         DownloadFileToFolder folder, DownloadFileWithCdp cdp) {
     downloadFileWithHttpRequest = httpGet;
     downloadFileWithProxyServer = proxy;
     downloadFileToFolder = folder;
     downloadFileWithCdp = cdp;
   }
 
-  @Override
-  public File execute(SelenideElement selenideElement, WebElementSource linkWithHref, Object @Nullable [] args) {
+  protected List<File> downloadFiles(SelenideElement selenideElement, WebElementSource linkWithHref, Object @Nullable [] args) {
     Driver driver = linkWithHref.driver();
     Config config = driver.config();
     DownloadOptions options = getDownloadOptions(config, args);

--- a/src/main/java/com/codeborne/selenide/commands/DownloadFile.java
+++ b/src/main/java/com/codeborne/selenide/commands/DownloadFile.java
@@ -3,6 +3,7 @@ package com.codeborne.selenide.commands;
 import com.codeborne.selenide.Command;
 import com.codeborne.selenide.Config;
 import com.codeborne.selenide.DownloadOptions;
+import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.FileDownloadMode;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.ex.ElementNotFound;
@@ -51,7 +52,8 @@ public class DownloadFile implements Command<File> {
 
   @Override
   public File execute(SelenideElement selenideElement, WebElementSource linkWithHref, Object @Nullable [] args) {
-    Config config = linkWithHref.driver().config();
+    Driver driver = linkWithHref.driver();
+    Config config = driver.config();
     DownloadOptions options = getDownloadOptions(config, args);
     long timeout = ofNullable(options.timeout()).map(Duration::toMillis).orElse(config.timeout());
     long incrementTimeout = ofNullable(options.incrementTimeout()).map(Duration::toMillis).orElse(timeout);
@@ -67,10 +69,10 @@ public class DownloadFile implements Command<File> {
     WebElement link = waitForLink(linkWithHref, incrementTimeout);
 
     return switch (method) {
-      case HTTPGET -> downloadFileWithHttpRequest.download(linkWithHref.driver(), link, timeout, options);
-      case PROXY -> downloadFileWithProxyServer.download(linkWithHref, link, timeout, options);
-      case FOLDER -> downloadFileToFolder.download(linkWithHref, link, timeout, incrementTimeout, options);
-      case CDP -> downloadFileWithCdp.download(linkWithHref, link, timeout, incrementTimeout, options);
+      case HTTPGET -> downloadFileWithHttpRequest.download(driver, link, timeout, options);
+      case PROXY -> downloadFileWithProxyServer.download(driver, link, timeout, options);
+      case FOLDER -> downloadFileToFolder.download(driver, link, timeout, incrementTimeout, options);
+      case CDP -> downloadFileWithCdp.download(driver, link, timeout, incrementTimeout, options);
     };
   }
 

--- a/src/main/java/com/codeborne/selenide/commands/DownloadMultipleFiles.java
+++ b/src/main/java/com/codeborne/selenide/commands/DownloadMultipleFiles.java
@@ -1,0 +1,16 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.jspecify.annotations.Nullable;
+
+import java.io.File;
+import java.util.List;
+
+public class DownloadMultipleFiles extends DownloadFile implements Command<List<File>> {
+  @Override
+  public List<File> execute(SelenideElement selenideElement, WebElementSource linkWithHref, Object @Nullable [] args) {
+    return downloadFiles(selenideElement, linkWithHref, args);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/commands/DownloadSingleFile.java
+++ b/src/main/java/com/codeborne/selenide/commands/DownloadSingleFile.java
@@ -1,0 +1,27 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.DownloadFileToFolder;
+import com.codeborne.selenide.impl.DownloadFileWithCdp;
+import com.codeborne.selenide.impl.DownloadFileWithHttpRequest;
+import com.codeborne.selenide.impl.DownloadFileWithProxyServer;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.jspecify.annotations.Nullable;
+
+import java.io.File;
+
+public class DownloadSingleFile extends DownloadFile implements Command<File> {
+  DownloadSingleFile() {
+  }
+
+  DownloadSingleFile(DownloadFileWithHttpRequest httpGet, DownloadFileWithProxyServer proxy,
+                     DownloadFileToFolder folder, DownloadFileWithCdp cdp) {
+    super(httpGet, proxy, folder, cdp);
+  }
+
+  @Override
+  public File execute(SelenideElement selenideElement, WebElementSource linkWithHref, Object @Nullable [] args) {
+    return downloadFiles(selenideElement, linkWithHref, args).get(0);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.codeborne.selenide.DownloadOptions.ContentStrategy.FULL_CONTENT;
 import static com.codeborne.selenide.impl.FileHelper.moveFile;
 import static java.lang.System.currentTimeMillis;
 import static java.lang.Thread.sleep;
@@ -45,24 +44,9 @@ public class DownloadFileToFolder {
 
   public File download(Driver driver,
                        WebElement clickable, long timeout, long requestedIncrementTimeout, DownloadOptions options) {
-    return download(driver, clickable, timeout, requestedIncrementTimeout,
-      options.getFilter(), options.getAction(), options.contentStrategy());
-  }
-
-  @Deprecated
-  public File download(Driver driver,
-                       WebElement clickable, long timeout, long incrementTimeout,
-                       FileFilter fileFilter,
-                       DownloadAction action) {
-    return download(driver, clickable, timeout, incrementTimeout, fileFilter, action, FULL_CONTENT);
-  }
-
-  File download(Driver driver,
-                WebElement clickable, long timeout, long requestedIncrementTimeout,
-                FileFilter fileFilter,
-                DownloadAction action,
-                ContentStrategy contentStrategy
-  ) {
+    FileFilter fileFilter = options.getFilter();
+    DownloadAction action = options.getAction();
+    ContentStrategy contentStrategy = options.contentStrategy();
     long incrementTimeout = Math.max(requestedIncrementTimeout, 1000);
     WebDriver webDriver = driver.getWebDriver();
     Config config = driver.config();

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
@@ -43,28 +43,27 @@ public class DownloadFileToFolder {
     this(new Downloader());
   }
 
-  public File download(WebElementSource link,
+  public File download(Driver driver,
                        WebElement clickable, long timeout, long requestedIncrementTimeout, DownloadOptions options) {
-    return download(link, clickable, timeout, requestedIncrementTimeout,
+    return download(driver, clickable, timeout, requestedIncrementTimeout,
       options.getFilter(), options.getAction(), options.contentStrategy());
   }
 
   @Deprecated
-  public File download(WebElementSource link,
+  public File download(Driver driver,
                        WebElement clickable, long timeout, long incrementTimeout,
                        FileFilter fileFilter,
                        DownloadAction action) {
-    return download(link, clickable, timeout, incrementTimeout, fileFilter, action, FULL_CONTENT);
+    return download(driver, clickable, timeout, incrementTimeout, fileFilter, action, FULL_CONTENT);
   }
 
-  File download(WebElementSource link,
+  File download(Driver driver,
                 WebElement clickable, long timeout, long requestedIncrementTimeout,
                 FileFilter fileFilter,
                 DownloadAction action,
                 ContentStrategy contentStrategy
   ) {
     long incrementTimeout = Math.max(requestedIncrementTimeout, 1000);
-    Driver driver = link.driver();
     WebDriver webDriver = driver.getWebDriver();
     Config config = driver.config();
     long pollingInterval = Math.max(config.pollingInterval(), 50);

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
@@ -42,8 +42,8 @@ public class DownloadFileToFolder {
     this(new Downloader());
   }
 
-  public File download(Driver driver,
-                       WebElement clickable, long timeout, long requestedIncrementTimeout, DownloadOptions options) {
+  public List<File> download(Driver driver,
+                             WebElement clickable, long timeout, long requestedIncrementTimeout, DownloadOptions options) {
     FileFilter fileFilter = options.getFilter();
     DownloadAction action = options.getAction();
     ContentStrategy contentStrategy = options.contentStrategy();
@@ -63,7 +63,7 @@ public class DownloadFileToFolder {
 
     action.perform(driver, clickable);
 
-    waitForNewFiles(driver, fileFilter, folder, previousFiles, timeout, incrementTimeout, pollingInterval);
+    waitForNewFiles(driver, fileFilter, folder, previousFiles, timeout, incrementTimeout, pollingInterval, options.minimumFileCount());
     waitUntilDownloadsCompleted(driver, folder, fileFilter, timeout, incrementTimeout, pollingInterval);
 
     Downloads newDownloads = new Downloads(folder.filesExcept(previousFiles));
@@ -74,12 +74,17 @@ public class DownloadFileToFolder {
       log.debug("All downloaded files: {}", folder.filesAsString());
     }
 
-    File downloadedFile = newDownloads.firstDownloadedFile(timeout, fileFilter);
+    List<File> downloadedFiles = newDownloads.getMatchingDownloadedFiles(timeout, fileFilter, options.minimumFileCount());
 
+    return downloadedFiles.stream().map(downloadedFile -> archive(downloadedFile,
+      timeout - (currentTimeMillis() - start), contentStrategy, config, webDriver)).toList();
+  }
+
+  private File archive(File downloadedFile, long timeout, ContentStrategy contentStrategy, Config config, WebDriver webDriver) {
     return switch (contentStrategy) {
       case FULL_CONTENT -> downloader.copyFileWithTimeout(downloadedFile.getName(),
         () -> archiveFile(config, webDriver, downloadedFile),
-        timeout - (currentTimeMillis() - start)
+        timeout
       );
       case EMPTY_CONTENT -> downloader.mockFileContent(config, downloadedFile.getName());
     };
@@ -145,7 +150,7 @@ public class DownloadFileToFolder {
 
   void waitForNewFiles(Driver driver, FileFilter fileFilter, DownloadsFolder folder,
                        List<DownloadedFile> previousFiles,
-                       long timeout, long incrementTimeout, long pollingInterval) {
+                       long timeout, long incrementTimeout, long pollingInterval, int minimumFileCount) {
     if (log.isDebugEnabled()) {
       log.debug("Waiting for files in {}...", folder);
     }
@@ -154,13 +159,13 @@ public class DownloadFileToFolder {
     for (; currentTimeMillis() - start <= timeout; pause(pollingInterval)) {
       Downloads downloads = new Downloads(folder.filesExcept(previousFiles));
       List<DownloadedFile> matchingFiles = downloads.files(fileFilter);
-      if (!matchingFiles.isEmpty()) {
-        log.debug("Matching files found: {}, all new files: {}, all files: {}",
-          matchingFiles, downloads.filesAsString(), folder.filesAsString());
+      log.debug("{} matching files found: {}, all new files: {}, all files: {}",
+        matchingFiles.size(), matchingFiles, downloads.filesAsString(), folder.filesAsString());
+
+      if (matchingFiles.size() >= minimumFileCount) {
         return;
       }
-      log.debug("Matching files not found: {}, all new files: {}, all files: {}",
-        matchingFiles, downloads.filesAsString(), folder.filesAsString());
+
       failFastIfNoChanges(driver, folder, fileFilter, start, timeout, incrementTimeout);
     }
 

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -33,7 +34,6 @@ import java.util.function.Consumer;
 
 import static com.codeborne.selenide.impl.FileHelper.moveFile;
 import static java.lang.System.currentTimeMillis;
-import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static org.openqa.selenium.devtools.v148.browser.Browser.downloadProgress;
 import static org.openqa.selenium.devtools.v148.browser.Browser.downloadWillBegin;
@@ -58,8 +58,8 @@ public class DownloadFileWithCdp {
     return driver.browserDownloadsFolder();
   }
 
-  public File download(Driver driver,
-                       WebElement clickable, long timeout, long incrementTimeout, DownloadOptions options) {
+  public List<File> download(Driver driver,
+                             WebElement clickable, long timeout, long incrementTimeout, DownloadOptions options) {
     FileFilter fileFilter = options.getFilter();
     DownloadAction action = options.getAction();
     ContentStrategy contentStrategy = options.contentStrategy();
@@ -78,25 +78,26 @@ public class DownloadFileWithCdp {
     action.perform(driver, clickable);
 
     try {
-      CdpDownload download = waitUntilDownloadsCompleted(driver, fileFilter, timeout, incrementTimeout, downloads);
+      MatchedCdpDownloads matchedDownloads = waitUntilDownloadsCompleted(driver, fileFilter,
+        timeout, incrementTimeout, downloads, options.minimumFileCount());
 
-      if (!fileFilter.match(new DownloadedFile(download.file(), download.lastModifiedAt, download.fileSize, emptyMap()))) {
-        String message = String.format("Failed to download file%s in %s%s;%n actually downloaded: %s",
-          fileFilter.description(), df.format(timeout), fileFilter.description(), download.file().getAbsolutePath());
-        throw new FileNotDownloadedError(message, timeout);
-      }
-
-      return switch (contentStrategy) {
-        case FULL_CONTENT -> downloader.copyFileWithTimeout(download.file().getName(),
-          () -> archiveFile(config, webDriver, download.file()),
-          timeout - (currentTimeMillis() - start)
-        );
-        case EMPTY_CONTENT -> downloader.mockFileContent(config, requireNonNull(download.fileName));
-      };
+      return matchedDownloads.files.stream()
+        .map(f -> archive(timeout - (currentTimeMillis() - start), contentStrategy, f, config, webDriver))
+        .toList();
     }
     finally {
       devTools.clearListeners();
     }
+  }
+
+  private File archive(long timeout, ContentStrategy contentStrategy, CdpDownload download, Config config, WebDriver webDriver) {
+    return switch (contentStrategy) {
+      case FULL_CONTENT -> downloader.copyFileWithTimeout(download.file().getName(),
+        () -> archiveFile(config, webDriver, download.file()),
+        timeout
+      );
+      case EMPTY_CONTENT -> downloader.mockFileContent(config, requireNonNull(download.fileName));
+    };
   }
 
   protected boolean isLocalBrowser(Config config) {
@@ -111,16 +112,17 @@ public class DownloadFileWithCdp {
     return archivedFile;
   }
 
-  private CdpDownload waitUntilDownloadsCompleted(Driver driver, FileFilter fileFilter,
-                                           long timeout, long incrementTimeout, CdpDownloads downloads) {
+  private MatchedCdpDownloads waitUntilDownloadsCompleted(
+    Driver driver, FileFilter fileFilter, long timeout, long incrementTimeout, CdpDownloads downloads, int minimumFileCount) {
+
     long pollingInterval = Math.max(driver.config().pollingInterval(), 100);
     long downloadStartedAt = currentTimeMillis();
     Stopwatch stopwatch = new Stopwatch(timeout);
     do {
-      Optional<CdpDownload> downloadedFile = downloads.find(fileFilter);
-      if (downloadedFile.isPresent()) {
-        log.debug("File {} download is complete after {} ms.", downloadedFile.get().fileName, stopwatch.getElapsedTimeMs());
-        return downloadedFile.get();
+      MatchedCdpDownloads downloadedFiles = downloads.find(fileFilter);
+      if (downloadedFiles.hasAtLeast(minimumFileCount)) {
+        log.debug("File download completed after {} ms: {}", stopwatch.getElapsedTimeMs(), downloadedFiles);
+        return downloadedFiles;
       }
       else {
         failFastIfNoChanges(downloads, fileFilter, downloadStartedAt, timeout, incrementTimeout);
@@ -129,8 +131,13 @@ public class DownloadFileWithCdp {
     }
     while (!stopwatch.isTimeoutReached());
 
-    String message = "Failed to download file%s in %s, found files: %s".formatted(
-      fileFilter.description(), df.format(timeout), downloads.folder().files());
+    List<DownloadedFile> files = downloads.folder().files();
+    String message = switch (minimumFileCount) {
+      case 1 -> "Failed to download file%s in %s (found %s files: %s)".formatted(
+        fileFilter.description(), df.format(timeout), files.size(), files);
+      default -> "Failed to download at least %s files%s in %s (found %s files: %s)".formatted(
+        minimumFileCount, fileFilter.description(), df.format(timeout), files.size(), files);
+    };
     throw new FileNotDownloadedError(message, timeout);
   }
 
@@ -155,7 +162,7 @@ public class DownloadFileWithCdp {
 
   private boolean isChromium(WebDriver webDriver) {
     return webDriver instanceof HasCapabilities hasCapabilities &&
-           new com.codeborne.selenide.Browser(hasCapabilities.getCapabilities().getBrowserName(), false).isChromium();
+      new com.codeborne.selenide.Browser(hasCapabilities.getCapabilities().getBrowserName(), false).isChromium();
   }
 
   private void prepareDownloadWithCdp(Driver driver, DevTools devTools,
@@ -179,11 +186,12 @@ public class DownloadFileWithCdp {
     DownloadsFolder folder,
     ConcurrentMap<String, CdpDownload> downloads
   ) {
-    private Optional<CdpDownload> find(FileFilter fileFilter) {
-      return downloads.values().stream()
+    private MatchedCdpDownloads find(FileFilter fileFilter) {
+      return new MatchedCdpDownloads(downloads.values().stream()
         .filter(download -> download.completed)
         .filter(download -> fileFilter.match(download.file()))
-        .findAny();
+        .toList()
+      );
     }
 
     private Optional<Long> lastModificationTime() {
@@ -219,6 +227,17 @@ public class DownloadFileWithCdp {
 
     private synchronized CdpDownload download(String guid) {
       return downloads.computeIfAbsent(guid, __ -> new CdpDownload(folder));
+    }
+  }
+
+  private record MatchedCdpDownloads(List<CdpDownload> files) {
+    public boolean hasAtLeast(int minimumFileCount) {
+      return files.size() >= minimumFileCount;
+    }
+
+    @Override
+    public String toString() {
+      return files.stream().map(f -> f.fileName).toList().toString();
     }
   }
 
@@ -293,9 +312,8 @@ public class DownloadFileWithCdp {
     long lastModifiedAt = downloads.lastModificationTime().orElse(downloadStartedAt);
     long filesHasNotBeenUpdatedForMs = now - lastModifiedAt;
     if (filesHasNotBeenUpdatedForMs > incrementTimeout) {
-      String message = String.format(
-        "Failed to download file%s in %s: files in %s haven't been modified for %s " +
-        "(lastUpdate: %s, now: %s, incrementTimeout: %s)",
+      String message = String.format("Failed to download file%s in %s: files in %s haven't been modified for %s " +
+          "(lastUpdate: %s, now: %s, incrementTimeout: %s)",
         filter.description(), df.format(timeout), downloads.folder, df.format(filesHasNotBeenUpdatedForMs),
         lastModifiedAt, now, df.format(incrementTimeout));
       throw new FileNotDownloadedError(message, timeout);

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
-import static com.codeborne.selenide.DownloadOptions.ContentStrategy.FULL_CONTENT;
 import static com.codeborne.selenide.impl.FileHelper.moveFile;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyMap;
@@ -59,24 +58,11 @@ public class DownloadFileWithCdp {
     return driver.browserDownloadsFolder();
   }
 
-  @Deprecated
-  public File download(Driver driver,
-                       WebElement clickable, long timeout, long incrementTimeout,
-                       FileFilter fileFilter,
-                       DownloadAction action) {
-    return download(driver, clickable, timeout, incrementTimeout, fileFilter, action, FULL_CONTENT);
-  }
-
   public File download(Driver driver,
                        WebElement clickable, long timeout, long incrementTimeout, DownloadOptions options) {
-    return download(driver, clickable, timeout, incrementTimeout, options.getFilter(), options.getAction(), options.contentStrategy());
-  }
-
-  private File download(Driver driver,
-                       WebElement clickable, long timeout, long incrementTimeout,
-                       FileFilter fileFilter,
-                       DownloadAction action,
-                       ContentStrategy contentStrategy) {
+    FileFilter fileFilter = options.getFilter();
+    DownloadAction action = options.getAction();
+    ContentStrategy contentStrategy = options.contentStrategy();
 
     long start = currentTimeMillis();
     Config config = driver.config();

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
@@ -60,26 +60,25 @@ public class DownloadFileWithCdp {
   }
 
   @Deprecated
-  public File download(WebElementSource link,
+  public File download(Driver driver,
                        WebElement clickable, long timeout, long incrementTimeout,
                        FileFilter fileFilter,
                        DownloadAction action) {
-    return download(link, clickable, timeout, incrementTimeout, fileFilter, action, FULL_CONTENT);
+    return download(driver, clickable, timeout, incrementTimeout, fileFilter, action, FULL_CONTENT);
   }
 
-  public File download(WebElementSource link,
+  public File download(Driver driver,
                        WebElement clickable, long timeout, long incrementTimeout, DownloadOptions options) {
-    return download(link, clickable, timeout, incrementTimeout, options.getFilter(), options.getAction(), options.contentStrategy());
+    return download(driver, clickable, timeout, incrementTimeout, options.getFilter(), options.getAction(), options.contentStrategy());
   }
 
-  private File download(WebElementSource link,
+  private File download(Driver driver,
                        WebElement clickable, long timeout, long incrementTimeout,
                        FileFilter fileFilter,
                        DownloadAction action,
                        ContentStrategy contentStrategy) {
 
     long start = currentTimeMillis();
-    Driver driver = link.driver();
     Config config = driver.config();
     WebDriver webDriver = driver.getWebDriver();
     DevTools devTools = initDevTools(driver);

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
@@ -44,6 +44,7 @@ import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -76,8 +77,11 @@ public class DownloadFileWithHttpRequest {
     this.downloader = downloader;
   }
 
-  public File download(Driver driver, WebElement element, long timeout, DownloadOptions options) {
-    return download(driver, element, timeout, options.getFilter(), options.contentStrategy());
+  public List<File> download(Driver driver, WebElement element, long timeout, DownloadOptions options) {
+    return switch (options.minimumFileCount()) {
+      case 1 -> List.of(download(driver, element, timeout, options.getFilter(), options.contentStrategy()));
+      default -> throw new IllegalArgumentException("HTTPGET download mode does not support downloading multiple files");
+    };
   }
 
   private File download(Driver driver, WebElement element, long timeout, FileFilter fileFilter, ContentStrategy contentStrategy) {

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithHttpRequest.java
@@ -80,11 +80,6 @@ public class DownloadFileWithHttpRequest {
     return download(driver, element, timeout, options.getFilter(), options.contentStrategy());
   }
 
-  @Deprecated
-  public File download(Driver driver, WebElement element, long timeout, FileFilter fileFilter) {
-    return download(driver, element, timeout, fileFilter, FULL_CONTENT);
-  }
-
   private File download(Driver driver, WebElement element, long timeout, FileFilter fileFilter, ContentStrategy contentStrategy) {
     String fileToDownloadLocation = element.getAttribute("href");
     if (fileToDownloadLocation == null || fileToDownloadLocation.trim().isEmpty()) {

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.List;
 import java.util.function.Supplier;
 
 import static com.codeborne.selenide.proxy.SelenideProxyServer.SELENIDE_PROXY_FILTER_PREFIX;
@@ -30,7 +31,7 @@ public class DownloadFileWithProxyServer {
     this(new Waiter());
   }
 
-  public File download(Driver driver, WebElement clickable, long timeout, DownloadOptions options) {
+  public List<File> download(Driver driver, WebElement clickable, long timeout, DownloadOptions options) {
     FileFilter fileFilter = options.getFilter();
     DownloadAction action = options.getAction();
     ContentStrategy contentStrategy = options.contentStrategy();
@@ -60,7 +61,7 @@ public class DownloadFileWithProxyServer {
         log.info("Downloaded {}", filter.downloads().filesAsString());
         log.info("Just in case, intercepted {}", filter.responsesAsString());
       }
-      return filter.downloads().firstDownloadedFile(timeout, fileFilter);
+      return filter.downloads().getMatchingDownloadedFiles(timeout, fileFilter, options.minimumFileCount());
     }
     finally {
       filter.deactivate();

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.function.Supplier;
 
-import static com.codeborne.selenide.DownloadOptions.ContentStrategy.FULL_CONTENT;
 import static com.codeborne.selenide.proxy.SelenideProxyServer.SELENIDE_PROXY_FILTER_PREFIX;
 
 public class DownloadFileWithProxyServer {
@@ -31,23 +30,14 @@ public class DownloadFileWithProxyServer {
     this(new Waiter());
   }
 
-  @Deprecated
-  public File download(WebElementSource anyClickableElement,
-                       WebElement clickable, long timeout,
-                       FileFilter fileFilter,
-                       DownloadAction action) {
-    return clickAndInterceptFileByProxyServer(anyClickableElement, clickable, timeout, fileFilter, action, FULL_CONTENT);
-  }
-
-  public File download(WebElementSource link, WebElement clickable, long timeout, DownloadOptions options) {
-    return clickAndInterceptFileByProxyServer(link, clickable, timeout,
+  public File download(Driver driver, WebElement clickable, long timeout, DownloadOptions options) {
+    return clickAndInterceptFileByProxyServer(driver, clickable, timeout,
       options.getFilter(), options.getAction(), options.contentStrategy());
   }
 
-  private File clickAndInterceptFileByProxyServer(WebElementSource link, WebElement clickable,
+  private File clickAndInterceptFileByProxyServer(Driver driver, WebElement clickable,
                                                   long timeout, FileFilter fileFilter,
                                                   DownloadAction action, ContentStrategy contentStrategy) {
-    Driver driver = link.driver();
     Config config = driver.config();
     if (!config.proxyEnabled()) {
       throw new IllegalStateException("Cannot download file: proxy server is not enabled. Setup proxyEnabled");

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithProxyServer.java
@@ -31,13 +31,9 @@ public class DownloadFileWithProxyServer {
   }
 
   public File download(Driver driver, WebElement clickable, long timeout, DownloadOptions options) {
-    return clickAndInterceptFileByProxyServer(driver, clickable, timeout,
-      options.getFilter(), options.getAction(), options.contentStrategy());
-  }
-
-  private File clickAndInterceptFileByProxyServer(Driver driver, WebElement clickable,
-                                                  long timeout, FileFilter fileFilter,
-                                                  DownloadAction action, ContentStrategy contentStrategy) {
+    FileFilter fileFilter = options.getFilter();
+    DownloadAction action = options.getAction();
+    ContentStrategy contentStrategy = options.contentStrategy();
     Config config = driver.config();
     if (!config.proxyEnabled()) {
       throw new IllegalStateException("Cannot download file: proxy server is not enabled. Setup proxyEnabled");

--- a/src/main/java/com/codeborne/selenide/impl/Downloads.java
+++ b/src/main/java/com/codeborne/selenide/impl/Downloads.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
 
 import static java.lang.System.currentTimeMillis;
 import static java.util.stream.Collectors.toList;
@@ -39,8 +40,20 @@ public class Downloads {
     return files.stream().filter(fileFilter::match).collect(toList());
   }
 
+  @Deprecated
+  public List<DownloadedFile> matchingFiles(FileFilter fileFilter) {
+    return findMatchingFiles(fileFilter).toList();
+  }
+
+  @Deprecated
   public Optional<DownloadedFile> firstMatchingFile(FileFilter fileFilter) {
-    return files.stream().filter(fileFilter::match).sorted(new DownloadDetector()).findFirst();
+    return findMatchingFiles(fileFilter).findFirst();
+  }
+
+  private Stream<DownloadedFile> findMatchingFiles(FileFilter fileFilter) {
+    return files.stream()
+      .filter(fileFilter::match)
+      .sorted(new DownloadDetector());
   }
 
   public String filesAsString() {
@@ -64,12 +77,23 @@ public class Downloads {
     return files.size();
   }
 
-  public File firstDownloadedFile(long timeout, FileFilter fileFilter) {
-    return firstMatchingFile(fileFilter)
-      .orElseThrow(() -> {
-        String message = String.format("Failed to download file%s in %s", fileFilter.description(), df.format(timeout));
-          return new FileNotDownloadedError(message.trim(), timeout);
-        }
-      ).getFile();
+  public List<File> getMatchingDownloadedFiles(long timeout, FileFilter fileFilter, int minimumFileCount) {
+    List<DownloadedFile> matchingFiles = findMatchingFiles(fileFilter).toList();
+    if (matchingFiles.size() >= minimumFileCount) {
+      return matchingFiles.stream().map(DownloadedFile::getFile).toList();
+    }
+
+    switch (minimumFileCount) {
+      case 1 -> {
+        String message = String.format("Failed to download file%s in %s (found %s files: %s)",
+          fileFilter.description(), df.format(timeout), files.size(), files);
+        throw new FileNotDownloadedError(message.trim(), timeout);
+      }
+      default -> {
+        String message = String.format("Failed to download at least %s files%s in %s (found %s files: %s)",
+          minimumFileCount, fileFilter.description(), df.format(timeout), files.size(), files);
+        throw new FileNotDownloadedError(message.trim(), timeout);
+      }
+    }
   }
 }

--- a/src/test/java/com/codeborne/selenide/DownloadOptionsTest.java
+++ b/src/test/java/com/codeborne/selenide/DownloadOptionsTest.java
@@ -1,18 +1,26 @@
 package com.codeborne.selenide;
 
+import com.codeborne.selenide.files.DownloadAction;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
 
 import java.time.Duration;
 
+import static com.codeborne.selenide.DownloadOptions.ContentStrategy.FULL_CONTENT;
 import static com.codeborne.selenide.DownloadOptions.file;
+import static com.codeborne.selenide.DownloadOptions.files;
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.FOLDER;
 import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
+import static com.codeborne.selenide.files.DownloadActions.click;
 import static com.codeborne.selenide.files.FileFilters.none;
 import static com.codeborne.selenide.files.FileFilters.withExtension;
+import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@NullMarked
 final class DownloadOptionsTest {
   @Test
   void defaultOptions() {
@@ -20,7 +28,11 @@ final class DownloadOptionsTest {
 
     assertThat(options.getMethod()).isEqualTo(PROXY);
     assertThat(options.timeout()).isNull();
+    assertThat(options.incrementTimeout()).isNull();
     assertThat(options.getFilter()).isEqualTo(none());
+    assertThat(options.getAction()).isEqualTo(click());
+    assertThat(options.contentStrategy()).isEqualTo(FULL_CONTENT);
+    assertThat(options.minimumFileCount()).isEqualTo(1);
   }
 
   @Test
@@ -29,6 +41,7 @@ final class DownloadOptionsTest {
 
     assertThat(options.getMethod()).isEqualTo(PROXY);
     assertThat(options.timeout()).isEqualTo(Duration.ofMillis(9999));
+    assertThat(options.incrementTimeout()).isNull();
     assertThat(options.getFilter()).isEqualTo(none());
   }
 
@@ -38,6 +51,7 @@ final class DownloadOptionsTest {
 
     assertThat(options.getMethod()).isEqualTo(FOLDER);
     assertThat(options.timeout()).isNull();
+    assertThat(options.incrementTimeout()).isNull();
     assertThat(options.getFilter()).usingRecursiveComparison().isEqualTo(withExtension("pdf"));
   }
 
@@ -47,6 +61,7 @@ final class DownloadOptionsTest {
 
     assertThat(options.getMethod()).isEqualTo(FOLDER);
     assertThat(options.timeout()).isEqualTo(Duration.ofMillis(1234));
+    assertThat(options.incrementTimeout()).isNull();
     assertThat(options.getFilter()).usingRecursiveComparison().isEqualTo(withExtension("ppt"));
   }
 
@@ -57,6 +72,9 @@ final class DownloadOptionsTest {
 
     assertThat(using(PROXY).withTimeout(9999))
       .hasToString("method: PROXY, timeout: 9.999s");
+
+    assertThat(using(PROXY).withTimeout(9999).withIncrementTimeout(ofMillis(2200)))
+      .hasToString("method: PROXY, timeout: 9.999s, incrementTimeout: 2.2s");
 
     assertThat(using(HTTPGET).withTimeout(9999).withExtension("ppt"))
       .hasToString("method: HTTPGET, timeout: 9.999s, with extension \"ppt\"");
@@ -69,5 +87,27 @@ final class DownloadOptionsTest {
 
     assertThat(file().withExtension("exe"))
       .hasToString("with extension \"exe\"");
+
+    assertThat(file().withExtension("exe").withAction(new DoubleClick()))
+      .hasToString("with extension \"exe\"");
+
+    assertThat(files())
+      .hasToString("minimumFileCount: 2");
+
+    assertThat(files().withExtension("zip").withoutContent())
+      .hasToString("minimumFileCount: 2, with extension \"zip\"");
+  }
+
+  private static class DoubleClick implements DownloadAction {
+    @Override
+    public void perform(Driver driver, WebElement link) {
+      link.click();
+      link.click();
+    }
+
+    @Override
+    public String toString() {
+      return "Double click";
+    }
   }
 }

--- a/src/test/java/com/codeborne/selenide/commands/DownloadFileTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/DownloadFileTest.java
@@ -70,13 +70,14 @@ final class DownloadFileTest {
   void canDownloadFile_withProxyServer() {
     config.proxyEnabled(true).fileDownload(PROXY);
     SelenideProxyServer selenideProxy = mock();
-    when(linkWithHref.driver()).thenReturn(new DriverStub(config, selenideProxy));
+    DriverStub driverWithProxy = new DriverStub(config, selenideProxy);
+    when(linkWithHref.driver()).thenReturn(driverWithProxy);
     when(proxy.download(any(), any(), anyLong(), any())).thenReturn(file);
 
     File f = command.execute(seLink, linkWithHref, new Object[]{9000L});
 
     assertThat(f).isSameAs(file);
-    verify(proxy).download(eq(linkWithHref), eq(link), eq(9000L), refEq(file().withMethod(PROXY).withTimeout(9000)));
+    verify(proxy).download(eq(driverWithProxy), eq(link), eq(9000L), refEq(file().withMethod(PROXY).withTimeout(9000)));
     verifyNoMoreInteractions(httpGet);
   }
 

--- a/src/test/java/com/codeborne/selenide/commands/DownloadSingleFileTest.java
+++ b/src/test/java/com/codeborne/selenide/commands/DownloadSingleFileTest.java
@@ -19,6 +19,7 @@ import org.mockito.ArgumentMatchers;
 import org.openqa.selenium.WebElement;
 
 import java.io.File;
+import java.util.List;
 
 import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.FileDownloadMode.HTTPGET;
@@ -33,14 +34,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-final class DownloadFileTest {
+final class DownloadSingleFileTest {
   private final SelenideConfig config = new SelenideConfig();
   private final Driver driver = mock();
   private final DownloadFileWithHttpRequest httpGet = mock();
   private final DownloadFileWithProxyServer proxy = mock();
   private final DownloadFileToFolder folder = mock();
   private final DownloadFileWithCdp cdp = mock();
-  private final DownloadFile command = new DownloadFile(httpGet, proxy, folder, cdp);
+  private final DownloadSingleFile command = new DownloadSingleFile(httpGet, proxy, folder, cdp);
   private final SelenideElement seLink = mock();
   private final WebElementSource linkWithHref = mock();
   private final WebElement link = mock();
@@ -57,7 +58,7 @@ final class DownloadFileTest {
   void canDownloadFile_withHttpGetRequest() {
     config.fileDownload(HTTPGET);
 
-    when(httpGet.download(any(), any(WebElement.class), anyLong(), any(DownloadOptions.class))).thenReturn(file);
+    when(httpGet.download(any(), any(WebElement.class), anyLong(), any(DownloadOptions.class))).thenReturn(List.of(file));
 
     File f = command.execute(seLink, linkWithHref, new Object[]{8000L});
 
@@ -72,7 +73,7 @@ final class DownloadFileTest {
     SelenideProxyServer selenideProxy = mock();
     DriverStub driverWithProxy = new DriverStub(config, selenideProxy);
     when(linkWithHref.driver()).thenReturn(driverWithProxy);
-    when(proxy.download(any(), any(), anyLong(), any())).thenReturn(file);
+    when(proxy.download(any(), any(), anyLong(), any())).thenReturn(List.of(file));
 
     File f = command.execute(seLink, linkWithHref, new Object[]{9000L});
 

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileToFolderTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileToFolderTest.java
@@ -51,7 +51,7 @@ final class DownloadFileToFolderTest {
       return null;
     }).when(link).click();
 
-    File downloadedFile = command.download(linkWithHref, link, 3000, 300, file().withMethod(FOLDER));
+    File downloadedFile = command.download(driver, link, 3000, 300, file().withMethod(FOLDER));
 
     assertThat(downloadedFile.getName()).isEqualTo(newFileName);
     assertThat(downloadedFile.getParentFile()).isNotEqualTo(downloadsFolder.getFolder());

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileToFolderTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileToFolderTest.java
@@ -14,6 +14,7 @@ import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.FileDownloadMode.FOLDER;
@@ -51,11 +52,12 @@ final class DownloadFileToFolderTest {
       return null;
     }).when(link).click();
 
-    File downloadedFile = command.download(driver, link, 3000, 300, file().withMethod(FOLDER));
+    List<File> downloadedFiles = command.download(driver, link, 3000, 300, file().withMethod(FOLDER));
 
-    assertThat(downloadedFile.getName()).isEqualTo(newFileName);
-    assertThat(downloadedFile.getParentFile()).isNotEqualTo(downloadsFolder.getFolder());
-    assertThat(readFileToString(downloadedFile, UTF_8)).isEqualTo("Hello Bingo-Bongo");
+    assertThat(downloadedFiles).hasSize(1);
+    assertThat(downloadedFiles.get(0).getName()).isEqualTo(newFileName);
+    assertThat(downloadedFiles.get(0).getParentFile()).isNotEqualTo(downloadsFolder.getFolder());
+    assertThat(readFileToString(downloadedFiles.get(0), UTF_8)).isEqualTo("Hello Bingo-Bongo");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
@@ -53,7 +53,7 @@ final class DownloadFileWithProxyServerTest {
   void canInterceptFileViaProxyServer() {
     emulateServerResponseWithFiles(new File("report.pdf"));
 
-    File file = command.download(driver, link, 3000, file());
+    File file = command.download(driver, link, 3000, file()).get(0);
 
     assertThat(file.getName()).isEqualTo("report.pdf");
     verify(filter).activate(FULL_CONTENT);
@@ -65,7 +65,7 @@ final class DownloadFileWithProxyServerTest {
   void closesNewWindowIfFileWasOpenedInSeparateWindow() {
     emulateServerResponseWithFiles(new File("report.pdf"));
 
-    File file = command.download(driver, link, 3000, file());
+    File file = command.download(driver, link, 3000, file()).get(0);
 
     assertThat(file.getName()).isEqualTo("report.pdf");
   }

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileWithProxyServerTest.java
@@ -34,6 +34,7 @@ final class DownloadFileWithProxyServerTest {
   private final SelenideConfig config = new SelenideConfig();
   private final WebDriver webdriver = new DummyWebDriver();
   private final SelenideProxyServer proxy = mock();
+  private final DriverStub driver = new DriverStub(config, new Browser("opera", false), webdriver, proxy);
   private final WebElementSource linkWithHref = mock();
   private final WebElement link = mock();
   private final FileDownloadFilter filter = spy(new FileDownloadFilter(config));
@@ -43,7 +44,7 @@ final class DownloadFileWithProxyServerTest {
     config.proxyEnabled(true);
     config.fileDownload(PROXY);
     when(proxy.responseFilter("selenide.proxy.filter.download")).thenReturn(filter);
-    when(linkWithHref.driver()).thenReturn(new DriverStub(config, new Browser("opera", false), webdriver, proxy));
+    when(linkWithHref.driver()).thenReturn(driver);
     when(linkWithHref.findAndAssertElementIsInteractable()).thenReturn(link);
     when(linkWithHref.toString()).thenReturn("<a href='report.pdf'>report</a>");
   }
@@ -52,7 +53,7 @@ final class DownloadFileWithProxyServerTest {
   void canInterceptFileViaProxyServer() {
     emulateServerResponseWithFiles(new File("report.pdf"));
 
-    File file = command.download(linkWithHref, link, 3000, file());
+    File file = command.download(driver, link, 3000, file());
 
     assertThat(file.getName()).isEqualTo("report.pdf");
     verify(filter).activate(FULL_CONTENT);
@@ -64,7 +65,7 @@ final class DownloadFileWithProxyServerTest {
   void closesNewWindowIfFileWasOpenedInSeparateWindow() {
     emulateServerResponseWithFiles(new File("report.pdf"));
 
-    File file = command.download(linkWithHref, link, 3000, file());
+    File file = command.download(driver, link, 3000, file());
 
     assertThat(file.getName()).isEqualTo("report.pdf");
   }
@@ -73,7 +74,7 @@ final class DownloadFileWithProxyServerTest {
   void throws_FileNotDownloaded_ifNoFilesHaveBeenDownloadedAfterClick() {
     emulateServerResponseWithFiles();
 
-    assertThatThrownBy(() -> command.download(linkWithHref, link, 3000, file()))
+    assertThatThrownBy(() -> command.download(driver, link, 3000, file()))
       .isInstanceOf(FileNotDownloadedError.class)
       .hasMessageStartingWith("Failed to download file in 3s");
   }
@@ -83,16 +84,16 @@ final class DownloadFileWithProxyServerTest {
     config.proxyEnabled(false);
     config.fileDownload(PROXY);
 
-    assertThatThrownBy(() -> command.download(linkWithHref, link, 3000, file()))
+    assertThatThrownBy(() -> command.download(driver, link, 3000, file()))
       .isInstanceOf(IllegalStateException.class)
       .hasMessageContaining("Cannot download file: proxy server is not enabled");
   }
 
   @Test
   void proxyServerShouldBeStarted() {
-    when(linkWithHref.driver()).thenReturn(new DriverStub(config, mock(), new DummyWebDriver(), null));
+    DriverStub driverWithProxy = new DriverStub(config, mock(), new DummyWebDriver(), null);
 
-    assertThatThrownBy(() -> command.download(linkWithHref, link, 3000, file()))
+    assertThatThrownBy(() -> command.download(driverWithProxy, link, 3000, file()))
       .isInstanceOf(IllegalStateException.class)
       .hasMessageContaining("config.proxyEnabled == true but proxy server is not created.");
   }

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -21,12 +21,14 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Map;
 import java.util.regex.Pattern;
 
 import static com.codeborne.selenide.Configuration.downloadsFolder;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.DownloadOptions.file;
+import static com.codeborne.selenide.DownloadOptions.files;
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.FOLDER;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
@@ -45,6 +47,7 @@ import static java.nio.file.Files.createTempDirectory;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static java.util.regex.Pattern.DOTALL;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -329,6 +332,34 @@ final class FileDownloadToFolderTest extends IntegrationTest {
 
     assertThat(text.getName()).isEqualTo(fileName);
     assertThat(text.length()).isEqualTo(new FileContent(fileName).content().length());
+  }
+
+  @Test
+  void downloadMultipleFilesAtOnce() {
+    openFile("downloadMultipleFiles.html");
+
+    Collection<File> result = $("#multiple-downloads").downloadFiles(files(3));
+
+    Map<String, File> files = result.stream().collect(toMap(File::getName, file -> file));
+    assertThat(files).hasSizeGreaterThanOrEqualTo(3);
+    assertThat(files.keySet()).containsExactlyInAnyOrder("empty.html", "hello_world.txt", "download.html");
+
+    assertThat(files.get("empty.html")).content().isEqualToIgnoringNewLines(new FileContent("empty.html").content());
+    assertThat(files.get("hello_world.txt")).content().isEqualToIgnoringNewLines(new FileContent("hello_world.txt").content());
+    assertThat(files.get("download.html")).content().isEqualToIgnoringNewLines(new FileContent("download.html").content());
+  }
+
+  @Test
+  void downloadMultipleFiles_errorMessage() {
+    openFile("downloadMultipleFiles.html");
+
+    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(22).withTimeout(2)))
+      .isInstanceOf(FileNotDownloadedError.class)
+      .hasMessageStartingWith("Failed to download at least 22 files in 2ms (found 3 files: [")
+      .hasMessageContaining("hello_world.txt")
+      .hasMessageContaining("empty.html")
+      .hasMessageContaining("download.html")
+      .hasMessageContaining("Timeout: 2ms");
   }
 
   @Test

--- a/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
@@ -17,11 +17,14 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Collection;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static com.codeborne.selenide.Configuration.downloadsFolder;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.DownloadOptions.file;
+import static com.codeborne.selenide.DownloadOptions.files;
 import static com.codeborne.selenide.DownloadOptions.using;
 import static com.codeborne.selenide.FileDownloadMode.CDP;
 import static com.codeborne.selenide.FileDownloadMode.PROXY;
@@ -39,6 +42,7 @@ import static java.nio.file.Files.createTempDirectory;
 import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
 import static java.util.regex.Pattern.DOTALL;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -291,6 +295,34 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
 
     assertThat(text.getName()).isEqualTo(fileName);
     assertThat(text.length()).isEqualTo(new FileContent(fileName).content().length());
+  }
+
+  @Test
+  void downloadMultipleFilesAtOnce() {
+    openFile("downloadMultipleFiles.html");
+
+    Collection<File> result = $("#multiple-downloads").downloadFiles(files(3));
+
+    Map<String, File> files = result.stream().collect(toMap(File::getName, file -> file));
+    assertThat(files).hasSizeGreaterThanOrEqualTo(3);
+    assertThat(files.keySet()).containsExactlyInAnyOrder("empty.html", "hello_world.txt", "download.html");
+
+    assertThat(files.get("empty.html")).content().isEqualToIgnoringNewLines(new FileContent("empty.html").content());
+    assertThat(files.get("hello_world.txt")).content().isEqualToIgnoringNewLines(new FileContent("hello_world.txt").content());
+    assertThat(files.get("download.html")).content().isEqualToIgnoringNewLines(new FileContent("download.html").content());
+  }
+
+  @Test
+  void downloadMultipleFiles_errorMessage() {
+    openFile("downloadMultipleFiles.html");
+
+    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(33).withTimeout(100)))
+      .isInstanceOf(FileNotDownloadedError.class)
+      .hasMessageStartingWith("Failed to download at least 33 files in 100ms (found 3 files: [")
+      .hasMessageContaining("hello_world.txt")
+      .hasMessageContaining("empty.html")
+      .hasMessageContaining("download.html")
+      .hasMessageContaining("Timeout: 100ms");
   }
 
   @Test


### PR DESCRIPTION
another implementation of #3261

Now it's possible to download multiple files with one call:

```java
List<File> result = $("#multiple-downloads").downloadFiles(files(5).withExtension("zip"));
assertThat(files).hasSizeGreaterThanOrEqualTo(5);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download multiple files at once via SelenideElement.downloadFiles(...) and new downloadFiles command.
  * DownloadOptions: minimumFileCount and files(...) factory to request multi-file downloads.

* **Refactor**
  * Unified download internals; separate single-file vs multi-file command flows and consistent multi-file return values.

* **Tests**
  * Added/updated unit and integration tests for multi-file downloads and clearer error messages.

* **Chores**
  * Added debug logging around remote download cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->