### PR TITLE
#3357 Deprecate clearBrowserLocalStorage() and clearBrowserCookies()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 7.17.0 (TBD)
+* #3357 deprecated `clearBrowserLocalStorage()` and `clearBrowserCookies()` in favor of `localStorage().clear()` and `SelenideDriver.clearCookies()`
 * update Selenium from 4.44.0 to 4.45.0 (incl. CDP from 148 -> 149)
 
 ## 7.16.2 (27.05.2026)

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -395,6 +395,10 @@ public class SelenideDriver {
     return new WebDriverLogs(driver());
   }
 
+  /**
+   * @deprecated Use {@link Selenide#localStorage()} and {@link LocalStorage#clear()} instead
+   */
+  @Deprecated
   public void clearBrowserLocalStorage() {
     executeJavaScript("localStorage.clear();");
   }

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -1039,7 +1039,10 @@ public class Selenide {
    * Clear browser cookies.
    * <p>
    * It can be useful e.g. if you are trying to avoid restarting browser between tests
+   *
+   * @deprecated Use {@link SelenideDriver#clearCookies()} instead
    */
+  @Deprecated
   public static void clearBrowserCookies() {
     getSelenideDriver().clearCookies();
   }
@@ -1048,7 +1051,10 @@ public class Selenide {
    * Clear browser local storage.
    * <p>
    * In case if you need to be sure that browser's localStorage is empty
+   *
+   * @deprecated Use {@link #localStorage()} and {@link LocalStorage#clear()} instead
    */
+  @Deprecated
   public static void clearBrowserLocalStorage() {
     getSelenideDriver().clearBrowserLocalStorage();
   }

--- a/statics/src/test/java/integration/ClearCookiesTest.java
+++ b/statics/src/test/java/integration/ClearCookiesTest.java
@@ -8,7 +8,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Set;
 
-import static com.codeborne.selenide.Selenide.clearBrowserCookies;
+import static com.codeborne.selenide.WebDriverRunner.driver;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,7 +27,7 @@ final class ClearCookiesTest extends IntegrationTest {
 
   @Test
   void clearCookieTest() {
-    clearBrowserCookies();
+    driver().clearCookies();
     Set<Cookie> cookieSet = getWebDriver().manage().getCookies();
     assertThat(cookieSet).isEmpty();
   }

--- a/statics/src/test/java/integration/ClearLocalStorageTest.java
+++ b/statics/src/test/java/integration/ClearLocalStorageTest.java
@@ -3,7 +3,7 @@ package integration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Selenide.clearBrowserLocalStorage;
+import static com.codeborne.selenide.Selenide.localStorage;
 import static com.codeborne.selenide.Selenide.executeJavaScript;
 import static com.codeborne.selenide.Selenide.open;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,7 +20,7 @@ final class ClearLocalStorageTest extends IntegrationTest {
   void clearLocalStorageTest() {
     assertThat(getLocalStorageLength()).isEqualTo(2L);
 
-    clearBrowserLocalStorage();
+    localStorage().clear();
 
     assertThat(getLocalStorageLength()).isEqualTo(0L);
   }

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -15,7 +15,7 @@ import static com.codeborne.selenide.Configuration.baseUrl;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.Selenide.clearBrowserCookies;
+import static com.codeborne.selenide.WebDriverRunner.driver;
 import static com.codeborne.selenide.Selenide.switchTo;
 import static com.codeborne.selenide.Selenide.webdriver;
 import static com.codeborne.selenide.WebDriverConditions.cookie;
@@ -340,7 +340,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
 
   private void openPageWithCookies() {
     openFile("cookies.html");
-    clearBrowserCookies();
+    driver().clearCookies();
   }
 
   private void addCustomCookie() {


### PR DESCRIPTION
## Summary
- Mark `Selenide.clearBrowserLocalStorage()` and `Selenide.clearBrowserCookies()` as `@Deprecated`
- Mark `SelenideDriver.clearBrowserLocalStorage()` as `@Deprecated`
- Point Javadoc to preferred APIs: `localStorage().clear()`, `sessionStorage().clear()`, and `SelenideDriver.clearCookies()` (they log steps via SelenideLogger)
- Update integration tests to use the preferred APIs

Per @asolntsev's feedback: `sessionStorage().clear()` / `localStorage().clear()` are the right methods; legacy `clearBrowser*()` shortcuts should be deprecated instead of adding `clearBrowserSessionStorage()`.

Closes #3357

## Test plan
- [x] `./gradlew check`
- [x] `./gradlew :statics:chrome_headless --tests integration.ClearLocalStorageTest --tests integration.ClearCookiesTest --tests integration.SessionStorageTest --tests integration.LocalStorageTest`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked browser cookie and local storage clearing helpers as deprecated and added guidance to the newer APIs.

* **Bug Fixes**
  * Updated usage guidance so cookie and local storage cleanup now points to the current supported methods.

* **Tests**
  * Adjusted integration tests to use the newer cookie and local storage APIs.
  * Kept coverage aligned with the updated deprecation notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->