### PR TITLE
#2675 Fix stale temporary downloads in folder mode

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
@@ -25,11 +25,14 @@ import java.util.Set;
 import static com.codeborne.selenide.impl.FileHelper.moveFile;
 import static java.lang.System.currentTimeMillis;
 import static java.lang.Thread.sleep;
+import static java.util.Locale.ROOT;
+import static java.util.stream.Collectors.toMap;
 
 public class DownloadFileToFolder {
   private static final Logger log = LoggerFactory.getLogger(DownloadFileToFolder.class);
   private static final Set<String> CHROMIUM_TEMPORARY_FILES = Set.of("crdownload", "tmp");
   private static final Set<String> FIREFOX_TEMPORARY_FILES = Set.of("part");
+  private static final Set<String> TEMPORARY_FILES = Set.of("crdownload", "tmp", "part");
   private static final DurationFormat df = new DurationFormat();
 
   private final Downloader downloader;
@@ -58,15 +61,15 @@ public class DownloadFileToFolder {
       throw new IllegalStateException("Downloads folder is not configured");
     }
 
-    folder.cleanupBeforeDownload();
-    List<DownloadedFile> previousFiles = folder.files(); // some `DownloadsFolder` implementations cannot remove files
+    List<DownloadedFile> existingFiles = cleanupAndListExistingFiles(config, folder);
 
     action.perform(driver, clickable);
 
-    waitForNewFiles(driver, fileFilter, folder, previousFiles, timeout, incrementTimeout, pollingInterval, options.minimumFileCount());
-    waitUntilDownloadsCompleted(driver, folder, fileFilter, timeout, incrementTimeout, pollingInterval);
+    waitForNewFiles(driver, fileFilter, folder, existingFiles, timeout, incrementTimeout, pollingInterval,
+      options.minimumFileCount());
+    waitUntilDownloadsCompleted(driver, folder, fileFilter, existingFiles, timeout, incrementTimeout, pollingInterval);
 
-    Downloads newDownloads = new Downloads(folder.filesExcept(previousFiles));
+    Downloads newDownloads = new Downloads(currentAttemptFiles(folder, existingFiles, fileFilter));
     if (log.isInfoEnabled()) {
       log.info("Downloaded files in {}: {}", folder, newDownloads.filesAsString());
     }
@@ -78,6 +81,105 @@ public class DownloadFileToFolder {
 
     return downloadedFiles.stream().map(downloadedFile -> archive(downloadedFile,
       timeout - (currentTimeMillis() - start), contentStrategy, config, webDriver)).toList();
+  }
+
+  private List<DownloadedFile> cleanupAndListExistingFiles(Config config, DownloadsFolder folder) {
+    try {
+      folder.cleanupBeforeDownload();
+    }
+    catch (IllegalStateException cleanupFailure) {
+      if (!canContinueAfterCleanupFailure(config, cleanupFailure)) {
+        throw cleanupFailure;
+      }
+      return filesAfterFailedCleanup(folder, cleanupFailure);
+    }
+    return folder.files();
+  }
+
+  private List<DownloadedFile> filesAfterFailedCleanup(DownloadsFolder folder, IllegalStateException cleanupFailure) {
+    log.warn("Failed to clean local downloads folder {} before download; existing files will be used as the baseline " +
+        "for detecting files from this download",
+      folder, cleanupFailure);
+
+    try {
+      List<DownloadedFile> survivingFiles = folder.files();
+      if (log.isDebugEnabled()) {
+        log.debug("Files after failed cleanup in {}: {}", folder, new Downloads(survivingFiles).filesAsString());
+      }
+      return survivingFiles;
+    }
+    catch (RuntimeException listingFailure) {
+      cleanupFailure.addSuppressed(listingFailure);
+      throw cleanupFailure;
+    }
+  }
+
+  private boolean canContinueAfterCleanupFailure(Config config, IllegalStateException cleanupFailure) {
+    return isLocalBrowser(config) && cleanupFailure.getCause() instanceof IOException;
+  }
+
+  private List<DownloadedFile> currentAttemptFiles(DownloadsFolder folder, List<DownloadedFile> existingFiles,
+                                                   FileFilter fileFilter) {
+    Map<String, DownloadedFile> existingFilesByName = existingFiles.stream()
+      .collect(toMap(DownloadedFile::getName, file -> file, (first, second) -> first));
+    return folder.files().stream()
+      .filter(file -> isCurrentAttemptFile(file, existingFilesByName.get(file.getName()), fileFilter))
+      .toList();
+  }
+
+  private DownloadsFolder currentAttemptFolder(DownloadsFolder folder, List<DownloadedFile> existingFiles,
+                                               FileFilter fileFilter) {
+    return new DownloadsFolder() {
+      @Override
+      public List<DownloadedFile> files() {
+        return currentAttemptFiles(folder, existingFiles, fileFilter);
+      }
+
+      @Override
+      public void cleanupBeforeDownload() {
+        folder.cleanupBeforeDownload();
+      }
+
+      @Override
+      public void deleteIfEmpty() {
+        folder.deleteIfEmpty();
+      }
+
+      @Override
+      public String getPath() {
+        return folder.getPath();
+      }
+
+      @Override
+      public String toString() {
+        return folder.toString();
+      }
+    };
+  }
+
+  private boolean isCurrentAttemptFile(DownloadedFile file, @Nullable DownloadedFile existingFile, FileFilter fileFilter) {
+    if (existingFile == null) {
+      return true;
+    }
+    if (!fileHasChanged(file, existingFile)) {
+      return false;
+    }
+    if (isTemporaryFile(existingFile)) {
+      return isExpectedTemporaryFile(file, fileFilter);
+    }
+    return true;
+  }
+
+  private boolean isExpectedTemporaryFile(DownloadedFile file, FileFilter fileFilter) {
+    return !fileFilter.isEmpty() && fileFilter.match(file.getFile());
+  }
+
+  private boolean fileHasChanged(DownloadedFile file, DownloadedFile existingFile) {
+    return file.lastModifiedTime() != existingFile.lastModifiedTime() || file.size() != existingFile.size();
+  }
+
+  private boolean isTemporaryFile(DownloadedFile file) {
+    return TEMPORARY_FILES.contains(file.extension().toLowerCase(ROOT));
   }
 
   private File archive(File downloadedFile, long timeout, ContentStrategy contentStrategy, Config config, WebDriver webDriver) {
@@ -95,36 +197,50 @@ public class DownloadFileToFolder {
     return driver.browserDownloadsFolder();
   }
 
-  void waitUntilDownloadsCompleted(Driver driver, DownloadsFolder folder, FileFilter filter,
+  void waitUntilDownloadsCompleted(Driver driver, DownloadsFolder folder, FileFilter filter, List<DownloadedFile> existingFiles,
                                    long timeout, long incrementTimeout, long pollingInterval) {
     Browser browser = driver.browser();
     if (browser.isChrome() || browser.isEdge()) {
-      waitUntilFileDisappears(driver, folder, CHROMIUM_TEMPORARY_FILES, filter, timeout, incrementTimeout, pollingInterval);
+      waitUntilFileDisappears(driver, folder, CHROMIUM_TEMPORARY_FILES, filter, existingFiles, timeout, incrementTimeout,
+        pollingInterval);
     } else if (browser.isFirefox()) {
-      waitUntilFileDisappears(driver, folder, FIREFOX_TEMPORARY_FILES, filter, timeout, incrementTimeout, pollingInterval);
+      waitUntilFileDisappears(driver, folder, FIREFOX_TEMPORARY_FILES, filter, existingFiles, timeout, incrementTimeout,
+        pollingInterval);
     } else {
       waitWhileFilesAreBeingModified(driver, folder, timeout, pollingInterval);
     }
   }
 
   private void waitUntilFileDisappears(Driver driver, DownloadsFolder folder, Set<String> extension, FileFilter filter,
+                                       List<DownloadedFile> existingFiles,
                                        long timeout, long incrementTimeout, long pollingInterval) {
+    DownloadsFolder currentAttemptFolder = currentAttemptFolder(folder, existingFiles, filter);
     for (long start = currentTimeMillis(); currentTimeMillis() - start <= timeout; pause(pollingInterval)) {
-      if (!folder.hasFiles(extension, filter)) {
+      List<DownloadedFile> temporaryFiles = currentAttemptTemporaryFiles(currentAttemptFolder, extension, filter);
+      if (temporaryFiles.isEmpty()) {
         log.debug("No {} files found, conclude download is completed (filter: {})", extension, filter);
         return;
       }
       log.debug("Found {} files, waiting for {} ms (filter: {}, found files: {})...",
-        extension, pollingInterval, filter, folder.filesAsString());
-      failFastIfNoChanges(driver, folder, filter, start, timeout, incrementTimeout);
+        extension, pollingInterval, filter, new Downloads(temporaryFiles).filesAsString());
+      failFastIfNoChanges(driver, currentAttemptFolder, filter, start, timeout, incrementTimeout);
     }
 
-    if (folder.hasFiles(extension, filter)) {
+    List<DownloadedFile> temporaryFiles = currentAttemptTemporaryFiles(currentAttemptFolder, extension, filter);
+    if (!temporaryFiles.isEmpty()) {
       String message = String.format("Folder %s still contains files %s after %s ms. " +
           "Apparently, the downloading hasn't completed in time. Found files: %s",
-        folder, extension, df.format(timeout), folder.filesAsString());
+        folder, extension, df.format(timeout), new Downloads(temporaryFiles).filesAsString());
       throw new FileNotDownloadedError(message, timeout);
     }
+  }
+
+  private List<DownloadedFile> currentAttemptTemporaryFiles(DownloadsFolder currentAttemptFolder, Set<String> extensions,
+                                                            FileFilter filter) {
+    return currentAttemptFolder.files().stream()
+      .filter(file -> extensions.contains(file.extension().toLowerCase(ROOT)))
+      .filter(file -> filter.notMatch(file.getFile()))
+      .toList();
   }
 
   protected void waitWhileFilesAreBeingModified(Driver driver, DownloadsFolder folder, long timeout, long pollingInterval) {
@@ -156,8 +272,9 @@ public class DownloadFileToFolder {
     }
 
     long start = currentTimeMillis();
+    DownloadsFolder currentAttemptFolder = currentAttemptFolder(folder, previousFiles, fileFilter);
     for (; currentTimeMillis() - start <= timeout; pause(pollingInterval)) {
-      Downloads downloads = new Downloads(folder.filesExcept(previousFiles));
+      Downloads downloads = new Downloads(currentAttemptFolder.files());
       List<DownloadedFile> matchingFiles = downloads.files(fileFilter);
       log.debug("{} matching files found: {}, all new files: {}, all files: {}",
         matchingFiles.size(), matchingFiles, downloads.filesAsString(), folder.filesAsString());
@@ -166,7 +283,7 @@ public class DownloadFileToFolder {
         return;
       }
 
-      failFastIfNoChanges(driver, folder, fileFilter, start, timeout, incrementTimeout);
+      failFastIfNoChanges(driver, currentAttemptFolder, fileFilter, start, timeout, incrementTimeout);
     }
 
     log.debug("Matching files still not found -> stop waiting for new files after {} ms. (timeout: {} ms.)",

--- a/src/test/java/com/codeborne/selenide/impl/DownloadFileToFolderTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/DownloadFileToFolderTest.java
@@ -2,20 +2,34 @@ package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.BrowserDownloadsFolder;
+import com.codeborne.selenide.DownloadOptions;
+import com.codeborne.selenide.DownloadsFolder;
+import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.DriverStub;
 import com.codeborne.selenide.DummyWebDriver;
 import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.SharedDownloadsFolder;
+import com.codeborne.selenide.ex.FileNotDownloadedError;
+import com.codeborne.selenide.files.DownloadedFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.stubbing.Answer;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
+import static com.codeborne.selenide.Browsers.CHROME;
+import static com.codeborne.selenide.Browsers.EDGE;
+import static com.codeborne.selenide.Browsers.FIREFOX;
 import static com.codeborne.selenide.DownloadOptions.file;
 import static com.codeborne.selenide.FileDownloadMode.FOLDER;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -23,8 +37,11 @@ import static java.util.UUID.randomUUID;
 import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.apache.commons.io.FileUtils.writeStringToFile;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 final class DownloadFileToFolderTest {
@@ -60,6 +77,173 @@ final class DownloadFileToFolderTest {
     assertThat(readFileToString(downloadedFiles.get(0), UTF_8)).isEqualTo("Hello Bingo-Bongo");
   }
 
+  @ParameterizedTest
+  @MethodSource("staleTemporaryFiles")
+  void ignoresTemporaryFilesFromPreviousFailedDownload(String browser, String staleTemporaryFile) throws IOException {
+    config.pollingInterval(50);
+    DriverStub driver = driver(browser, downloadsFolder);
+    writeStringToFile(downloadsFolder.file(staleTemporaryFile), "Partial old download", UTF_8);
+    clickCreates(downloadsFolder, "document.pdf", "%PDF new file");
+
+    List<File> downloadedFiles = command.download(driver, link, 1500, 1000,
+      file().withMethod(FOLDER).withName("document.pdf"));
+
+    assertThat(downloadedFiles).hasSize(1);
+    assertThat(downloadedFiles.get(0).getName()).isEqualTo("document.pdf");
+    assertThat(readFileToString(downloadedFiles.get(0), UTF_8)).isEqualTo("%PDF new file");
+  }
+
+  @Test
+  void continuesDownloadWhenLocalCleanupFailsWithIoException() throws IOException {
+    config.pollingInterval(50);
+    FailingIoCleanupDownloadsFolder downloadsFolder = new FailingIoCleanupDownloadsFolder("build/downloads/" + randomUUID());
+    DriverStub driver = driver(CHROME, downloadsFolder);
+    writeStringToFile(downloadsFolder.file("old-file.crdownload"), "Partial old download", UTF_8);
+    clickCreates(downloadsFolder, "document.pdf", "%PDF new file");
+
+    List<File> downloadedFiles = command.download(driver, link, 1500, 1000,
+      file().withMethod(FOLDER).withName("document.pdf"));
+
+    assertThat(downloadedFiles).hasSize(1);
+    assertThat(downloadedFiles.get(0).getName()).isEqualTo("document.pdf");
+    assertThat(readFileToString(downloadedFiles.get(0), UTF_8)).isEqualTo("%PDF new file");
+    assertThat(downloadsFolder.cleanupAttempts).isEqualTo(1);
+  }
+
+  @Test
+  void detectsOverwrittenFileAfterLocalCleanupFailure() throws IOException {
+    config.pollingInterval(50);
+    FailingIoCleanupDownloadsFolder downloadsFolder = new FailingIoCleanupDownloadsFolder("build/downloads/" + randomUUID());
+    DriverStub driver = driver(CHROME, downloadsFolder);
+    writeStringToFile(downloadsFolder.file("document.pdf"), "old", UTF_8);
+    writeStringToFile(downloadsFolder.file("old-file.crdownload"), "Partial old download", UTF_8);
+    clickCreates(downloadsFolder, "document.pdf", "%PDF new file");
+
+    List<File> downloadedFiles = command.download(driver, link, 1500, 1000,
+      file().withMethod(FOLDER).withName("document.pdf"));
+
+    assertThat(downloadedFiles).hasSize(1);
+    assertThat(downloadedFiles.get(0).getName()).isEqualTo("document.pdf");
+    assertThat(readFileToString(downloadedFiles.get(0), UTF_8)).isEqualTo("%PDF new file");
+  }
+
+  @Test
+  void propagatesRemoteCleanupFailure() {
+    FailingIoCleanupDownloadsFolder downloadsFolder = new FailingIoCleanupDownloadsFolder("build/downloads/" + randomUUID());
+    DriverStub driver = remoteDriver(CHROME, downloadsFolder);
+
+    assertThatThrownBy(() -> command.download(driver, link, 1500, 1000,
+      file().withMethod(FOLDER).withName("document.pdf")))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Simulated cleanup failure");
+    verify(link, never()).click();
+  }
+
+  @Test
+  void propagatesUnexpectedLocalCleanupFailure() {
+    FailingCleanupDownloadsFolder downloadsFolder = new FailingCleanupDownloadsFolder("build/downloads/" + randomUUID());
+    DriverStub driver = driver(CHROME, downloadsFolder);
+
+    assertThatThrownBy(() -> command.download(driver, link, 1500, 1000,
+      file().withMethod(FOLDER).withName("document.pdf")))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Simulated cleanup failure");
+    verify(link, never()).click();
+  }
+
+  @Test
+  void propagatesListingFailureAfterRecoverableCleanupFailure() {
+    FailingFilesAfterCleanupFolder downloadsFolder = new FailingFilesAfterCleanupFolder("build/downloads/" + randomUUID());
+    DriverStub driver = driver(CHROME, downloadsFolder);
+
+    assertThatThrownBy(() -> command.download(driver, link, 1500, 1000,
+      file().withMethod(FOLDER).withName("document.pdf")))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Simulated cleanup failure")
+      .satisfies(error -> {
+        assertThat(error.getSuppressed()).hasSize(1);
+        assertThat(error.getSuppressed()[0])
+          .isInstanceOf(UncheckedIOException.class)
+          .hasMessage("Failed to list files");
+      });
+    verify(link, never()).click();
+  }
+
+  @Test
+  void ignoresTemporaryFileFromPreviousFailedDownloadIfItChangesDuringClick() throws IOException {
+    config.pollingInterval(50);
+    writeStringToFile(downloadsFolder.file("image.iso.crdownload"), "Partial old download", UTF_8);
+    doAnswer((Answer<Void>) i -> {
+      writeStringToFile(downloadsFolder.file("image.iso.crdownload"), "Partial old download still growing", UTF_8);
+      writeStringToFile(downloadsFolder.file("document.pdf"), "%PDF new file", UTF_8);
+      return null;
+    }).when(link).click();
+
+    List<File> downloadedFiles = command.download(driver(CHROME, downloadsFolder), link, 1500, 1000,
+      file().withMethod(FOLDER).withName("document.pdf"));
+
+    assertThat(downloadedFiles).hasSize(1);
+    assertThat(downloadedFiles.get(0).getName()).isEqualTo("document.pdf");
+    assertThat(readFileToString(downloadedFiles.get(0), UTF_8)).isEqualTo("%PDF new file");
+  }
+
+  @Test
+  void failsFastIfOnlyStaleTemporaryFileKeepsChanging() {
+    config.pollingInterval(50);
+    ChangingStaleTemporaryDownloadsFolder downloadsFolder =
+      new ChangingStaleTemporaryDownloadsFolder("build/downloads/" + randomUUID());
+
+    assertThatThrownBy(() -> command.download(driver(CHROME, downloadsFolder), link, 1500, 200,
+      file().withMethod(FOLDER).withName("document.pdf")))
+      .isInstanceOf(FileNotDownloadedError.class)
+      .hasMessageContaining("haven't been modified");
+  }
+
+  @ParameterizedTest
+  @MethodSource("expectedFilesWithTemporaryExtensions")
+  void detectsExpectedTemporaryLikeFileAfterLocalCleanupFailure(String browser, String fileName, DownloadOptions options)
+    throws IOException {
+    config.pollingInterval(50);
+    FailingIoCleanupDownloadsFolder downloadsFolder = new FailingIoCleanupDownloadsFolder("build/downloads/" + randomUUID());
+    DriverStub driver = driver(browser, downloadsFolder);
+    writeStringToFile(downloadsFolder.file(fileName), "old", UTF_8);
+    clickCreates(downloadsFolder, fileName, "actual downloaded file");
+
+    List<File> downloadedFiles = command.download(driver, link, 1500, 1000, options);
+
+    assertThat(downloadedFiles).hasSize(1);
+    assertThat(downloadedFiles.get(0).getName()).isEqualTo(fileName);
+    assertThat(readFileToString(downloadedFiles.get(0), UTF_8)).isEqualTo("actual downloaded file");
+  }
+
+  @ParameterizedTest
+  @MethodSource("sameFinalNameFilters")
+  void detectsExpectedFileEvenIfPreviousTemporaryFileHadSameFinalName(DownloadOptions options) throws IOException {
+    config.pollingInterval(50);
+    writeStringToFile(downloadsFolder.file("document.pdf.crdownload"), "Partial old download", UTF_8);
+    clickCreates(downloadsFolder, "document.pdf", "%PDF new file");
+
+    List<File> downloadedFiles = command.download(driver(CHROME, downloadsFolder), link, 1500, 1000, options);
+
+    assertThat(downloadedFiles).hasSize(1);
+    assertThat(downloadedFiles.get(0).getName()).isEqualTo("document.pdf");
+    assertThat(readFileToString(downloadedFiles.get(0), UTF_8)).isEqualTo("%PDF new file");
+  }
+
+  @Test
+  void waitWhileFilesAreBeingModifiedReceivesOriginalFolder() throws IOException {
+    config.pollingInterval(50);
+    HookCapturingDownloadFileToFolder command = new HookCapturingDownloadFileToFolder(downloader);
+    writeStringToFile(downloadsFolder.file("stale.tmp"), "old file", UTF_8);
+    clickCreates(downloadsFolder, "document.pdf", "%PDF new file");
+
+    List<File> downloadedFiles = command.download(driver("opera", downloadsFolder), link, 1500, 1000,
+      file().withMethod(FOLDER).withName("document.pdf"));
+
+    assertThat(downloadedFiles).hasSize(1);
+    assertThat(command.folderSeenByWaitWhileBeingModified).isSameAs(downloadsFolder);
+  }
+
   @Test
   void filesHasNotBeenUpdatedForMs() {
     assertThat(command.filesHasNotBeenUpdatedForMs(1111111114000L, 1111111114998L, 1111111114998L)).isEqualTo(0);
@@ -72,5 +256,108 @@ final class DownloadFileToFolderTest {
     assertThat(command.filesHasNotBeenUpdatedForMs(1111111114000L, 1111111114998L, 0))
       .as("File modification time may be 0 (if file path is treated as invalid for some reason)")
       .isEqualTo(998);
+  }
+
+  private DriverStub driver(String browser, BrowserDownloadsFolder downloadsFolder) {
+    return new DriverStub(config, new Browser(browser, false), webdriver, null, downloadsFolder);
+  }
+
+  private DriverStub remoteDriver(String browser, BrowserDownloadsFolder downloadsFolder) {
+    SelenideConfig remoteConfig = new SelenideConfig().remote("http://example.com:4444/wd/hub");
+    return new DriverStub(remoteConfig, new Browser(browser, false), webdriver, null, downloadsFolder);
+  }
+
+  private void clickCreates(BrowserDownloadsFolder downloadsFolder, String name, String content) {
+    doAnswer((Answer<Void>) i -> {
+      writeStringToFile(downloadsFolder.file(name), content, UTF_8);
+      return null;
+    }).when(link).click();
+  }
+
+  private static Stream<Arguments> staleTemporaryFiles() {
+    return Stream.of(
+      Arguments.of(CHROME, "stale.crdownload"),
+      Arguments.of(CHROME, "stale.tmp"),
+      Arguments.of(EDGE, "stale.crdownload"),
+      Arguments.of(EDGE, "stale.tmp"),
+      Arguments.of(FIREFOX, "stale.part")
+    );
+  }
+
+  private static Stream<DownloadOptions> sameFinalNameFilters() {
+    return Stream.of(
+      file().withMethod(FOLDER),
+      file().withMethod(FOLDER).withExtension("pdf"),
+      file().withMethod(FOLDER).withName("document.pdf")
+    );
+  }
+
+  private static Stream<Arguments> expectedFilesWithTemporaryExtensions() {
+    return Stream.of(
+      Arguments.of(CHROME, "report.crdownload", file().withMethod(FOLDER).withName("report.crdownload")),
+      Arguments.of(CHROME, "report.tmp", file().withMethod(FOLDER).withName("report.tmp")),
+      Arguments.of(FIREFOX, "report.part", file().withMethod(FOLDER).withName("report.part"))
+    );
+  }
+
+  private static class FailingCleanupDownloadsFolder extends SharedDownloadsFolder {
+    protected int cleanupAttempts;
+
+    FailingCleanupDownloadsFolder(String folder) {
+      super(folder);
+    }
+
+    @Override
+    public void cleanupBeforeDownload() {
+      cleanupAttempts++;
+      throw new IllegalStateException("Simulated cleanup failure");
+    }
+  }
+
+  private static class FailingIoCleanupDownloadsFolder extends FailingCleanupDownloadsFolder {
+    FailingIoCleanupDownloadsFolder(String folder) {
+      super(folder);
+    }
+
+    @Override
+    public void cleanupBeforeDownload() {
+      cleanupAttempts++;
+      throw new IllegalStateException("Simulated cleanup failure", new IOException("File is busy"));
+    }
+  }
+
+  private static final class FailingFilesAfterCleanupFolder extends FailingIoCleanupDownloadsFolder {
+    FailingFilesAfterCleanupFolder(String folder) {
+      super(folder);
+    }
+
+    @Override
+    public List<DownloadedFile> files() {
+      throw new UncheckedIOException("Failed to list files", new IOException("Cannot read folder"));
+    }
+  }
+
+  private static final class ChangingStaleTemporaryDownloadsFolder extends SharedDownloadsFolder {
+    ChangingStaleTemporaryDownloadsFolder(String folder) {
+      super(folder);
+    }
+
+    @Override
+    public List<DownloadedFile> files() {
+      return List.of(new DownloadedFile(file("image.iso.crdownload"), System.currentTimeMillis(), 1024, Map.of()));
+    }
+  }
+
+  private static final class HookCapturingDownloadFileToFolder extends DownloadFileToFolder {
+    private DownloadsFolder folderSeenByWaitWhileBeingModified;
+
+    HookCapturingDownloadFileToFolder(Downloader downloader) {
+      super(downloader);
+    }
+
+    @Override
+    protected void waitWhileFilesAreBeingModified(Driver driver, DownloadsFolder folder, long timeout, long pollingInterval) {
+      folderSeenByWaitWhileBeingModified = folder;
+    }
   }
 }


### PR DESCRIPTION
## Proposed changes
Fixes #2675.

This PR fixes `FileDownloadMode.FOLDER` handling when a previous failed browser download leaves a stale temporary file (`.crdownload`, `.tmp`, `.part`) in the downloads folder.

The change:
- continues after local `IOException` cleanup failures by using surviving files as the baseline
- keeps remote cleanup failures and unexpected local cleanup failures unchanged
- ignores stale temporary files from previous attempts while waiting for the current download
- still allows explicitly requested files ending with `.crdownload`, `.tmp`, or `.part`

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)