### PR TITLE
Remove flaky FedericoCarboni/setup-ffmpeg action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup FFmpeg
-        run: sudo apt-get install -y ffmpeg
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ffmpeg
+          version: 1.0
       - run: ffmpeg -version
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,13 +71,10 @@ jobs:
         uses: actions/checkout@v7
       - name: Setup FFmpeg
         if: ${{ matrix.gradle-task == 'firefox_headless' || matrix.gradle-task == 'chrome_headless' }}
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: ffmpeg
-          version: 1.1
-      - name: Refresh shared library cache
-        run: sudo ldconfig
-      - run: ffmpeg -version
+        run: sudo apt-get install -y ffmpeg
+      - name: Check FFmpeg
+        if: ${{ matrix.gradle-task == 'firefox_headless' || matrix.gradle-task == 'chrome_headless' }}
+        run: ffmpeg -version
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,10 +71,9 @@ jobs:
         uses: actions/checkout@v7
       - name: Setup FFmpeg
         if: ${{ matrix.gradle-task == 'firefox_headless' || matrix.gradle-task == 'chrome_headless' }}
-        run: sudo apt-get install -y ffmpeg
-      - name: Check FFmpeg
-        if: ${{ matrix.gradle-task == 'firefox_headless' || matrix.gradle-task == 'chrome_headless' }}
-        run: ffmpeg -version
+        run: |
+          sudo apt-get install -y ffmpeg
+          ffmpeg -version
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup FFmpeg
+        if: ${{ matrix.gradle-task == 'firefox_headless' || matrix.gradle-task == 'chrome_headless' }}
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: ffmpeg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: ffmpeg
-          version: 1.0
+          version: 1.1
       - name: Refresh shared library cache
         run: sudo ldconfig
       - run: ffmpeg -version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - name: Setup FFmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - run: ffmpeg -version
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,10 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup FFmpeg
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: ffmpeg
-          version: 1.0
+        run: sudo apt-get install -y ffmpeg
       - run: ffmpeg -version
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Setup FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
       - run: ffmpeg -version
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup FFmpeg
-        run: sudo apt-get install -y ffmpeg
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ffmpeg
+          version: 1.0
+      - name: Refresh shared library cache
+        run: sudo ldconfig
       - run: ffmpeg -version
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Setup FFmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: sudo apt-get install -y ffmpeg
       - run: ffmpeg -version
       - name: Set up JDK
         uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary
- The `FedericoCarboni/setup-ffmpeg@v3` action intermittently fails with `AssertionError: Failed to get latest johnvansickle ffmpeg release`, since it depends on an external release lookup.
- `ffmpeg` is already preinstalled on `ubuntu-latest` GitHub-hosted runners, so the action is unnecessary. Removed it and kept the existing `ffmpeg -version` step as a sanity check.

## Test plan
- [ ] CI (`run-tests-on-linux` job) passes and `ffmpeg -version` prints a valid version, confirming ffmpeg is present without the extra action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Linux CI test pipeline to install FFmpeg directly during the test run.
  * Retained the existing FFmpeg version check to verify installation success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->