### PR TITLE
Publish selenide-mcp under @selenide npm org scope

### DIFF
--- a/mcp-server-legacy/README.md
+++ b/mcp-server-legacy/README.md
@@ -1,0 +1,24 @@
+# selenide-mcp (deprecated)
+
+This package has moved to [`@selenide/mcp`](https://www.npmjs.com/package/@selenide/mcp).
+
+`selenide-mcp` still works — it's a thin shim that forwards to `@selenide/mcp` — but new
+installs and configs should point at the scoped package name directly:
+
+```bash
+npx @selenide/mcp --browser=chrome --headless
+```
+
+```json
+{
+  "mcpServers": {
+    "selenide-mcp": {
+      "command": "npx",
+      "args": ["@selenide/mcp", "--browser=chrome"]
+    }
+  }
+}
+```
+
+See the [Selenide MCP docs](https://github.com/selenide/selenide/blob/main/modules/mcp/README.md)
+for full configuration options.

--- a/mcp-server-legacy/index.js
+++ b/mcp-server-legacy/index.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+process.stderr.write('[selenide-mcp] This package has moved to "@selenide/mcp". ' +
+  'Please update your MCP config to use "@selenide/mcp" instead.\n');
+
+require('@selenide/mcp');

--- a/mcp-server-legacy/package.json
+++ b/mcp-server-legacy/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@selenide/mcp",
+  "name": "selenide-mcp",
   "version": "7.17.0",
-  "description": "Selenide MCP server — browser automation with smart waits for AI agents",
+  "description": "DEPRECATED — moved to @selenide/mcp. This package forwards to the new scoped package.",
   "bin": {
     "selenide-mcp": "index.js"
   },
@@ -11,7 +11,8 @@
     "browser",
     "testing",
     "automation",
-    "selenium"
+    "selenium",
+    "deprecated"
   ],
   "license": "MIT",
   "repository": {
@@ -21,7 +22,7 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "publishConfig": {
-    "access": "public"
+  "dependencies": {
+    "@selenide/mcp": "^7.17.0"
   }
 }

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -12,13 +12,13 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 ### Using `claude mcp add`
 
 ```bash
-claude mcp add selenide-mcp 
+claude mcp add selenide-mcp -- npx @selenide/mcp
 ```
 
 With options:
 
 ```bash
-claude mcp add selenide-mcp  \
+claude mcp add selenide-mcp -- npx @selenide/mcp \
   --browser=chrome --base-url=https://app.example.com --remote=http://selenium-hub:4444/wd/hub
 ```
 
@@ -32,11 +32,14 @@ Add to `.claude/settings.json` (project) or `~/.claude/settings.json` (global):
   "mcpServers": {
     "selenide-mcp": {
       "command": "npx",
-      "args": ["selenide-mcp", "--browser=chrome", "--remote=http://selenium-hub:4444/wd/hub"]
+      "args": ["@selenide/mcp", "--browser=chrome", "--remote=http://selenium-hub:4444/wd/hub"]
     }
   }
 }
 ```
+
+> Note: the package was previously published as `selenide-mcp` on npm. That name still works
+> as a deprecated shim, but new configs should use `@selenide/mcp`.
 
 ## Configuration Parameters
 

--- a/release
+++ b/release
@@ -37,8 +37,15 @@ git commit -m "publish javadoc for Selenide ${version}"
 git push
 cd - || exit 3
 
-cd mcp-server
 npm login
-npm publish -i
-npm logout
+
+cd mcp-server
+npm publish --access public -i
 cd -
+
+cd mcp-server-legacy
+npm publish -i
+npm deprecate selenide-mcp@"*" "selenide-mcp has moved to @selenide/mcp. Please update your config to use @selenide/mcp instead."
+cd -
+
+npm logout


### PR DESCRIPTION

## New address:

https://www.npmjs.com/package/@selenide/mcp


## Summary
- Reserves the `@selenide/*` npm namespace (mirrors `@playwright/mcp`) so third parties can't publish confusingly-named scoped packages.
- `mcp-server/` now publishes as `@selenide/mcp` instead of unscoped `selenide-mcp`.
- Added `mcp-server-legacy/` — a thin shim published as `selenide-mcp` that forwards to `@selenide/mcp`, so existing installs/configs keep working while being flagged deprecated.
- Updated `modules/mcp/README.md` install/config examples and the `release` script (publishes both packages, runs `npm deprecate` on the old one each release).

## Test plan
- [x] `npm publish --access public --dry-run` from `mcp-server/` succeeds and confirms `asolntsev` has publish rights on the `@selenide` org.
- [x] `node -c` syntax check on `mcp-server-legacy/index.js`.
- [x] `package.json` files validated with `npm pkg fix` (repository.url normalized).
- [ ] Real `npm publish` of both packages + `npm deprecate` happens on next release via `./release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the scoped `@selenide/mcp` package for new installations and configurations.
  * Added a compatibility shim for the legacy `selenide-mcp` package that forwards to `@selenide/mcp`.

* **Documentation**
  * Updated setup instructions and configuration examples to use `@selenide/mcp`.
  * Added migration guidance and clarified legacy package support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->