### PR TITLE
update Selenium from 4.45.0 to 4.46.0 (incl. CDP from 149 -> 150)

### DIFF
--- a/.github/workflows/test-with-selenium-nightly-build.yml
+++ b/.github/workflows/test-with-selenium-nightly-build.yml
@@ -27,7 +27,7 @@ jobs:
           chrome-version: stable
       - uses: gradle/actions/setup-gradle@v6
       - name: Build with Gradle
-        run: ./gradlew ${{ matrix.gradle-task }} -PseleniumVersionNightlyBuild=4.46.0-SNAPSHOT --no-parallel --no-daemon --console=plain
+        run: ./gradlew ${{ matrix.gradle-task }} -PseleniumVersionNightlyBuild=4.47.0-SNAPSHOT --no-parallel --no-daemon --console=plain
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.17.0 (TBD)
 * update Selenium from 4.44.0 to 4.45.0 (incl. CDP from 148 -> 149)
+* update Selenium from 4.45.0 to 4.46.0 (incl. CDP from 149 -> 150)
 
 ## 7.16.2 (27.05.2026)
 * Selenide MCP: added more configuration parameters  --  thanks to Mike Sidelnikov (#3323)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-  seleniumVersionStable = '4.45.0'
+  seleniumVersionStable = '4.46.0'
   seleniumVersion = project.properties['seleniumVersionNightlyBuild'] ?: seleniumVersionStable
   httpClientVersion = '5.6.2'
   junitVersion = '6.1.1'

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumAliasTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumAliasTest.java
@@ -23,7 +23,7 @@ class SelenideAppiumAliasTest {
   void setUp() {
     AndroidDriver androidDriver = mock();
     when(androidDriver.getCapabilities()).thenReturn(new DesiredCapabilities());
-    when(androidDriver.getBiDi()).thenThrow(BiDiException.class);
+    when(androidDriver.getBiDi()).thenThrow(new BiDiException("Not working in Android"));
     WebDriverRunner.setWebDriver(androidDriver);
   }
 

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumPageFactoryTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/SelenideAppiumPageFactoryTest.java
@@ -39,7 +39,7 @@ class SelenideAppiumPageFactoryTest {
   void mobile_platform_element_successfully_init_with_created_webdriver() {
     AndroidDriver androidDriver = mock();
     when(androidDriver.getCapabilities()).thenReturn(new DesiredCapabilities());
-    when(androidDriver.getBiDi()).thenThrow(BiDiException.class);
+    when(androidDriver.getBiDi()).thenThrow(new BiDiException("Not working in Android"));
     WebDriverRunner.setWebDriver(androidDriver);
 
     var page = Selenide.page(PageWithPlatformSelectors.class);
@@ -51,7 +51,7 @@ class SelenideAppiumPageFactoryTest {
   void mobile_element_with_custom_type_successfully_init() {
     AndroidDriver androidDriver = mock();
     when(androidDriver.getCapabilities()).thenReturn(new DesiredCapabilities());
-    when(androidDriver.getBiDi()).thenThrow(BiDiException.class);
+    when(androidDriver.getBiDi()).thenThrow(new BiDiException("Not working in Android"));
     WebDriverRunner.setWebDriver(androidDriver);
 
     var page = Selenide.page(PageWithCustomElementType.class);

--- a/modules/proxy/src/test/java/integration/proxy/MultipleDownloadsTest.java
+++ b/modules/proxy/src/test/java/integration/proxy/MultipleDownloadsTest.java
@@ -63,12 +63,12 @@ public class MultipleDownloadsTest extends ProxyIntegrationTest {
 
   @Test
   void downloadMultipleFiles_errorMessage() {
-    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(2).withMethod(PROXY).withExtension("txt").withTimeout(100)))
+    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(2).withMethod(PROXY).withExtension("txt").withTimeout(200)))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download at least 2 files with extension \"txt\" in 100ms (found ")
+      .hasMessageStartingWith("Failed to download at least 2 files with extension \"txt\" in 200ms (found ")
       .hasMessageContaining("empty.html")
       .hasMessageContaining("download.html")
       .hasMessageContaining("hello_world.txt")
-      .hasMessageContaining("Timeout: 100ms");
+      .hasMessageContaining("Timeout: 200ms");
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/BiDiUti.java
+++ b/src/main/java/com/codeborne/selenide/impl/BiDiUti.java
@@ -5,9 +5,9 @@ import org.openqa.selenium.bidi.BiDi;
 import org.openqa.selenium.bidi.BiDiException;
 import org.openqa.selenium.bidi.HasBiDi;
 import org.openqa.selenium.bidi.log.GenericLogEntry;
-import org.openqa.selenium.bidi.log.Log;
 import org.openqa.selenium.bidi.log.LogLevel;
 import org.openqa.selenium.bidi.log.StackFrame;
+import org.openqa.selenium.bidi.module.LogInspector;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.remote.http.ConnectionFailedException;
 import org.slf4j.Logger;
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.stream.Stream;
 
@@ -25,20 +26,21 @@ public class BiDiUti {
   private static final Logger log = LoggerFactory.getLogger(BiDiUti.class);
 
   public static boolean isBiDiEnabled(WebDriver webDriver) {
-    if (!(webDriver instanceof HasBiDi hasBiDi)) {
+    if (!(webDriver instanceof HasBiDi)) {
       return false;
     }
 
-    try {
-      hasBiDi.getBiDi();
+    try (LogInspector ignore = new LogInspector(webDriver)) {
       return true;
     }
-    catch (BiDiException notEnabled) {
+    catch (BiDiException | ConnectionFailedException notEnabled) {
       log.warn("Failed to establish BiDi connection: {}", notEnabled.toString());
       return false;
     }
   }
 
+  @Deprecated(since = "7.17.0", forRemoval = true)
+  @SuppressWarnings("removal")
   public static Optional<BiDi> getBiDiIfEnabled(WebDriver webDriver) {
     try {
       return webDriver instanceof HasBiDi hasBiDi ? Optional.of(hasBiDi.getBiDi()) : Optional.empty();
@@ -48,14 +50,31 @@ public class BiDiUti {
     }
   }
 
+  private static <T> Optional<T> ifBiDiEnabled(String action, WebDriver webDriver, Supplier<T> bidiUsage) {
+    if (!(webDriver instanceof HasBiDi)) {
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.of(bidiUsage.get());
+    }
+    catch (BiDiException | ConnectionFailedException bidiNotWorking) {
+      log.warn("Failed to use BiDi to {}: {}", action, bidiNotWorking.toString());
+      return Optional.empty();
+    }
+  }
+
+  @SuppressWarnings("resource")
   public static List<LogEntry> collectBrowserLogs(WebDriver webDriver) {
-    return getBiDiIfEnabled(webDriver).map((BiDi biDi) -> {
+    return ifBiDiEnabled("collect browser logs", webDriver, () -> {
+
       List<LogEntry> logs = new CopyOnWriteArrayList<>();
-      biDi.addListener(Log.entryAdded(), (org.openqa.selenium.bidi.log.LogEntry logEntry) -> {
+      new LogInspector(webDriver).onLog((org.openqa.selenium.bidi.log.LogEntry logEntry) -> {
         log.trace("Received browser log {}", logEntry);
         logs.addAll(readBiDiLogEntry(logEntry));
       });
       return logs;
+
     }).orElse(emptyList());
   }
 

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileToFolder.java
@@ -120,7 +120,7 @@ public class DownloadFileToFolder {
     }
 
     if (folder.hasFiles(extension, filter)) {
-      String message = String.format("Folder %s still contains files %s after %s ms. " +
+      String message = String.format("Folder %s still contains files %s after %s. " +
           "Apparently, the downloading hasn't completed in time. Found files: %s",
         folder, extension, df.format(timeout), folder.filesAsString());
       throw new FileNotDownloadedError(message, timeout);
@@ -169,8 +169,8 @@ public class DownloadFileToFolder {
       failFastIfNoChanges(driver, folder, fileFilter, start, timeout, incrementTimeout);
     }
 
-    log.debug("Matching files still not found -> stop waiting for new files after {} ms. (timeout: {} ms.)",
-      currentTimeMillis() - start, df.format(timeout));
+    log.debug("Matching files still not found -> stop waiting for new files after {} (timeout: {})",
+      df.format(currentTimeMillis() - start), df.format(timeout));
   }
 
   protected void failFastIfNoChanges(Driver driver, DownloadsFolder folder, FileFilter filter,

--- a/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/SelenideElementProxyTest.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.bidi.BiDiException;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.slf4j.Logger;
@@ -52,16 +53,23 @@ import static org.mockito.Mockito.when;
 final class SelenideElementProxyTest {
   private static final Logger log = LoggerFactory.getLogger(SelenideElementProxyTest.class);
 
-  private final RemoteWebDriver webdriver = mock();
+  private final RemoteWebDriver webdriver = mockWebDriver();
   private final WebElement element = mock();
   private final SelenideConfig config = new SelenideConfig().screenshots(false).timeout(1);
   private final SelenideDriver driver = new SelenideDriver(config, webdriver, null, new SharedDownloadsFolder("build/downloads/123"));
 
-  @BeforeEach
-  void mockWebDriver() {
-    when(webdriver.executeScript(anyString(), same(element))).thenReturn(Map.of("id", "id1", "class", "class1"));
+  @SuppressWarnings("removal")
+  private static RemoteWebDriver mockWebDriver() {
+    RemoteWebDriver webdriver = mock();
+    when(webdriver.getBiDi()).thenThrow(new BiDiException("Not enabled"));
     when(webdriver.getPageSource()).thenReturn("<html>mock</html>");
     when(webdriver.executeScript("return navigator.platform")).thenReturn("Win32");
+    return webdriver;
+  }
+
+  @BeforeEach
+  void setUp() {
+    when(webdriver.executeScript(anyString(), same(element))).thenReturn(Map.of("id", "id1", "class", "class1"));
     when(element.getTagName()).thenReturn("h1");
     when(element.getText()).thenReturn("Hello world");
     when(element.isDisplayed()).thenReturn(true);

--- a/statics/src/test/java/integration/FileDownloadToFolderTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderTest.java
@@ -353,13 +353,13 @@ final class FileDownloadToFolderTest extends IntegrationTest {
   void downloadMultipleFiles_errorMessage() {
     openFile("downloadMultipleFiles.html");
 
-    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(22).withTimeout(100)))
+    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(22).withTimeout(200)))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download at least 22 files in 100ms (found ")
+      .hasMessageStartingWith("Failed to download at least 22 files in 200ms (found ")
       .hasMessageContaining("hello_world.txt")
       .hasMessageContaining("empty.html")
       .hasMessageContaining("download.html")
-      .hasMessageContaining("Timeout: 100ms");
+      .hasMessageContaining("Timeout: 200ms");
   }
 
   @Test

--- a/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
+++ b/statics/src/test/java/integration/FileDownloadToFolderWithCdpTest.java
@@ -316,13 +316,13 @@ final class FileDownloadToFolderWithCdpTest extends IntegrationTest {
   void downloadMultipleFiles_errorMessage() {
     openFile("downloadMultipleFiles.html");
 
-    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(33).withTimeout(100)))
+    assertThatThrownBy(() -> $("#multiple-downloads").downloadFiles(files(33).withTimeout(200)))
       .isInstanceOf(FileNotDownloadedError.class)
-      .hasMessageStartingWith("Failed to download at least 33 files in 100ms (found ")
+      .hasMessageStartingWith("Failed to download at least 33 files in 200ms (found ")
       .hasMessageContaining("hello_world.txt")
       .hasMessageContaining("empty.html")
       .hasMessageContaining("download.html")
-      .hasMessageContaining("Timeout: 100ms");
+      .hasMessageContaining("Timeout: 200ms");
   }
 
   @Test

--- a/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
+++ b/statics/src/test/java/integration/FileDownloadViaHttpGetTest.java
@@ -169,12 +169,12 @@ final class FileDownloadViaHttpGetTest extends IntegrationTest {
   @Test
   void downloadsGetsTimeoutException() {
     assertThatThrownBy(() -> {
-      File downloadedFile = $(byText("Start download after delay (2000 ms)")).download(file().withTimeout(100));
+      File downloadedFile = $(byText("Start download after delay (2000 ms)")).download(file().withTimeout(200));
       assertThat(downloadedFile).hasContent("File downloading should fail with timeout");
     })
       .isInstanceOf(FileNotDownloadedError.class)
       .hasMessageStartingWith("Failed to download ")
-      .hasMessageContaining("/files/hello_world.txt?pause=2000 in 100 ms.");
+      .hasMessageContaining("/files/hello_world.txt?pause=2000 in 200 ms.");
   }
 
   @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated default Selenium to **4.46.0** (including CDP updates).
  - Updated nightly Selenium testing to use **4.47.0** nightly builds.

- **Bug Fixes**
  - Improved **BiDi availability detection** and made browser log collection more resilient when BiDi isn’t available.

- **Tests**
  - Updated Appium/BiDi-related tests to consistently reflect “not working in Android”.
  - Adjusted file download timeout assertions from **100ms** to **200ms**.

- **Documentation**
  - Refreshed timeout-related message formatting in download diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->