### PR TITLE
add method `Selenide.cookies()`

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -26,6 +26,7 @@
     <suppress checks="AvoidStarImport" files="src[/\\]test[/\\]java[/\\].*"/>
     <suppress checks="ClassFanOutComplexity" files=".*[/\\]Commands.java|.*[/\\]DownloadFileWithHttpRequest.java"/>
     <suppress checks="ClassFanOutComplexity" files=".*[/\\]SelenideDriver.java"/>
+    <suppress checks="ClassFanOutComplexity" files=".*[/\\]Selenide.java"/>
     <suppress checks="RedundantModifier" files=".*[/\\]Browsers.java"/>
     <suppress checks="NPathComplexity" files=".*[/\\]ScreenShotLaboratory.java"/>
 </suppressions>

--- a/src/main/java/com/codeborne/selenide/CookieStore.java
+++ b/src/main/java/com/codeborne/selenide/CookieStore.java
@@ -1,0 +1,70 @@
+package com.codeborne.selenide;
+
+import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+
+import java.util.Set;
+
+public class CookieStore implements Conditional<CookieStore> {
+  private final Driver driver;
+
+  CookieStore(Driver driver) {
+    this.driver = driver;
+  }
+
+  @Override
+  public Driver driver() {
+    return driver;
+  }
+
+  @Override
+  public CookieStore object() {
+    return this;
+  }
+
+  /**
+   * Delete all the cookies for the current domain.
+   * @see WebDriver.Options#deleteAllCookies()
+   */
+  public void clear() {
+    driver.getWebDriver().manage().deleteAllCookies();
+  }
+
+  /**
+   * Delete the named cookie from the current domain.
+   * @see WebDriver.Options#deleteCookieNamed(String)
+   */
+  public void delete(String name) {
+    driver.getWebDriver().manage().deleteCookieNamed(name);
+  }
+
+  /**
+   * Get all the cookies for the current domain.
+   * @see WebDriver.Options#getCookies()
+   */
+  public Set<Cookie> getAll() {
+    return driver.getWebDriver().manage().getCookies();
+  }
+
+  /**
+   * Get cookie with given name for the current domain.
+   * @see WebDriver.Options#getCookies()
+   */
+  @Nullable
+  public Cookie get(String name) {
+    return driver.getWebDriver().manage().getCookieNamed(name);
+  }
+
+  public void add(String name, String value) {
+    add(new Cookie(name, value, null));
+  }
+
+  public void add(Cookie cookie) {
+    driver.getWebDriver().manage().addCookie(cookie);
+  }
+
+  public int size() {
+    return getAll().size();
+  }
+}

--- a/src/main/java/com/codeborne/selenide/CookieStoreConditions.java
+++ b/src/main/java/com/codeborne/selenide/CookieStoreConditions.java
@@ -1,0 +1,14 @@
+package com.codeborne.selenide;
+
+import com.codeborne.selenide.conditions.cookiestore.CookieWithName;
+import com.codeborne.selenide.conditions.cookiestore.CookieWithNameAndValue;
+
+public class CookieStoreConditions {
+  public static ObjectCondition<CookieStore> cookie(String name) {
+    return new CookieWithName(name);
+  }
+
+  public static ObjectCondition<CookieStore> cookie(String name, String value) {
+    return new CookieWithNameAndValue(name, value);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/SelenideDriver.java
+++ b/src/main/java/com/codeborne/selenide/SelenideDriver.java
@@ -396,7 +396,7 @@ public class SelenideDriver {
   }
 
   /**
-   * @deprecated Use {@link Selenide#localStorage()} and {@link LocalStorage#clear()} instead
+   * @deprecated Use {@code getLocalStorage().clear()} instead
    */
   @Deprecated
   public void clearBrowserLocalStorage() {
@@ -475,6 +475,10 @@ public class SelenideDriver {
 
   public SessionStorage getSessionStorage() {
     return new SessionStorage(driver());
+  }
+
+  public CookieStore getCookieStore() {
+    return new CookieStore(driver());
   }
 
   public Clipboard getClipboard() {

--- a/src/main/java/com/codeborne/selenide/conditions/cookiestore/CookieWithName.java
+++ b/src/main/java/com/codeborne/selenide/conditions/cookiestore/CookieWithName.java
@@ -1,0 +1,40 @@
+package com.codeborne.selenide.conditions.cookiestore;
+
+import com.codeborne.selenide.CheckResult;
+import com.codeborne.selenide.CookieStore;
+import com.codeborne.selenide.ObjectCondition;
+import org.jspecify.annotations.Nullable;
+
+public class CookieWithName implements ObjectCondition<CookieStore> {
+  private final com.codeborne.selenide.conditions.webdriver.CookieWithName delegate;
+
+  public CookieWithName(String name) {
+    delegate = new com.codeborne.selenide.conditions.webdriver.CookieWithName(name);
+  }
+
+  @Override
+  public String description() {
+    return delegate.description();
+  }
+
+  @Override
+  public String negativeDescription() {
+    return delegate.negativeDescription();
+  }
+
+  @Override
+  @Nullable
+  public String expectedValue() {
+    return delegate.expectedValue();
+  }
+
+  @Override
+  public CheckResult check(CookieStore store) {
+    return delegate.check(store.driver().getWebDriver());
+  }
+
+  @Override
+  public String describe(CookieStore store) {
+    return "cookieStore";
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/cookiestore/CookieWithNameAndValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/cookiestore/CookieWithNameAndValue.java
@@ -1,0 +1,40 @@
+package com.codeborne.selenide.conditions.cookiestore;
+
+import com.codeborne.selenide.CheckResult;
+import com.codeborne.selenide.CookieStore;
+import com.codeborne.selenide.ObjectCondition;
+import org.jspecify.annotations.Nullable;
+
+public class CookieWithNameAndValue implements ObjectCondition<CookieStore> {
+  private final com.codeborne.selenide.conditions.webdriver.CookieWithNameAndValue delegate;
+
+  public CookieWithNameAndValue(String name, String value) {
+    this.delegate = new com.codeborne.selenide.conditions.webdriver.CookieWithNameAndValue(name, value);
+  }
+
+  @Override
+  public String description() {
+    return delegate.description();
+  }
+
+  @Override
+  public String negativeDescription() {
+    return delegate.negativeDescription();
+  }
+
+  @Override
+  @Nullable
+  public String expectedValue() {
+    return delegate.expectedValue();
+  }
+
+  @Override
+  public CheckResult check(CookieStore store) {
+    return delegate.check(store.driver().getWebDriver());
+  }
+
+  @Override
+  public String describe(CookieStore store) {
+    return "cookieStore";
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/cookiestore/package-info.java
+++ b/src/main/java/com/codeborne/selenide/conditions/cookiestore/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Conditions to check cookies
+ */
+@NullMarked
+@CheckReturnValue
+package com.codeborne.selenide.conditions.cookiestore;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+import org.jspecify.annotations.NullMarked;

--- a/statics/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/statics/src/main/java/com/codeborne/selenide/Selenide.java
@@ -1040,9 +1040,11 @@ public class Selenide {
    * <p>
    * It can be useful e.g. if you are trying to avoid restarting browser between tests
    *
-   * @deprecated Use {@link SelenideDriver#clearCookies()} instead
+   * @deprecated Use {@code cookies().clear()}
+   * @see #cookies()
+   * @see CookieStore#clear()
    */
-  @Deprecated
+  @Deprecated(since = "7.17.0")
   public static void clearBrowserCookies() {
     getSelenideDriver().clearCookies();
   }
@@ -1052,9 +1054,11 @@ public class Selenide {
    * <p>
    * In case if you need to be sure that browser's localStorage is empty
    *
-   * @deprecated Use {@link #localStorage()} and {@link LocalStorage#clear()} instead
+   * @deprecated Use {@code localStorage().clear()} instead
+   * @see #localStorage()
+   * @see LocalStorage#clear()
    */
-  @Deprecated
+  @Deprecated(since = "7.17.0")
   public static void clearBrowserLocalStorage() {
     getSelenideDriver().clearBrowserLocalStorage();
   }
@@ -1125,7 +1129,7 @@ public class Selenide {
    * Access browser's local storage.
    * Allows setting, getting, removing items as well as getting the size and clear the storage.
    *
-   * @return LocalStorage
+   * @return instance of {@link LocalStorage} for current browser
    */
   public static LocalStorage localStorage() {
     return getSelenideDriver().getLocalStorage();
@@ -1135,10 +1139,20 @@ public class Selenide {
    * Access browser's session storage.
    * Allows setting, getting, removing items as well as getting the size, check for contains item and clear the storage.
    *
-   * @return sessionStorage
+   * @return instance of {@link SessionStorage} for current browser
    */
   public static SessionStorage sessionStorage() {
     return getSelenideDriver().getSessionStorage();
+  }
+
+  /**
+   * Access browser's cookies
+   * Allows setting, getting, removing cookies
+   *
+   * @return instance of {@link CookieStore} for current browser
+   */
+  public static CookieStore cookies() {
+    return getSelenideDriver().getCookieStore();
   }
 
   /**

--- a/statics/src/test/java/integration/ClearCookiesTest.java
+++ b/statics/src/test/java/integration/ClearCookiesTest.java
@@ -8,7 +8,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Set;
 
-import static com.codeborne.selenide.WebDriverRunner.driver;
+import static com.codeborne.selenide.Selenide.cookies;
 import static com.codeborne.selenide.Selenide.open;
 import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,7 +27,7 @@ final class ClearCookiesTest extends IntegrationTest {
 
   @Test
   void clearCookieTest() {
-    driver().clearCookies();
+    cookies().clear();
     Set<Cookie> cookieSet = getWebDriver().manage().getCookies();
     assertThat(cookieSet).isEmpty();
   }

--- a/statics/src/test/java/integration/ClearLocalStorageTest.java
+++ b/statics/src/test/java/integration/ClearLocalStorageTest.java
@@ -1,13 +1,15 @@
 package integration;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Selenide.localStorage;
+import static com.codeborne.selenide.Selenide.clearBrowserLocalStorage;
 import static com.codeborne.selenide.Selenide.executeJavaScript;
 import static com.codeborne.selenide.Selenide.open;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 final class ClearLocalStorageTest extends IntegrationTest {
   @BeforeEach
   void addDataToLocalStorage() {
@@ -20,12 +22,13 @@ final class ClearLocalStorageTest extends IntegrationTest {
   void clearLocalStorageTest() {
     assertThat(getLocalStorageLength()).isEqualTo(2L);
 
-    localStorage().clear();
+    clearBrowserLocalStorage();
 
     assertThat(getLocalStorageLength()).isEqualTo(0L);
   }
 
-  private long getLocalStorageLength() {
-    return (Long) executeJavaScript("return localStorage.length;");
+  @Nullable
+  private Long getLocalStorageLength() {
+    return executeJavaScript("return localStorage.length;");
   }
 }

--- a/statics/src/test/java/integration/CookieStoreTest.java
+++ b/statics/src/test/java/integration/CookieStoreTest.java
@@ -1,0 +1,152 @@
+package integration;
+
+import com.codeborne.selenide.ex.ConditionMetError;
+import com.codeborne.selenide.ex.ConditionNotMetError;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Cookie;
+
+import java.util.Set;
+
+import static com.codeborne.selenide.Configuration.timeout;
+import static com.codeborne.selenide.CookieStoreConditions.cookie;
+import static com.codeborne.selenide.Selenide.$;
+import static com.codeborne.selenide.Selenide.cookies;
+import static java.time.Duration.ofMillis;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class CookieStoreTest extends IntegrationTest {
+  private static final String NAME = "TEST_COOKIE";
+  private static final String VALUE = "AF33892F98ABC39A";
+
+  @AfterAll
+  static void resetCookieStore() {
+    cookies().clear();
+  }
+
+  @BeforeEach
+  void openTestPage() {
+    openFile("cookies.html");
+  }
+
+  @Test
+  void addAndCheckCookie() {
+    cookies().add("mouse", "Jerry");
+    cookies().shouldHave(cookie("cat"), ofMillis(10000));
+    cookies().shouldHave(cookie("cat", "Tom"), ofMillis(10000));
+    cookies().shouldHave(cookie("mouse", "Jerry"));
+  }
+
+  @Test
+  void getAll() {
+    cookies().add("cat", "Tom");
+    cookies().add("mouse", "Jerry");
+
+    Set<Cookie> cookies = cookies().getAll();
+
+    assertThat(cookies).hasSizeGreaterThanOrEqualTo(2);
+    assertThat(cookies).contains(new Cookie("cat", "Tom"));
+    assertThat(cookies).contains(new Cookie("mouse", "Jerry"));
+  }
+
+  @Test
+  void assertPresenceOfSpecificCookie() {
+    $("#button-put").click();
+    cookies().shouldHave(cookie(NAME), ofMillis(2000));
+    cookies().shouldHave(cookie(NAME, VALUE), ofMillis(2000));
+  }
+
+  @Test
+  void assertAbsenceOfCookie() {
+    cookies().add(NAME, VALUE);
+    $("#button-remove").click();
+    cookies().shouldNotHave(cookie(NAME), ofMillis(2000));
+    cookies().shouldNotHave(cookie(NAME, VALUE), ofMillis(2000));
+  }
+
+  @Test
+  void checkCookieValue() {
+    $("#button-put").click();
+    cookies().shouldNotHave(cookie(NAME, "another value"), ofMillis(2000));
+  }
+
+  @Test
+  void errorMessageWhenCookieIsMissing() {
+    assertThatThrownBy(() ->
+      cookies().shouldHave(cookie("foo"), ofMillis(10))
+    )
+      .isInstanceOf(ConditionNotMetError.class)
+      .hasMessageStartingWith("cookieStore should have a cookie with name \"foo\"")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 10ms");
+  }
+
+  @Test
+  void errorMessageWhenCookieHasWrongValue() {
+    timeout = 1;
+    $("#button-put").click();
+
+    assertThatThrownBy(() ->
+      cookies().shouldHave(cookie(NAME, "wrong value"))
+    )
+      .isInstanceOf(ConditionNotMetError.class)
+      .hasMessageStartingWith("cookieStore should have a cookie with name \"%s\" and value \"wrong value\"".formatted(NAME))
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 1ms");
+  }
+
+  @Test
+  void deleteCookie() {
+    cookies().add("cat", "Tom");
+    assertThat(cookies().get("cat").getValue()).isEqualTo("Tom");
+
+    cookies().delete("cat");
+    assertThat(cookies().get("cat")).isNull();
+  }
+
+  @Test
+  void clearAndSize() {
+    cookies().add("cat", "Tom");
+    cookies().add("mouse", "Jerry");
+    assertThat(cookies().size()).isGreaterThanOrEqualTo(3);
+    assertThat(cookies().getAll()).contains(new Cookie("cat", "Tom"), new Cookie("mouse", "Jerry"));
+
+    cookies().clear();
+    assertThat(cookies().size()).isEqualTo(0);
+  }
+
+
+  @Test
+  void errorMessageWhenCookieShouldNotExist() {
+    timeout = 1;
+    cookies().add("cat", "Tom");
+
+    assertThatThrownBy(() ->
+      cookies().shouldNotHave(cookie("cat"))
+    )
+      .isInstanceOf(ConditionMetError.class)
+      .hasMessageStartingWith("cookieStore should not have cookie with name \"cat\"")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 1ms");
+  }
+
+  @Test
+  void errorMessageWhenCookieShouldNotHaveGivenValue() {
+    timeout = 1;
+    cookies().add("cat", "Tom");
+
+    assertThatThrownBy(() ->
+      cookies().shouldNotHave(cookie("cat", "Tom"))
+    )
+      .isInstanceOf(ConditionMetError.class)
+      .hasMessageStartingWith("cookieStore should not have cookie with name \"cat\" and value \"Tom\"")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 1ms");
+  }
+}

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -15,7 +15,7 @@ import static com.codeborne.selenide.Configuration.baseUrl;
 import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.WebDriverRunner.driver;
+import static com.codeborne.selenide.Selenide.cookies;
 import static com.codeborne.selenide.Selenide.switchTo;
 import static com.codeborne.selenide.Selenide.webdriver;
 import static com.codeborne.selenide.WebDriverConditions.cookie;
@@ -340,7 +340,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
 
   private void openPageWithCookies() {
     openFile("cookies.html");
-    driver().clearCookies();
+    cookies().clear();
   }
 
   private void addCustomCookie() {


### PR DESCRIPTION
it allows clearing/getting/varifying cookies in the same style as sessionStorage and localStorage:
* sessionStorage().clear()
* localStorage().clear()
* cookies().clear()

Unfortunately, Selenide already has similar methods:
* Selenide.webdriver().shouldHave(cookie("name"));
* Selenide.webdriver().shouldHave(cookie("name", "value"));

So I had to keep these methods, and partially reuse their code in the new methods.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a cookie store API for adding, retrieving, deleting, clearing, and counting browser cookies.
  - Added cookie conditions for checking cookie presence and values.
  - Added access to the cookie store through the browser driver.

- **Documentation**
  - Updated cookie and storage API guidance.
  - Clarified deprecation notices and recommended alternatives.

- **Tests**
  - Added comprehensive coverage for cookie management and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->