### PR TITLE
#2757 Save page source as MHTML in Chromium browsers

### DIFF
--- a/src/main/java/com/codeborne/selenide/Config.java
+++ b/src/main/java/com/codeborne/selenide/Config.java
@@ -31,6 +31,7 @@ public interface Config {
   boolean clickViaJs();
   boolean screenshots();
   boolean savePageSource();
+  boolean savePageSourceWithResources();
 
   String reportsFolder();
   String downloadsFolder();

--- a/src/main/java/com/codeborne/selenide/SelenideConfig.java
+++ b/src/main/java/com/codeborne/selenide/SelenideConfig.java
@@ -45,6 +45,7 @@ public class SelenideConfig implements Config {
   private boolean screenshots = properties.getBoolean("selenide.screenshots", true);
 
   private boolean savePageSource = properties.getBoolean("selenide.savePageSource", true);
+  private boolean savePageSourceWithResources = properties.getBoolean("selenide.savePageSourceWithResources", false);
   private String reportsFolder = getProperty("selenide.reportsFolder", "build/reports/tests");
   private String downloadsFolder = getProperty("selenide.downloadsFolder", "build/downloads");
   @Nullable
@@ -148,6 +149,17 @@ public class SelenideConfig implements Config {
   @CanIgnoreReturnValue
   public SelenideConfig savePageSource(boolean savePageSource) {
     this.savePageSource = savePageSource;
+    return this;
+  }
+
+  @Override
+  public boolean savePageSourceWithResources() {
+    return savePageSourceWithResources;
+  }
+
+  @CanIgnoreReturnValue
+  public SelenideConfig savePageSourceWithResources(boolean savePageSourceWithResources) {
+    this.savePageSourceWithResources = savePageSourceWithResources;
     return this;
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/FileHelper.java
+++ b/src/main/java/com/codeborne/selenide/impl/FileHelper.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 
 import static java.nio.file.Files.createDirectories;
@@ -49,6 +50,15 @@ public final class FileHelper {
       }
     }
     return folder;
+  }
+
+  public static File fileInFolder(File folder, String nameWithoutExtension, String extension) {
+    Path root = folder.getAbsoluteFile().toPath().normalize();
+    Path file = root.resolve(nameWithoutExtension + "." + extension).normalize();
+    if (!file.startsWith(root)) {
+      throw new IllegalArgumentException("Invalid file name: " + nameWithoutExtension);
+    }
+    return file.toFile();
   }
 
   public static void moveFile(File srcFile, File destFile) {

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -89,7 +89,8 @@ public class ScreenShotLaboratory {
   /**
    * Takes screenshot of current browser window.
    * Stores 2 files:
-   * 1. html of the page (if "savePageSource" parameter is true), and
+   * 1. page source of the page (if "savePageSource" parameter is true):
+   *    MHTML in Chromium browsers, plain HTML in other browsers, and
    * 2. screenshot of the page in PNG format (if "saveScreenshot" parameter is true)
    * <p>
    * Either file may be null if webdriver has failed to save it.

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -90,7 +90,7 @@ public class ScreenShotLaboratory {
    * Takes screenshot of current browser window.
    * Stores 2 files:
    * 1. page source of the page (if "savePageSource" parameter is true):
-   *    MHTML in Chromium browsers, plain HTML in other browsers, and
+   *    plain HTML by default, or MHTML in Chromium browsers when "savePageSourceWithResources" is enabled, and
    * 2. screenshot of the page in PNG format (if "saveScreenshot" parameter is true)
    * <p>
    * Either file may be null if webdriver has failed to save it.

--- a/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
@@ -1,17 +1,22 @@
 package com.codeborne.selenide.impl;
 
+import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Config;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Alert;
+import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chromium.HasCdp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 
@@ -30,17 +35,8 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
 
   @CanIgnoreReturnValue
   private File extract(Config config, WebDriver driver, String fileName, boolean retryIfAlert) {
-    File pageSource = createFile(config, driver, fileName);
     try {
-      String source = driver.getPageSource();
-      if (source == null) {
-        log.error("Failed to save page source to {}: page source is <null>", fileName);
-        writeToFile("<null>", pageSource);
-      }
-      else {
-        writeToFile(source, pageSource);
-        attachmentHandler.attach(pageSource);
-      }
+      return doExtract(config, driver, fileName);
     }
     catch (UnhandledAlertException e) {
       if (retryIfAlert) {
@@ -52,18 +48,71 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
     catch (WebDriverException e) {
       log.warn("Failed to save page source to {}", fileName, e);
+      File pageSource = createFile(config, driver, fileName);
       writeToFile(e.toString(), pageSource);
       return pageSource;
     }
     catch (RuntimeException e) {
       log.error("Failed to save page source to {}", fileName, e);
+      File pageSource = createFile(config, driver, fileName);
       writeToFile(e.toString(), pageSource);
+      return pageSource;
+    }
+    return createFile(config, driver, fileName);
+  }
+
+  private File doExtract(Config config, WebDriver driver, String fileName) {
+    @Nullable String mhtml = extractMhtml(driver);
+    if (mhtml != null) {
+      File pageSource = createFileWithExtension(config, fileName, "mhtml");
+      writeToFile(mhtml, pageSource);
+      attachmentHandler.attach(pageSource);
+      return pageSource;
+    }
+
+    File pageSource = createFile(config, driver, fileName);
+    String source = driver.getPageSource();
+    if (source == null) {
+      log.error("Failed to save page source to {}: page source is <null>", fileName);
+      writeToFile("<null>", pageSource);
+    }
+    else {
+      writeToFile(source, pageSource);
+      attachmentHandler.attach(pageSource);
     }
     return pageSource;
   }
 
+  @Nullable
+  private String extractMhtml(WebDriver driver) {
+    if (!(driver instanceof HasCdp hasCdp) || !isChromium(driver)) {
+      return null;
+    }
+    try {
+      Map<String, Object> result = hasCdp.executeCdpCommand("Page.captureSnapshot", Map.of());
+      Object data = result.get("data");
+      if (data instanceof String mhtml && !mhtml.isBlank()) {
+        return mhtml;
+      }
+      log.warn("Page.captureSnapshot returned empty data, will fallback to plain HTML");
+    }
+    catch (RuntimeException e) {
+      log.warn("Failed to save page as MHTML, will fallback to plain HTML: {}", e.toString());
+    }
+    return null;
+  }
+
+  private boolean isChromium(WebDriver driver) {
+    return driver instanceof HasCapabilities hasCapabilities &&
+      new Browser(hasCapabilities.getCapabilities().getBrowserName(), false).isChromium();
+  }
+
   protected File createFile(Config config, WebDriver driver, String fileName) {
-    return new File(config.reportsFolder(), fileName + ".html").getAbsoluteFile();
+    return createFileWithExtension(config, fileName, "html");
+  }
+
+  protected File createFileWithExtension(Config config, String fileName, String extension) {
+    return new File(config.reportsFolder(), fileName + "." + extension).getAbsoluteFile();
   }
 
   protected void writeToFile(String content, File targetFile) {

--- a/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
@@ -40,7 +40,7 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
     catch (UnhandledAlertException e) {
       if (retryIfAlert) {
-        retryingExtractionOnAlert(config, driver, fileName, e);
+        return retryingExtractionOnAlert(config, driver, fileName, e);
       }
       else {
         printOnce("savePageSourceToFile", e);
@@ -62,12 +62,14 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
   }
 
   private File doExtract(Config config, WebDriver driver, String fileName) {
-    @Nullable String mhtml = extractMhtml(driver);
-    if (mhtml != null) {
-      File pageSource = createFileWithExtension(config, fileName, "mhtml");
-      writeToFile(mhtml, pageSource);
-      attachmentHandler.attach(pageSource);
-      return pageSource;
+    if (config.savePageSourceWithResources()) {
+      @Nullable String mhtml = extractMhtml(driver);
+      if (mhtml != null) {
+        File pageSource = createFileWithExtension(config, fileName, "mhtml");
+        writeToFile(mhtml, pageSource);
+        attachmentHandler.attach(pageSource);
+        return pageSource;
+      }
     }
 
     File pageSource = createFile(config, driver, fileName);
@@ -134,15 +136,16 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
   }
 
-  private void retryingExtractionOnAlert(Config config, WebDriver driver, String fileName, Exception e) {
+  private File retryingExtractionOnAlert(Config config, WebDriver driver, String fileName, Exception e) {
     try {
       Alert alert = driver.switchTo().alert();
       log.error("{}: {}", e, alert.getText());
       alert.accept();
-      extract(config, driver, fileName, false);
+      return extract(config, driver, fileName, false);
     }
     catch (Exception unableToCloseAlert) {
       log.error("Failed to close alert", unableToCloseAlert);
+      return createFile(config, driver, fileName);
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
@@ -112,7 +112,7 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
   }
 
   protected File createFileWithExtension(Config config, String fileName, String extension) {
-    return new File(config.reportsFolder(), fileName + "." + extension).getAbsoluteFile();
+    return FileHelper.fileInFolder(new File(config.reportsFolder()), fileName, extension);
   }
 
   protected void writeToFile(String content, File targetFile) {

--- a/src/test/java/com/codeborne/selenide/impl/FileHelperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/FileHelperTest.java
@@ -4,29 +4,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 
-import static com.codeborne.selenide.impl.FileHelper.deleteFolderIfEmpty;
-import static org.apache.commons.io.FileUtils.touch;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class FileHelperTest {
+  @TempDir
+  File reportsFolder;
+
   @Test
-  void deletesFolderIfItIsEmpty(@TempDir File folder) {
-    assertThat(folder).exists();
+  void fileInFolder_allowsSubdirectories() {
+    File file = FileHelper.fileInFolder(reportsFolder, "com/example/Test.123", "mhtml");
 
-    deleteFolderIfEmpty(folder);
-
-    assertThat(folder).doesNotExist();
+    assertThat(file.getPath()).endsWith("com" + File.separator + "example" + File.separator + "Test.123.mhtml");
+    assertThat(file.getAbsolutePath()).startsWith(reportsFolder.getAbsolutePath());
   }
 
   @Test
-  void ignoresFolderWhichContainsFiles(@TempDir File folder) throws IOException {
-    touch(new File(folder, "file1"));
-
-    deleteFolderIfEmpty(folder);
-
-    assertThat(folder).exists();
-    assertThat(new File(folder, "file1")).exists();
+  void fileInFolder_rejectsPathTraversal() {
+    assertThatThrownBy(() -> FileHelper.fileInFolder(reportsFolder, "../../outside", "html"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid file name: ../../outside");
   }
 }

--- a/src/test/java/com/codeborne/selenide/impl/FileHelperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/FileHelperTest.java
@@ -26,4 +26,12 @@ final class FileHelperTest {
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Invalid file name: ../../outside");
   }
+
+  @Test
+  void fileInFolder_rejectsSiblingFolderWithSamePrefix() {
+    assertThatThrownBy(() -> FileHelper.fileInFolder(reportsFolder,
+      "../" + reportsFolder.getName() + "-other/escaped", "html"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid file name: ../" + reportsFolder.getName() + "-other/escaped");
+  }
 }

--- a/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
@@ -39,7 +39,8 @@ final class WebPageSourceExtractorTest {
   }
 
   @Test
-  void savesMhtmlForChromiumBrowserWhenCdpWorks() throws Exception {
+  void savesMhtmlForChromiumBrowserWhenResourcesEnabledAndCdpWorks() throws Exception {
+    config.savePageSourceWithResources(true);
     ChromiumDriver driver = mock(ChromiumDriver.class);
     when(driver.getCapabilities()).thenReturn(chromeCapabilities());
     doReturn(Map.of("data", "From: <Saved by Blink>\r\nContent-Type: multipart/related\r\n\r\npage")).when(driver)
@@ -53,7 +54,21 @@ final class WebPageSourceExtractorTest {
   }
 
   @Test
+  void savesHtmlForChromiumBrowserWhenResourcesNotEnabled() throws Exception {
+    ChromiumDriver driver = mock(ChromiumDriver.class);
+    when(driver.getCapabilities()).thenReturn(chromeCapabilities());
+    when(driver.getPageSource()).thenReturn("<html>plain</html>");
+
+    File file = extractor.extract(config, driver, "page-1b");
+
+    assertThat(file).hasName("page-1b.html");
+    assertThat(Files.readString(file.toPath())).isEqualTo("<html>plain</html>");
+    verify(driver, never()).executeCdpCommand(eq("Page.captureSnapshot"), any());
+  }
+
+  @Test
   void fallsBackToHtmlWhenCdpFails() throws Exception {
+    config.savePageSourceWithResources(true);
     ChromiumDriver driver = mock(ChromiumDriver.class);
     when(driver.getCapabilities()).thenReturn(chromeCapabilities());
     doThrow(new WebDriverException("CDP failed")).when(driver).executeCdpCommand(eq("Page.captureSnapshot"), any());

--- a/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -73,6 +74,16 @@ final class WebPageSourceExtractorTest {
 
     assertThat(file).hasName("page-3.html");
     assertThat(Files.readString(file.toPath())).isEqualTo("<html>firefox</html>");
+  }
+
+  @Test
+  void rejectsPathTraversalInFileName() {
+    ChromiumDriver driver = mock(ChromiumDriver.class);
+    when(driver.getCapabilities()).thenReturn(chromeCapabilities());
+
+    assertThatThrownBy(() -> extractor.extract(config, driver, "../../outside"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid file name: ../../outside");
   }
 
   private static Capabilities chromeCapabilities() {

--- a/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
@@ -81,6 +81,20 @@ final class WebPageSourceExtractorTest {
   }
 
   @Test
+  void fallsBackToHtmlWhenCdpReturnsEmptyData() throws Exception {
+    config.savePageSourceWithResources(true);
+    ChromiumDriver driver = mock(ChromiumDriver.class);
+    when(driver.getCapabilities()).thenReturn(chromeCapabilities());
+    doReturn(Map.of("data", "")).when(driver).executeCdpCommand(eq("Page.captureSnapshot"), any());
+    when(driver.getPageSource()).thenReturn("<html>plain</html>");
+
+    File file = extractor.extract(config, driver, "page-2b");
+
+    assertThat(file).hasName("page-2b.html");
+    assertThat(Files.readString(file.toPath())).isEqualTo("<html>plain</html>");
+  }
+
+  @Test
   void savesHtmlForNonChromiumBrowser() throws Exception {
     WebDriver driver = mock(WebDriver.class);
     when(driver.getPageSource()).thenReturn("<html>firefox</html>");

--- a/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
@@ -1,0 +1,84 @@
+package com.codeborne.selenide.impl;
+
+import com.codeborne.selenide.SelenideConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.HasCapabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chromium.HasCdp;
+import org.openqa.selenium.MutableCapabilities;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+final class WebPageSourceExtractorTest {
+  @TempDir
+  File reportsFolder;
+
+  private final WebPageSourceExtractor extractor = new WebPageSourceExtractor();
+  private SelenideConfig config;
+
+  @BeforeEach
+  void setUp() {
+    config = new SelenideConfig().reportsFolder(reportsFolder.getAbsolutePath());
+  }
+
+  @Test
+  void savesMhtmlForChromiumBrowserWhenCdpWorks() throws Exception {
+    ChromiumDriver driver = mock(ChromiumDriver.class);
+    when(driver.getCapabilities()).thenReturn(chromeCapabilities());
+    doReturn(Map.of("data", "From: <Saved by Blink>\r\nContent-Type: multipart/related\r\n\r\npage")).when(driver)
+      .executeCdpCommand(eq("Page.captureSnapshot"), any());
+
+    File file = extractor.extract(config, driver, "page-1");
+
+    assertThat(file).hasName("page-1.mhtml");
+    assertThat(Files.readString(file.toPath())).contains("multipart/related");
+    verify(driver, never()).getPageSource();
+  }
+
+  @Test
+  void fallsBackToHtmlWhenCdpFails() throws Exception {
+    ChromiumDriver driver = mock(ChromiumDriver.class);
+    when(driver.getCapabilities()).thenReturn(chromeCapabilities());
+    doThrow(new WebDriverException("CDP failed")).when(driver).executeCdpCommand(eq("Page.captureSnapshot"), any());
+    when(driver.getPageSource()).thenReturn("<html>plain</html>");
+
+    File file = extractor.extract(config, driver, "page-2");
+
+    assertThat(file).hasName("page-2.html");
+    assertThat(Files.readString(file.toPath())).isEqualTo("<html>plain</html>");
+  }
+
+  @Test
+  void savesHtmlForNonChromiumBrowser() throws Exception {
+    WebDriver driver = mock(WebDriver.class);
+    when(driver.getPageSource()).thenReturn("<html>firefox</html>");
+
+    File file = extractor.extract(config, driver, "page-3");
+
+    assertThat(file).hasName("page-3.html");
+    assertThat(Files.readString(file.toPath())).isEqualTo("<html>firefox</html>");
+  }
+
+  private static Capabilities chromeCapabilities() {
+    return new MutableCapabilities(Map.of("browserName", "chrome"));
+  }
+
+  private interface ChromiumDriver extends WebDriver, HasCdp, HasCapabilities {
+  }
+}

--- a/statics/src/main/java/com/codeborne/selenide/Configuration.java
+++ b/statics/src/main/java/com/codeborne/selenide/Configuration.java
@@ -193,6 +193,16 @@ public class Configuration {
   public static boolean savePageSource = defaults.savePageSource();
 
   /**
+   * If set to true, Selenide saves page source with embedded resources (CSS, images) as MHTML in Chromium browsers.
+   * Falls back to plain HTML if MHTML capture is not available.
+   * Can be configured either programmatically, via selenide.properties file
+   * or by system property "-Dselenide.savePageSourceWithResources=true".
+   * <br>
+   * Default value: false
+   */
+  public static boolean savePageSourceWithResources = defaults.savePageSourceWithResources();
+
+  /**
    * Folder to store screenshots to.
    * Can be configured either programmatically, via selenide.properties file
    * or by system property "-Dselenide.reportsFolder=test-result/reports".
@@ -389,6 +399,7 @@ public class Configuration {
       .clickViaJs(clickViaJs)
       .screenshots(screenshots)
       .savePageSource(savePageSource)
+      .savePageSourceWithResources(savePageSourceWithResources)
       .reportsFolder(reportsFolder)
       .downloadsFolder(downloadsFolder)
       .reportsUrl(reportsUrl)

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -285,12 +285,13 @@ public class Selenide {
   }
 
   /**
-   * Take the screenshot of current page and save to file "fileName.png" (and optionally, "fileName.html")
+   * Take the screenshot of current page and save to file "fileName.png" (and optionally, "fileName.mhtml" or "fileName.html")
    * <ul>
    *   <li>File "fileName.png" is created always, even if {@code Configuration.screenshots == false}</li>
-   *   <li>File "fileName.html" is created only if {@code Configuration.savePageSource == true}</li>
+   *   <li>File "fileName.mhtml" (Chromium) or "fileName.html" (other browsers) is created
+   *       only if {@code Configuration.savePageSource == true}</li>
    * </ul>
-   * @param fileName Name of file (without extension) to save PNG (and HTML) to
+   * @param fileName Name of file (without extension) to save PNG (and page source) to
    * @return URL of screenshot file
    */
   @Nullable

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -285,11 +285,12 @@ public class Selenide {
   }
 
   /**
-   * Take the screenshot of current page and save to file "fileName.png" (and optionally, "fileName.mhtml" or "fileName.html")
+   * Take the screenshot of current page and save to file "fileName.png" (and optionally, "fileName.html" or "fileName.mhtml")
    * <ul>
    *   <li>File "fileName.png" is created always, even if {@code Configuration.screenshots == false}</li>
-   *   <li>File "fileName.mhtml" (Chromium) or "fileName.html" (other browsers) is created
-   *       only if {@code Configuration.savePageSource == true}</li>
+   *   <li>File "fileName.html" is created only if {@code Configuration.savePageSource == true}</li>
+   *   <li>File "fileName.mhtml" (Chromium only) is created instead of HTML when
+   *       {@code Configuration.savePageSourceWithResources == true}</li>
    * </ul>
    * @param fileName Name of file (without extension) to save PNG (and page source) to
    * @return URL of screenshot file

--- a/statics/src/main/java/com/codeborne/selenide/StaticConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/StaticConfig.java
@@ -54,6 +54,11 @@ final class StaticConfig implements Config {
   }
 
   @Override
+  public boolean savePageSourceWithResources() {
+    return Configuration.savePageSourceWithResources;
+  }
+
+  @Override
   public String reportsFolder() {
     return Configuration.reportsFolder;
   }

--- a/statics/src/main/java/com/codeborne/selenide/ThreadLocalSelenideConfig.java
+++ b/statics/src/main/java/com/codeborne/selenide/ThreadLocalSelenideConfig.java
@@ -122,6 +122,11 @@ final class ThreadLocalSelenideConfig implements Config {
   }
 
   @Override
+  public boolean savePageSourceWithResources() {
+    return config.get().savePageSourceWithResources();
+  }
+
+  @Override
   public String reportsFolder() {
     return config.get().reportsFolder();
   }

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -85,6 +85,7 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     Configuration.proxyHost = "";
     Configuration.fileDownload = HTTPGET;
     Configuration.reopenBrowserOnFail = Boolean.parseBoolean(System.getProperty("selenide.reopenBrowserOnFail", "false"));
+    Configuration.savePageSourceWithResources = false;
     Configuration.textCheck = FULL_TEXT;
     Configuration.browserCapabilities = defaultBrowserCapabilities();
     Configuration.remoteConnectionTimeout = Duration.ofSeconds(10).toMillis();

--- a/statics/src/test/java/integration/ScreenshotsTest.java
+++ b/statics/src/test/java/integration/ScreenshotsTest.java
@@ -19,7 +19,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.Base64;
+
+import static com.codeborne.selenide.WebDriverRunner.isChrome;
+import static com.codeborne.selenide.WebDriverRunner.isEdge;
 
 import static com.codeborne.selenide.impl.Plugins.inject;
 import static java.util.Objects.requireNonNull;
@@ -69,7 +73,7 @@ final class ScreenshotsTest extends IntegrationTest {
   }
 
   @Test
-  void canTakeScreenshotAtEveryMoment() throws URISyntaxException {
+  void canTakeScreenshotAtEveryMoment() throws URISyntaxException, IOException {
     String fileName = "screenshot-" + randomUUID();
     String screenshot = Selenide.screenshot(fileName);
 
@@ -77,8 +81,15 @@ final class ScreenshotsTest extends IntegrationTest {
     assertThat(screenshot).endsWith(".png");
     assertThatFileExistsAndAttachmentIsLogged(screenshot);
 
-    String pageSource = screenshot.replace(".png", ".html");
+    String pageSource = screenshot.replace(".png", pageSourceExtension());
     assertThatFileExistsAndAttachmentIsLogged(pageSource);
+    if (isChrome() || isEdge()) {
+      assertThat(Files.readString(new File(new URI(pageSource)).toPath())).contains("multipart/related");
+    }
+  }
+
+  private static String pageSourceExtension() {
+    return isChrome() || isEdge() ? ".mhtml" : ".html";
   }
 
   private void assertThatFileExistsAndAttachmentIsLogged(String url) throws URISyntaxException {

--- a/statics/src/test/java/integration/ScreenshotsTest.java
+++ b/statics/src/test/java/integration/ScreenshotsTest.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.impl.ScreenShotLaboratory;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
@@ -22,13 +23,13 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Base64;
 
-import static com.codeborne.selenide.WebDriverRunner.isChrome;
-import static com.codeborne.selenide.WebDriverRunner.isEdge;
-
 import static com.codeborne.selenide.impl.Plugins.inject;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static com.codeborne.selenide.WebDriverRunner.isChrome;
+import static com.codeborne.selenide.WebDriverRunner.isEdge;
 import static uk.org.webcompere.systemstubs.stream.output.OutputFactories.tapAndOutput;
 
 @ExtendWith(SystemStubsExtension.class)
@@ -81,15 +82,25 @@ final class ScreenshotsTest extends IntegrationTest {
     assertThat(screenshot).endsWith(".png");
     assertThatFileExistsAndAttachmentIsLogged(screenshot);
 
-    String pageSource = screenshot.replace(".png", pageSourceExtension());
+    String pageSource = screenshot.replace(".png", ".html");
     assertThatFileExistsAndAttachmentIsLogged(pageSource);
-    if (isChrome() || isEdge()) {
-      assertThat(Files.readString(new File(new URI(pageSource)).toPath())).contains("multipart/related");
-    }
   }
 
-  private static String pageSourceExtension() {
-    return isChrome() || isEdge() ? ".mhtml" : ".html";
+  @Test
+  void canTakeScreenshotWithEmbeddedResourcesAsMhtml() throws URISyntaxException, IOException {
+    assumeThat(isChrome() || isEdge()).isTrue();
+    Configuration.savePageSourceWithResources = true;
+
+    String fileName = "screenshot-" + randomUUID();
+    String screenshot = Selenide.screenshot(fileName);
+
+    assertThat(screenshot).startsWith("file:/");
+    assertThat(screenshot).endsWith(".png");
+    assertThatFileExistsAndAttachmentIsLogged(screenshot);
+
+    String pageSource = screenshot.replace(".png", ".mhtml");
+    assertThatFileExistsAndAttachmentIsLogged(pageSource);
+    assertThat(Files.readString(new File(new URI(pageSource)).toPath())).contains("multipart/related");
   }
 
   private void assertThatFileExistsAndAttachmentIsLogged(String url) throws URISyntaxException {

--- a/statics/src/test/java/integration/ScreenshotsTest.java
+++ b/statics/src/test/java/integration/ScreenshotsTest.java
@@ -98,9 +98,14 @@ final class ScreenshotsTest extends IntegrationTest {
     assertThat(screenshot).endsWith(".png");
     assertThatFileExistsAndAttachmentIsLogged(screenshot);
 
-    String pageSource = screenshot.replace(".png", ".mhtml");
+    String mhtmlPageSource = screenshot.replace(".png", ".mhtml");
+    String htmlPageSource = screenshot.replace(".png", ".html");
+    boolean isMhtml = new File(new URI(mhtmlPageSource)).exists();
+    String pageSource = isMhtml ? mhtmlPageSource : htmlPageSource;
     assertThatFileExistsAndAttachmentIsLogged(pageSource);
-    assertThat(Files.readString(new File(new URI(pageSource)).toPath())).contains("multipart/related");
+    if (isMhtml) {
+      assertThat(Files.readString(new File(new URI(pageSource)).toPath())).contains("multipart/related");
+    }
   }
 
   private void assertThatFileExistsAndAttachmentIsLogged(String url) throws URISyntaxException {


### PR DESCRIPTION
## Summary

Closes #2757 (MVP).

When `Configuration.savePageSource == true`, Selenide saves page source as plain `.html` via `getPageSource()` — **same behavior as before**.

To save the page **with embedded resources** (CSS, images) as `.mhtml` in Chromium browsers, enable:

```java
Configuration.savePageSourceWithResources = true;
// or -Dselenide.savePageSourceWithResources=true
```

Default: `savePageSourceWithResources = false`.

## How it works

1. `savePageSourceWithResources == false` (default) → `{fileName}.html` on all browsers
2. `savePageSourceWithResources == true` + Chromium + CDP → `Page.captureSnapshot` → `{fileName}.mhtml`
3. Otherwise (non-Chromium, CDP unavailable, CDP error, empty data) → fallback to `{fileName}.html`

## Browser support (with `savePageSourceWithResources = true`)

| Browser / environment | Page source file | MHTML with resources |
|-----------------------|------------------|----------------------|
| Chrome (local) | `.mhtml` | ✅ |
| Edge (local) | `.mhtml` | ✅ |
| Chrome/Edge on Selenoid / remote grid | `.mhtml` | ✅ if CDP is available |
| Firefox | `.html` | ❌ no CDP `Page.captureSnapshot` |
| Safari | `.html` | ❌ no CDP |
| Internet Explorer | `.html` | ❌ no CDP |
| Appium (mobile) | `.xml` | ❌ not a web page |
| Chromium, CDP unavailable | `.html` | ❌ fallback |
| Any browser, CDP error (alert, etc.) | `.html` | ❌ fallback |

## Known MHTML limitations (Chromium)

- Cross-origin assets may be missing (CORS)
- Dynamically loaded content after page load may be absent
- Partial support for canvas, WebGL, iframes
- Larger file size than plain HTML

## Test plan

- [x] `./gradlew check`
- [x] `./gradlew :statics:chrome_headless --tests integration.ScreenshotsTest`
- [x] Unit tests: `WebPageSourceExtractorTest` (MHTML, CDP fallback, empty CDP data, non-Chromium, path traversal)
- [x] Unit tests: `FileHelperTest` (subdirs, path traversal, sibling-folder prefix)
- [ ] Manual: open saved `.mhtml` in Chrome — page renders with styles
- [ ] Manual (optional): Selenoid remote — verify `.mhtml` on test failure with flag enabled

## Follow-up (out of scope)

- Firefox/Safari: proxy-based or JS-inlining approach for page source with resources

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `savePageSourceWithResources` configuration (default `false`) to save page source with embedded resources as `.mhtml` on Chromium; `.html` is used otherwise/fallback.
* **Bug Fixes**
  * Improved page-source capture flow to prefer MHTML (when supported) and reliably fall back to plain HTML when unavailable, empty, or failing.
  * Refinements to capture-error handling and when page-source artifacts are attached.
* **Security / Reliability**
  * Strengthened protection against path traversal when generating/saving page-source filenames.
* **Documentation**
  * Updated Javadocs for screenshot/page-source filename extensions.
* **Tests**
  * Expanded unit and integration coverage for Chromium vs non-Chromium outputs, MHTML fallback cases, and traversal rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->