### PR TITLE
Sign artifacts via gpg-agent instead of in-process key+password

### DIFF
--- a/gradle/publish-module.gradle
+++ b/gradle/publish-module.gradle
@@ -17,11 +17,6 @@ tasks.withType(Jar).configureEach {
 }
 
 mavenPublishing {
-  if (project.hasProperty("signing.keyId")) {
-    publishToMavenCentral(true)
-    signAllPublications()
-  }
-
   coordinates(project.groupId, project.artifactId, project.version)
   pom {
     name = base.archivesName
@@ -61,5 +56,15 @@ mavenPublishing {
       developerConnection = 'scm:git@github.com:selenide/selenide.git'
       url = 'https://github.com/selenide/selenide'
     }
+  }
+}
+
+if (project.hasProperty("signing.gnupg.keyName")) {
+  mavenPublishing {
+    publishToMavenCentral(true)
+    signAllPublications()
+  }
+  signing {
+    useGpgCmd()
   }
 }

--- a/release
+++ b/release
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -e
 
+# Prerequisites for signing artifacts (publishToMavenCentral below):
+#   - gpg, gpg-agent and a pinentry program installed (e.g. `brew install gnupg pinentry` on macOS,
+#     `apt install gnupg pinentry-curses` on Linux)
+#   - the signing private key imported into your local GPG keyring
+#   - ~/.gradle/gradle.properties containing: signing.gnupg.keyName=<your key id>
+#   - GPG_TTY exported in your shell (e.g. `export GPG_TTY=$(tty)`), so gpg-agent can prompt
+#     for the key passphrase in this terminal
+# See gradle/publish-module.gradle for how signing is wired up (uses signing.useGpgCmd()).
+
 version=$1
 
 if [ -z "$version" ] ; then


### PR DESCRIPTION
## Summary
- Switches Maven Central publishing signature configuration to `signing.useGpgCmd()`, so signing shells out to the local `gpg` binary through `gpg-agent` instead of Gradle's default PGP signatory reading `signing.keyId`/`signing.secretKeyRingFile`/`signing.password` directly.
- This lets a real pinentry prompt (Touch ID / password, via `gpg-agent`'s configured `pinentry-program`) gate every signing operation, instead of relying on a plaintext passphrase sitting in `~/.gradle/gradle.properties`.
- No functional change to what gets published — only how the signing step obtains its private key/passphrase.

## Test plan
- [x] `./gradlew :statics:signMavenPublication -i` locally confirms `gpg` is now invoked via `useGpgCmd()` and produces valid `.asc` signatures (verified with `gpg --verify`).
- [x] Published `7.17.1.1-SNAPSHOT` and `7.17.1.2-SNAPSHOT` to Maven Central end-to-end with this change; all artifacts had valid signatures from the current signing key.
- [ ] CI run on this PR (`check`, `javadocForSite`) — unaffected by this change but should be verified green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Maven Central publishing and artifact signing behavior so publishing is enabled based on provided signing credentials.
  * Added GPG command-based signing support when a GPG key name is supplied.
* **Documentation**
  * Added prerequisite/signing guidance for publishing artifacts, including GPG/pinentry considerations and where signing is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->