### PR TITLE
#3348 Add element()/elements() aliases to SelenideAppium

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppium.java
@@ -150,4 +150,29 @@ public class SelenideAppium {
   public static SelenideAppiumCollection $$(Collection<? extends WebElement> elements) {
     return new SelenideAppiumCollection(driver(), elements);
   }
+
+  /** Alias for {@code $(By)}, usable without backticks in Kotlin page objects. */
+  public static SelenideAppiumElement element(By seleniumSelector) {
+    return $(seleniumSelector);
+  }
+
+  /** Alias for {@code $(By, int)}, usable without backticks in Kotlin page objects. */
+  public static SelenideAppiumElement element(By seleniumSelector, int index) {
+    return $(seleniumSelector, index);
+  }
+
+  /** Alias for {@code $(WebElement)}, usable without backticks in Kotlin page objects. */
+  public static SelenideAppiumElement element(WebElement webElement) {
+    return $(webElement);
+  }
+
+  /** Alias for {@code $$(By)}, usable without backticks in Kotlin page objects. */
+  public static SelenideAppiumCollection elements(By selector) {
+    return $$(selector);
+  }
+
+  /** Alias for {@code $$(Collection)}, usable without backticks in Kotlin page objects. */
+  public static SelenideAppiumCollection elements(Collection<? extends WebElement> elements) {
+    return $$(elements);
+  }
 }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumAliasTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumAliasTest.java
@@ -1,0 +1,69 @@
+package com.codeborne.selenide.appium;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.WebDriverRunner;
+import io.appium.java_client.android.AndroidDriver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.bidi.BiDiException;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.util.List;
+
+class SelenideAppiumAliasTest {
+
+  @BeforeEach
+  void setUp() {
+    AndroidDriver androidDriver = mock();
+    when(androidDriver.getCapabilities()).thenReturn(new DesiredCapabilities());
+    when(androidDriver.getBiDi()).thenThrow(BiDiException.class);
+    WebDriverRunner.setWebDriver(androidDriver);
+  }
+
+  @AfterEach
+  void tearDown() {
+    Selenide.closeWebDriver();
+  }
+
+  @Test
+  void element_is_alias_for_dollar() {
+    By selector = By.id("submit");
+    assertThat(SelenideAppium.element(selector))
+      .hasToString(SelenideAppium.$(selector).toString());
+  }
+
+  @Test
+  void element_with_index_is_alias_for_dollar() {
+    By selector = By.className("android.widget.TextView");
+    assertThat(SelenideAppium.element(selector, 2))
+      .hasToString(SelenideAppium.$(selector, 2).toString());
+  }
+
+  @Test
+  void elements_is_alias_for_dollar_dollar() {
+    By selector = By.className("android.widget.TextView");
+    assertThat(SelenideAppium.elements(selector))
+      .hasToString(SelenideAppium.$$(selector).toString());
+  }
+
+  @Test
+  void element_from_webElement_is_alias_for_dollar() {
+    WebElement raw = mock();
+    assertThat(SelenideAppium.element(raw))
+      .hasToString(SelenideAppium.$(raw).toString());
+  }
+
+  @Test
+  void elements_from_collection_is_alias_for_dollar_dollar() {
+    List<WebElement> raw = List.of(mock(), mock());
+    assertThat(SelenideAppium.elements(raw))
+      .hasToString(SelenideAppium.$$(raw).toString());
+  }
+}


### PR DESCRIPTION
## Proposed changes

Adds `element()` / `elements()` to `SelenideAppium` as aliases for `$()` / `$$()`, so they can be used without backtick-escaping in Kotlin page objects (mirroring the web `Selenide` API). Each overload — `element(By)`, `element(By, int)`, `element(WebElement)`, `elements(By)`, `elements(Collection)` — delegates to the existing `$` / `$$`, leaving behavior unchanged.

```kotlin
// before
private val button = SelenideAppium.`$`(CombinedBy.android(...).ios(...))
// after
private val button = SelenideAppium.element(CombinedBy.android(...).ios(...))
```

Resolves #3348.

## Checklist
- [x] Checkstyle and unit tests pass locally for `:modules:appium` (`gradlew :modules:appium:test :modules:appium:checkstyleMain :modules:appium:checkstyleTest`)
- [x] Added `SelenideAppiumAliasTest` covering the new aliases
- [x] New methods documented with javadoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kotlin-friendly alias methods for Appium element and collection lookups, with overloads supporting `By` selectors and direct `WebElement` inputs for more natural page object syntax.
* **Tests**
  * Added new test coverage to confirm the alias methods behave consistently with the existing `$`/`$$` lookup variants across overloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->