### PR TITLE
#2761 Make SelenideAppiumElement.$$ return SelenideAppiumCollection

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumCollection.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumCollection.java
@@ -1,28 +1,147 @@
 package com.codeborne.selenide.appium;
 
-import com.codeborne.selenide.BaseElementsCollection;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.WebElementCondition;
+import com.codeborne.selenide.WebElementsCondition;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.codeborne.selenide.impl.BySelectorCollection;
+import com.codeborne.selenide.impl.CollectionElement;
+import com.codeborne.selenide.impl.CollectionElementByCondition;
 import com.codeborne.selenide.impl.CollectionSource;
+import com.codeborne.selenide.impl.LastCollectionElement;
+import com.codeborne.selenide.impl.WebElementSource;
+import com.codeborne.selenide.impl.WebElementsCollectionWrapper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
 import java.util.Collection;
 
-public class SelenideAppiumCollection extends BaseElementsCollection<SelenideAppiumElement, SelenideAppiumCollection> {
+public class SelenideAppiumCollection extends ElementsCollection {
+  private final CollectionSource source;
+
   SelenideAppiumCollection(CollectionSource collection) {
     super(collection);
+    this.source = collection;
   }
 
   SelenideAppiumCollection(Driver driver, Collection<? extends WebElement> elements) {
-    super(driver, elements);
+    this(new WebElementsCollectionWrapper(driver, elements));
   }
 
   SelenideAppiumCollection(Driver driver, By seleniumSelector) {
-    super(driver, seleniumSelector);
+    this(new BySelectorCollection(driver, seleniumSelector));
+  }
+
+  public SelenideAppiumCollection(WebElementSource parent, By selector) {
+    this(new BySelectorCollection(parent.driver(), parent, selector));
   }
 
   @Override
   protected SelenideAppiumCollection create(CollectionSource source) {
     return new SelenideAppiumCollection(source);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection should(WebElementsCondition... conditions) {
+    return (SelenideAppiumCollection) super.should(conditions);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection should(WebElementsCondition condition, Duration timeout) {
+    return (SelenideAppiumCollection) super.should(condition, timeout);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection shouldBe(WebElementsCondition... conditions) {
+    return (SelenideAppiumCollection) super.shouldBe(conditions);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection shouldBe(WebElementsCondition condition, Duration timeout) {
+    return (SelenideAppiumCollection) super.shouldBe(condition, timeout);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection shouldHave(WebElementsCondition... conditions) {
+    return (SelenideAppiumCollection) super.shouldHave(conditions);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection shouldHave(WebElementsCondition condition, Duration timeout) {
+    return (SelenideAppiumCollection) super.shouldHave(condition, timeout);
+  }
+
+  @Override
+  public SelenideAppiumCollection filter(WebElementCondition condition) {
+    return (SelenideAppiumCollection) super.filter(condition);
+  }
+
+  @Override
+  public SelenideAppiumCollection filterBy(WebElementCondition condition) {
+    return (SelenideAppiumCollection) super.filterBy(condition);
+  }
+
+  @Override
+  public SelenideAppiumCollection exclude(WebElementCondition condition) {
+    return (SelenideAppiumCollection) super.exclude(condition);
+  }
+
+  @Override
+  public SelenideAppiumCollection excludeWith(WebElementCondition condition) {
+    return (SelenideAppiumCollection) super.excludeWith(condition);
+  }
+
+  @Override
+  public SelenideAppiumCollection first(int elements) {
+    return (SelenideAppiumCollection) super.first(elements);
+  }
+
+  @Override
+  public SelenideAppiumCollection last(int elements) {
+    return (SelenideAppiumCollection) super.last(elements);
+  }
+
+  @Override
+  public SelenideAppiumCollection snapshot() {
+    return (SelenideAppiumCollection) super.snapshot();
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection as(String alias) {
+    return (SelenideAppiumCollection) super.as(alias);
+  }
+
+  @Override
+  public SelenideAppiumElement get(int index) {
+    return CollectionElement.wrap(SelenideAppiumElement.class, source, index);
+  }
+
+  @Override
+  public SelenideAppiumElement first() {
+    return get(0);
+  }
+
+  @Override
+  public SelenideAppiumElement last() {
+    return LastCollectionElement.wrap(source, SelenideAppiumElement.class);
+  }
+
+  @Override
+  public SelenideAppiumElement find(WebElementCondition condition) {
+    return CollectionElementByCondition.wrap(source, condition, SelenideAppiumElement.class);
+  }
+
+  @Override
+  public SelenideAppiumElement findBy(WebElementCondition condition) {
+    return find(condition);
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumElement.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumElement.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.WebElementCondition;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import org.openqa.selenium.By;
 
 public interface SelenideAppiumElement extends SelenideElement {
   @CanIgnoreReturnValue
@@ -107,4 +108,29 @@ public interface SelenideAppiumElement extends SelenideElement {
   @Override
   @CanIgnoreReturnValue
   SelenideAppiumElement should(WebElementCondition... condition);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFindAll
+   */
+  SelenideAppiumCollection findAll(String cssSelector);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFindAll
+   */
+  SelenideAppiumCollection findAll(By selector);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFindAll
+   */
+  SelenideAppiumCollection $$(String cssSelector);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFindAll
+   */
+  SelenideAppiumCollection $$(By selector);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFindAllByXpath
+   */
+  SelenideAppiumCollection $$x(String xpath);
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -131,9 +131,15 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
       super.createCollection(collection, klass);
   }
 
-  private static class SelenideAppiumList extends SelenideAppiumCollection implements NoOpsList<SelenideAppiumElement> {
+  private static class SelenideAppiumList extends BaseElementsCollection<SelenideAppiumElement, SelenideAppiumList>
+    implements NoOpsList<SelenideAppiumElement> {
     SelenideAppiumList(CollectionSource collection) {
       super(collection);
+    }
+
+    @Override
+    protected SelenideAppiumList create(CollectionSource source) {
+      return new SelenideAppiumList(source);
     }
   }
 

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindAll.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindAll.java
@@ -1,0 +1,16 @@
+package com.codeborne.selenide.appium.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.appium.SelenideAppiumCollection;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import static com.codeborne.selenide.commands.Util.firstOf;
+
+public class AppiumFindAll implements Command<SelenideAppiumCollection> {
+  @Override
+  public SelenideAppiumCollection execute(SelenideElement parentElement, WebElementSource parentLocator, Object... args) {
+    Object selector = firstOf(args);
+    return new SelenideAppiumCollection(parentLocator, WebElementSource.getSelector(selector));
+  }
+}

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindAllByXpath.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindAllByXpath.java
@@ -1,0 +1,18 @@
+package com.codeborne.selenide.appium.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.appium.SelenideAppiumCollection;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.By;
+
+import static com.codeborne.selenide.commands.Util.firstOf;
+
+public class AppiumFindAllByXpath implements Command<SelenideAppiumCollection> {
+  @Override
+  public SelenideAppiumCollection execute(SelenideElement parentElement, WebElementSource parentLocator, Object @Nullable [] args) {
+    String xpath = firstOf(args);
+    return new SelenideAppiumCollection(parentLocator, By.xpath(xpath));
+  }
+}

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/SelenideAppiumCommands.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/SelenideAppiumCommands.java
@@ -4,6 +4,9 @@ import com.codeborne.selenide.commands.Commands;
 
 public class SelenideAppiumCommands extends Commands {
   public SelenideAppiumCommands() {
+    add("findAll", new AppiumFindAll());
+    add("$$", new AppiumFindAll());
+    add("$$x", new AppiumFindAllByXpath());
     add("dragAndDrop", new AppiumDragAndDrop());
     add("click", new AppiumClick());
     add("doubleClick", new AppiumDoubleClick());

--- a/modules/appium/src/test/java/it/mobile/android/AppiumCollectionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AppiumCollectionsTest.java
@@ -13,6 +13,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.appium.AppiumScrollOptions.down;
 import static com.codeborne.selenide.appium.AppiumScrollOptions.up;
 import static com.codeborne.selenide.appium.SelenideAppium.$$;
+import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AppiumCollectionsTest extends BaseSwagLabsAndroidTest {
@@ -44,5 +45,12 @@ public class AppiumCollectionsTest extends BaseSwagLabsAndroidTest {
 
     SelenideAppiumElement field = inputFields.find(attribute("password", "true")).shouldBe(visible);
     assertThat(field).isInstanceOf(SelenideAppiumElement.class);
+  }
+
+  @Test
+  void appiumCollectionFromParentElement() {
+    SelenideAppiumElement loginForm = $(By.xpath("//android.view.ViewGroup[@content-desc='Login button']/.."));
+    SelenideAppiumCollection inputFields = loginForm.$$(By.xpath(".//android.widget.EditText")).shouldHave(size(2));
+    assertThat(inputFields.first()).isInstanceOf(SelenideAppiumElement.class);
   }
 }


### PR DESCRIPTION
## Summary
- Override `findAll`, `$$`, and `$$x` on `SelenideAppiumElement` to return `SelenideAppiumCollection` instead of `ElementsCollection`
- Register Appium-specific `FindAll` commands so nested searches inside a parent element produce Appium collections and elements
- Make `SelenideAppiumCollection` extend `ElementsCollection` (required for covariant return types in Java) while preserving Appium element typing in `get()`, `first()`, `last()`, and chained collection operations

Fixes #2761

## Test plan
- [x] `./gradlew :modules:appium:check`
- [ ] Run Android integration test `AppiumCollectionsTest.appiumCollectionFromParentElement` on a device/emulator


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Appium collection lookup methods, including CSS, XPath, and shorthand selectors.
  * Enabled collecting child elements from a parent element in Appium flows.
* **Bug Fixes**
  * Improved collection handling so returned Appium element groups support more fluent actions and searches.
* **Tests**
  * Added coverage for collecting elements from a parent Appium element.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->