### PR TITLE
add more MCP tools (tabs, resize, fill_form, wait_for, network)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-mcp-additional-tools.md
+++ b/docs/superpowers/plans/2026-05-24-mcp-additional-tools.md
@@ -15,7 +15,7 @@
 
 ---
 
-### Task 1: Tab management tools (browser_tab_list, browser_tab_select, browser_tab_new, browser_tab_close)
+## Task 1: Tab management tools (browser_tab_list, browser_tab_select, browser_tab_new, browser_tab_close)
 
 **Files:**
 - Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabListTool.java`
@@ -289,7 +289,7 @@ git commit -m "mcp: add tab management tools (list/select/new/close)"
 
 ---
 
-### Task 2: browser_resize tool
+## Task 2: browser_resize tool
 
 **Files:**
 - Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ResizeTool.java`
@@ -374,7 +374,7 @@ git commit -m "mcp: add browser_resize tool"
 
 ---
 
-### Task 3: browser_fill_form tool
+## Task 3: browser_fill_form tool
 
 **Files:**
 - Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/FillFormTool.java`
@@ -486,7 +486,7 @@ git commit -m "mcp: add browser_fill_form tool"
 
 ---
 
-### Task 4: browser_wait_for tool (with unit test for argument validation)
+## Task 4: browser_wait_for tool (with unit test for argument validation)
 
 **Files:**
 - Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/WaitForTool.java`
@@ -733,7 +733,7 @@ git commit -m "mcp: add browser_wait_for tool"
 
 ---
 
-### Task 5: Network inspection tools (browser_network_requests, browser_network_request) + NetworkTools group
+## Task 5: Network inspection tools (browser_network_requests, browser_network_request) + NetworkTools group
 
 **Files:**
 - Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java`
@@ -969,7 +969,7 @@ git commit -m "mcp: add network inspection tools (browser_network_requests, brow
 
 ---
 
-### Task 6: Final verification
+## Task 6: Final verification
 
 - [ ] **Step 1: Confirm Javadoc-for-site still builds**
 

--- a/docs/superpowers/plans/2026-05-24-mcp-additional-tools.md
+++ b/docs/superpowers/plans/2026-05-24-mcp-additional-tools.md
@@ -1,0 +1,996 @@
+# MCP Additional Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 9 new MCP tools (tab management, resize, fill_form, wait_for, network inspection) to `modules/mcp` to bring selenide-mcp closer to Playwright MCP feature parity.
+
+**Architecture:** Each tool subclasses `McpTool` in package `com.codeborne.selenide.mcp.tools`, package-private, with `name` / `description` / `inputSchema` / `execute(args)`. New `NetworkTools` group registrar mirrors the existing `NavigationTools`/`ElementInteractionTools`/`InspectTools`/`AdvancedInteractionTools` pattern. `SelenideMcpServer` registers the new group.
+
+**Tech Stack:** Java 17, Gradle, Selenide (`SelenideDriver`), Selenium WebDriver, MCP SDK 1.1.3, BrowserUp Proxy 3.3.0, JUnit Jupiter, AssertJ.
+
+**Code style reminders (project conventions enforced by Checkstyle):**
+- 2-space indent, no tabs, no star imports, max line length 136, LF endings.
+- Tool files are package-private; group registrars (`*Tools.java`) are public.
+- No `@since`/javadoc requirement for internal MCP tools; existing tools have none.
+
+---
+
+### Task 1: Tab management tools (browser_tab_list, browser_tab_select, browser_tab_new, browser_tab_close)
+
+**Files:**
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabListTool.java`
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java`
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabNewTool.java`
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabCloseTool.java`
+- Modify: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NavigationTools.java`
+
+- [ ] **Step 1: Create TabListTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.WebDriver;
+
+import java.util.Map;
+
+class TabListTool extends McpTool {
+  TabListTool(BrowserSession session) {
+    super(session, "browser_tab_list",
+      "List all open browser tabs with index, handle, title and url");
+  }
+
+  @Override
+  String inputSchema() {
+    return EMPTY_SCHEMA;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    WebDriver driver = session.getDriver().getWebDriver();
+    String activeHandle = driver.getWindowHandle();
+    StringBuilder out = new StringBuilder();
+    int i = 0;
+    for (String handle : driver.getWindowHandles()) {
+      driver.switchTo().window(handle);
+      out.append('[').append(i++).append("] handle=\"").append(handle).append('"')
+        .append(" title=\"").append(driver.getTitle()).append('"')
+        .append(" url=\"").append(driver.getCurrentUrl()).append('"');
+      if (handle.equals(activeHandle)) {
+        out.append(" (active)");
+      }
+      out.append('\n');
+    }
+    driver.switchTo().window(activeHandle);
+    return success(out.toString().trim());
+  }
+}
+```
+
+- [ ] **Step 2: Create TabSelectTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.WebDriver;
+
+import java.util.List;
+import java.util.Map;
+
+class TabSelectTool extends McpTool {
+  TabSelectTool(BrowserSession session) {
+    super(session, "browser_tab_select",
+      "Switch to a tab by 0-based index or by window handle");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "index":  {"type": "integer", "description": "0-based tab index"},
+          "handle": {"type": "string",  "description": "Window handle string"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    Number indexRaw = (Number) args.get("index");
+    String handle = (String) args.get("handle");
+    if (indexRaw == null && handle == null) {
+      throw new IllegalArgumentException("Provide either 'index' or 'handle'");
+    }
+    if (indexRaw != null && handle != null) {
+      throw new IllegalArgumentException("Provide only one of 'index' or 'handle'");
+    }
+    WebDriver driver = session.getDriver().getWebDriver();
+    String target;
+    if (indexRaw != null) {
+      List<String> handles = List.copyOf(driver.getWindowHandles());
+      int index = indexRaw.intValue();
+      if (index < 0 || index >= handles.size()) {
+        throw new IllegalArgumentException(
+          "Tab index " + index + " out of range (0.." + (handles.size() - 1) + ")");
+      }
+      target = handles.get(index);
+    } else {
+      target = handle;
+    }
+    driver.switchTo().window(target);
+    return success("Switched to tab: " + target);
+  }
+}
+```
+
+- [ ] **Step 3: Create TabNewTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+
+import java.util.Map;
+
+class TabNewTool extends McpTool {
+  TabNewTool(BrowserSession session) {
+    super(session, "browser_tab_new",
+      "Open a new browser tab; optionally navigate to a URL");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string", "description": "Optional URL to open in the new tab"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    String url = (String) args.get("url");
+    WebDriver driver = session.getDriver().getWebDriver();
+    driver.switchTo().newWindow(WindowType.TAB);
+    if (url != null && !url.isEmpty()) {
+      session.getDriver().open(url);
+    }
+    return success("Opened new tab" + (url != null ? " at " + url : ""));
+  }
+}
+```
+
+- [ ] **Step 4: Create TabCloseTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.WebDriver;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class TabCloseTool extends McpTool {
+  TabCloseTool(BrowserSession session) {
+    super(session, "browser_tab_close",
+      "Close a browser tab. With no args, closes the current tab");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "index":  {"type": "integer", "description": "0-based tab index"},
+          "handle": {"type": "string",  "description": "Window handle string"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    WebDriver driver = session.getDriver().getWebDriver();
+    Number indexRaw = (Number) args.get("index");
+    String handle = (String) args.get("handle");
+    String target;
+    if (indexRaw == null && handle == null) {
+      target = driver.getWindowHandle();
+    } else if (indexRaw != null && handle != null) {
+      throw new IllegalArgumentException("Provide only one of 'index' or 'handle'");
+    } else if (indexRaw != null) {
+      List<String> handles = List.copyOf(driver.getWindowHandles());
+      int index = indexRaw.intValue();
+      if (index < 0 || index >= handles.size()) {
+        throw new IllegalArgumentException(
+          "Tab index " + index + " out of range (0.." + (handles.size() - 1) + ")");
+      }
+      target = handles.get(index);
+    } else {
+      target = handle;
+    }
+    String active = driver.getWindowHandle();
+    driver.switchTo().window(target);
+    driver.close();
+    Set<String> remaining = driver.getWindowHandles();
+    if (remaining.isEmpty()) {
+      return success("Closed last tab; no remaining tabs");
+    }
+    String next = target.equals(active) ? remaining.iterator().next() : active;
+    driver.switchTo().window(next);
+    return success("Closed tab: " + target);
+  }
+}
+```
+
+- [ ] **Step 5: Update NavigationTools.java to register the new tab tools**
+
+Replace the full file contents:
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.server.McpServerFeatures;
+
+import java.util.List;
+
+public class NavigationTools {
+  private NavigationTools() {
+  }
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs(BrowserSession session) {
+    return List.of(
+      new NavigateTool(session).spec(),
+      new BackTool(session).spec(),
+      new ForwardTool(session).spec(),
+      new RefreshTool(session).spec(),
+      new CloseTool(session).spec(),
+      new GetUrlTool(session).spec(),
+      new TabListTool(session).spec(),
+      new TabSelectTool(session).spec(),
+      new TabNewTool(session).spec(),
+      new TabCloseTool(session).spec()
+    );
+  }
+}
+```
+
+- [ ] **Step 6: Build and run MCP module check**
+
+Run: `./gradlew :modules:mcp:check`
+Expected: `BUILD SUCCESSFUL`, no Checkstyle or SpotBugs warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabListTool.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabNewTool.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabCloseTool.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NavigationTools.java
+git commit -m "mcp: add tab management tools (list/select/new/close)"
+```
+
+---
+
+### Task 2: browser_resize tool
+
+**Files:**
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ResizeTool.java`
+- Modify: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NavigationTools.java`
+
+- [ ] **Step 1: Create ResizeTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.Dimension;
+
+import java.util.Map;
+
+class ResizeTool extends McpTool {
+  ResizeTool(BrowserSession session) {
+    super(session, "browser_resize",
+      "Resize the browser viewport to the given width and height (pixels)");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "width":  {"type": "integer", "description": "Width in pixels"},
+          "height": {"type": "integer", "description": "Height in pixels"}
+        },
+        "required": ["width", "height"]
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    int width = ((Number) args.get("width")).intValue();
+    int height = ((Number) args.get("height")).intValue();
+    session.getDriver().getWebDriver().manage().window()
+      .setSize(new Dimension(width, height));
+    return success("Resized to " + width + "x" + height);
+  }
+}
+```
+
+- [ ] **Step 2: Update NavigationTools.java to register ResizeTool**
+
+Insert `new ResizeTool(session).spec()` at the end of the `List.of(...)`:
+
+```java
+  public static List<McpServerFeatures.SyncToolSpecification> specs(BrowserSession session) {
+    return List.of(
+      new NavigateTool(session).spec(),
+      new BackTool(session).spec(),
+      new ForwardTool(session).spec(),
+      new RefreshTool(session).spec(),
+      new CloseTool(session).spec(),
+      new GetUrlTool(session).spec(),
+      new TabListTool(session).spec(),
+      new TabSelectTool(session).spec(),
+      new TabNewTool(session).spec(),
+      new TabCloseTool(session).spec(),
+      new ResizeTool(session).spec()
+    );
+  }
+```
+
+- [ ] **Step 3: Build and run MCP module check**
+
+Run: `./gradlew :modules:mcp:check`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ResizeTool.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NavigationTools.java
+git commit -m "mcp: add browser_resize tool"
+```
+
+---
+
+### Task 3: browser_fill_form tool
+
+**Files:**
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/FillFormTool.java`
+- Modify: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ElementInteractionTools.java`
+
+- [ ] **Step 1: Create FillFormTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+
+import java.util.List;
+import java.util.Map;
+
+class FillFormTool extends McpTool {
+  FillFormTool(BrowserSession session) {
+    super(session, "browser_fill_form",
+      "Fill multiple form fields in one call. Each field is {selector, value}.");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "description": "Ordered list of fields to fill",
+            "items": {
+              "type": "object",
+              "properties": {
+                "selector": {"type": "string", "description": "CSS selector, XPath, or text= selector"},
+                "value":    {"type": "string", "description": "Value to set on the element"}
+              },
+              "required": ["selector", "value"]
+            }
+          }
+        },
+        "required": ["fields"]
+      }
+      """;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    List<Map<String, Object>> fields = (List<Map<String, Object>>) args.get("fields");
+    if (fields == null || fields.isEmpty()) {
+      throw new IllegalArgumentException("'fields' must be a non-empty array");
+    }
+    for (Map<String, Object> field : fields) {
+      String selector = (String) field.get("selector");
+      String value = (String) field.get("value");
+      if (selector == null || value == null) {
+        throw new IllegalArgumentException(
+          "Each field requires both 'selector' and 'value'");
+      }
+      session.getDriver().$(resolve(selector)).setValue(value);
+    }
+    return success("Filled " + fields.size() + " fields");
+  }
+}
+```
+
+- [ ] **Step 2: Update ElementInteractionTools.java to register FillFormTool**
+
+Replace the full file contents:
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.server.McpServerFeatures;
+
+import java.util.List;
+
+public class ElementInteractionTools {
+  private ElementInteractionTools() {
+  }
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs(BrowserSession session) {
+    return List.of(
+      new ClickTool(session).spec(),
+      new TypeTool(session).spec(),
+      new SetValueTool(session).spec(),
+      new ClearTool(session).spec(),
+      new HoverTool(session).spec(),
+      new FillFormTool(session).spec()
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Build and run MCP module check**
+
+Run: `./gradlew :modules:mcp:check`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/FillFormTool.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ElementInteractionTools.java
+git commit -m "mcp: add browser_fill_form tool"
+```
+
+---
+
+### Task 4: browser_wait_for tool (with unit test for argument validation)
+
+**Files:**
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/WaitForTool.java`
+- Create: `modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/WaitForToolTest.java`
+- Modify: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/InspectTools.java`
+
+- [ ] **Step 1: Write the failing test (WaitForToolTest.java)**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WaitForToolTest {
+
+  @Test
+  void rejectsZeroConditions() {
+    assertThatThrownBy(() -> WaitForTool.parseCondition(Map.of()))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("exactly one of");
+  }
+
+  @Test
+  void rejectsMultipleConditions() {
+    Map<String, Object> args = new HashMap<>();
+    args.put("text", "hello");
+    args.put("time", 1);
+    assertThatThrownBy(() -> WaitForTool.parseCondition(args))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("exactly one of");
+  }
+
+  @Test
+  void parsesTextCondition() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(Map.of("text", "hello"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.TEXT);
+    assertThat(c.value()).isEqualTo("hello");
+  }
+
+  @Test
+  void parsesTextGoneCondition() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(Map.of("textGone", "bye"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.TEXT_GONE);
+    assertThat(c.value()).isEqualTo("bye");
+  }
+
+  @Test
+  void parsesSelectorConditionDefaultsToVisible() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(Map.of("selector", "#foo"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.SELECTOR_VISIBLE);
+    assertThat(c.value()).isEqualTo("#foo");
+  }
+
+  @Test
+  void parsesSelectorConditionHidden() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(
+      Map.of("selector", "#foo", "state", "hidden"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.SELECTOR_HIDDEN);
+    assertThat(c.value()).isEqualTo("#foo");
+  }
+
+  @Test
+  void parsesTimeCondition() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(Map.of("time", 2.5));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.TIME);
+    assertThat(c.numericValue()).isEqualTo(2.5);
+  }
+
+  @Test
+  void rejectsUnknownSelectorState() {
+    assertThatThrownBy(() -> WaitForTool.parseCondition(
+      Map.of("selector", "#foo", "state", "weird")))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("state");
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :modules:mcp:test --tests WaitForToolTest`
+Expected: FAIL — class `WaitForTool` does not exist.
+
+- [ ] **Step 3: Create WaitForTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.jspecify.annotations.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.codeborne.selenide.Condition.appear;
+import static com.codeborne.selenide.Condition.disappear;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selectors.byTagName;
+
+class WaitForTool extends McpTool {
+  enum Kind { TEXT, TEXT_GONE, SELECTOR_VISIBLE, SELECTOR_HIDDEN, TIME }
+
+  record Condition(Kind kind, @Nullable String value, double numericValue) {
+    static Condition of(Kind kind, String value) {
+      return new Condition(kind, value, 0);
+    }
+    static Condition ofTime(double seconds) {
+      return new Condition(Kind.TIME, null, seconds);
+    }
+  }
+
+  WaitForTool(BrowserSession session) {
+    super(session, "browser_wait_for",
+      "Wait for a condition: text appearing/disappearing on page, "
+        + "an element becoming visible/hidden, or a fixed time in seconds. "
+        + "Exactly one of 'text', 'textGone', 'selector', 'time' must be provided.");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "text":     {"type": "string",  "description": "Text to wait for on the page"},
+          "textGone": {"type": "string",  "description": "Text to wait to disappear from the page"},
+          "selector": {"type": "string",  "description": "Element selector to wait for"},
+          "state":    {"type": "string",  "enum": ["visible", "hidden"], "description": "Selector state (default visible)"},
+          "time":     {"type": "number",  "description": "Seconds to sleep"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    Condition c = parseCondition(args);
+    switch (c.kind()) {
+      case TEXT -> session.getDriver().$(byTagName("body")).shouldHave(text(c.value()));
+      case TEXT_GONE -> session.getDriver().$(byTagName("body")).shouldNotHave(text(c.value()));
+      case SELECTOR_VISIBLE -> session.getDriver().$(resolve(c.value())).should(appear);
+      case SELECTOR_HIDDEN -> session.getDriver().$(resolve(c.value())).should(disappear);
+      case TIME -> sleep((long) (c.numericValue() * 1000));
+    }
+    return success("Wait condition satisfied: " + c.kind());
+  }
+
+  static Condition parseCondition(Map<String, Object> args) {
+    Map<String, Object> present = new LinkedHashMap<>();
+    for (String key : new String[]{"text", "textGone", "selector", "time"}) {
+      if (args.get(key) != null) {
+        present.put(key, args.get(key));
+      }
+    }
+    if (present.size() != 1) {
+      throw new IllegalArgumentException(
+        "browser_wait_for requires exactly one of: text, textGone, selector, time "
+          + "(got " + present.size() + ")");
+    }
+    Map.Entry<String, Object> entry = present.entrySet().iterator().next();
+    return switch (entry.getKey()) {
+      case "text" -> Condition.of(Kind.TEXT, entry.getValue().toString());
+      case "textGone" -> Condition.of(Kind.TEXT_GONE, entry.getValue().toString());
+      case "time" -> Condition.ofTime(((Number) entry.getValue()).doubleValue());
+      case "selector" -> {
+        String state = args.get("state") == null ? "visible" : args.get("state").toString();
+        yield switch (state) {
+          case "visible" -> Condition.of(Kind.SELECTOR_VISIBLE, entry.getValue().toString());
+          case "hidden" -> Condition.of(Kind.SELECTOR_HIDDEN, entry.getValue().toString());
+          default -> throw new IllegalArgumentException(
+            "Unknown state '" + state + "'; expected 'visible' or 'hidden'");
+        };
+      }
+      default -> throw new IllegalStateException("unreachable");
+    };
+  }
+
+  private static void sleep(long ms) {
+    try {
+      Thread.sleep(ms);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Sleep interrupted", e);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :modules:mcp:test --tests WaitForToolTest`
+Expected: PASS — 8 tests.
+
+- [ ] **Step 5: Update InspectTools.java to register WaitForTool**
+
+Replace the full file contents:
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.server.McpServerFeatures;
+
+import java.util.List;
+
+public class InspectTools {
+  private InspectTools() {
+  }
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs(BrowserSession session) {
+    return List.of(
+      new SnapshotTool(session).spec(),
+      new FindTool(session).spec(),
+      new FindAllTool(session).spec(),
+      new GetTextTool(session).spec(),
+      new ConsoleLogsTool(session).spec(),
+      new WaitForTool(session).spec()
+    );
+  }
+}
+```
+
+- [ ] **Step 6: Run full MCP module check**
+
+Run: `./gradlew :modules:mcp:check`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/WaitForTool.java \
+        modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/WaitForToolTest.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/InspectTools.java
+git commit -m "mcp: add browser_wait_for tool"
+```
+
+---
+
+### Task 5: Network inspection tools (browser_network_requests, browser_network_request) + NetworkTools group
+
+**Files:**
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java`
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java`
+- Create: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkTools.java`
+- Modify: `modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java`
+
+- [ ] **Step 1: Create NetworkRequestsTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.browserup.bup.BrowserUpProxy;
+import com.codeborne.selenide.mcp.BrowserSession;
+import de.sstoehr.harreader.model.Har;
+import de.sstoehr.harreader.model.HarEntry;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+class NetworkRequestsTool extends McpTool {
+  private static final int MAX_ENTRIES = 100;
+
+  NetworkRequestsTool(BrowserSession session) {
+    super(session, "browser_network_requests",
+      "List recently captured network requests. Requires --proxy-enabled at startup. "
+        + "Optional 'urlPattern' filters by URL substring.");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "urlPattern": {"type": "string", "description": "Substring to match against the URL"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    SelenideProxyServer proxy = session.getDriver().getProxy();
+    if (proxy == null) {
+      throw new IllegalStateException(
+        "Network capture requires --proxy-enabled at server startup");
+    }
+    String pattern = (String) args.get("urlPattern");
+    List<HarEntry> entries = harEntries(proxy.getProxy());
+    StringBuilder out = new StringBuilder();
+    int start = Math.max(0, entries.size() - MAX_ENTRIES);
+    int shown = 0;
+    for (int i = start; i < entries.size(); i++) {
+      HarEntry e = entries.get(i);
+      String url = e.getRequest().getUrl();
+      if (pattern != null && !url.contains(pattern)) continue;
+      out.append(e.getRequest().getMethod()).append(' ').append(url)
+        .append(" -> ").append(e.getResponse().getStatus()).append(' ')
+        .append(nullToDash(e.getResponse().getContent().getMimeType())).append(' ')
+        .append((long) e.getTime()).append("ms\n");
+      shown++;
+    }
+    if (shown == 0) {
+      return success("No matching network requests");
+    }
+    return success(out.toString().trim());
+  }
+
+  static List<HarEntry> harEntries(BrowserUpProxy proxy) {
+    Har har = proxy.getHar();
+    if (har == null) {
+      proxy.newHar("selenide-mcp");
+      return List.of();
+    }
+    return har.getLog().getEntries();
+  }
+
+  private static String nullToDash(@Nullable String s) {
+    return s == null || s.isEmpty() ? "-" : s;
+  }
+}
+```
+
+- [ ] **Step 2: Create NetworkRequestTool.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import de.sstoehr.harreader.model.HarEntry;
+import de.sstoehr.harreader.model.HarHeader;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
+import io.modelcontextprotocol.spec.McpSchema;
+
+import java.util.List;
+import java.util.Map;
+
+class NetworkRequestTool extends McpTool {
+  NetworkRequestTool(BrowserSession session) {
+    super(session, "browser_network_request",
+      "Get full detail (headers, status, duration) for the most recent network "
+        + "request whose URL contains 'urlPattern'. Requires --proxy-enabled.");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "urlPattern": {"type": "string", "description": "Substring to match against the URL"}
+        },
+        "required": ["urlPattern"]
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    SelenideProxyServer proxy = session.getDriver().getProxy();
+    if (proxy == null) {
+      throw new IllegalStateException(
+        "Network capture requires --proxy-enabled at server startup");
+    }
+    String pattern = (String) args.get("urlPattern");
+    if (pattern == null || pattern.isEmpty()) {
+      throw new IllegalArgumentException("'urlPattern' is required");
+    }
+    List<HarEntry> entries = NetworkRequestsTool.harEntries(proxy.getProxy());
+    HarEntry match = null;
+    for (int i = entries.size() - 1; i >= 0; i--) {
+      if (entries.get(i).getRequest().getUrl().contains(pattern)) {
+        match = entries.get(i);
+        break;
+      }
+    }
+    if (match == null) {
+      throw new IllegalArgumentException("No network request matching: " + pattern);
+    }
+    return success(format(match));
+  }
+
+  private static String format(HarEntry e) {
+    StringBuilder out = new StringBuilder();
+    out.append(e.getRequest().getMethod()).append(' ')
+      .append(e.getRequest().getUrl()).append('\n');
+    out.append("Status: ").append(e.getResponse().getStatus()).append(' ')
+      .append(e.getResponse().getStatusText()).append('\n');
+    out.append("Duration: ").append((long) e.getTime()).append("ms\n");
+    out.append("Request headers:\n");
+    appendHeaders(out, e.getRequest().getHeaders());
+    out.append("Response headers:\n");
+    appendHeaders(out, e.getResponse().getHeaders());
+    return out.toString().trim();
+  }
+
+  private static void appendHeaders(StringBuilder out, List<HarHeader> headers) {
+    for (HarHeader h : headers) {
+      out.append("  ").append(h.getName()).append(": ").append(h.getValue()).append('\n');
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Create NetworkTools.java**
+
+```java
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.server.McpServerFeatures;
+
+import java.util.List;
+
+public class NetworkTools {
+  private NetworkTools() {
+  }
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs(BrowserSession session) {
+    return List.of(
+      new NetworkRequestsTool(session).spec(),
+      new NetworkRequestTool(session).spec()
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Update SelenideMcpServer.java to register NetworkTools**
+
+Add the import:
+
+```java
+import com.codeborne.selenide.mcp.tools.NetworkTools;
+```
+
+In `start(String[] args)`, extend the builder chain (replace the existing block):
+
+```java
+    var builder = McpServer.sync(transport)
+      .serverInfo("selenide-mcp", getVersion())
+      .tools(NavigationTools.specs(session))
+      .tools(ElementInteractionTools.specs(session))
+      .tools(AdvancedInteractionTools.specs(session))
+      .tools(InspectTools.specs(session))
+      .tools(NetworkTools.specs(session));
+```
+
+- [ ] **Step 5: Build and run full MCP module check**
+
+Run: `./gradlew :modules:mcp:check`
+Expected: `BUILD SUCCESSFUL`.
+
+Verify SpotBugs/Checkstyle do not complain about the new code; if `@SuppressFBWarnings` is needed for the JSON suppression or the unchecked cast, address per the existing tools' patterns (search the module for prior examples).
+
+- [ ] **Step 6: Run full root check to catch any cross-module regressions**
+
+Run: `./gradlew check`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkTools.java \
+        modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
+git commit -m "mcp: add network inspection tools (browser_network_requests, browser_network_request)"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Confirm Javadoc-for-site still builds**
+
+Run: `./gradlew javadocForSite`
+Expected: `BUILD SUCCESSFUL`. (Per CLAUDE.md: this gate must hold before push.)
+
+- [ ] **Step 2: Inspect the new tool list**
+
+Run: `git diff main..HEAD --stat` and verify only files under `modules/mcp/` and `docs/superpowers/` are affected, no spurious changes.
+
+- [ ] **Step 3: Report back to user**
+
+Summarize: branch `worktree-mcp-additional-tools` contains 9 new tools across 6 commits, all checks green, ready to review/merge.
+
+---
+
+## Notes for the implementer
+
+- The `BrowserUp` HAR API: `BrowserUpProxy.getHar()` returns a `de.sstoehr.harreader.model.Har` (from the `de.sstoehr:har-reader` dependency). It is `null` until `newHar(...)` is called. The plan lazily starts HAR on first network-tool call (`NetworkRequestsTool.harEntries`). This means traffic before the first network-tool call is not captured — acceptable for the MCP use case.
+- `WindowType.TAB` import is `org.openqa.selenium.WindowType`.
+- `Condition` static imports already used elsewhere in the codebase: `appear`, `disappear`, `text`. `Selectors.byTagName` for `body`.
+- `SelenideProxyServer.getProxy()` returns the underlying `BrowserUpProxy` (`com.browserup.bup.BrowserUpProxy`).
+- The MCP module depends only on `modules:core` and the MCP SDK. BrowserUp/HarReader classes (`com.browserup.bup.*`, `com.browserup.harreader.model.*`) come transitively through `modules:core`. If a compile-time visibility issue arises (e.g., the dependency is `runtimeOnly` on the core side), add `implementation "com.browserup:browserup-proxy-core:..."` to `modules/mcp/build.gradle` matching the version from the root `build.gradle`. Investigate before adding — the implementer should prefer not to add unnecessary deps.
+- All new files use 2-space indentation, no tabs, LF line endings, newline at EOF, max 136 chars/line.

--- a/docs/superpowers/specs/2026-05-24-mcp-additional-tools-design.md
+++ b/docs/superpowers/specs/2026-05-24-mcp-additional-tools-design.md
@@ -1,0 +1,107 @@
+# MCP additional tools (parity with Playwright MCP)
+
+## Goal
+
+Extend `selenide-mcp` with the capabilities Playwright MCP exposes but Selenide MCP currently lacks: tab management, generic wait condition, network request inspection, viewport resize, bulk form fill.
+
+## Tools added
+
+| Tool                       | Group               | Purpose                                                   |
+|----------------------------|---------------------|-----------------------------------------------------------|
+| `browser_tab_list`         | NavigationTools     | List all open tabs                                        |
+| `browser_tab_select`       | NavigationTools     | Switch to tab by index or handle                          |
+| `browser_tab_new`          | NavigationTools     | Open a new tab (optional URL)                             |
+| `browser_tab_close`        | NavigationTools     | Close current tab, or a specific one                      |
+| `browser_resize`           | NavigationTools     | Resize viewport `{width, height}`                         |
+| `browser_fill_form`        | ElementInteraction  | Bulk-fill `{fields: [{selector, value}]}`                 |
+| `browser_wait_for`         | InspectTools        | Wait for text / textGone / selector / time                |
+| `browser_network_requests` | NetworkTools (new)  | List captured network requests                            |
+| `browser_network_request`  | NetworkTools (new)  | Get one request by URL pattern (with headers, status)     |
+
+Total: 9 new tools, 1 new tool-group registration.
+
+## Detailed behavior
+
+### Tabs
+
+Each tab tool returns concise text content (no JSON) like the existing tools.
+
+- `browser_tab_list` — no args. Returns lines: `[i] handle="..." title="..." url="..."` plus `(active)` marker.
+- `browser_tab_select` — `{index?: int, handle?: string}` (exactly one). Uses `driver.getWebDriver().switchTo().window(handle)`.
+- `browser_tab_new` — `{url?: string}`. Uses `switchTo().newWindow(WindowType.TAB)`; if `url` given, then `open(url)`.
+- `browser_tab_close` — `{index?: int, handle?: string}` (both optional → closes current). After closing, if any tabs remain, switches to the first remaining handle so subsequent calls don't hit a dead driver.
+
+### Resize
+
+`browser_resize` — `{width: int, height: int}`. Calls `driver.getWebDriver().manage().window().setSize(new Dimension(w, h))`. Returns confirmation string.
+
+### Fill form
+
+`browser_fill_form` — `{fields: [{selector: string, value: string}, ...]}`. Iterates in order, calls `$(resolve(selector)).setValue(value)` on each. Returns `"Filled N fields"`. If any field fails, the existing `McpTool.error` path surfaces it.
+
+### Wait for
+
+`browser_wait_for` — exactly one of:
+- `text: string` — wait for `$("body").shouldHave(text(text))`
+- `textGone: string` — wait for `$("body").shouldNotHave(text(textGone))`
+- `selector: string` + optional `state: "visible" | "hidden"` (default `visible`) — `$(resolve(selector)).should(visible ? appear : disappear)`
+- `time: number` — seconds; `Thread.sleep(time * 1000)`
+
+Validation: exactly one of `{text, textGone, selector, time}` must be present. Tool errors with a clear message otherwise. Selenide's configured timeout applies to the should-based waits; `time` ignores it.
+
+### Network
+
+Both tools require the BrowserUp proxy. On invocation:
+1. Check `session.getDriver().getProxy()`. If null, return error: `"Network capture requires --proxy-enabled at server startup"`.
+2. Get the underlying `BrowserUpProxy` via `selenideProxy.getProxy()`.
+3. Lazy-start HAR: if `proxy.getHar() == null`, call `proxy.newHar("selenide-mcp")`. Idempotent via the `getHar()` check.
+
+- `browser_network_requests` — `{urlPattern?: string}`. Returns up to 100 most recent entries (newest last) as lines: `<method> <url> -> <status> <contentType> <durationMs>ms`. If `urlPattern` provided, filter by substring match against URL.
+- `browser_network_request` — `{urlPattern: string}` (required). Returns the most recent matching entry with method, URL, status, all request headers, all response headers, and duration. Errors if no match.
+
+Registration: a new `NetworkTools.specs(session)` is added unconditionally to the server builder. Tools self-report the proxy-not-enabled error at call time. (Hiding the tools entirely would be cleaner but introduces conditional registration logic; the error path keeps the design simple and the tool list stable.)
+
+## File structure
+
+```
+modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/
+  TabListTool.java               (new)
+  TabSelectTool.java             (new)
+  TabNewTool.java                (new)
+  TabCloseTool.java              (new)
+  ResizeTool.java                (new)
+  FillFormTool.java              (new)
+  WaitForTool.java               (new)
+  NetworkRequestsTool.java       (new)
+  NetworkRequestTool.java        (new)
+  NetworkTools.java              (new — group registrar)
+  NavigationTools.java           (extend: +5 tools)
+  ElementInteractionTools.java   (extend: +1 tool)
+  InspectTools.java              (extend: +1 tool)
+
+modules/mcp/src/main/java/com/codeborne/selenide/mcp/
+  SelenideMcpServer.java         (extend: register NetworkTools group)
+```
+
+Each tool class extends `McpTool`, lives in package `com.codeborne.selenide.mcp.tools`, is package-private. Pattern is identical to the existing tools (`NavigateTool`, `SetValueTool`, etc.).
+
+## Testing
+
+Mirror the existing MCP module test convention: unit tests for non-trivial logic only — the thin wrapper tools have no direct tests. Where added value exists:
+
+- `WaitForToolTest` — verify that zero conditions and >1 conditions both produce a clear error; verify each condition path dispatches correctly (via a small input-validation pre-check that we can test without a browser). The actual wait/should calls require a real browser and are not unit-testable here.
+
+That is the only new test class — other tools are thin enough that unit testing offers no real coverage.
+
+## Out of scope
+
+- README/docs updates for the new tools.
+- Integration tests using a real browser (no precedent in `modules/mcp` today).
+- New `--caps=...` flag for network tools (always registered; error at call time when proxy is off).
+- Page-level `waitForLoadState`-style helpers — not in Playwright MCP either.
+
+## Risks / open questions
+
+- `BrowserUpProxy.getHar()` returns `null` until `newHar(...)` is called. We lazy-start at first network-tool call, which means requests made before the first call aren't captured. Acceptable: tests using these tools will call them before the meaningful traffic. (Mitigation considered: start HAR at session creation when proxy is enabled. Rejected as it couples `BrowserSession` to network internals; reconsider if usage patterns show it's needed.)
+- After closing the active tab, WebDriver requires switching to a surviving handle before further calls. The design above handles this; need to also handle "closed the last tab" by surfacing a clean message.
+- `setValue` semantics on non-input elements differ from Playwright's `fill`. Acceptable — this mirrors Selenide's own form-filling behavior.

--- a/modules/mcp/build.gradle
+++ b/modules/mcp/build.gradle
@@ -10,6 +10,12 @@ ext {
 dependencies {
   implementation project(':modules:core')
   implementation "io.modelcontextprotocol.sdk:mcp:$mcpSdkVersion"
+  compileOnly("com.github.valfirst.browserup-proxy:browserup-proxy-core:${browserupProxyVersion}") {
+    exclude group: 'io.netty'
+    exclude group: 'org.seleniumhq.selenium'
+    exclude group: 'xyz.rogfam'
+  }
+  compileOnly 'de.sstoehr:har-reader:2.5.0'
 
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.assertj:assertj-core:$assertjVersion") { transitive = false }

--- a/modules/mcp/build.gradle
+++ b/modules/mcp/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     exclude group: 'org.seleniumhq.selenium'
     exclude group: 'xyz.rogfam'
   }
-  compileOnly 'de.sstoehr:har-reader:2.5.0'
+  implementation 'de.sstoehr:har-reader:2.5.0'
 
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.assertj:assertj-core:$assertjVersion") { transitive = false }

--- a/modules/mcp/build.gradle
+++ b/modules/mcp/build.gradle
@@ -10,12 +10,7 @@ ext {
 dependencies {
   implementation project(':modules:core')
   implementation "io.modelcontextprotocol.sdk:mcp:$mcpSdkVersion"
-  compileOnly("com.github.valfirst.browserup-proxy:browserup-proxy-core:${browserupProxyVersion}") {
-    exclude group: 'io.netty'
-    exclude group: 'org.seleniumhq.selenium'
-    exclude group: 'xyz.rogfam'
-  }
-  implementation 'de.sstoehr:har-reader:2.5.0'
+  implementation project(':modules:proxy')
 
   testImplementation("org.junit.jupiter:junit-jupiter")
   testImplementation("org.assertj:assertj-core:$assertjVersion") { transitive = false }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
@@ -10,6 +10,7 @@ import com.codeborne.selenide.mcp.tools.CodegenTools;
 import com.codeborne.selenide.mcp.tools.ElementInteractionTools;
 import com.codeborne.selenide.mcp.tools.InspectTools;
 import com.codeborne.selenide.mcp.tools.NavigationTools;
+import com.codeborne.selenide.mcp.tools.NetworkTools;
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
@@ -49,7 +50,8 @@ public class SelenideMcpServer {
       .tools(NavigationTools.specs(session))
       .tools(ElementInteractionTools.specs(session))
       .tools(AdvancedInteractionTools.specs(session))
-      .tools(InspectTools.specs(session));
+      .tools(InspectTools.specs(session))
+      .tools(NetworkTools.specs(session));
 
     if (hasCapability(args, "codegen")) {
       builder = builder.tools(CodegenTools.specs(session));

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ElementInteractionTools.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ElementInteractionTools.java
@@ -15,7 +15,8 @@ public class ElementInteractionTools {
       new TypeTool(session).spec(),
       new SetValueTool(session).spec(),
       new ClearTool(session).spec(),
-      new HoverTool(session).spec()
+      new HoverTool(session).spec(),
+      new FillFormTool(session).spec()
     );
   }
 }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/FillFormTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/FillFormTool.java
@@ -1,0 +1,57 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+
+import java.util.List;
+import java.util.Map;
+
+class FillFormTool extends McpTool {
+  FillFormTool(BrowserSession session) {
+    super(session, "browser_fill_form",
+      "Fill multiple form fields in one call. Each field is {selector, value}.");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "description": "Ordered list of fields to fill",
+            "items": {
+              "type": "object",
+              "properties": {
+                "selector": {"type": "string", "description": "CSS selector, XPath, or text= selector"},
+                "value":    {"type": "string", "description": "Value to set on the element"}
+              },
+              "required": ["selector", "value"]
+            }
+          }
+        },
+        "required": ["fields"]
+      }
+      """;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    List<Map<String, Object>> fields = (List<Map<String, Object>>) args.get("fields");
+    if (fields == null || fields.isEmpty()) {
+      throw new IllegalArgumentException("'fields' must be a non-empty array");
+    }
+    for (Map<String, Object> field : fields) {
+      String selector = (String) field.get("selector");
+      String value = (String) field.get("value");
+      if (selector == null || value == null) {
+        throw new IllegalArgumentException(
+          "Each field requires both 'selector' and 'value'");
+      }
+      session.getDriver().$(resolve(selector)).setValue(value);
+    }
+    return success("Filled " + fields.size() + " fields");
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/FillFormTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/FillFormTool.java
@@ -44,8 +44,8 @@ class FillFormTool extends McpTool {
       throw new IllegalArgumentException("'fields' must be a non-empty array");
     }
     for (Map<String, Object> field : fields) {
-      String selector = (String) field.get("selector");
-      String value = (String) field.get("value");
+      String selector = field == null ? null : (String) field.get("selector");
+      String value = field == null ? null : (String) field.get("value");
       if (selector == null || value == null) {
         throw new IllegalArgumentException(
           "Each field requires both 'selector' and 'value'");

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/InspectTools.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/InspectTools.java
@@ -15,7 +15,8 @@ public class InspectTools {
       new FindTool(session).spec(),
       new FindAllTool(session).spec(),
       new GetTextTool(session).spec(),
-      new ConsoleLogsTool(session).spec()
+      new ConsoleLogsTool(session).spec(),
+      new WaitForTool(session).spec()
     );
   }
 }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/McpTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/McpTool.java
@@ -86,9 +86,12 @@ abstract class McpTool {
 
   /**
    * Resolves a browser tab's window handle from either a 0-based {@code index} or an explicit
-   * {@code handle}, given exactly one of them is non-null (mutual exclusivity is validated here).
+   * {@code handle}. Exactly one of them must be non-null; both are validated here.
    */
   protected static String resolveWindowHandle(WebDriver driver, @Nullable Number index, @Nullable String handle) {
+    if (index == null && handle == null) {
+      throw new IllegalArgumentException("Provide either 'index' or 'handle'");
+    }
     if (index != null && handle != null) {
       throw new IllegalArgumentException("Provide only one of 'index' or 'handle'");
     }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/McpTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/McpTool.java
@@ -6,7 +6,9 @@ import com.codeborne.selenide.mcp.ToolErrorHandler;
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 
 import java.util.List;
 import java.util.Map;
@@ -80,6 +82,25 @@ abstract class McpTool {
 
   protected static By resolve(String selector) {
     return RESOLVER.resolve(selector);
+  }
+
+  /**
+   * Resolves a browser tab's window handle from either a 0-based {@code index} or an explicit
+   * {@code handle}, given exactly one of them is non-null (mutual exclusivity is validated here).
+   */
+  protected static String resolveWindowHandle(WebDriver driver, @Nullable Number index, @Nullable String handle) {
+    if (index != null && handle != null) {
+      throw new IllegalArgumentException("Provide only one of 'index' or 'handle'");
+    }
+    if (index == null) {
+      return handle;
+    }
+    List<String> handles = List.copyOf(driver.getWindowHandles());
+    int i = index.intValue();
+    if (i < 0 || i >= handles.size()) {
+      throw new IllegalArgumentException("Tab index " + i + " out of range (0.." + (handles.size() - 1) + ")");
+    }
+    return handles.get(i);
   }
 
   protected McpSchema.CallToolResult success(String text) {

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NavigationTools.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NavigationTools.java
@@ -20,7 +20,8 @@ public class NavigationTools {
       new TabListTool(session).spec(),
       new TabSelectTool(session).spec(),
       new TabNewTool(session).spec(),
-      new TabCloseTool(session).spec()
+      new TabCloseTool(session).spec(),
+      new ResizeTool(session).spec()
     );
   }
 }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NavigationTools.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NavigationTools.java
@@ -16,7 +16,11 @@ public class NavigationTools {
       new ForwardTool(session).spec(),
       new RefreshTool(session).spec(),
       new CloseTool(session).spec(),
-      new GetUrlTool(session).spec()
+      new GetUrlTool(session).spec(),
+      new TabListTool(session).spec(),
+      new TabSelectTool(session).spec(),
+      new TabNewTool(session).spec(),
+      new TabCloseTool(session).spec()
     );
   }
 }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java
@@ -43,7 +43,8 @@ class NetworkRequestTool extends McpTool {
     List<HarEntry> entries = NetworkRequestsTool.harEntries(proxy.getProxy());
     HarEntry match = null;
     for (int i = entries.size() - 1; i >= 0; i--) {
-      if (entries.get(i).getRequest().getUrl().contains(pattern)) {
+      String url = entries.get(i).getRequest().getUrl();
+      if (url != null && url.contains(pattern)) {
         match = entries.get(i);
         break;
       }
@@ -60,7 +61,7 @@ class NetworkRequestTool extends McpTool {
       .append(e.getRequest().getUrl()).append('\n');
     out.append("Status: ").append(e.getResponse().getStatus()).append(' ')
       .append(e.getResponse().getStatusText()).append('\n');
-    out.append("Duration: ").append((long) e.getTime()).append("ms\n");
+    out.append("Duration: ").append(e.getTime() != null ? (long) e.getTime() : 0L).append("ms\n");
     out.append("Request headers:\n");
     appendHeaders(out, e.getRequest().getHeaders());
     out.append("Response headers:\n");

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java
@@ -57,10 +57,10 @@ class NetworkRequestTool extends McpTool {
 
   private static String format(HarEntry e) {
     StringBuilder out = new StringBuilder();
-    out.append(e.getRequest().getMethod()).append(' ')
+    out.append(NetworkRequestsTool.nullToDash(e.getRequest().getMethod())).append(' ')
       .append(e.getRequest().getUrl()).append('\n');
     out.append("Status: ").append(e.getResponse().getStatus()).append(' ')
-      .append(e.getResponse().getStatusText()).append('\n');
+      .append(NetworkRequestsTool.nullToDash(e.getResponse().getStatusText())).append('\n');
     out.append("Duration: ").append(e.getTime() != null ? (long) e.getTime() : 0L).append("ms\n");
     out.append("Request headers:\n");
     appendHeaders(out, e.getRequest().getHeaders());

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java
@@ -1,0 +1,76 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
+import de.sstoehr.harreader.model.HarEntry;
+import de.sstoehr.harreader.model.HarHeader;
+import io.modelcontextprotocol.spec.McpSchema;
+
+import java.util.List;
+import java.util.Map;
+
+class NetworkRequestTool extends McpTool {
+  NetworkRequestTool(BrowserSession session) {
+    super(session, "browser_network_request",
+      "Get full detail (headers, status, duration) for the most recent network "
+        + "request whose URL contains 'urlPattern'. Requires --proxy-enabled.");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "urlPattern": {"type": "string", "description": "Substring to match against the URL"}
+        },
+        "required": ["urlPattern"]
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    SelenideProxyServer proxy = session.getDriver().getProxy();
+    if (proxy == null) {
+      throw new IllegalStateException(
+        "Network capture requires --proxy-enabled at server startup");
+    }
+    String pattern = (String) args.get("urlPattern");
+    if (pattern == null || pattern.isEmpty()) {
+      throw new IllegalArgumentException("'urlPattern' is required");
+    }
+    List<HarEntry> entries = NetworkRequestsTool.harEntries(proxy.getProxy());
+    HarEntry match = null;
+    for (int i = entries.size() - 1; i >= 0; i--) {
+      if (entries.get(i).getRequest().getUrl().contains(pattern)) {
+        match = entries.get(i);
+        break;
+      }
+    }
+    if (match == null) {
+      throw new IllegalArgumentException("No network request matching: " + pattern);
+    }
+    return success(format(match));
+  }
+
+  private static String format(HarEntry e) {
+    StringBuilder out = new StringBuilder();
+    out.append(e.getRequest().getMethod()).append(' ')
+      .append(e.getRequest().getUrl()).append('\n');
+    out.append("Status: ").append(e.getResponse().getStatus()).append(' ')
+      .append(e.getResponse().getStatusText()).append('\n');
+    out.append("Duration: ").append((long) e.getTime()).append("ms\n");
+    out.append("Request headers:\n");
+    appendHeaders(out, e.getRequest().getHeaders());
+    out.append("Response headers:\n");
+    appendHeaders(out, e.getResponse().getHeaders());
+    return out.toString().trim();
+  }
+
+  private static void appendHeaders(StringBuilder out, List<HarHeader> headers) {
+    for (HarHeader h : headers) {
+      out.append("  ").append(h.getName()).append(": ").append(h.getValue()).append('\n');
+    }
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestTool.java
@@ -31,11 +31,7 @@ class NetworkRequestTool extends McpTool {
 
   @Override
   McpSchema.CallToolResult execute(Map<String, Object> args) {
-    SelenideProxyServer proxy = session.getDriver().getProxy();
-    if (proxy == null) {
-      throw new IllegalStateException(
-        "Network capture requires --proxy-enabled at server startup");
-    }
+    SelenideProxyServer proxy = NetworkTools.requireProxy(session);
     String pattern = (String) args.get("urlPattern");
     if (pattern == null || pattern.isEmpty()) {
       throw new IllegalArgumentException("'urlPattern' is required");

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
@@ -47,11 +47,12 @@ class NetworkRequestsTool extends McpTool {
     for (int i = start; i < entries.size(); i++) {
       HarEntry e = entries.get(i);
       String url = e.getRequest().getUrl();
+      if (url == null) continue;
       if (pattern != null && !url.contains(pattern)) continue;
       out.append(e.getRequest().getMethod()).append(' ').append(url)
         .append(" -> ").append(e.getResponse().getStatus()).append(' ')
         .append(nullToDash(e.getResponse().getContent().getMimeType())).append(' ')
-        .append((long) e.getTime()).append("ms\n");
+        .append(e.getTime() != null ? (long) e.getTime() : 0L).append("ms\n");
       shown++;
     }
     if (shown == 0) {

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
@@ -1,0 +1,75 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.browserup.bup.BrowserUpProxy;
+import com.codeborne.selenide.mcp.BrowserSession;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
+import de.sstoehr.harreader.model.Har;
+import de.sstoehr.harreader.model.HarEntry;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+class NetworkRequestsTool extends McpTool {
+  private static final int MAX_ENTRIES = 100;
+
+  NetworkRequestsTool(BrowserSession session) {
+    super(session, "browser_network_requests",
+      "List recently captured network requests. Requires --proxy-enabled at startup. "
+        + "Optional 'urlPattern' filters by URL substring.");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "urlPattern": {"type": "string", "description": "Substring to match against the URL"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    SelenideProxyServer proxy = session.getDriver().getProxy();
+    if (proxy == null) {
+      throw new IllegalStateException(
+        "Network capture requires --proxy-enabled at server startup");
+    }
+    String pattern = (String) args.get("urlPattern");
+    List<HarEntry> entries = harEntries(proxy.getProxy());
+    StringBuilder out = new StringBuilder();
+    int start = Math.max(0, entries.size() - MAX_ENTRIES);
+    int shown = 0;
+    for (int i = start; i < entries.size(); i++) {
+      HarEntry e = entries.get(i);
+      String url = e.getRequest().getUrl();
+      if (pattern != null && !url.contains(pattern)) continue;
+      out.append(e.getRequest().getMethod()).append(' ').append(url)
+        .append(" -> ").append(e.getResponse().getStatus()).append(' ')
+        .append(nullToDash(e.getResponse().getContent().getMimeType())).append(' ')
+        .append((long) e.getTime()).append("ms\n");
+      shown++;
+    }
+    if (shown == 0) {
+      return success("No matching network requests");
+    }
+    return success(out.toString().trim());
+  }
+
+  static List<HarEntry> harEntries(BrowserUpProxy proxy) {
+    Har har = proxy.getHar();
+    if (har == null) {
+      proxy.newHar("selenide-mcp");
+      return List.of();
+    }
+    return har.getLog().getEntries();
+  }
+
+  private static String nullToDash(@Nullable String s) {
+    return s == null || s.isEmpty() ? "-" : s;
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
@@ -49,7 +49,7 @@ class NetworkRequestsTool extends McpTool {
       String url = e.getRequest().getUrl();
       if (url == null) continue;
       if (pattern != null && !url.contains(pattern)) continue;
-      out.append(e.getRequest().getMethod()).append(' ').append(url)
+      out.append(nullToDash(e.getRequest().getMethod())).append(' ').append(url)
         .append(" -> ").append(e.getResponse().getStatus()).append(' ')
         .append(nullToDash(e.getResponse().getContent().getMimeType())).append(' ')
         .append(e.getTime() != null ? (long) e.getTime() : 0L).append("ms\n");
@@ -70,7 +70,9 @@ class NetworkRequestsTool extends McpTool {
     return har.getLog().getEntries();
   }
 
-  private static String nullToDash(@Nullable String s) {
-    return s == null || s.isEmpty() ? "-" : s;
+  static String nullToDash(@Nullable Object o) {
+    if (o == null) return "-";
+    String s = o.toString();
+    return s.isEmpty() ? "-" : s;
   }
 }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
@@ -34,11 +34,7 @@ class NetworkRequestsTool extends McpTool {
 
   @Override
   McpSchema.CallToolResult execute(Map<String, Object> args) {
-    SelenideProxyServer proxy = session.getDriver().getProxy();
-    if (proxy == null) {
-      throw new IllegalStateException(
-        "Network capture requires --proxy-enabled at server startup");
-    }
+    SelenideProxyServer proxy = NetworkTools.requireProxy(session);
     String pattern = (String) args.get("urlPattern");
     List<HarEntry> entries = harEntries(proxy.getProxy());
     StringBuilder out = new StringBuilder();

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkRequestsTool.java
@@ -8,6 +8,7 @@ import de.sstoehr.harreader.model.HarEntry;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.jspecify.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -36,25 +37,31 @@ class NetworkRequestsTool extends McpTool {
   McpSchema.CallToolResult execute(Map<String, Object> args) {
     SelenideProxyServer proxy = NetworkTools.requireProxy(session);
     String pattern = (String) args.get("urlPattern");
-    List<HarEntry> entries = harEntries(proxy.getProxy());
+    List<HarEntry> matching = matchingEntries(harEntries(proxy.getProxy()), pattern);
+    if (matching.isEmpty()) {
+      return success("No matching network requests");
+    }
     StringBuilder out = new StringBuilder();
-    int start = Math.max(0, entries.size() - MAX_ENTRIES);
-    int shown = 0;
-    for (int i = start; i < entries.size(); i++) {
-      HarEntry e = entries.get(i);
-      String url = e.getRequest().getUrl();
-      if (url == null) continue;
-      if (pattern != null && !url.contains(pattern)) continue;
-      out.append(nullToDash(e.getRequest().getMethod())).append(' ').append(url)
+    int start = Math.max(0, matching.size() - MAX_ENTRIES);
+    for (int i = start; i < matching.size(); i++) {
+      HarEntry e = matching.get(i);
+      out.append(nullToDash(e.getRequest().getMethod())).append(' ').append(e.getRequest().getUrl())
         .append(" -> ").append(e.getResponse().getStatus()).append(' ')
         .append(nullToDash(e.getResponse().getContent().getMimeType())).append(' ')
         .append(e.getTime() != null ? (long) e.getTime() : 0L).append("ms\n");
-      shown++;
-    }
-    if (shown == 0) {
-      return success("No matching network requests");
     }
     return success(out.toString().trim());
+  }
+
+  private static List<HarEntry> matchingEntries(List<HarEntry> entries, @Nullable String pattern) {
+    List<HarEntry> matching = new ArrayList<>();
+    for (HarEntry e : entries) {
+      String url = e.getRequest().getUrl();
+      if (url == null) continue;
+      if (pattern != null && !url.contains(pattern)) continue;
+      matching.add(e);
+    }
+    return matching;
   }
 
   static List<HarEntry> harEntries(BrowserUpProxy proxy) {

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkTools.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkTools.java
@@ -1,0 +1,18 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.server.McpServerFeatures;
+
+import java.util.List;
+
+public class NetworkTools {
+  private NetworkTools() {
+  }
+
+  public static List<McpServerFeatures.SyncToolSpecification> specs(BrowserSession session) {
+    return List.of(
+      new NetworkRequestsTool(session).spec(),
+      new NetworkRequestTool(session).spec()
+    );
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkTools.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/NetworkTools.java
@@ -1,6 +1,7 @@
 package com.codeborne.selenide.mcp.tools;
 
 import com.codeborne.selenide.mcp.BrowserSession;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
 import io.modelcontextprotocol.server.McpServerFeatures;
 
 import java.util.List;
@@ -14,5 +15,19 @@ public class NetworkTools {
       new NetworkRequestsTool(session).spec(),
       new NetworkRequestTool(session).spec()
     );
+  }
+
+  /**
+   * {@code session.getDriver().getProxy()} never returns null: it throws its own
+   * {@code IllegalStateException} when the proxy isn't enabled. Translate that into
+   * the message these tools actually document.
+   */
+  static SelenideProxyServer requireProxy(BrowserSession session) {
+    try {
+      return session.getDriver().getProxy();
+    }
+    catch (IllegalStateException e) {
+      throw new IllegalStateException("Network capture requires --proxy-enabled at server startup", e);
+    }
   }
 }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ResizeTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ResizeTool.java
@@ -1,0 +1,37 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.Dimension;
+
+import java.util.Map;
+
+class ResizeTool extends McpTool {
+  ResizeTool(BrowserSession session) {
+    super(session, "browser_resize",
+      "Resize the browser viewport to the given width and height (pixels)");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "width":  {"type": "integer", "description": "Width in pixels"},
+          "height": {"type": "integer", "description": "Height in pixels"}
+        },
+        "required": ["width", "height"]
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    int width = ((Number) args.get("width")).intValue();
+    int height = ((Number) args.get("height")).intValue();
+    session.getDriver().getWebDriver().manage().window()
+      .setSize(new Dimension(width, height));
+    return success("Resized to " + width + "x" + height);
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ResizeTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/ResizeTool.java
@@ -28,8 +28,13 @@ class ResizeTool extends McpTool {
 
   @Override
   McpSchema.CallToolResult execute(Map<String, Object> args) {
-    int width = ((Number) args.get("width")).intValue();
-    int height = ((Number) args.get("height")).intValue();
+    Number widthRaw = (Number) args.get("width");
+    Number heightRaw = (Number) args.get("height");
+    if (widthRaw == null || heightRaw == null) {
+      throw new IllegalArgumentException("Both 'width' and 'height' are required");
+    }
+    int width = widthRaw.intValue();
+    int height = heightRaw.intValue();
     session.getDriver().getWebDriver().manage().window()
       .setSize(new Dimension(width, height));
     return success("Resized to " + width + "x" + height);

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabCloseTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabCloseTool.java
@@ -1,0 +1,62 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.WebDriver;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class TabCloseTool extends McpTool {
+  TabCloseTool(BrowserSession session) {
+    super(session, "browser_tab_close",
+      "Close a browser tab. With no args, closes the current tab");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "index":  {"type": "integer", "description": "0-based tab index"},
+          "handle": {"type": "string",  "description": "Window handle string"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    WebDriver driver = session.getDriver().getWebDriver();
+    Number indexRaw = (Number) args.get("index");
+    String handle = (String) args.get("handle");
+    String target;
+    if (indexRaw == null && handle == null) {
+      target = driver.getWindowHandle();
+    } else if (indexRaw != null && handle != null) {
+      throw new IllegalArgumentException("Provide only one of 'index' or 'handle'");
+    } else if (indexRaw != null) {
+      List<String> handles = List.copyOf(driver.getWindowHandles());
+      int index = indexRaw.intValue();
+      if (index < 0 || index >= handles.size()) {
+        throw new IllegalArgumentException(
+          "Tab index " + index + " out of range (0.." + (handles.size() - 1) + ")");
+      }
+      target = handles.get(index);
+    } else {
+      target = handle;
+    }
+    String active = driver.getWindowHandle();
+    driver.switchTo().window(target);
+    driver.close();
+    Set<String> remaining = driver.getWindowHandles();
+    if (remaining.isEmpty()) {
+      return success("Closed last tab; no remaining tabs");
+    }
+    String next = target.equals(active) ? remaining.iterator().next() : active;
+    driver.switchTo().window(next);
+    return success("Closed tab: " + target);
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabCloseTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabCloseTool.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.mcp.BrowserSession;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.openqa.selenium.WebDriver;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,22 +31,9 @@ class TabCloseTool extends McpTool {
     WebDriver driver = session.getDriver().getWebDriver();
     Number indexRaw = (Number) args.get("index");
     String handle = (String) args.get("handle");
-    String target;
-    if (indexRaw == null && handle == null) {
-      target = driver.getWindowHandle();
-    } else if (indexRaw != null && handle != null) {
-      throw new IllegalArgumentException("Provide only one of 'index' or 'handle'");
-    } else if (indexRaw != null) {
-      List<String> handles = List.copyOf(driver.getWindowHandles());
-      int index = indexRaw.intValue();
-      if (index < 0 || index >= handles.size()) {
-        throw new IllegalArgumentException(
-          "Tab index " + index + " out of range (0.." + (handles.size() - 1) + ")");
-      }
-      target = handles.get(index);
-    } else {
-      target = handle;
-    }
+    String target = indexRaw == null && handle == null
+      ? driver.getWindowHandle()
+      : resolveWindowHandle(driver, indexRaw, handle);
     String active = driver.getWindowHandle();
     // Closing the last open window typically ends the WebDriver session, so getWindowHandles()
     // afterwards would throw; decide upfront instead of probing the driver after close().

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabCloseTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabCloseTool.java
@@ -49,13 +49,16 @@ class TabCloseTool extends McpTool {
       target = handle;
     }
     String active = driver.getWindowHandle();
+    // Closing the last open window typically ends the WebDriver session, so getWindowHandles()
+    // afterwards would throw; decide upfront instead of probing the driver after close().
+    boolean closingLastTab = driver.getWindowHandles().size() == 1;
     driver.switchTo().window(target);
     driver.close();
-    Set<String> remaining = driver.getWindowHandles();
-    if (remaining.isEmpty()) {
+    if (closingLastTab) {
       return success("Closed last tab; no remaining tabs");
     }
-    String next = target.equals(active) ? remaining.iterator().next() : active;
+    Set<String> remaining = driver.getWindowHandles();
+    String next = remaining.contains(active) ? active : remaining.iterator().next();
     driver.switchTo().window(next);
     return success("Closed tab: " + target);
   }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabListTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabListTool.java
@@ -23,17 +23,20 @@ class TabListTool extends McpTool {
     String activeHandle = driver.getWindowHandle();
     StringBuilder out = new StringBuilder();
     int i = 0;
-    for (String handle : driver.getWindowHandles()) {
-      driver.switchTo().window(handle);
-      out.append('[').append(i++).append("] handle=\"").append(handle).append('"')
-        .append(" title=\"").append(driver.getTitle()).append('"')
-        .append(" url=\"").append(driver.getCurrentUrl()).append('"');
-      if (handle.equals(activeHandle)) {
-        out.append(" (active)");
+    try {
+      for (String handle : driver.getWindowHandles()) {
+        driver.switchTo().window(handle);
+        out.append('[').append(i++).append("] handle=\"").append(handle).append('"')
+          .append(" title=\"").append(driver.getTitle()).append('"')
+          .append(" url=\"").append(driver.getCurrentUrl()).append('"');
+        if (handle.equals(activeHandle)) {
+          out.append(" (active)");
+        }
+        out.append('\n');
       }
-      out.append('\n');
+    } finally {
+      driver.switchTo().window(activeHandle);
     }
-    driver.switchTo().window(activeHandle);
     return success(out.toString().trim());
   }
 }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabListTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabListTool.java
@@ -1,0 +1,39 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.WebDriver;
+
+import java.util.Map;
+
+class TabListTool extends McpTool {
+  TabListTool(BrowserSession session) {
+    super(session, "browser_tab_list",
+      "List all open browser tabs with index, handle, title and url");
+  }
+
+  @Override
+  String inputSchema() {
+    return EMPTY_SCHEMA;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    WebDriver driver = session.getDriver().getWebDriver();
+    String activeHandle = driver.getWindowHandle();
+    StringBuilder out = new StringBuilder();
+    int i = 0;
+    for (String handle : driver.getWindowHandles()) {
+      driver.switchTo().window(handle);
+      out.append('[').append(i++).append("] handle=\"").append(handle).append('"')
+        .append(" title=\"").append(driver.getTitle()).append('"')
+        .append(" url=\"").append(driver.getCurrentUrl()).append('"');
+      if (handle.equals(activeHandle)) {
+        out.append(" (active)");
+      }
+      out.append('\n');
+    }
+    driver.switchTo().window(activeHandle);
+    return success(out.toString().trim());
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabNewTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabNewTool.java
@@ -1,0 +1,38 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+
+import java.util.Map;
+
+class TabNewTool extends McpTool {
+  TabNewTool(BrowserSession session) {
+    super(session, "browser_tab_new",
+      "Open a new browser tab; optionally navigate to a URL");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "url": {"type": "string", "description": "Optional URL to open in the new tab"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    String url = (String) args.get("url");
+    WebDriver driver = session.getDriver().getWebDriver();
+    driver.switchTo().newWindow(WindowType.TAB);
+    if (url != null && !url.isEmpty()) {
+      session.getDriver().open(url);
+    }
+    return success("Opened new tab" + (url != null ? " at " + url : ""));
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java
@@ -1,0 +1,55 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.openqa.selenium.WebDriver;
+
+import java.util.List;
+import java.util.Map;
+
+class TabSelectTool extends McpTool {
+  TabSelectTool(BrowserSession session) {
+    super(session, "browser_tab_select",
+      "Switch to a tab by 0-based index or by window handle");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "index":  {"type": "integer", "description": "0-based tab index"},
+          "handle": {"type": "string",  "description": "Window handle string"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    Number indexRaw = (Number) args.get("index");
+    String handle = (String) args.get("handle");
+    if (indexRaw == null && handle == null) {
+      throw new IllegalArgumentException("Provide either 'index' or 'handle'");
+    }
+    if (indexRaw != null && handle != null) {
+      throw new IllegalArgumentException("Provide only one of 'index' or 'handle'");
+    }
+    WebDriver driver = session.getDriver().getWebDriver();
+    String target;
+    if (indexRaw != null) {
+      List<String> handles = List.copyOf(driver.getWindowHandles());
+      int index = indexRaw.intValue();
+      if (index < 0 || index >= handles.size()) {
+        throw new IllegalArgumentException(
+          "Tab index " + index + " out of range (0.." + (handles.size() - 1) + ")");
+      }
+      target = handles.get(index);
+    } else {
+      target = handle;
+    }
+    driver.switchTo().window(target);
+    return success("Switched to tab: " + target);
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java
@@ -21,7 +21,8 @@ class TabSelectTool extends McpTool {
         "properties": {
           "index":  {"type": "integer", "description": "0-based tab index"},
           "handle": {"type": "string",  "description": "Window handle string"}
-        }
+        },
+        "minProperties": 1
       }
       """;
   }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java
@@ -30,9 +30,6 @@ class TabSelectTool extends McpTool {
   McpSchema.CallToolResult execute(Map<String, Object> args) {
     Number indexRaw = (Number) args.get("index");
     String handle = (String) args.get("handle");
-    if (indexRaw == null && handle == null) {
-      throw new IllegalArgumentException("Provide either 'index' or 'handle'");
-    }
     WebDriver driver = session.getDriver().getWebDriver();
     String target = resolveWindowHandle(driver, indexRaw, handle);
     driver.switchTo().window(target);

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/TabSelectTool.java
@@ -4,7 +4,6 @@ import com.codeborne.selenide.mcp.BrowserSession;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.openqa.selenium.WebDriver;
 
-import java.util.List;
 import java.util.Map;
 
 class TabSelectTool extends McpTool {
@@ -34,22 +33,8 @@ class TabSelectTool extends McpTool {
     if (indexRaw == null && handle == null) {
       throw new IllegalArgumentException("Provide either 'index' or 'handle'");
     }
-    if (indexRaw != null && handle != null) {
-      throw new IllegalArgumentException("Provide only one of 'index' or 'handle'");
-    }
     WebDriver driver = session.getDriver().getWebDriver();
-    String target;
-    if (indexRaw != null) {
-      List<String> handles = List.copyOf(driver.getWindowHandles());
-      int index = indexRaw.intValue();
-      if (index < 0 || index >= handles.size()) {
-        throw new IllegalArgumentException(
-          "Tab index " + index + " out of range (0.." + (handles.size() - 1) + ")");
-      }
-      target = handles.get(index);
-    } else {
-      target = handle;
-    }
+    String target = resolveWindowHandle(driver, indexRaw, handle);
     driver.switchTo().window(target);
     return success("Switched to tab: " + target);
   }

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/WaitForTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/WaitForTool.java
@@ -1,0 +1,103 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.jspecify.annotations.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.codeborne.selenide.Condition.appear;
+import static com.codeborne.selenide.Condition.disappear;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selectors.byTagName;
+
+class WaitForTool extends McpTool {
+  enum Kind { TEXT, TEXT_GONE, SELECTOR_VISIBLE, SELECTOR_HIDDEN, TIME }
+
+  record Condition(Kind kind, @Nullable String value, double numericValue) {
+    static Condition of(Kind kind, String value) {
+      return new Condition(kind, value, 0);
+    }
+
+    static Condition ofTime(double seconds) {
+      return new Condition(Kind.TIME, null, seconds);
+    }
+  }
+
+  WaitForTool(BrowserSession session) {
+    super(session, "browser_wait_for",
+      "Wait for a condition: text appearing/disappearing on page, "
+        + "an element becoming visible/hidden, or a fixed time in seconds. "
+        + "Exactly one of 'text', 'textGone', 'selector', 'time' must be provided.");
+  }
+
+  @Override
+  String inputSchema() {
+    return """
+      {
+        "type": "object",
+        "properties": {
+          "text":     {"type": "string",  "description": "Text to wait for on the page"},
+          "textGone": {"type": "string",  "description": "Text to wait to disappear from the page"},
+          "selector": {"type": "string",  "description": "Element selector to wait for"},
+          "state":    {"type": "string",  "enum": ["visible", "hidden"], "description": "Selector state (default visible)"},
+          "time":     {"type": "number",  "description": "Seconds to sleep"}
+        }
+      }
+      """;
+  }
+
+  @Override
+  McpSchema.CallToolResult execute(Map<String, Object> args) {
+    Condition c = parseCondition(args);
+    switch (c.kind()) {
+      case TEXT -> session.getDriver().$(byTagName("body")).shouldHave(text(c.value()));
+      case TEXT_GONE -> session.getDriver().$(byTagName("body")).shouldNotHave(text(c.value()));
+      case SELECTOR_VISIBLE -> session.getDriver().$(resolve(c.value())).should(appear);
+      case SELECTOR_HIDDEN -> session.getDriver().$(resolve(c.value())).should(disappear);
+      case TIME -> sleep((long) (c.numericValue() * 1000));
+    }
+    return success("Wait condition satisfied: " + c.kind());
+  }
+
+  static Condition parseCondition(Map<String, Object> args) {
+    Map<String, Object> present = new LinkedHashMap<>();
+    for (String key : new String[]{"text", "textGone", "selector", "time"}) {
+      if (args.get(key) != null) {
+        present.put(key, args.get(key));
+      }
+    }
+    if (present.size() != 1) {
+      throw new IllegalArgumentException(
+        "browser_wait_for requires exactly one of: text, textGone, selector, time "
+          + "(got " + present.size() + ")");
+    }
+    Map.Entry<String, Object> entry = present.entrySet().iterator().next();
+    return switch (entry.getKey()) {
+      case "text" -> Condition.of(Kind.TEXT, entry.getValue().toString());
+      case "textGone" -> Condition.of(Kind.TEXT_GONE, entry.getValue().toString());
+      case "time" -> Condition.ofTime(((Number) entry.getValue()).doubleValue());
+      case "selector" -> {
+        String state = args.get("state") == null ? "visible" : args.get("state").toString();
+        yield switch (state) {
+            case "visible" -> Condition.of(Kind.SELECTOR_VISIBLE, entry.getValue().toString());
+            case "hidden" -> Condition.of(Kind.SELECTOR_HIDDEN, entry.getValue().toString());
+            default -> throw new IllegalArgumentException(
+              "Unknown state '" + state + "'; expected 'visible' or 'hidden'");
+          };
+      }
+      default -> throw new IllegalStateException("unreachable");
+    };
+  }
+
+  private static void sleep(long ms) {
+    try {
+      Thread.sleep(ms);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Sleep interrupted", e);
+    }
+  }
+}

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/WaitForTool.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/tools/WaitForTool.java
@@ -1,5 +1,6 @@
 package com.codeborne.selenide.mcp.tools;
 
+import com.codeborne.selenide.Stopwatch;
 import com.codeborne.selenide.mcp.BrowserSession;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.jspecify.annotations.Nullable;
@@ -56,7 +57,7 @@ class WaitForTool extends McpTool {
       case TEXT_GONE -> session.getDriver().$(byTagName("body")).shouldNotHave(text(c.value()));
       case SELECTOR_VISIBLE -> session.getDriver().$(resolve(c.value())).should(appear);
       case SELECTOR_HIDDEN -> session.getDriver().$(resolve(c.value())).should(disappear);
-      case TIME -> sleep((long) (c.numericValue() * 1000));
+      case TIME -> Stopwatch.sleepAtLeast((long) (c.numericValue() * 1000));
     }
     return success("Wait condition satisfied: " + c.kind());
   }
@@ -89,15 +90,5 @@ class WaitForTool extends McpTool {
       }
       default -> throw new IllegalStateException("unreachable");
     };
-  }
-
-  private static void sleep(long ms) {
-    try {
-      Thread.sleep(ms);
-    }
-    catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException("Sleep interrupted", e);
-    }
   }
 }

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/FillFormToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/FillFormToolTest.java
@@ -20,8 +20,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class FillFormToolTest {
-  private final SelenideDriver driver = mock(SelenideDriver.class);
-  private final SelenideElement element = mock(SelenideElement.class);
+  private final SelenideDriver driver = mock();
+  private final SelenideElement element = mock();
   private final FillFormTool tool = new FillFormTool(session(driver));
 
   @Test
@@ -74,7 +74,7 @@ class FillFormToolTest {
   }
 
   static BrowserSession session(SelenideDriver driver) {
-    BrowserSession session = mock(BrowserSession.class);
+    BrowserSession session = mock();
     when(session.getDriver()).thenReturn(driver);
     return session;
   }

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/FillFormToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/FillFormToolTest.java
@@ -1,0 +1,81 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.codeborne.selenide.mcp.tools.McpToolTestSupport.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FillFormToolTest {
+  private final SelenideDriver driver = mock(SelenideDriver.class);
+  private final SelenideElement element = mock(SelenideElement.class);
+  private final FillFormTool tool = new FillFormTool(session(driver));
+
+  @Test
+  void fillsEveryFieldInOrder() {
+    when(driver.$(any(By.class))).thenReturn(element);
+
+    McpSchema.CallToolResult result = tool.execute(Map.of(
+      "fields", List.of(
+        Map.of("selector", "#a", "value", "1"),
+        Map.of("selector", "#b", "value", "2")
+      )
+    ));
+
+    verify(element).setValue("1");
+    verify(element).setValue("2");
+    assertThat(text(result)).isEqualTo("Filled 2 fields");
+  }
+
+  @Test
+  void rejectsMissingFields() {
+    assertThatThrownBy(() -> tool.execute(Map.of()))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("non-empty array");
+  }
+
+  @Test
+  void rejectsEmptyFields() {
+    assertThatThrownBy(() -> tool.execute(Map.of("fields", List.of())))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("non-empty array");
+  }
+
+  @Test
+  void rejectsNullElementInFieldsArray() {
+    List<Map<String, Object>> fieldsWithNull = new ArrayList<>();
+    fieldsWithNull.add(null);
+    fieldsWithNull.add(Map.of("selector", "#a", "value", "1"));
+
+    assertThatThrownBy(() -> tool.execute(Map.of("fields", fieldsWithNull)))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("requires both 'selector' and 'value'");
+  }
+
+  @Test
+  void rejectsFieldMissingSelectorOrValue() {
+    assertThatThrownBy(() -> tool.execute(Map.of(
+      "fields", List.of(Map.of("value", "1"))
+    ))).isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("requires both 'selector' and 'value'");
+  }
+
+  static BrowserSession session(SelenideDriver driver) {
+    BrowserSession session = mock(BrowserSession.class);
+    when(session.getDriver()).thenReturn(driver);
+    return session;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/HarEntryTestFactory.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/HarEntryTestFactory.java
@@ -1,0 +1,23 @@
+package com.codeborne.selenide.mcp.tools;
+
+import de.sstoehr.harreader.model.HarEntry;
+import de.sstoehr.harreader.model.HarRequest;
+import de.sstoehr.harreader.model.HarResponse;
+import de.sstoehr.harreader.model.HttpMethod;
+
+final class HarEntryTestFactory {
+  private HarEntryTestFactory() {
+  }
+
+  static HarEntry entry(String url, int status) {
+    HarRequest request = new HarRequest();
+    request.setUrl(url);
+    request.setMethod(HttpMethod.GET);
+    HarResponse response = new HarResponse();
+    response.setStatus(status);
+    HarEntry entry = new HarEntry();
+    entry.setRequest(request);
+    entry.setResponse(response);
+    return entry;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/McpToolTestSupport.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/McpToolTestSupport.java
@@ -1,0 +1,12 @@
+package com.codeborne.selenide.mcp.tools;
+
+import io.modelcontextprotocol.spec.McpSchema;
+
+final class McpToolTestSupport {
+  private McpToolTestSupport() {
+  }
+
+  static String text(McpSchema.CallToolResult result) {
+    return ((McpSchema.TextContent) result.content().get(0)).text();
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestToolTest.java
@@ -21,8 +21,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class NetworkRequestToolTest {
-  private final BrowserUpProxy browserUpProxy = mock(BrowserUpProxy.class);
-  private final SelenideDriver driver = mock(SelenideDriver.class);
+  private final BrowserUpProxy browserUpProxy = mock();
+  private final SelenideDriver driver = mock();
   private final NetworkRequestTool tool = new NetworkRequestTool(session(driver));
 
   @Test
@@ -65,7 +65,7 @@ class NetworkRequestToolTest {
   }
 
   private void withHar(HarEntry... entries) {
-    SelenideProxyServer proxy = mock(SelenideProxyServer.class);
+    SelenideProxyServer proxy = mock();
     when(driver.getProxy()).thenReturn(proxy);
     when(proxy.getProxy()).thenReturn(browserUpProxy);
     Har har = new Har();
@@ -76,7 +76,7 @@ class NetworkRequestToolTest {
   }
 
   static BrowserSession session(SelenideDriver driver) {
-    BrowserSession session = mock(BrowserSession.class);
+    BrowserSession session = mock();
     when(session.getDriver()).thenReturn(driver);
     return session;
   }

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestToolTest.java
@@ -1,0 +1,83 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.browserup.bup.BrowserUpProxy;
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.mcp.BrowserSession;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
+import de.sstoehr.harreader.model.Har;
+import de.sstoehr.harreader.model.HarEntry;
+import de.sstoehr.harreader.model.HarLog;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.codeborne.selenide.mcp.tools.HarEntryTestFactory.entry;
+import static com.codeborne.selenide.mcp.tools.McpToolTestSupport.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NetworkRequestToolTest {
+  private final BrowserUpProxy browserUpProxy = mock(BrowserUpProxy.class);
+  private final SelenideDriver driver = mock(SelenideDriver.class);
+  private final NetworkRequestTool tool = new NetworkRequestTool(session(driver));
+
+  @Test
+  void returnsTheMostRecentMatchingRequest() {
+    withHar(
+      entry("https://a.test/login", 200),
+      entry("https://a.test/login", 500)
+    );
+
+    McpSchema.CallToolResult result = tool.execute(Map.of("urlPattern", "login"));
+
+    assertThat(text(result))
+      .contains("GET https://a.test/login")
+      .contains("Status: 500");
+  }
+
+  @Test
+  void rejectsMissingUrlPattern() {
+    assertThatThrownBy(() -> tool.execute(Map.of()))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("'urlPattern' is required");
+  }
+
+  @Test
+  void throwsWhenNothingMatches() {
+    withHar(entry("https://a.test/other", 200));
+
+    assertThatThrownBy(() -> tool.execute(Map.of("urlPattern", "login")))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("No network request matching: login");
+  }
+
+  @Test
+  void translatesProxyNotEnabledIntoAFriendlyMessage() {
+    when(driver.getProxy()).thenThrow(new IllegalStateException("Proxy server is not enabled."));
+
+    assertThatThrownBy(() -> tool.execute(Map.of("urlPattern", "login")))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Network capture requires --proxy-enabled at server startup");
+  }
+
+  private void withHar(HarEntry... entries) {
+    SelenideProxyServer proxy = mock(SelenideProxyServer.class);
+    when(driver.getProxy()).thenReturn(proxy);
+    when(proxy.getProxy()).thenReturn(browserUpProxy);
+    Har har = new Har();
+    HarLog log = new HarLog();
+    log.setEntries(List.of(entries));
+    har.setLog(log);
+    when(browserUpProxy.getHar()).thenReturn(har);
+  }
+
+  static BrowserSession session(SelenideDriver driver) {
+    BrowserSession session = mock(BrowserSession.class);
+    when(session.getDriver()).thenReturn(driver);
+    return session;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestsToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestsToolTest.java
@@ -22,8 +22,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class NetworkRequestsToolTest {
-  private final BrowserUpProxy browserUpProxy = mock(BrowserUpProxy.class);
-  private final SelenideDriver driver = mock(SelenideDriver.class);
+  private final BrowserUpProxy browserUpProxy = mock();
+  private final SelenideDriver driver = mock();
   private final NetworkRequestsTool tool = new NetworkRequestsTool(session(driver));
 
   @Test
@@ -72,7 +72,7 @@ class NetworkRequestsToolTest {
   }
 
   private void withHar(HarEntry... entries) {
-    SelenideProxyServer proxy = mock(SelenideProxyServer.class);
+    SelenideProxyServer proxy = mock();
     when(driver.getProxy()).thenReturn(proxy);
     when(proxy.getProxy()).thenReturn(browserUpProxy);
     Har har = new Har();
@@ -83,7 +83,7 @@ class NetworkRequestsToolTest {
   }
 
   static BrowserSession session(SelenideDriver driver) {
-    BrowserSession session = mock(BrowserSession.class);
+    BrowserSession session = mock();
     when(session.getDriver()).thenReturn(driver);
     return session;
   }

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestsToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestsToolTest.java
@@ -10,6 +10,7 @@ import de.sstoehr.harreader.model.HarLog;
 import io.modelcontextprotocol.spec.McpSchema;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -34,6 +35,22 @@ class NetworkRequestsToolTest {
     assertThat(text(result))
       .contains("GET https://a.test/1 -> 200")
       .contains("GET https://b.test/2 -> 404");
+  }
+
+  @Test
+  void filtersByUrlPatternAcrossTheFullHistoryBeforeCappingTo100() {
+    // The one matching entry is far older than the most recent 100 entries; a fix that
+    // truncates to the last 100 raw entries *before* filtering would lose it.
+    List<HarEntry> entries = new ArrayList<>();
+    entries.add(entry("https://match.test/keep", 200));
+    for (int i = 0; i < 149; i++) {
+      entries.add(entry("https://noise.test/" + i, 200));
+    }
+    withHar(entries.toArray(new HarEntry[0]));
+
+    McpSchema.CallToolResult result = tool.execute(Map.of("urlPattern", "match.test"));
+
+    assertThat(text(result)).contains("https://match.test/keep");
   }
 
   @Test

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestsToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/NetworkRequestsToolTest.java
@@ -1,0 +1,73 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.browserup.bup.BrowserUpProxy;
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.mcp.BrowserSession;
+import com.codeborne.selenide.proxy.SelenideProxyServer;
+import de.sstoehr.harreader.model.Har;
+import de.sstoehr.harreader.model.HarEntry;
+import de.sstoehr.harreader.model.HarLog;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.codeborne.selenide.mcp.tools.HarEntryTestFactory.entry;
+import static com.codeborne.selenide.mcp.tools.McpToolTestSupport.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NetworkRequestsToolTest {
+  private final BrowserUpProxy browserUpProxy = mock(BrowserUpProxy.class);
+  private final SelenideDriver driver = mock(SelenideDriver.class);
+  private final NetworkRequestsTool tool = new NetworkRequestsTool(session(driver));
+
+  @Test
+  void listsAllCapturedRequestsWhenNoPatternGiven() {
+    withHar(entry("https://a.test/1", 200), entry("https://b.test/2", 404));
+
+    McpSchema.CallToolResult result = tool.execute(Map.of());
+
+    assertThat(text(result))
+      .contains("GET https://a.test/1 -> 200")
+      .contains("GET https://b.test/2 -> 404");
+  }
+
+  @Test
+  void reportsNoMatchesRatherThanThrowing() {
+    withHar();
+
+    McpSchema.CallToolResult result = tool.execute(Map.of());
+
+    assertThat(text(result)).isEqualTo("No matching network requests");
+  }
+
+  @Test
+  void translatesProxyNotEnabledIntoAFriendlyMessage() {
+    when(driver.getProxy()).thenThrow(new IllegalStateException("Proxy server is not enabled."));
+
+    assertThatThrownBy(() -> tool.execute(Map.of()))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Network capture requires --proxy-enabled at server startup");
+  }
+
+  private void withHar(HarEntry... entries) {
+    SelenideProxyServer proxy = mock(SelenideProxyServer.class);
+    when(driver.getProxy()).thenReturn(proxy);
+    when(proxy.getProxy()).thenReturn(browserUpProxy);
+    Har har = new Har();
+    HarLog log = new HarLog();
+    log.setEntries(List.of(entries));
+    har.setLog(log);
+    when(browserUpProxy.getHar()).thenReturn(har);
+  }
+
+  static BrowserSession session(SelenideDriver driver) {
+    BrowserSession session = mock(BrowserSession.class);
+    when(session.getDriver()).thenReturn(driver);
+    return session;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/ResizeToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/ResizeToolTest.java
@@ -1,0 +1,53 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.WebDriver;
+
+import java.util.Map;
+
+import static com.codeborne.selenide.mcp.tools.McpToolTestSupport.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ResizeToolTest {
+  private final WebDriver webDriver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final ResizeTool tool = new ResizeTool(session(webDriver));
+
+  @Test
+  void resizesToGivenDimensions() {
+    McpSchema.CallToolResult result = tool.execute(Map.of("width", 1024, "height", 768));
+
+    verify(webDriver.manage().window()).setSize(new Dimension(1024, 768));
+    assertThat(text(result)).isEqualTo("Resized to 1024x768");
+  }
+
+  @Test
+  void rejectsMissingWidth() {
+    assertThatThrownBy(() -> tool.execute(Map.of("height", 768)))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("'width' and 'height' are required");
+  }
+
+  @Test
+  void rejectsMissingHeight() {
+    assertThatThrownBy(() -> tool.execute(Map.of("width", 1024)))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("'width' and 'height' are required");
+  }
+
+  static BrowserSession session(WebDriver webDriver) {
+    BrowserSession session = mock(BrowserSession.class);
+    SelenideDriver driver = mock(SelenideDriver.class);
+    when(session.getDriver()).thenReturn(driver);
+    when(driver.getWebDriver()).thenReturn(webDriver);
+    return session;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/ResizeToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/ResizeToolTest.java
@@ -16,9 +16,10 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 class ResizeToolTest {
-  private final WebDriver webDriver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final WebDriver webDriver = mock(withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
   private final ResizeTool tool = new ResizeTool(session(webDriver));
 
   @Test
@@ -44,8 +45,8 @@ class ResizeToolTest {
   }
 
   static BrowserSession session(WebDriver webDriver) {
-    BrowserSession session = mock(BrowserSession.class);
-    SelenideDriver driver = mock(SelenideDriver.class);
+    BrowserSession session = mock();
+    SelenideDriver driver = mock();
     when(session.getDriver()).thenReturn(driver);
     when(driver.getWebDriver()).thenReturn(webDriver);
     return session;

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabCloseToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabCloseToolTest.java
@@ -20,9 +20,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 class TabCloseToolTest {
-  private final WebDriver driver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final WebDriver driver = mock(withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
   private final TabCloseTool tool = new TabCloseTool(session(driver));
 
   @Test
@@ -83,8 +84,8 @@ class TabCloseToolTest {
   }
 
   static BrowserSession session(WebDriver webDriver) {
-    BrowserSession session = mock(BrowserSession.class);
-    SelenideDriver driver = mock(SelenideDriver.class);
+    BrowserSession session = mock();
+    SelenideDriver driver = mock();
     when(session.getDriver()).thenReturn(driver);
     when(driver.getWebDriver()).thenReturn(webDriver);
     return session;

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabCloseToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabCloseToolTest.java
@@ -1,0 +1,92 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchSessionException;
+import org.openqa.selenium.WebDriver;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.codeborne.selenide.mcp.tools.McpToolTestSupport.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TabCloseToolTest {
+  private final WebDriver driver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final TabCloseTool tool = new TabCloseTool(session(driver));
+
+  @Test
+  void closingTheOnlyRemainingTabDoesNotProbeHandlesAfterClose() {
+    when(driver.getWindowHandle()).thenReturn("h1");
+    when(driver.getWindowHandles())
+      .thenReturn(Set.of("h1"))
+      .thenThrow(new NoSuchSessionException("session already ended"));
+
+    McpSchema.CallToolResult result = tool.execute(Map.of());
+
+    assertThat(text(result)).isEqualTo("Closed last tab; no remaining tabs");
+    verify(driver, times(1)).getWindowHandles();
+    verify(driver).close();
+  }
+
+  @Test
+  void closingTheActiveTabSwitchesToARemainingOne() {
+    when(driver.getWindowHandle()).thenReturn("h1");
+    when(driver.getWindowHandles())
+      .thenReturn(new LinkedHashSet<>(List.of("h1", "h2")))
+      .thenReturn(Set.of("h2"));
+
+    McpSchema.CallToolResult result = tool.execute(Map.of());
+
+    verify(driver.switchTo()).window("h2");
+    assertThat(text(result)).isEqualTo("Closed tab: h1");
+  }
+
+  @Test
+  void closingANonActiveTabByIndexKeepsTheActiveOneFocused() {
+    when(driver.getWindowHandle()).thenReturn("active");
+    Set<String> beforeClose = new LinkedHashSet<>(List.of("active", "other"));
+    when(driver.getWindowHandles())
+      .thenReturn(beforeClose, beforeClose, Set.of("active"));
+
+    McpSchema.CallToolResult result = tool.execute(Map.of("index", 1));
+
+    verify(driver.switchTo()).window("other");
+    verify(driver.switchTo()).window("active");
+    assertThat(text(result)).isEqualTo("Closed tab: other");
+  }
+
+  @Test
+  void rejectsOutOfRangeIndex() {
+    when(driver.getWindowHandles()).thenReturn(Set.of("h1"));
+
+    assertThatThrownBy(() -> tool.execute(Map.of("index", 3)))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Tab index 3 out of range");
+  }
+
+  @Test
+  void rejectsBothIndexAndHandle() {
+    assertThatThrownBy(() -> tool.execute(Map.of("index", 0, "handle", "h1")))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Provide only one of 'index' or 'handle'");
+  }
+
+  static BrowserSession session(WebDriver webDriver) {
+    BrowserSession session = mock(BrowserSession.class);
+    SelenideDriver driver = mock(SelenideDriver.class);
+    when(session.getDriver()).thenReturn(driver);
+    when(driver.getWebDriver()).thenReturn(webDriver);
+    return session;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabListToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabListToolTest.java
@@ -15,9 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 class TabListToolTest {
-  private final WebDriver driver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final WebDriver driver = mock(withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
   private final TabListTool tool = new TabListTool(session(driver));
 
   @Test
@@ -36,8 +37,8 @@ class TabListToolTest {
   }
 
   static BrowserSession session(WebDriver webDriver) {
-    BrowserSession session = mock(BrowserSession.class);
-    SelenideDriver driver = mock(SelenideDriver.class);
+    BrowserSession session = mock();
+    SelenideDriver driver = mock();
     when(session.getDriver()).thenReturn(driver);
     when(driver.getWebDriver()).thenReturn(webDriver);
     return session;

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabListToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabListToolTest.java
@@ -1,0 +1,45 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import static com.codeborne.selenide.mcp.tools.McpToolTestSupport.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TabListToolTest {
+  private final WebDriver driver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final TabListTool tool = new TabListTool(session(driver));
+
+  @Test
+  void listsAllTabsAndMarksTheActiveOne() {
+    when(driver.getWindowHandle()).thenReturn("h1");
+    when(driver.getWindowHandles()).thenReturn(new LinkedHashSet<>(List.of("h1", "h2")));
+    when(driver.getTitle()).thenReturn("Page One", "Page Two");
+    when(driver.getCurrentUrl()).thenReturn("https://a.test", "https://b.test");
+
+    McpSchema.CallToolResult result = tool.execute(Map.of());
+
+    assertThat(text(result))
+      .contains("[0] handle=\"h1\" title=\"Page One\" url=\"https://a.test\" (active)")
+      .contains("[1] handle=\"h2\" title=\"Page Two\" url=\"https://b.test\"")
+      .doesNotContain("[1] handle=\"h2\" title=\"Page Two\" url=\"https://b.test\" (active)");
+  }
+
+  static BrowserSession session(WebDriver webDriver) {
+    BrowserSession session = mock(BrowserSession.class);
+    SelenideDriver driver = mock(SelenideDriver.class);
+    when(session.getDriver()).thenReturn(driver);
+    when(driver.getWebDriver()).thenReturn(webDriver);
+    return session;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabNewToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabNewToolTest.java
@@ -1,0 +1,50 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WindowType;
+
+import java.util.Map;
+
+import static com.codeborne.selenide.mcp.tools.McpToolTestSupport.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TabNewToolTest {
+  private final WebDriver webDriver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final SelenideDriver driver = mock(SelenideDriver.class);
+  private final TabNewTool tool = new TabNewTool(session(driver, webDriver));
+
+  @Test
+  void opensNewTabWithoutNavigating() {
+    McpSchema.CallToolResult result = tool.execute(Map.of());
+
+    verify(webDriver.switchTo()).newWindow(WindowType.TAB);
+    verify(driver, never()).open(anyString());
+    assertThat(text(result)).isEqualTo("Opened new tab");
+  }
+
+  @Test
+  void opensNewTabAndNavigatesToUrl() {
+    McpSchema.CallToolResult result = tool.execute(Map.of("url", "https://example.test"));
+
+    verify(webDriver.switchTo()).newWindow(WindowType.TAB);
+    verify(driver).open("https://example.test");
+    assertThat(text(result)).isEqualTo("Opened new tab at https://example.test");
+  }
+
+  static BrowserSession session(SelenideDriver driver, WebDriver webDriver) {
+    BrowserSession session = mock(BrowserSession.class);
+    when(session.getDriver()).thenReturn(driver);
+    when(driver.getWebDriver()).thenReturn(webDriver);
+    return session;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabNewToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabNewToolTest.java
@@ -17,10 +17,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 class TabNewToolTest {
-  private final WebDriver webDriver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
-  private final SelenideDriver driver = mock(SelenideDriver.class);
+  private final WebDriver webDriver = mock(withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
+  private final SelenideDriver driver = mock();
   private final TabNewTool tool = new TabNewTool(session(driver, webDriver));
 
   @Test
@@ -42,7 +43,7 @@ class TabNewToolTest {
   }
 
   static BrowserSession session(SelenideDriver driver, WebDriver webDriver) {
-    BrowserSession session = mock(BrowserSession.class);
+    BrowserSession session = mock();
     when(session.getDriver()).thenReturn(driver);
     when(driver.getWebDriver()).thenReturn(webDriver);
     return session;

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabSelectToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabSelectToolTest.java
@@ -1,0 +1,73 @@
+package com.codeborne.selenide.mcp.tools;
+
+import com.codeborne.selenide.SelenideDriver;
+import com.codeborne.selenide.mcp.BrowserSession;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import static com.codeborne.selenide.mcp.tools.McpToolTestSupport.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TabSelectToolTest {
+  private final WebDriver driver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final TabSelectTool tool = new TabSelectTool(session(driver));
+
+  @Test
+  void switchesByIndex() {
+    when(driver.getWindowHandles()).thenReturn(new LinkedHashSet<>(List.of("h1", "h2")));
+
+    McpSchema.CallToolResult result = tool.execute(Map.of("index", 1));
+
+    verify(driver.switchTo()).window("h2");
+    assertThat(text(result)).isEqualTo("Switched to tab: h2");
+  }
+
+  @Test
+  void switchesByHandle() {
+    McpSchema.CallToolResult result = tool.execute(Map.of("handle", "h9"));
+
+    verify(driver.switchTo()).window("h9");
+    assertThat(text(result)).isEqualTo("Switched to tab: h9");
+  }
+
+  @Test
+  void rejectsNeitherIndexNorHandle() {
+    assertThatThrownBy(() -> tool.execute(Map.of()))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Provide either 'index' or 'handle'");
+  }
+
+  @Test
+  void rejectsBothIndexAndHandle() {
+    assertThatThrownBy(() -> tool.execute(Map.of("index", 0, "handle", "h1")))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Provide only one of 'index' or 'handle'");
+  }
+
+  @Test
+  void rejectsOutOfRangeIndex() {
+    when(driver.getWindowHandles()).thenReturn(new LinkedHashSet<>(List.of("h1", "h2")));
+
+    assertThatThrownBy(() -> tool.execute(Map.of("index", 5)))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Tab index 5 out of range (0..1)");
+  }
+
+  static BrowserSession session(WebDriver webDriver) {
+    BrowserSession session = mock(BrowserSession.class);
+    SelenideDriver driver = mock(SelenideDriver.class);
+    when(session.getDriver()).thenReturn(driver);
+    when(driver.getWebDriver()).thenReturn(webDriver);
+    return session;
+  }
+}

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabSelectToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/TabSelectToolTest.java
@@ -17,9 +17,10 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 class TabSelectToolTest {
-  private final WebDriver driver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
+  private final WebDriver driver = mock(withSettings().defaultAnswer(RETURNS_DEEP_STUBS));
   private final TabSelectTool tool = new TabSelectTool(session(driver));
 
   @Test
@@ -64,8 +65,8 @@ class TabSelectToolTest {
   }
 
   static BrowserSession session(WebDriver webDriver) {
-    BrowserSession session = mock(BrowserSession.class);
-    SelenideDriver driver = mock(SelenideDriver.class);
+    BrowserSession session = mock();
+    SelenideDriver driver = mock();
     when(session.getDriver()).thenReturn(driver);
     when(driver.getWebDriver()).thenReturn(webDriver);
     return session;

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/WaitForToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/WaitForToolTest.java
@@ -49,6 +49,14 @@ class WaitForToolTest {
   }
 
   @Test
+  void parsesSelectorConditionExplicitVisible() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(
+      Map.of("selector", "#foo", "state", "visible"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.SELECTOR_VISIBLE);
+    assertThat(c.value()).isEqualTo("#foo");
+  }
+
+  @Test
   void parsesSelectorConditionHidden() {
     WaitForTool.Condition c = WaitForTool.parseCondition(
       Map.of("selector", "#foo", "state", "hidden"));

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/WaitForToolTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/tools/WaitForToolTest.java
@@ -1,0 +1,73 @@
+package com.codeborne.selenide.mcp.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WaitForToolTest {
+
+  @Test
+  void rejectsZeroConditions() {
+    assertThatThrownBy(() -> WaitForTool.parseCondition(Map.of()))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("exactly one of");
+  }
+
+  @Test
+  void rejectsMultipleConditions() {
+    Map<String, Object> args = new HashMap<>();
+    args.put("text", "hello");
+    args.put("time", 1);
+    assertThatThrownBy(() -> WaitForTool.parseCondition(args))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("exactly one of");
+  }
+
+  @Test
+  void parsesTextCondition() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(Map.of("text", "hello"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.TEXT);
+    assertThat(c.value()).isEqualTo("hello");
+  }
+
+  @Test
+  void parsesTextGoneCondition() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(Map.of("textGone", "bye"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.TEXT_GONE);
+    assertThat(c.value()).isEqualTo("bye");
+  }
+
+  @Test
+  void parsesSelectorConditionDefaultsToVisible() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(Map.of("selector", "#foo"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.SELECTOR_VISIBLE);
+    assertThat(c.value()).isEqualTo("#foo");
+  }
+
+  @Test
+  void parsesSelectorConditionHidden() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(
+      Map.of("selector", "#foo", "state", "hidden"));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.SELECTOR_HIDDEN);
+    assertThat(c.value()).isEqualTo("#foo");
+  }
+
+  @Test
+  void parsesTimeCondition() {
+    WaitForTool.Condition c = WaitForTool.parseCondition(Map.of("time", 2.5));
+    assertThat(c.kind()).isEqualTo(WaitForTool.Kind.TIME);
+    assertThat(c.numericValue()).isEqualTo(2.5);
+  }
+
+  @Test
+  void rejectsUnknownSelectorState() {
+    assertThatThrownBy(() -> WaitForTool.parseCondition(
+      Map.of("selector", "#foo", "state", "weird")))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("state");
+  }
+}


### PR DESCRIPTION
## Summary

Extends `selenide-mcp` with 9 new tools to bring it closer to Playwright MCP feature parity:

- **Tab management:** `browser_tab_list`, `browser_tab_select`, `browser_tab_new`, `browser_tab_close`
- **Viewport:** `browser_resize`
- **Forms:** `browser_fill_form` (bulk fill via `{fields: [{selector, value}, ...]}`)
- **Synchronization:** `browser_wait_for` (text / textGone / selector+state / time)
- **Network inspection:** `browser_network_requests`, `browser_network_request` (require `--proxy-enabled` at startup; HAR is lazy-started on first call)

Adds a new `NetworkTools` registrar (registered in `SelenideMcpServer`). Other groups (`NavigationTools`, `ElementInteractionTools`, `InspectTools`) are extended in place. Adds `de.sstoehr:har-reader` as an `implementation` dep on `modules/mcp` and `browserup-proxy-core` as `compileOnly` (runtime supplied transitively via `:modules:core`). Design and implementation plan are in `docs/superpowers/`.

## Test Plan

- [x] `./gradlew :modules:mcp:check` passes (65 tests, zero Checkstyle/SpotBugs warnings)
- [x] `./gradlew check` passes (full root build)
- [x] `./gradlew javadocForSite` passes (CLAUDE.md push gate)
- [x] `WaitForToolTest` covers argument-parsing validation (9 tests: 0/multi conditions, each kind, default vs explicit `visible`, `hidden`, unknown state)
- [x] `:modules:mcp:dependencies --configuration runtimeClasspath` confirms `de.sstoehr:har-reader` is on the runtime classpath (so network tools won't `ClassNotFoundException` in production)
- [ ] Manual smoke: start MCP server with `--proxy-enabled`, navigate to a page, call `browser_network_requests` and verify a non-empty result
- [ ] Manual smoke: open multiple tabs, verify `browser_tab_list` / `browser_tab_select` / `browser_tab_close` behave correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP tools for tab management (list/select/new/close), viewport resizing, bulk form fill, richer inspection (console logs), waiting (text/textGone/selector/time), and network inspection (list requests, fetch one by URL pattern).
* **Bug Fixes**
  * Improved tab-closing behavior to avoid losing focus and to safely switch to the next tab.
* **Documentation**
  * Added a design spec and an implementation plan for the additional MCP tools.
* **Tests**
  * Added/expanded unit tests for waiting, form fill, resizing, tabs, and network tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->