### PR TITLE
Selenide MCP: added capabilities set support

### DIFF
--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -104,14 +104,29 @@ Add to `.claude/settings.json` (project) or `~/.claude/settings.json` (global):
 | `--selector-mode=<mode>` | Selector mode: `CSS`, `Sizzle` | `CSS` |
 | `--assertion-mode=<mode>` | Assertion mode: `STRICT`, `SOFT` | `STRICT` |
 
-### Capabilities
+### Tools
 
 | Parameter | Description |
 |---|---|
-| `--caps=<list>` | Comma-separated list of capabilities to enable |
+| `--tools=<list>` | Comma-separated list of tools to enable |
 
-Available capabilities:
+Available tools:
 
 - `codegen` — enables test code generation tools
 
-Example: `--caps=codegen`
+Example: `--tools=codegen`
+
+### Browser Capabilities
+
+| Parameter | Description |
+|---|---|
+| `--cap=<name>=<value>` | Add a custom browser capability |
+
+You can pass multiple `--cap=` parameters to add several capabilities.
+
+Examples:
+```bash
+--cap=browserName=chrome
+--cap=selenoid:options={"enableVNC":true}
+--cap=custom:option=value
+```

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
@@ -17,6 +17,7 @@ import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -39,7 +40,7 @@ public class SelenideMcpServer {
   /**
    * Starts the MCP server over stdio and blocks until the JVM shuts down.
    *
-   * @param args command-line arguments; {@code --caps=codegen} enables the codegen toolset
+   * @param args command-line arguments; {@code --tools=codegen} enables the codegen toolset
    */
   @SuppressWarnings("unchecked") // MCP SDK's tools() uses generic varargs
   public void start(String[] args) {
@@ -53,7 +54,7 @@ public class SelenideMcpServer {
       .tools(InspectTools.specs(session))
       .tools(NetworkTools.specs(session));
 
-    if (hasCapability(args, "codegen")) {
+    if (hasTool(args, "codegen")) {
       builder = builder.tools(CodegenTools.specs(session));
     }
 
@@ -80,11 +81,11 @@ public class SelenideMcpServer {
     server.start(args);
   }
 
-  static boolean hasCapability(String[] args, String capability) {
+  static boolean hasTool(String[] args, String tool) {
     for (String arg : args) {
-      if (arg.startsWith("--caps=")) {
-        String[] caps = arg.substring("--caps=".length()).split(",");
-        if (Arrays.asList(caps).contains(capability)) {
+      if (arg.startsWith("--tools=")) {
+        String[] tools = arg.substring("--tools=".length()).split(",");
+        if (Arrays.asList(tools).contains(tool)) {
           return true;
         }
       }
@@ -105,8 +106,19 @@ public class SelenideMcpServer {
       applyProxyArg(config, arg);
       applyBehaviorArg(config, arg);
       applyModeArg(config, arg);
+      applyCapability(config, arg);
     }
     return config;
+  }
+
+  private static void applyCapability(SelenideConfig config, String arg) {
+    if (arg.startsWith("--cap=")) {
+      String[] cap = arg.substring("--cap=".length()).split("=", 2);
+      if (cap.length < 2) {
+        throw new IllegalArgumentException("Capability must have name and value separated by `=`. Current capability: " + arg);
+      }
+      config.browserCapabilities().setCapability(cap[0], cap[1]);
+    }
   }
 
   private static void applyBrowserArg(SelenideConfig config, String arg) {

--- a/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
+++ b/modules/mcp/src/main/java/com/codeborne/selenide/mcp/SelenideMcpServer.java
@@ -17,7 +17,6 @@ import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 /**

--- a/modules/mcp/src/test/java/com/codeborne/selenide/mcp/SelenideMcpServerTest.java
+++ b/modules/mcp/src/test/java/com/codeborne/selenide/mcp/SelenideMcpServerTest.java
@@ -239,38 +239,68 @@ class SelenideMcpServerTest {
   }
 
   @Test
-  void hasCapabilityFindsMatch() {
-    assertThat(SelenideMcpServer.hasCapability(
-      new String[]{"--caps=codegen,inspect"}, "codegen")).isTrue();
+  void hasToolFindsMatch() {
+    assertThat(SelenideMcpServer.hasTool(
+      new String[]{"--tools=codegen,inspect"}, "codegen")).isTrue();
   }
 
   @Test
-  void hasCapabilityNoMatch() {
-    assertThat(SelenideMcpServer.hasCapability(
-      new String[]{"--caps=inspect"}, "codegen")).isFalse();
+  void hasToolNoMatch() {
+    assertThat(SelenideMcpServer.hasTool(
+      new String[]{"--tools=inspect"}, "codegen")).isFalse();
   }
 
   @Test
-  void hasCapabilityDoesNotSubstringMatch() {
-    assertThat(SelenideMcpServer.hasCapability(
-      new String[]{"--caps=nocodegen"}, "codegen")).isFalse();
+  void hasToolDoesNotSubstringMatch() {
+    assertThat(SelenideMcpServer.hasTool(
+      new String[]{"--tools=nocodegen"}, "codegen")).isFalse();
   }
 
   @Test
-  void hasCapabilityMultipleCaps() {
-    assertThat(SelenideMcpServer.hasCapability(
-      new String[]{"--caps=inspect,codegen"}, "codegen")).isTrue();
+  void hasToolMultipleTools() {
+    assertThat(SelenideMcpServer.hasTool(
+      new String[]{"--tools=inspect,codegen"}, "codegen")).isTrue();
   }
 
   @Test
-  void hasCapabilityNoFlag() {
-    assertThat(SelenideMcpServer.hasCapability(
+  void hasToolNoFlag() {
+    assertThat(SelenideMcpServer.hasTool(
       new String[]{"--browser=chrome"}, "codegen")).isFalse();
   }
 
   @Test
-  void hasCapabilityEmptyArgs() {
-    assertThat(SelenideMcpServer.hasCapability(
+  void hasToolEmptyArgs() {
+    assertThat(SelenideMcpServer.hasTool(
       new String[]{}, "codegen")).isFalse();
+  }
+
+  @Test
+  void parseConfigCapability() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--cap=browserName=chrome"});
+    assertThat(config.browserCapabilities().getCapability("browserName")).isEqualTo("chrome");
+  }
+
+  @Test
+  void parseConfigCapabilityWithValueContainingEquals() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--cap=selenoid:options={\"enableVNC\":true}"});
+    assertThat(config.browserCapabilities().getCapability("selenoid:options")).isEqualTo("{\"enableVNC\":true}");
+  }
+
+  @Test
+  void parseConfigMultipleCapabilities() {
+    SelenideConfig config = SelenideMcpServer.parseConfig(
+      new String[]{"--cap=custom:option1=value1", "--cap=custom:option2=value2"});
+    assertThat(config.browserCapabilities().getCapability("custom:option1")).isEqualTo("value1");
+    assertThat(config.browserCapabilities().getCapability("custom:option2")).isEqualTo("value2");
+  }
+
+  @Test
+  void parseConfigCapabilityWithoutValueThrows() {
+    assertThatThrownBy(() ->
+      SelenideMcpServer.parseConfig(new String[]{"--cap=browserName"})
+    ).isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Capability must have name and value separated by `=`");
   }
 }


### PR DESCRIPTION
## Proposed changes
In previous version there was a problem with set of capabilities. Due to this problem - there can be problem with start browser: for example new chrome need --no-sandbox in google capability.

Now there is 2 changes:

1. --caps parameter moved to --tools, because previous implementation of this parameter was not about browser capabilities, more about code tools connection
2. added --cap parameters to specify browser capabilities. It now implemented as multi parameter with specific format `name=value`

## Checklist
- [ ] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated configuration options to use separate flags for enabling tools and setting browser capabilities.
  * Added support for enabling the `codegen` tool via `--tools=<list>`.
  * Added support for custom browser capabilities via repeated `--cap=<name>=<value>` entries.

* **Bug Fixes**
  * Improved parsing to correctly preserve capability values that include `=`.
  * Added validation that errors when `--cap` entries don’t include a valid `name=value` pair.

* **Documentation**
  * Refreshed configuration documentation to reflect the new `Tools` and `Browser Capabilities` flags.

* **Tests**
  * Updated and expanded test coverage for tool and capability flag parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->