### PR TITLE
#2761 Make SelenideAppiumElement's find/$/$x/findAll/$$/$$x return Appium-typed results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,13 @@ Selenide is a Java framework providing a concise fluent API for Selenium WebDriv
 
 Before submitting a PR or pushing a branch, check that command `./gradlew javadocForSite` is not broken. 
 
+### Appium/Android integration tests
+
+The `modules/appium` integration tests (`modules/appium/src/test/java/it/mobile/android`) require a running Android
+emulator/device — they are not part of `./gradlew check` and can't run headlessly. To run them locally, start the
+emulator first: `emulator -avd Pixel_4_API_28_1` (aliased as `em` on Andrei's machine), then run the appium module's
+test task against it.
+
 ## Architecture
 
 ### Module Structure

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumCollection.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumCollection.java
@@ -1,28 +1,141 @@
 package com.codeborne.selenide.appium;
 
-import com.codeborne.selenide.BaseElementsCollection;
 import com.codeborne.selenide.Driver;
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.WebElementCondition;
+import com.codeborne.selenide.WebElementsCondition;
+import com.codeborne.selenide.impl.BySelectorCollection;
 import com.codeborne.selenide.impl.CollectionSource;
+import com.codeborne.selenide.impl.WebElementSource;
+import com.codeborne.selenide.impl.WebElementsCollectionWrapper;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
 import java.util.Collection;
 
-public class SelenideAppiumCollection extends BaseElementsCollection<SelenideAppiumElement, SelenideAppiumCollection> {
+public class SelenideAppiumCollection extends ElementsCollection {
   SelenideAppiumCollection(CollectionSource collection) {
-    super(collection);
+    super(collection, SelenideAppiumElement.class);
   }
 
   SelenideAppiumCollection(Driver driver, Collection<? extends WebElement> elements) {
-    super(driver, elements);
+    this(new WebElementsCollectionWrapper(driver, elements));
   }
 
   SelenideAppiumCollection(Driver driver, By seleniumSelector) {
-    super(driver, seleniumSelector);
+    this(new BySelectorCollection(driver, seleniumSelector));
+  }
+
+  public SelenideAppiumCollection(WebElementSource parent, By selector) {
+    this(new BySelectorCollection(parent.driver(), parent, selector));
   }
 
   @Override
   protected SelenideAppiumCollection create(CollectionSource source) {
     return new SelenideAppiumCollection(source);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection should(WebElementsCondition... conditions) {
+    return (SelenideAppiumCollection) super.should(conditions);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection should(WebElementsCondition condition, Duration timeout) {
+    return (SelenideAppiumCollection) super.should(condition, timeout);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection shouldBe(WebElementsCondition... conditions) {
+    return (SelenideAppiumCollection) super.shouldBe(conditions);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection shouldBe(WebElementsCondition condition, Duration timeout) {
+    return (SelenideAppiumCollection) super.shouldBe(condition, timeout);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection shouldHave(WebElementsCondition... conditions) {
+    return (SelenideAppiumCollection) super.shouldHave(conditions);
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection shouldHave(WebElementsCondition condition, Duration timeout) {
+    return (SelenideAppiumCollection) super.shouldHave(condition, timeout);
+  }
+
+  @Override
+  public SelenideAppiumCollection filter(WebElementCondition condition) {
+    return (SelenideAppiumCollection) super.filter(condition);
+  }
+
+  @Override
+  public SelenideAppiumCollection filterBy(WebElementCondition condition) {
+    return filter(condition);
+  }
+
+  @Override
+  public SelenideAppiumCollection exclude(WebElementCondition condition) {
+    return (SelenideAppiumCollection) super.exclude(condition);
+  }
+
+  @Override
+  public SelenideAppiumCollection excludeWith(WebElementCondition condition) {
+    return exclude(condition);
+  }
+
+  @Override
+  public SelenideAppiumCollection first(int elements) {
+    return (SelenideAppiumCollection) super.first(elements);
+  }
+
+  @Override
+  public SelenideAppiumCollection last(int elements) {
+    return (SelenideAppiumCollection) super.last(elements);
+  }
+
+  @Override
+  public SelenideAppiumCollection snapshot() {
+    return (SelenideAppiumCollection) super.snapshot();
+  }
+
+  @Override
+  @CanIgnoreReturnValue
+  public SelenideAppiumCollection as(String alias) {
+    return (SelenideAppiumCollection) super.as(alias);
+  }
+
+  @Override
+  public SelenideAppiumElement get(int index) {
+    return (SelenideAppiumElement) super.get(index);
+  }
+
+  @Override
+  public SelenideAppiumElement first() {
+    return (SelenideAppiumElement) super.first();
+  }
+
+  @Override
+  public SelenideAppiumElement last() {
+    return (SelenideAppiumElement) super.last();
+  }
+
+  @Override
+  public SelenideAppiumElement find(WebElementCondition condition) {
+    return (SelenideAppiumElement) super.find(condition);
+  }
+
+  @Override
+  public SelenideAppiumElement findBy(WebElementCondition condition) {
+    return find(condition);
   }
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumElement.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumElement.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.WebElementCondition;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import org.openqa.selenium.By;
 
 public interface SelenideAppiumElement extends SelenideElement {
   @CanIgnoreReturnValue
@@ -107,4 +108,61 @@ public interface SelenideAppiumElement extends SelenideElement {
   @Override
   @CanIgnoreReturnValue
   SelenideAppiumElement should(WebElementCondition... condition);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFind
+   */
+  @Override
+  SelenideAppiumElement find(String cssSelector);
+
+  @Override
+  SelenideAppiumElement find(String cssSelector, int index);
+
+  @Override
+  SelenideAppiumElement find(By selector);
+
+  @Override
+  SelenideAppiumElement find(By selector, int index);
+
+  @Override
+  SelenideAppiumElement $(String cssSelector);
+
+  @Override
+  SelenideAppiumElement $(String cssSelector, int index);
+
+  @Override
+  SelenideAppiumElement $(By selector);
+
+  @Override
+  SelenideAppiumElement $(By selector, int index);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFindByXpath
+   */
+  @Override
+  SelenideAppiumElement $x(String xpath);
+
+  @Override
+  SelenideAppiumElement $x(String xpath, int index);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFindAll
+   */
+  @Override
+  SelenideAppiumCollection findAll(String cssSelector);
+
+  @Override
+  SelenideAppiumCollection findAll(By selector);
+
+  @Override
+  SelenideAppiumCollection $$(String cssSelector);
+
+  @Override
+  SelenideAppiumCollection $$(By selector);
+
+  /**
+   * @see com.codeborne.selenide.appium.commands.AppiumFindAllByXpath
+   */
+  @Override
+  SelenideAppiumCollection $$x(String xpath);
 }

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/SelenideAppiumPageFactory.java
@@ -126,14 +126,24 @@ public class SelenideAppiumPageFactory extends SelenidePageFactory {
   protected BaseElementsCollection<? extends SelenideElement, ? extends BaseElementsCollection<?, ?>> createCollection(
     CollectionSource collection, Class<?> klass
   ) {
-    return klass.isAssignableFrom(SelenideAppiumList.class) ?
-      new SelenideAppiumList(collection) :
-      super.createCollection(collection, klass);
+    if (klass.isAssignableFrom(SelenideAppiumList.class)) {
+      return new SelenideAppiumList(collection);
+    }
+    if (klass.isAssignableFrom(SelenideAppiumCollection.class)) {
+      return new SelenideAppiumCollection(collection);
+    }
+    return super.createCollection(collection, klass);
   }
 
-  private static class SelenideAppiumList extends SelenideAppiumCollection implements NoOpsList<SelenideAppiumElement> {
+  private static class SelenideAppiumList extends BaseElementsCollection<SelenideAppiumElement, SelenideAppiumList>
+    implements NoOpsList<SelenideAppiumElement> {
     SelenideAppiumList(CollectionSource collection) {
       super(collection);
+    }
+
+    @Override
+    protected SelenideAppiumList create(CollectionSource source) {
+      return new SelenideAppiumList(source);
     }
   }
 

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFind.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFind.java
@@ -1,0 +1,20 @@
+package com.codeborne.selenide.appium.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.appium.SelenideAppiumElement;
+import com.codeborne.selenide.impl.ElementFinder;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
+
+import static com.codeborne.selenide.commands.Util.firstOf;
+
+public class AppiumFind implements Command<SelenideAppiumElement> {
+  @Override
+  public SelenideAppiumElement execute(SelenideElement parentElement, WebElementSource parentLocator, Object... args) {
+    Object selector = firstOf(args);
+    By by = WebElementSource.getSelector(selector);
+    int index = args.length > 1 ? (Integer) args[1] : 0;
+    return ElementFinder.wrap(parentLocator.driver(), SelenideAppiumElement.class, parentLocator, by, index);
+  }
+}

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindAll.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindAll.java
@@ -1,0 +1,16 @@
+package com.codeborne.selenide.appium.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.appium.SelenideAppiumCollection;
+import com.codeborne.selenide.impl.WebElementSource;
+
+import static com.codeborne.selenide.commands.Util.firstOf;
+
+public class AppiumFindAll implements Command<SelenideAppiumCollection> {
+  @Override
+  public SelenideAppiumCollection execute(SelenideElement parentElement, WebElementSource parentLocator, Object... args) {
+    Object selector = firstOf(args);
+    return new SelenideAppiumCollection(parentLocator, WebElementSource.getSelector(selector));
+  }
+}

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindAllByXpath.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindAllByXpath.java
@@ -1,0 +1,18 @@
+package com.codeborne.selenide.appium.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.appium.SelenideAppiumCollection;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.By;
+
+import static com.codeborne.selenide.commands.Util.firstOf;
+
+public class AppiumFindAllByXpath implements Command<SelenideAppiumCollection> {
+  @Override
+  public SelenideAppiumCollection execute(SelenideElement parentElement, WebElementSource parentLocator, Object @Nullable [] args) {
+    String xpath = firstOf(args);
+    return new SelenideAppiumCollection(parentLocator, By.xpath(xpath));
+  }
+}

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindByXpath.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumFindByXpath.java
@@ -1,0 +1,20 @@
+package com.codeborne.selenide.appium.commands;
+
+import com.codeborne.selenide.Command;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.appium.SelenideAppiumElement;
+import com.codeborne.selenide.impl.ElementFinder;
+import com.codeborne.selenide.impl.WebElementSource;
+import org.openqa.selenium.By;
+
+import static com.codeborne.selenide.commands.Util.firstOf;
+
+public class AppiumFindByXpath implements Command<SelenideAppiumElement> {
+  @Override
+  public SelenideAppiumElement execute(SelenideElement parentElement, WebElementSource parentLocator, Object... args) {
+    String xpath = firstOf(args);
+    By byXpath = By.xpath(xpath);
+    int index = args.length > 1 ? (Integer) args[1] : 0;
+    return ElementFinder.wrap(parentLocator.driver(), SelenideAppiumElement.class, parentLocator, byXpath, index);
+  }
+}

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/SelenideAppiumCommands.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/SelenideAppiumCommands.java
@@ -4,6 +4,12 @@ import com.codeborne.selenide.commands.Commands;
 
 public class SelenideAppiumCommands extends Commands {
   public SelenideAppiumCommands() {
+    add("find", new AppiumFind());
+    add("$", new AppiumFind());
+    add("$x", new AppiumFindByXpath());
+    add("findAll", new AppiumFindAll());
+    add("$$", new AppiumFindAll());
+    add("$$x", new AppiumFindAllByXpath());
     add("dragAndDrop", new AppiumDragAndDrop());
     add("click", new AppiumClick());
     add("doubleClick", new AppiumDoubleClick());

--- a/modules/appium/src/test/java/it/mobile/android/AppiumCollectionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AppiumCollectionsTest.java
@@ -1,5 +1,6 @@
 package it.mobile.android;
 
+import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.appium.SelenideAppium;
 import com.codeborne.selenide.appium.SelenideAppiumCollection;
 import com.codeborne.selenide.appium.SelenideAppiumElement;
@@ -12,6 +13,7 @@ import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.appium.AppiumScrollOptions.down;
 import static com.codeborne.selenide.appium.AppiumScrollOptions.up;
+import static com.codeborne.selenide.appium.SelenideAppium.$;
 import static com.codeborne.selenide.appium.SelenideAppium.$$;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,5 +46,40 @@ public class AppiumCollectionsTest extends BaseSwagLabsAndroidTest {
 
     SelenideAppiumElement field = inputFields.find(attribute("password", "true")).shouldBe(visible);
     assertThat(field).isInstanceOf(SelenideAppiumElement.class);
+  }
+
+  @Test
+  void collectionMethodsChainedFromAParentElement() {
+    SelenideAppiumElement loginForm = $(By.xpath("//android.view.ViewGroup[@content-desc='Login button']/.."));
+
+    SelenideAppiumCollection viaFindAll = loginForm.findAll(By.xpath(".//android.widget.EditText")).shouldHave(size(2));
+    assertThat(viaFindAll.first()).isInstanceOf(SelenideAppiumElement.class);
+
+    SelenideAppiumCollection viaDollarDollar = loginForm.$$(By.xpath(".//android.widget.EditText")).shouldHave(size(2));
+    assertThat(viaDollarDollar.get(0)).isInstanceOf(SelenideAppiumElement.class);
+
+    SelenideAppiumCollection viaXpathShortcut = loginForm.$$x(".//android.widget.EditText").shouldHave(size(2));
+    assertThat(viaXpathShortcut.last()).isInstanceOf(SelenideAppiumElement.class);
+  }
+
+  @Test
+  void singleElementMethodsChainedFromAParentElement() {
+    SelenideAppiumElement loginForm = $(By.xpath("//android.view.ViewGroup[@content-desc='Login button']/.."));
+
+    // these calls only compile at all if find()/$()/$x() are typed as SelenideAppiumElement, not SelenideElement:
+    loginForm.find(By.xpath(".//android.widget.EditText")).scroll(up()).shouldHave(attribute("password", "false"));
+    loginForm.$(By.xpath(".//android.widget.EditText"), 1).scroll(down()).shouldHave(attribute("password", "true"));
+    SelenideAppiumElement field = loginForm.$x(".//android.widget.EditText");
+    assertThat(field).isInstanceOf(SelenideAppiumElement.class);
+  }
+
+  @Test
+  void elementsProducedByIteratingACollection_canBeSafelyCastToSelenideAppiumElement() {
+    SelenideAppiumCollection inputFields = $$(By.xpath("//android.widget.EditText")).shouldHave(size(2));
+
+    for (SelenideElement element : inputFields) {
+      SelenideAppiumElement appiumElement = (SelenideAppiumElement) element;
+      assertThat(appiumElement).isInstanceOf(SelenideAppiumElement.class);
+    }
   }
 }

--- a/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/BaseElementsCollection.java
@@ -45,12 +45,24 @@ public abstract class BaseElementsCollection<T extends SelenideElement, SELF ext
   implements Iterable<T> {
   private static final ElementCommunicator communicator = inject(ElementCommunicator.class);
 
-  private final Class<T> clazz;
+  private final Class<? extends T> clazz;
   private final CollectionSource collection;
 
   @SafeVarargs
   protected BaseElementsCollection(CollectionSource collection, T... clazz) {
     this.clazz = classOf(clazz);
+    this.collection = collection;
+  }
+
+  /**
+   * Lets a subclass build elements of a more specific class than {@code T},
+   * without changing the declared generic parameter {@code T} (and therefore
+   * without changing the return type of any inherited method).
+   *
+   * @param elementClass the actual class of elements this collection should produce
+   */
+  protected BaseElementsCollection(CollectionSource collection, Class<? extends T> elementClass) {
+    this.clazz = elementClass;
     this.collection = collection;
   }
 

--- a/src/main/java/com/codeborne/selenide/ElementsCollection.java
+++ b/src/main/java/com/codeborne/selenide/ElementsCollection.java
@@ -23,6 +23,16 @@ public class ElementsCollection extends BaseElementsCollection<SelenideElement, 
     super(driver, seleniumSelector);
   }
 
+  /**
+   * Lets a subclass produce elements of a more specific class than {@link SelenideElement},
+   * e.g. a plugin module's own element interface, while keeping this class' own generic parameter
+   * (and therefore the declared return type of {@code get()}/{@code first()}/{@code last()}/{@code find()}/
+   * {@code findBy()}/{@code iterator()}/{@code stream()}) unchanged.
+   */
+  protected ElementsCollection(CollectionSource collection, Class<? extends SelenideElement> elementClass) {
+    super(collection, elementClass);
+  }
+
   @Override
   protected ElementsCollection create(CollectionSource source) {
     return new ElementsCollection(source);

--- a/src/main/java/com/codeborne/selenide/impl/SelenideElementIterator.java
+++ b/src/main/java/com/codeborne/selenide/impl/SelenideElementIterator.java
@@ -6,10 +6,10 @@ import java.util.Iterator;
 
 public class SelenideElementIterator<T extends SelenideElement> implements Iterator<T> {
   protected final CollectionSource collection;
-  private final Class<T> clazz;
+  private final Class<? extends T> clazz;
   protected int index;
 
-  public SelenideElementIterator(CollectionSource collection, Class<T> clazz) {
+  public SelenideElementIterator(CollectionSource collection, Class<? extends T> clazz) {
     this.collection = collection;
     this.clazz = clazz;
   }

--- a/src/test/java/com/codeborne/selenide/BaseElementsCollectionExtensibilityTest.java
+++ b/src/test/java/com/codeborne/selenide/BaseElementsCollectionExtensibilityTest.java
@@ -1,0 +1,58 @@
+package com.codeborne.selenide;
+
+import com.codeborne.selenide.impl.CollectionSource;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+
+import static com.codeborne.selenide.Mocks.mockCollection;
+import static com.codeborne.selenide.Mocks.mockWebElement;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class BaseElementsCollectionExtensibilityTest {
+  interface CustomElement extends SelenideElement {
+  }
+
+  static class CustomCollection extends ElementsCollection {
+    CustomCollection(CollectionSource source) {
+      super(source, CustomElement.class);
+    }
+  }
+
+  private final WebElement element1 = mockWebElement("h1", "Hello");
+  private final WebElement element2 = mockWebElement("h2", "Mark");
+
+  @Test
+  void getReturnsAnElementImplementingTheClassPassedToTheConstructor() {
+    CollectionSource source = mockCollection("custom", element1, element2);
+    CustomCollection collection = new CustomCollection(source);
+
+    assertThat(collection.get(0)).isInstanceOf(CustomElement.class);
+  }
+
+  @Test
+  void firstAndLastAlsoImplementTheCustomClass() {
+    CollectionSource source = mockCollection("custom", element1, element2);
+    CustomCollection collection = new CustomCollection(source);
+
+    assertThat(collection.first()).isInstanceOf(CustomElement.class);
+    assertThat(collection.last()).isInstanceOf(CustomElement.class);
+  }
+
+  @Test
+  void elementsProducedByIteration_alsoImplementTheCustomClass() {
+    CollectionSource source = mockCollection("custom", element1, element2);
+    CustomCollection collection = new CustomCollection(source);
+
+    SelenideElement first = collection.iterator().next();
+
+    assertThat(first).isInstanceOf(CustomElement.class);
+  }
+
+  @Test
+  void elementsProducedByStream_alsoImplementTheCustomClass() {
+    CollectionSource source = mockCollection("custom", element1, element2);
+    CustomCollection collection = new CustomCollection(source);
+
+    assertThat(collection.stream()).allSatisfy(element -> assertThat(element).isInstanceOf(CustomElement.class));
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #2761 completely (both halves of the issue):
- `SelenideAppiumElement.findAll()/$$()/$$x()` now return `SelenideAppiumCollection` instead of `ElementsCollection` when chained from an Appium element.
- `SelenideAppiumElement.find()/$()/$x()` now return `SelenideAppiumElement` instead of `SelenideElement` when chained (the `$().$()` case reported in a follow-up comment on the issue, not covered by the earlier attempt at this fix).

### Approach
- `SelenideAppiumCollection` extends `ElementsCollection` — required for covariant return types, since `SelenideElement.findAll()` is declared to return the concrete `ElementsCollection` class (kept unchanged; loosening it would break the very common `ElementsCollection list = element.findAll(...)` idiom for existing users).
- Because `ElementsCollection` fixes its element type to `SelenideElement`, naively extending it leaves `iterator()`/`stream()`/`asFixedIterable()`/`asDynamicIterable()` producing `SelenideElement`-only proxies — casting one to `SelenideAppiumElement` would throw `ClassCastException`. To fix this without changing any declared return type, `BaseElementsCollection`/`ElementsCollection`/`SelenideElementIterator` now accept an explicit runtime element `Class` decoupled from their declared generic parameter (backed by an additive `protected` constructor), so every inherited method produces genuinely Appium-typed elements.
- Added `AppiumFind`/`AppiumFindByXpath` commands (mirroring the existing `AppiumFindAll`/`AppiumFindAllByXpath`) for the single-element case.
- `SelenideAppiumPageFactory.SelenideAppiumList` now extends `BaseElementsCollection` directly instead of `SelenideAppiumCollection` — `NoOpsList<SelenideAppiumElement>` needs `Iterator<SelenideAppiumElement>`, which a class stuck at `Iterable<SelenideElement>` can't provide (a compile-time catch). `createCollection()` also now recognizes `SelenideAppiumCollection`-typed page object fields, which broke without an explicit check once `SelenideAppiumList` stopped being a `SelenideAppiumCollection`.

No public API signatures changed outside the appium module; fully backward compatible.

## Test plan
- [x] `./gradlew check` (all modules, unit tests + checkstyle + spotbugs)
- [x] `./gradlew javadocForSite`
- [x] New unit test `BaseElementsCollectionExtensibilityTest` covers the core mechanism in isolation (no browser needed)
- [x] Full `./gradlew :modules:appium:android` suite run against a real emulator (Pixel_4_API_28_1): 48 tests passed, 1 pre-existing skip, 0 failures — including the new collection-chaining and single-element-chaining tests in `AppiumCollectionsTest`, and all existing page-object/collection tests

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Appium element and collection lookup methods, including CSS, XPath, and selector-based queries.
  * Added support for indexed element retrieval and fluent collection filtering and assertions.
  * Improved preservation of Appium-specific element types when iterating, streaming, and chaining queries.

* **Documentation**
  * Added guidance for running Appium/Android integration tests with an active emulator or device.

* **Tests**
  * Added coverage for Appium lookup, collection chaining, iteration, and custom element types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->