### PR TITLE
#1741 Add visibleText() and exactVisibleText() conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 7.17.0 (TBD)
+* #1741 added `visibleText()` condition for overflow-truncated elements
 * update Selenium from 4.44.0 to 4.45.0 (incl. CDP from 148 -> 149)
 
 ## 7.16.2 (27.05.2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 7.17.0 (TBD)
-* #1741 added `visibleText()` condition for overflow-truncated elements
+* #1741 added `visibleText()` and `exactVisibleText()` conditions for overflow-truncated elements
 * update Selenium from 4.44.0 to 4.45.0 (incl. CDP from 148 -> 149)
 
 ## 7.16.2 (27.05.2026)

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -26,6 +26,7 @@ import com.codeborne.selenide.conditions.Hidden;
 import com.codeborne.selenide.conditions.Href;
 import com.codeborne.selenide.conditions.InnerText;
 import com.codeborne.selenide.conditions.VisibleText;
+import com.codeborne.selenide.conditions.ExactVisibleText;
 import com.codeborne.selenide.conditions.Interactable;
 import com.codeborne.selenide.conditions.IsImageLoaded;
 import com.codeborne.selenide.conditions.MatchAttributeWithValue;
@@ -461,6 +462,20 @@ public final class Condition {
    */
   public static WebElementCondition visibleText(String text) {
     return new VisibleText(text);
+  }
+
+  /**
+   * Assert that element has exactly (case-insensitive) given <b>visibly rendered</b> text.
+   * <p>Sample: {@code $("h1").shouldHave(exactVisibleText("Hello"))}</p>
+   * <p>
+   * Unlike {@link #exactText(String)}, takes into account CSS that hides overflowing text
+   * (e.g. {@code overflow: hidden} with {@code text-overflow: ellipsis}).
+   *
+   * <p>Case insensitive</p>
+   * <p>NB! Ignores multiple whitespaces between words</p>
+   */
+  public static WebElementCondition exactVisibleText(String text) {
+    return new ExactVisibleText(text);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/Condition.java
+++ b/src/main/java/com/codeborne/selenide/Condition.java
@@ -25,6 +25,7 @@ import com.codeborne.selenide.conditions.Focused;
 import com.codeborne.selenide.conditions.Hidden;
 import com.codeborne.selenide.conditions.Href;
 import com.codeborne.selenide.conditions.InnerText;
+import com.codeborne.selenide.conditions.VisibleText;
 import com.codeborne.selenide.conditions.Interactable;
 import com.codeborne.selenide.conditions.IsImageLoaded;
 import com.codeborne.selenide.conditions.MatchAttributeWithValue;
@@ -446,6 +447,20 @@ public final class Condition {
    */
   public static WebElementCondition innerText(String text) {
     return new InnerText(text);
+  }
+
+  /**
+   * Assert that element contains given <b>visibly rendered</b> text.
+   * <p>Sample: {@code $("h1").shouldHave(visibleText("Hello"))}</p>
+   * <p>
+   * Unlike {@link #text(String)}, takes into account CSS that hides overflowing text
+   * (e.g. {@code overflow: hidden} with {@code text-overflow: ellipsis}).
+   *
+   * <p>Case insensitive</p>
+   * <p>NB! Ignores multiple whitespaces between words</p>
+   */
+  public static WebElementCondition visibleText(String text) {
+    return new VisibleText(text);
   }
 
   /**

--- a/src/main/java/com/codeborne/selenide/commands/GetVisibleText.java
+++ b/src/main/java/com/codeborne/selenide/commands/GetVisibleText.java
@@ -1,0 +1,30 @@
+package com.codeborne.selenide.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.impl.JavaScript;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.WebElement;
+
+import static java.util.Objects.requireNonNull;
+
+public class GetVisibleText implements Command<String> {
+  private static final JavaScript js = new JavaScript("visible-text.js");
+
+  @Override
+  public String execute(SelenideElement proxy, WebElementSource locator, Object @Nullable [] args) {
+    return getVisibleText(locator.driver(), locator.getWebElement());
+  }
+
+  public static String getVisibleText(Driver driver, WebElement element) {
+    return getVisibleText(driver, element, new GetSelectedOptionText());
+  }
+
+  public static String getVisibleText(Driver driver, WebElement element, GetSelectedOptionText getSelectedOptionText) {
+    return "select".equalsIgnoreCase(element.getTagName()) ?
+      getSelectedOptionText.execute(driver, element) :
+      requireNonNull(js.execute(driver, element));
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/ExactVisibleText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/ExactVisibleText.java
@@ -1,0 +1,31 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.commands.GetSelectedOptionText;
+import com.codeborne.selenide.impl.Html;
+import org.openqa.selenium.WebElement;
+
+import static com.codeborne.selenide.commands.GetVisibleText.getVisibleText;
+
+public class ExactVisibleText extends TextCondition {
+  private final GetSelectedOptionText getSelectedOptionText;
+
+  public ExactVisibleText(String expectedText) {
+    this(expectedText, new GetSelectedOptionText());
+  }
+
+  ExactVisibleText(String expectedText, GetSelectedOptionText getSelectedOptionText) {
+    super("exact visible text", expectedText);
+    this.getSelectedOptionText = getSelectedOptionText;
+  }
+
+  @Override
+  protected boolean match(String actualText, String expectedText) {
+    return Html.text.equals(actualText, expectedText);
+  }
+
+  @Override
+  protected String getText(Driver driver, WebElement element) {
+    return getVisibleText(driver, element, getSelectedOptionText);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/VisibleText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/VisibleText.java
@@ -8,19 +8,19 @@ import static com.codeborne.selenide.commands.GetVisibleText.getVisibleText;
 
 public class VisibleText extends CaseInsensitiveTextCondition {
 
-  private final GetSelectedOptionText getSelectedOptionsTexts;
+  private final GetSelectedOptionText getSelectedOptionText;
 
   public VisibleText(String expectedText) {
     this(expectedText, new GetSelectedOptionText());
   }
 
-  VisibleText(String expectedText, GetSelectedOptionText getSelectedOptionsTexts) {
+  VisibleText(String expectedText, GetSelectedOptionText getSelectedOptionText) {
     super("visible text", expectedText);
-    this.getSelectedOptionsTexts = getSelectedOptionsTexts;
+    this.getSelectedOptionText = getSelectedOptionText;
   }
 
   @Override
   protected String getText(Driver driver, WebElement element) {
-    return getVisibleText(driver, element, getSelectedOptionsTexts);
+    return getVisibleText(driver, element, getSelectedOptionText);
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/VisibleText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/VisibleText.java
@@ -2,13 +2,11 @@ package com.codeborne.selenide.conditions;
 
 import com.codeborne.selenide.Driver;
 import com.codeborne.selenide.commands.GetSelectedOptionText;
-import com.codeborne.selenide.impl.JavaScript;
 import org.openqa.selenium.WebElement;
 
-import static java.util.Objects.requireNonNull;
+import static com.codeborne.selenide.commands.GetVisibleText.getVisibleText;
 
 public class VisibleText extends CaseInsensitiveTextCondition {
-  private static final JavaScript js = new JavaScript("visible-text.js");
 
   private final GetSelectedOptionText getSelectedOptionsTexts;
 
@@ -23,8 +21,6 @@ public class VisibleText extends CaseInsensitiveTextCondition {
 
   @Override
   protected String getText(Driver driver, WebElement element) {
-    return "select".equalsIgnoreCase(element.getTagName()) ?
-      getSelectedOptionsTexts.execute(driver, element) :
-      requireNonNull(js.execute(driver, element));
+    return getVisibleText(driver, element, getSelectedOptionsTexts);
   }
 }

--- a/src/main/java/com/codeborne/selenide/conditions/VisibleText.java
+++ b/src/main/java/com/codeborne/selenide/conditions/VisibleText.java
@@ -1,0 +1,30 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.commands.GetSelectedOptionText;
+import com.codeborne.selenide.impl.JavaScript;
+import org.openqa.selenium.WebElement;
+
+import static java.util.Objects.requireNonNull;
+
+public class VisibleText extends CaseInsensitiveTextCondition {
+  private static final JavaScript js = new JavaScript("visible-text.js");
+
+  private final GetSelectedOptionText getSelectedOptionsTexts;
+
+  public VisibleText(String expectedText) {
+    this(expectedText, new GetSelectedOptionText());
+  }
+
+  VisibleText(String expectedText, GetSelectedOptionText getSelectedOptionsTexts) {
+    super("visible text", expectedText);
+    this.getSelectedOptionsTexts = getSelectedOptionsTexts;
+  }
+
+  @Override
+  protected String getText(Driver driver, WebElement element) {
+    return "select".equalsIgnoreCase(element.getTagName()) ?
+      getSelectedOptionsTexts.execute(driver, element) :
+      requireNonNull(js.execute(driver, element));
+  }
+}

--- a/src/main/resources/visible-text.js
+++ b/src/main/resources/visible-text.js
@@ -1,0 +1,74 @@
+(function (element) {
+  const fullText = element.innerText;
+  if (!fullText) {
+    return '';
+  }
+
+  const clone = element.cloneNode(true);
+  clone.style.position = 'absolute';
+  clone.style.visibility = 'hidden';
+  clone.style.left = '-9999px';
+  clone.style.top = '0';
+  clone.style.overflow = 'visible';
+  clone.style.textOverflow = 'clip';
+  clone.style.maxWidth = 'none';
+  clone.style.width = 'auto';
+  clone.style.height = 'auto';
+  document.body.appendChild(clone);
+
+  const availableWidth = element.getBoundingClientRect().width;
+  const fullWidth = clone.getBoundingClientRect().width;
+
+  if (fullWidth <= availableWidth + 0.5) {
+    document.body.removeChild(clone);
+    return fullText;
+  }
+
+  const sourceTextNodes = [];
+  const cloneTextNodes = [];
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null);
+  const cloneWalker = document.createTreeWalker(clone, NodeFilter.SHOW_TEXT, null);
+  while (walker.nextNode()) {
+    sourceTextNodes.push(walker.currentNode);
+    cloneWalker.nextNode();
+    cloneTextNodes.push(cloneWalker.currentNode);
+  }
+
+  const originalText = sourceTextNodes.map(node => node.textContent).join('');
+
+  function setCloneTextLength(length) {
+    let remaining = length;
+    for (let index = 0; index < cloneTextNodes.length; index++) {
+      const nodeText = sourceTextNodes[index].textContent;
+      if (remaining >= nodeText.length) {
+        cloneTextNodes[index].textContent = nodeText;
+        remaining -= nodeText.length;
+      } else {
+        cloneTextNodes[index].textContent = nodeText.substring(0, remaining);
+        for (let clearIndex = index + 1; clearIndex < cloneTextNodes.length; clearIndex++) {
+          cloneTextNodes[clearIndex].textContent = '';
+        }
+        return;
+      }
+    }
+  }
+
+  let low = 0;
+  let high = originalText.length;
+  let visibleLength = 0;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    setCloneTextLength(mid);
+    const width = clone.getBoundingClientRect().width;
+    if (width <= availableWidth + 0.5) {
+      visibleLength = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  document.body.removeChild(clone);
+  return originalText.substring(0, visibleLength).trim();
+})(arguments[0]);

--- a/src/main/resources/visible-text.js
+++ b/src/main/resources/visible-text.js
@@ -14,54 +14,28 @@
   clone.style.maxWidth = 'none';
   clone.style.width = 'auto';
   clone.style.height = 'auto';
+  clone.style.whiteSpace = 'nowrap';
   document.body.appendChild(clone);
 
   const availableWidth = element.getBoundingClientRect().width;
-  const fullWidth = clone.getBoundingClientRect().width;
 
-  if (fullWidth <= availableWidth + 0.5) {
-    document.body.removeChild(clone);
+  function measureTextWidth(text) {
+    clone.textContent = text;
+    return clone.getBoundingClientRect().width;
+  }
+
+  if (measureTextWidth(fullText) <= availableWidth + 0.5) {
+    clone.remove();
     return fullText;
   }
 
-  const sourceTextNodes = [];
-  const cloneTextNodes = [];
-  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null);
-  const cloneWalker = document.createTreeWalker(clone, NodeFilter.SHOW_TEXT, null);
-  while (walker.nextNode()) {
-    sourceTextNodes.push(walker.currentNode);
-    cloneWalker.nextNode();
-    cloneTextNodes.push(cloneWalker.currentNode);
-  }
-
-  const originalText = sourceTextNodes.map(node => node.textContent).join('');
-
-  function setCloneTextLength(length) {
-    let remaining = length;
-    for (let index = 0; index < cloneTextNodes.length; index++) {
-      const nodeText = sourceTextNodes[index].textContent;
-      if (remaining >= nodeText.length) {
-        cloneTextNodes[index].textContent = nodeText;
-        remaining -= nodeText.length;
-      } else {
-        cloneTextNodes[index].textContent = nodeText.substring(0, remaining);
-        for (let clearIndex = index + 1; clearIndex < cloneTextNodes.length; clearIndex++) {
-          cloneTextNodes[clearIndex].textContent = '';
-        }
-        return;
-      }
-    }
-  }
-
   let low = 0;
-  let high = originalText.length;
+  let high = fullText.length;
   let visibleLength = 0;
 
   while (low <= high) {
     const mid = Math.floor((low + high) / 2);
-    setCloneTextLength(mid);
-    const width = clone.getBoundingClientRect().width;
-    if (width <= availableWidth + 0.5) {
+    if (measureTextWidth(fullText.substring(0, mid)) <= availableWidth + 0.5) {
       visibleLength = mid;
       low = mid + 1;
     } else {
@@ -69,6 +43,6 @@
     }
   }
 
-  document.body.removeChild(clone);
-  return originalText.substring(0, visibleLength).trim();
+  clone.remove();
+  return fullText.substring(0, visibleLength);
 })(arguments[0]);

--- a/src/test/java/com/codeborne/selenide/conditions/ExactVisibleTextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/ExactVisibleTextTest.java
@@ -1,0 +1,61 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.CheckResult;
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.commands.GetSelectedOptionText;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.Mocks.mockSelect;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class ExactVisibleTextTest {
+  private final Driver driver = new DriverStub();
+
+  @Test
+  void to_string() {
+    assertThat(new ExactVisibleText("Hello World")).hasToString("exact visible text \"Hello World\"");
+  }
+
+  @Test
+  void negate_to_string() {
+    assertThat(new ExactVisibleText("Hello World").negate()).hasToString("not exact visible text \"Hello World\"");
+  }
+
+  @Test
+  void check_select_caseInsensitive() {
+    ExactVisibleText condition = new ExactVisibleText("john malkovich", mockSelectedTextExtractor("John Malkovich The First"));
+    SelenideElement select = mockSelect();
+    assertThat(condition.check(driver, select).verdict()).isEqualTo(REJECT);
+  }
+
+  @Test
+  void check_select_exactMatch() {
+    ExactVisibleText condition = new ExactVisibleText("Hello World", mockSelectedTextExtractor("Hello World"));
+    SelenideElement select = mockSelect();
+    assertThat(condition.check(driver, select).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void check_select_partialMatchIsRejected() {
+    ExactVisibleText condition = new ExactVisibleText("Hello", mockSelectedTextExtractor("Hello World"));
+    SelenideElement select = mockSelect();
+
+    assertThat(condition.check(driver, select))
+      .usingRecursiveComparison()
+      .ignoringFields("timestamp")
+      .isEqualTo(new CheckResult(REJECT, "text=\"Hello World\""));
+  }
+
+  private GetSelectedOptionText mockSelectedTextExtractor(String selectedText) {
+    GetSelectedOptionText command = mock();
+    when(command.execute(any(), any())).thenReturn(selectedText);
+    return command;
+  }
+}

--- a/src/test/java/com/codeborne/selenide/conditions/VisibleTextTest.java
+++ b/src/test/java/com/codeborne/selenide/conditions/VisibleTextTest.java
@@ -1,0 +1,56 @@
+package com.codeborne.selenide.conditions;
+
+import com.codeborne.selenide.CheckResult;
+import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.DriverStub;
+import com.codeborne.selenide.SelenideConfig;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.commands.GetSelectedOptionText;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static com.codeborne.selenide.Mocks.mockSelect;
+import static com.codeborne.selenide.TextCheck.PARTIAL_TEXT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class VisibleTextTest {
+  private final Driver driver = new DriverStub(new SelenideConfig().textCheck(PARTIAL_TEXT));
+
+  @Test
+  void to_string() {
+    assertThat(new VisibleText("Hello World")).hasToString("visible text \"Hello World\"");
+  }
+
+  @Test
+  void negate_to_string() {
+    assertThat(new VisibleText("Hello World").negate()).hasToString("not visible text \"Hello World\"");
+  }
+
+  @Test
+  void check_select_caseInsensitive() {
+    VisibleText condition = new VisibleText("john malkovich", mockSelectedTextExtractor("John Malkovich The First"));
+    SelenideElement select = mockSelect();
+    assertThat(condition.check(driver, select).verdict()).isEqualTo(ACCEPT);
+  }
+
+  @Test
+  void check_select() {
+    VisibleText condition = new VisibleText("Hello World", mockSelectedTextExtractor("Hello from js underworld"));
+    SelenideElement select = mockSelect();
+
+    assertThat(condition.check(driver, select))
+      .usingRecursiveComparison()
+      .ignoringFields("timestamp")
+      .isEqualTo(new CheckResult(REJECT, "text=\"Hello from js underworld\""));
+  }
+
+  private GetSelectedOptionText mockSelectedTextExtractor(String selectedText) {
+    GetSelectedOptionText command = mock();
+    when(command.execute(any(), any())).thenReturn(selectedText);
+    return command;
+  }
+}

--- a/src/test/java/integration/VisibleTextTest.java
+++ b/src/test/java/integration/VisibleTextTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.exactText;
+import static com.codeborne.selenide.Condition.exactVisibleText;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visibleText;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -47,5 +48,27 @@ final class VisibleTextTest extends ITest {
   @Test
   void visibleTextMatchesFullyVisibleElement() {
     withLongTimeout(() -> $("#fully-visible").shouldHave(visibleText("Hello World")));
+  }
+
+  @Test
+  void exactVisibleTextFailsWhenExpectedTextIsNotFullyVisible() {
+    assertThatThrownBy(() -> withLongTimeout(() -> $("#partial").shouldHave(exactVisibleText(FULL_TEXT))))
+      .isInstanceOf(ElementShould.class);
+  }
+
+  @Test
+  void exactVisibleTextMatchesVisiblePortionExactly() {
+    withLongTimeout(() -> $("#partial").shouldHave(exactVisibleText(VISIBLE_PREFIX)));
+  }
+
+  @Test
+  void exactVisibleTextRejectsPartialMatchOnFullyVisibleElement() {
+    assertThatThrownBy(() -> withLongTimeout(() -> $("#fully-visible").shouldHave(exactVisibleText("Hello"))))
+      .isInstanceOf(ElementShould.class);
+  }
+
+  @Test
+  void exactVisibleTextMatchesFullyVisibleElement() {
+    withLongTimeout(() -> $("#fully-visible").shouldHave(exactVisibleText("Hello World")));
   }
 }

--- a/src/test/java/integration/VisibleTextTest.java
+++ b/src/test/java/integration/VisibleTextTest.java
@@ -1,0 +1,51 @@
+package integration;
+
+import com.codeborne.selenide.ex.ElementShould;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Condition.exactText;
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.visibleText;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class VisibleTextTest extends ITest {
+  private static final String FULL_TEXT = "987 654 321 100 100.876543321 AUTOOQODS";
+  private static final String VISIBLE_PREFIX = "987 654 321 100 100.87";
+
+  @BeforeEach
+  void openPage() {
+    openFile("page_with_partial_visible_text.html");
+  }
+
+  @Test
+  void textConditionMatchesFullDomTextEvenWhenOverflowIsHidden() {
+    withLongTimeout(() -> $("#partial").shouldHave(text(FULL_TEXT)));
+  }
+
+  @Test
+  void exactTextConditionMatchesFullDomTextEvenWhenOverflowIsHidden() {
+    withLongTimeout(() -> $("#partial").shouldHave(exactText(FULL_TEXT)));
+  }
+
+  @Test
+  void visibleTextFailsWhenExpectedTextIsNotFullyVisible() {
+    assertThatThrownBy(() -> withLongTimeout(() -> $("#partial").shouldHave(visibleText(FULL_TEXT))))
+      .isInstanceOf(ElementShould.class);
+  }
+
+  @Test
+  void visibleTextMatchesTruncatedPortion() {
+    withLongTimeout(() -> $("#partial").shouldHave(visibleText(VISIBLE_PREFIX)));
+  }
+
+  @Test
+  void visibleTextIsCaseInsensitive() {
+    withLongTimeout(() -> $("#partial").shouldHave(visibleText(VISIBLE_PREFIX.toLowerCase())));
+  }
+
+  @Test
+  void visibleTextMatchesFullyVisibleElement() {
+    withLongTimeout(() -> $("#fully-visible").shouldHave(visibleText("Hello World")));
+  }
+}

--- a/src/test/resources/page_with_partial_visible_text.html
+++ b/src/test/resources/page_with_partial_visible_text.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Test page :: partial visible text</title>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="/selenide-test.css">
+</head>
+<body>
+<div class="selenide-test-banner">Selenide</div>
+<h1>Partial visible text</h1>
+
+<div id="partial" style="border: 1px solid blue; display: block; height: 19px; max-width: 152.5px; overflow: hidden; text-overflow: ellipsis;">
+  <span id="field_value">987 654 321 100 100.876543321 AUTOOQODS</span>
+</div>
+
+<div id="fully-visible">Hello World</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `Condition.visibleText()` — partial match on text that fits within the element's visible layout
- Add `Condition.exactVisibleText()` — exact match on visibly rendered text
- Both respect CSS that hides overflowing text (`overflow: hidden`, `text-overflow: ellipsis`, etc.)
- Does **not** change behavior of existing `text()` / `exactText()` conditions

## Issue
Closes #1741

## Approach
`innerText` and Range API do not reflect CSS ellipsis clipping in Chromium. The JS helper clones the element without width constraints, compares full vs. available width, then binary-searches the longest text prefix that still fits.

Shared reading logic lives in `GetVisibleText` (mirrors `GetOwnText`).

## Test plan
- [x] `./gradlew :modules:core:check`
- [x] `./gradlew :modules:core:chrome_headless --tests integration.VisibleTextTest`
- [x] `./gradlew :modules:core:test --tests com.codeborne.selenide.conditions.VisibleTextTest`
- [x] `./gradlew :modules:core:test --tests com.codeborne.selenide.conditions.ExactVisibleTextTest`

## Notes for reviewer
- Previous experimental PR #2138 used Range API on `firstChild` only; this version handles nested text nodes and ellipsis via layout measurement
- Changing default `text()` behavior is intentionally out of scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `visibleText()` and `exactVisibleText()` conditions for checking text that is actually visible when content is truncated or overflow-hidden.
  * Improved text handling for partially visible elements while still supporting fully visible content and select elements.
* **Tests**
  * Added coverage for partial and full visibility scenarios, including case-sensitive and case-insensitive matching behavior.
* **Documentation**
  * Updated the changelog for the new release with the new text conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->