### PR TITLE
set Firefox browser size using arguments "-width 1980 -height 1080"

### DIFF
--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.Config;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.chromium.ChromiumOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,13 +42,15 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
     arguments.addAll(createHeadlessArguments(config));
 
     String browserSize = config.browserSize();
-    if (browserSize != null && BrowserResizer.isValidDimension(browserSize)) {
-      arguments.add("--window-size=" + convertToChromiumFormat(browserSize));
+    if (browserSize != null) {
+      Dimension size = BrowserResizer.parseSize(browserSize);
+      arguments.add("--window-size=" + "%s,%s".formatted(size.width, size.height));
     }
 
     String browserPosition = config.browserPosition();
     if (browserPosition != null) {
-      arguments.add("--window-position=" + convertToChromiumFormat(browserPosition));
+      Point position = BrowserResizer.parsePosition(browserPosition);
+      arguments.add("--window-position=" + "%s,%s".formatted(position.x, position.y));
     }
 
     return arguments;
@@ -130,11 +133,6 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
       arguments.add("--mute-audio");
     }
     return arguments;
-  }
-
-  String convertToChromiumFormat(String wxh) {
-    Dimension size = BrowserResizer.parseDimension(wxh);
-    return "%s,%s".formatted(size.width, size.height);
   }
 
   protected Map<String, Object> parsePreferencesFromString(String preferencesString) {

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -5,6 +5,7 @@ import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Point;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chromium.ChromiumOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,16 +45,26 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
     String browserSize = config.browserSize();
     if (browserSize != null) {
       Dimension size = BrowserResizer.parseSize(browserSize);
-      arguments.add("--window-size=" + "%s,%s".formatted(size.width, size.height));
+      arguments.add("--window-size=%s,%s".formatted(size.width, size.height));
     }
 
     String browserPosition = config.browserPosition();
     if (browserPosition != null) {
       Point position = BrowserResizer.parsePosition(browserPosition);
-      arguments.add("--window-position=" + "%s,%s".formatted(position.x, position.y));
+      arguments.add("--window-position=%s,%s".formatted(position.x, position.y));
     }
 
     return arguments;
+  }
+
+  @Override
+  public void setBrowserSize(Config config, WebDriver webdriver) {
+    // not needed: we set Chrome size with "--window-size=" argument
+  }
+
+  @Override
+  public void setBrowserPosition(Config config, WebDriver webdriver) {
+    // not needed: we set Chrome position with "--window-position" argument
   }
 
   protected Map<String, Object> prefs(@Nullable File browserDownloadsFolder, String externalPreferences) {

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.Config;
 import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.chromium.ChromiumOptions;
 import org.slf4j.Logger;
@@ -41,8 +42,9 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
 
     String browserSize = config.browserSize();
     if (browserSize != null && BrowserResizer.isValidDimension(browserSize)) {
-      arguments.add(convertBrowserSizeToChromeFormat(browserSize));
+      arguments.add("--window-size=" + convertToChromiumFormat(browserSize));
     }
+
     return arguments;
   }
 
@@ -125,8 +127,9 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
     return arguments;
   }
 
-  private String convertBrowserSizeToChromeFormat(String browserSize) {
-    return "--window-size=" + browserSize.replace("x", ",");
+  String convertToChromiumFormat(String wxh) {
+    Dimension size = BrowserResizer.parseDimension(wxh);
+    return "%s,%s".formatted(size.width, size.height);
   }
 
   protected Map<String, Object> parsePreferencesFromString(String preferencesString) {

--- a/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactory.java
@@ -45,6 +45,11 @@ public abstract class AbstractChromiumDriverFactory extends AbstractDriverFactor
       arguments.add("--window-size=" + convertToChromiumFormat(browserSize));
     }
 
+    String browserPosition = config.browserPosition();
+    if (browserPosition != null) {
+      arguments.add("--window-position=" + convertToChromiumFormat(browserPosition));
+    }
+
     return arguments;
   }
 

--- a/src/main/java/com/codeborne/selenide/webdriver/BrowserResizer.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/BrowserResizer.java
@@ -19,14 +19,8 @@ class BrowserResizer {
   void adjustBrowserPosition(Config config, WebDriver driver) {
     String browserPosition = config.browserPosition();
     if (browserPosition != null) {
-      if (!isValidDimension(browserPosition)) {
-        throw new IllegalArgumentException(String.format("Browser position %s is incorrect", browserPosition));
-      }
       log.info("Set browser position to {}", browserPosition);
-      String[] coordinates = browserPosition.split("x");
-      int x = parseInt(coordinates[0]);
-      int y = parseInt(coordinates[1]);
-      Point target = new Point(x, y);
+      Point target = parsePosition(browserPosition);
       Point current = driver.manage().window().getPosition();
       if (!current.equals(target)) {
         driver.manage().window().setPosition(target);
@@ -37,14 +31,9 @@ class BrowserResizer {
   void adjustBrowserSize(Config config, WebDriver driver) {
     String browserSize = config.browserSize();
     if (browserSize != null) {
-      if (!isValidDimension(browserSize)) {
-        throw new IllegalArgumentException(String.format("Browser size %s is incorrect", browserSize));
-      }
       log.info("Set browser size to {}", browserSize);
-      String[] dimension = browserSize.split("x");
-      int width = parseInt(dimension[0]);
-      int height = parseInt(dimension[1]);
-      driver.manage().window().setSize(new org.openqa.selenium.Dimension(width, height));
+      Dimension dimension = parseSize(browserSize);
+      driver.manage().window().setSize(dimension);
     }
   }
 
@@ -52,8 +41,21 @@ class BrowserResizer {
     return DIMENSION_REGEX.matcher(dimension).matches();
   }
 
-  static Dimension parseDimension(String dimension) {
+  static Dimension parseSize(String size) {
+    int[] wh = parse("browser size", size);
+    return new Dimension(wh[0], wh[1]);
+  }
+
+  static Point parsePosition(String position) {
+    int[] xy = parse("browser position", position);
+    return new Point(xy[0], xy[1]);
+  }
+
+  private static int[] parse(String name, String dimension) {
     Matcher matcher = DIMENSION_REGEX.matcher(dimension);
-    return new Dimension(parseInt(matcher.replaceFirst("$1")), parseInt(matcher.group(2)));
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(String.format("Invalid %s: \"%s\". Expected format: \"300x200\".", name, dimension));
+    }
+    return new int[] {parseInt(matcher.replaceFirst("$1")), parseInt(matcher.group(2))};
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/BrowserResizer.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/BrowserResizer.java
@@ -16,7 +16,7 @@ class BrowserResizer {
   private static final Pattern DIMENSION_REGEX = Pattern.compile("(-?\\d+)x(-?\\d+)");
   private static final Logger log = LoggerFactory.getLogger(BrowserResizer.class);
 
-  void adjustBrowserPosition(Config config, WebDriver driver) {
+  static void adjustBrowserPosition(Config config, WebDriver driver) {
     String browserPosition = config.browserPosition();
     if (browserPosition != null) {
       log.info("Set browser position to {}", browserPosition);
@@ -28,7 +28,7 @@ class BrowserResizer {
     }
   }
 
-  void adjustBrowserSize(Config config, WebDriver driver) {
+  static void adjustBrowserSize(Config config, WebDriver driver) {
     String browserSize = config.browserSize();
     if (browserSize != null) {
       log.info("Set browser size to {}", browserSize);

--- a/src/main/java/com/codeborne/selenide/webdriver/BrowserResizer.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/BrowserResizer.java
@@ -1,15 +1,19 @@
 package com.codeborne.selenide.webdriver;
 
 import com.codeborne.selenide.Config;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.lang.Integer.parseInt;
+
 class BrowserResizer {
-  private static final Pattern DIMENSION_REGEX = Pattern.compile("-?\\d+x-?\\d+");
+  private static final Pattern DIMENSION_REGEX = Pattern.compile("(-?\\d+)x(-?\\d+)");
   private static final Logger log = LoggerFactory.getLogger(BrowserResizer.class);
 
   void adjustBrowserPosition(Config config, WebDriver driver) {
@@ -20,8 +24,8 @@ class BrowserResizer {
       }
       log.info("Set browser position to {}", browserPosition);
       String[] coordinates = browserPosition.split("x");
-      int x = Integer.parseInt(coordinates[0]);
-      int y = Integer.parseInt(coordinates[1]);
+      int x = parseInt(coordinates[0]);
+      int y = parseInt(coordinates[1]);
       Point target = new Point(x, y);
       Point current = driver.manage().window().getPosition();
       if (!current.equals(target)) {
@@ -38,13 +42,18 @@ class BrowserResizer {
       }
       log.info("Set browser size to {}", browserSize);
       String[] dimension = browserSize.split("x");
-      int width = Integer.parseInt(dimension[0]);
-      int height = Integer.parseInt(dimension[1]);
+      int width = parseInt(dimension[0]);
+      int height = parseInt(dimension[1]);
       driver.manage().window().setSize(new org.openqa.selenium.Dimension(width, height));
     }
   }
 
   static boolean isValidDimension(String dimension) {
     return DIMENSION_REGEX.matcher(dimension).matches();
+  }
+
+  static Dimension parseDimension(String dimension) {
+    Matcher matcher = DIMENSION_REGEX.matcher(dimension);
+    return new Dimension(parseInt(matcher.replaceFirst("$1")), parseInt(matcher.group(2)));
   }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/DriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/DriverFactory.java
@@ -14,4 +14,12 @@ public interface DriverFactory {
                                          @Nullable Proxy proxy, @Nullable File browserDownloadsFolder);
 
   WebDriver create(Config config, Browser browser, @Nullable Proxy proxy, @Nullable File browserDownloadsFolder);
+
+  default void setBrowserSize(Config config, WebDriver webdriver) {
+    BrowserResizer.adjustBrowserSize(config, webdriver);
+  }
+
+  default void setBrowserPosition(Config config, WebDriver webdriver) {
+    BrowserResizer.adjustBrowserPosition(config, webdriver);
+  }
 }

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -84,6 +84,11 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
     }
   }
 
+  @Override
+  public void setBrowserSize(Config config, WebDriver webdriver) {
+    // not needed: we set Firefox size with "-width" and "-height" arguments
+  }
+
   protected void setupBrowserBinary(Config config, FirefoxOptions firefoxOptions) {
     if (isNotEmpty(config.browserBinary())) {
       log.info("Using browser binary: {}", config.browserBinary());

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -78,8 +78,8 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
 
   private void addFirefoxArguments(Config config, FirefoxOptions initialOptions) {
     String browserSize = config.browserSize();
-    if (browserSize != null && BrowserResizer.isValidDimension(browserSize)) {
-      Dimension size = BrowserResizer.parseDimension(browserSize);
+    if (browserSize != null) {
+      Dimension size = BrowserResizer.parseSize(browserSize);
       initialOptions.addArguments("-width", String.valueOf(size.width), "-height", String.valueOf(size.height));
     }
   }

--- a/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/FirefoxDriverFactory.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Config;
 import org.apache.commons.io.IOUtils;
 import org.jspecify.annotations.Nullable;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.SessionNotCreatedException;
 import org.openqa.selenium.WebDriver;
@@ -54,6 +55,7 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
     FirefoxOptions initialOptions = new FirefoxOptions();
     initialOptions.enableBiDi();
     setHeadless(config, initialOptions);
+    addFirefoxArguments(config, initialOptions);
     setupBrowserBinary(config, initialOptions);
     setupPreferences(initialOptions);
 
@@ -71,6 +73,14 @@ public class FirefoxDriverFactory extends AbstractDriverFactory {
   protected void setHeadless(Config config, FirefoxOptions initialOptions) {
     if (config.headless()) {
       initialOptions.addArguments("-headless");
+    }
+  }
+
+  private void addFirefoxArguments(Config config, FirefoxOptions initialOptions) {
+    String browserSize = config.browserSize();
+    if (browserSize != null && BrowserResizer.isValidDimension(browserSize)) {
+      Dimension size = BrowserResizer.parseDimension(browserSize);
+      initialOptions.addArguments("-width", String.valueOf(size.width), "-height", String.valueOf(size.height));
     }
   }
 

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -34,7 +34,6 @@ public class WebDriverFactory {
 
   private final Map<String, Class<? extends AbstractDriverFactory>> factories = factories();
   private final RemoteDriverFactory remoteDriverFactory = new RemoteDriverFactory();
-  private final BrowserResizer browserResizer = new BrowserResizer();
 
   private Map<String, Class<? extends AbstractDriverFactory>> factories() {
     return Map.of(
@@ -53,36 +52,14 @@ public class WebDriverFactory {
       currentThread().getId(), config.browser(), config.browserVersion(), config.browserSize(), remote, browserDownloadsFolder);
 
     Browser browser = new Browser(config.browser(), config.headless());
-    WebDriver webdriver = createWebDriverInstance(config, browser, proxy, browserDownloadsFolder);
-    if (needBrowserResize(webdriver)) {
-      browserResizer.adjustBrowserSize(config, webdriver);
-    }
-    if (needBrowserReposition(webdriver)) {
-      browserResizer.adjustBrowserPosition(config, webdriver);
-    }
+    DriverFactory factory = findFactory(browser);
+    WebDriver webdriver = createWebDriverInstance(factory, config, browser, proxy, browserDownloadsFolder);
+    factory.setBrowserSize(config, webdriver);
+    factory.setBrowserPosition(config, webdriver);
     setLoadTimeout(config, webdriver);
 
     logVersions(webdriver);
     return webdriver;
-  }
-
-  private boolean needBrowserResize(WebDriver webdriver) {
-    Browser browser = detectBrowser(webdriver);
-    return !browser.isChromium() && !"msedge".equals(browser.name) && !browser.isFirefox();
-  }
-
-  private boolean needBrowserReposition(WebDriver webdriver) {
-    Browser browser = detectBrowser(webdriver);
-    return !browser.isChromium();
-  }
-
-  private static Browser detectBrowser(WebDriver webdriver) {
-    String browserName = "";
-    if (webdriver instanceof HasCapabilities hasCapabilities) {
-      Capabilities capabilities = hasCapabilities.getCapabilities();
-      browserName = capabilities.getBrowserName();
-    }
-    return new Browser(browserName, false);
   }
 
   private void setLoadTimeout(Config config, WebDriver webdriver) {
@@ -100,10 +77,10 @@ public class WebDriverFactory {
     }
   }
 
-  private WebDriver createWebDriverInstance(Config config, Browser browser,
+  private WebDriver createWebDriverInstance(DriverFactory webdriverFactory,
+                                            Config config, Browser browser,
                                             @Nullable Proxy proxy,
                                             @Nullable File browserDownloadsFolder) {
-    DriverFactory webdriverFactory = findFactory(browser);
 
     if (config.remote() != null) {
       MutableCapabilities capabilities = webdriverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -57,7 +57,9 @@ public class WebDriverFactory {
     if (needBrowserResize(webdriver)) {
       browserResizer.adjustBrowserSize(config, webdriver);
     }
-    browserResizer.adjustBrowserPosition(config, webdriver);
+    if (needBrowserReposition(webdriver)) {
+      browserResizer.adjustBrowserPosition(config, webdriver);
+    }
     setLoadTimeout(config, webdriver);
 
     logVersions(webdriver);
@@ -67,6 +69,11 @@ public class WebDriverFactory {
   private boolean needBrowserResize(WebDriver webdriver) {
     Browser browser = detectBrowser(webdriver);
     return !browser.isChromium() && !"msedge".equals(browser.name) && !browser.isFirefox();
+  }
+
+  private boolean needBrowserReposition(WebDriver webdriver) {
+    Browser browser = detectBrowser(webdriver);
+    return !browser.isChromium();
   }
 
   private static Browser detectBrowser(WebDriver webdriver) {

--- a/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
+++ b/src/main/java/com/codeborne/selenide/webdriver/WebDriverFactory.java
@@ -65,13 +65,17 @@ public class WebDriverFactory {
   }
 
   private boolean needBrowserResize(WebDriver webdriver) {
+    Browser browser = detectBrowser(webdriver);
+    return !browser.isChromium() && !"msedge".equals(browser.name) && !browser.isFirefox();
+  }
+
+  private static Browser detectBrowser(WebDriver webdriver) {
     String browserName = "";
     if (webdriver instanceof HasCapabilities hasCapabilities) {
       Capabilities capabilities = hasCapabilities.getCapabilities();
       browserName = capabilities.getBrowserName();
     }
-    Browser browser = new Browser(browserName, false);
-    return !browser.isChromium() && !"msedge".equals(browserName);
+    return new Browser(browserName, false);
   }
 
   private void setLoadTimeout(Config config, WebDriver webdriver) {

--- a/src/test/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactoryTest.java
@@ -13,12 +13,6 @@ class AbstractChromiumDriverFactoryTest {
   private final SelenideConfig config = new SelenideConfig().browser("firefox").downloadsFolder("not-used");
 
   @Test
-  void convertToChromiumFormat() {
-    assertThat(factory.convertToChromiumFormat("100x200")).isEqualTo("100,200");
-    assertThat(factory.convertToChromiumFormat("200x67")).isEqualTo("200,67");
-  }
-
-  @Test
   void enablesProxyForLocalhost() {
     List<String> args = factory.createChromiumArguments(config, "");
 

--- a/src/test/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactoryTest.java
@@ -1,0 +1,16 @@
+package com.codeborne.selenide.webdriver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+
+class AbstractChromiumDriverFactoryTest {
+  private final AbstractChromiumDriverFactory factory = spy();
+
+  @Test
+  void convertToChromiumFormat() {
+    assertThat(factory.convertToChromiumFormat("100x200")).isEqualTo("100,200");
+    assertThat(factory.convertToChromiumFormat("200x67")).isEqualTo("200,67");
+  }
+}

--- a/src/test/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/AbstractChromiumDriverFactoryTest.java
@@ -1,16 +1,45 @@
 package com.codeborne.selenide.webdriver;
 
+import com.codeborne.selenide.SelenideConfig;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 
 class AbstractChromiumDriverFactoryTest {
   private final AbstractChromiumDriverFactory factory = spy();
+  private final SelenideConfig config = new SelenideConfig().browser("firefox").downloadsFolder("not-used");
 
   @Test
   void convertToChromiumFormat() {
     assertThat(factory.convertToChromiumFormat("100x200")).isEqualTo("100,200");
     assertThat(factory.convertToChromiumFormat("200x67")).isEqualTo("200,67");
+  }
+
+  @Test
+  void enablesProxyForLocalhost() {
+    List<String> args = factory.createChromiumArguments(config, "");
+
+    assertThat(args).contains("--proxy-bypass-list=<-loopback>");
+  }
+
+  @Test
+  void setsBrowserSizeWithChromiumArgument() {
+    config.browserSize("1096x812");
+
+    List<String> args = factory.createChromiumArguments(config, "");
+
+    assertThat(args).contains("--window-size=1096,812");
+  }
+
+  @Test
+  void setsBrowserPositionWithChromiumArgument() {
+    config.browserPosition("200x300");
+
+    List<String> args = factory.createChromiumArguments(config, "");
+
+    assertThat(args).contains("--window-position=200,300");
   }
 }

--- a/src/test/java/com/codeborne/selenide/webdriver/BrowserResizerTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/BrowserResizerTest.java
@@ -13,8 +13,10 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -33,12 +35,30 @@ final class BrowserResizerTest {
   }
 
   @Test
+  void canConfigureBrowserWindowSize_null() {
+    config.browserSize(null);
+
+    factory.adjustBrowserSize(config, webdriver);
+
+    verify(webdriver.manage().window(), never()).setSize(any());
+  }
+
+  @Test
   void canConfigureBrowserWindowPosition() {
     config.browserPosition("20x40");
 
     factory.adjustBrowserPosition(config, webdriver);
 
     verify(webdriver.manage().window()).setPosition(new Point(20, 40));
+  }
+
+  @Test
+  void canConfigureBrowserWindowPosition_null() {
+    config.browserPosition(null);
+
+    factory.adjustBrowserPosition(config, webdriver);
+
+    verify(webdriver.manage().window(), never()).setPosition(any());
   }
 
   @Test
@@ -59,13 +79,19 @@ final class BrowserResizerTest {
       .hasMessage("Browser position 1600,800 is incorrect");
   }
 
-  @ParameterizedTest
-  @MethodSource("provideSize")
-  void validateDimensionTest(String input, boolean expected) {
-    assertThat(BrowserResizer.isValidDimension(input)).isEqualTo(expected);
+  @Test
+  void parseDimension() {
+    assertThat(BrowserResizer.parseDimension("1920x1080")).isEqualTo(new Dimension(1920, 1080));
+    assertThat(BrowserResizer.parseDimension("-200x-100")).isEqualTo(new Dimension(-200, -100));
   }
 
-  private static Stream<Arguments> provideSize() {
+  @ParameterizedTest
+  @MethodSource("browserSize")
+  void validateDimensionTest(String input, boolean valid) {
+    assertThat(BrowserResizer.isValidDimension(input)).isEqualTo(valid);
+  }
+
+  private static Stream<Arguments> browserSize() {
     return Stream.of(
       Arguments.of("1920x1080", true),
       Arguments.of("-200x100", true),

--- a/src/test/java/com/codeborne/selenide/webdriver/BrowserResizerTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/BrowserResizerTest.java
@@ -17,11 +17,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 final class BrowserResizerTest {
-  private final BrowserResizer factory = spy(new BrowserResizer());
   private final WebDriver webdriver = mock(WebDriver.class, RETURNS_DEEP_STUBS);
   private final SelenideConfig config = new SelenideConfig();
 
@@ -29,7 +27,7 @@ final class BrowserResizerTest {
   void canConfigureBrowserWindowSize() {
     config.browserSize("1600x800");
 
-    factory.adjustBrowserSize(config, webdriver);
+    BrowserResizer.adjustBrowserSize(config, webdriver);
 
     verify(webdriver.manage().window()).setSize(new Dimension(1600, 800));
   }
@@ -38,7 +36,7 @@ final class BrowserResizerTest {
   void canConfigureBrowserWindowSize_null() {
     config.browserSize(null);
 
-    factory.adjustBrowserSize(config, webdriver);
+    BrowserResizer.adjustBrowserSize(config, webdriver);
 
     verify(webdriver.manage().window(), never()).setSize(any());
   }
@@ -47,7 +45,7 @@ final class BrowserResizerTest {
   void canConfigureBrowserWindowPosition() {
     config.browserPosition("20x40");
 
-    factory.adjustBrowserPosition(config, webdriver);
+    BrowserResizer.adjustBrowserPosition(config, webdriver);
 
     verify(webdriver.manage().window()).setPosition(new Point(20, 40));
   }
@@ -56,7 +54,7 @@ final class BrowserResizerTest {
   void canConfigureBrowserWindowPosition_null() {
     config.browserPosition(null);
 
-    factory.adjustBrowserPosition(config, webdriver);
+    BrowserResizer.adjustBrowserPosition(config, webdriver);
 
     verify(webdriver.manage().window(), never()).setPosition(any());
   }
@@ -65,7 +63,7 @@ final class BrowserResizerTest {
   void throwErrorIfBrowserWindowSizeIsIncorrect() {
     config.browserSize("1600,800");
 
-    assertThatThrownBy(() -> factory.adjustBrowserSize(config, webdriver))
+    assertThatThrownBy(() -> BrowserResizer.adjustBrowserSize(config, webdriver))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Invalid browser size: \"1600,800\". Expected format: \"300x200\".");
   }
@@ -74,7 +72,7 @@ final class BrowserResizerTest {
   void throwErrorIfBrowserPositionIsIncorrect() {
     config.browserPosition("1600,800");
 
-    assertThatThrownBy(() -> factory.adjustBrowserPosition(config, webdriver))
+    assertThatThrownBy(() -> BrowserResizer.adjustBrowserPosition(config, webdriver))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessage("Invalid browser position: \"1600,800\". Expected format: \"300x200\".");
   }

--- a/src/test/java/com/codeborne/selenide/webdriver/BrowserResizerTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/BrowserResizerTest.java
@@ -67,7 +67,7 @@ final class BrowserResizerTest {
 
     assertThatThrownBy(() -> factory.adjustBrowserSize(config, webdriver))
       .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Browser size 1600,800 is incorrect");
+      .hasMessage("Invalid browser size: \"1600,800\". Expected format: \"300x200\".");
   }
 
   @Test
@@ -76,13 +76,13 @@ final class BrowserResizerTest {
 
     assertThatThrownBy(() -> factory.adjustBrowserPosition(config, webdriver))
       .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Browser position 1600,800 is incorrect");
+      .hasMessage("Invalid browser position: \"1600,800\". Expected format: \"300x200\".");
   }
 
   @Test
   void parseDimension() {
-    assertThat(BrowserResizer.parseDimension("1920x1080")).isEqualTo(new Dimension(1920, 1080));
-    assertThat(BrowserResizer.parseDimension("-200x-100")).isEqualTo(new Dimension(-200, -100));
+    assertThat(BrowserResizer.parseSize("1920x1080")).isEqualTo(new Dimension(1920, 1080));
+    assertThat(BrowserResizer.parseSize("-200x-100")).isEqualTo(new Dimension(-200, -100));
   }
 
   @ParameterizedTest

--- a/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
@@ -20,6 +20,7 @@ import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBro
 import static com.codeborne.selenide.webdriver.SeleniumCapabilitiesHelper.getBrowserLaunchPrefs;
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 @Isolated("mutates JVM-global System properties")
@@ -145,10 +146,9 @@ final class FirefoxDriverFactoryTest {
   void setsBrowserSizeWithFirefoxArgument_invalidDimension() {
     config.browserSize("600,500");
 
-    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
-
-    List<String> args = args(options);
-    assertThat(args).isNull();
+    assertThatThrownBy(() -> driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid browser size: \"600,500\". Expected format: \"300x200\".");
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
+++ b/src/test/java/com/codeborne/selenide/webdriver/FirefoxDriverFactoryTest.java
@@ -5,7 +5,6 @@ import com.codeborne.selenide.SelenideConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
@@ -99,8 +98,8 @@ final class FirefoxDriverFactoryTest {
   @Test
   void browserBinaryCanBeSet() {
     config.browserBinary("c:/browser.exe");
-    Capabilities caps = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
-    Map options = (Map) caps.asMap().get(FirefoxOptions.FIREFOX_OPTIONS);
+    FirefoxOptions caps = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
+    Map<String, Object> options = firefoxOptions(caps);
     assertThat(options.get("binary")).isEqualTo("c:/browser.exe");
   }
 
@@ -119,7 +118,37 @@ final class FirefoxDriverFactoryTest {
     Map<String, Object> prefs = prefs(options);
     assertThat(prefs.get("network.proxy.no_proxies_on")).isEqualTo("");
     assertThat(prefs.get("network.proxy.allow_hijacking_localhost")).isEqualTo(true);
-    assertThat(options.asMap().get("firefox_profile")).isNull();
+    assertThat(options.asMap()).doesNotContainKey("firefox_profile");
+  }
+
+  @Test
+  void setsBrowserSizeWithFirefoxArgument() {
+    config.browserSize("1096x812");
+
+    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
+
+    List<String> args = args(options);
+    assertThat(args).containsExactly("-width", "1096", "-height", "812");
+  }
+
+  @Test
+  void setsBrowserSizeWithFirefoxArgument_null() {
+    config.browserSize(null);
+
+    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
+
+    List<String> args = args(options);
+    assertThat(args).isNull();
+  }
+
+  @Test
+  void setsBrowserSizeWithFirefoxArgument_invalidDimension() {
+    config.browserSize("600,500");
+
+    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, browserDownloadsFolder);
+
+    List<String> args = args(options);
+    assertThat(args).isNull();
   }
 
   @Test
@@ -168,10 +197,9 @@ final class FirefoxDriverFactoryTest {
     firefoxOptions.addPreference("int pref", 10);
     config.browserCapabilities(firefoxOptions);
 
-    Map<String, Object> options = driverFactory.createCapabilities(config, browser, proxy, null).asMap();
-    assertThat(options.get("moz:firefoxOptions")).isNotNull();
+    FirefoxOptions options = driverFactory.createCapabilities(config, browser, proxy, null);
 
-    Map<String, Object> prefs = (Map<String, Object>) ((Map<String, Object>) options.get("moz:firefoxOptions")).get("prefs");
+    Map<String, Object> prefs = prefs(options);
     assertThat(prefs.get("general.useragent.override")).isEqualTo("my agent");
     assertThat(prefs.get("boolean pref")).isEqualTo(true);
     assertThat(prefs.get("int pref")).isEqualTo(10);
@@ -188,6 +216,12 @@ final class FirefoxDriverFactoryTest {
     Map<String, Object> prefsMap = getBrowserLaunchPrefs(FirefoxOptions.FIREFOX_OPTIONS, firefoxOptionsMerged);
 
     assertThat(prefsMap).containsEntry("pdfjs.disabled", false);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> args(FirefoxOptions options) {
+    Map<String, Object> firefoxOptions = firefoxOptions(options);
+    return (List<String>) firefoxOptions.get("args");
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Seems it works faster than opening the browser and then changing its size with WebDriver methods. I hope it will speed up our FF tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Browser window size and position settings are now applied consistently when launching Chromium-based browsers.
  - Firefox launches with the configured browser dimensions.
  - Negative dimension values are supported where valid.

- **Bug Fixes**
  - Improved validation for browser size and position formats.
  - Invalid dimensions now produce clearer error messages.
  - Browser sizing and positioning are handled more reliably across supported drivers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->