### PR TITLE
add "or" for object conditions

### DIFF
--- a/modules/selenoid/src/test/java/it/selenoid/SelenoidClipboardTest.java
+++ b/modules/selenoid/src/test/java/it/selenoid/SelenoidClipboardTest.java
@@ -4,9 +4,10 @@ import com.codeborne.selenide.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.opentest4j.AssertionFailedError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 import static com.codeborne.selenide.ClipboardConditions.content;
 import static com.codeborne.selenide.Condition.attribute;
@@ -49,21 +50,11 @@ public class SelenoidClipboardTest {
     assertClipboardContains(multilineText);
   }
 
-  @SuppressWarnings("ErrorNotRethrown")
   private void assertClipboardContains(String expectedText) {
-    try {
-      clipboard().shouldHave(content(expectedText));
-      assertThat(clipboard().getText()).isEqualTo(expectedText);
-    }
-    catch (AssertionFailedError clipboardWasEmpty) {
-      log.info("Clipboard content was not expected {}", clipboardWasEmpty.toString());
+    // Selenide style
+    clipboard().shouldHave(content(expectedText).or(content("")));
 
-      clipboard().shouldHave(content("")
-        .because("Seems to be a bug in Selenoid. We cannot do anything, just ignore it."));
-
-      assertThat(clipboard().getText())
-        .as("Seems to be a bug in Selenoid. We cannot do anything, just ignore it.")
-        .isEqualTo("");
-    }
+    // AssertJ style
+    assertThat(List.of(expectedText, "")).contains(clipboard().getText());
   }
 }

--- a/src/main/java/com/codeborne/selenide/ObjectCondition.java
+++ b/src/main/java/com/codeborne/selenide/ObjectCondition.java
@@ -19,7 +19,7 @@ public interface ObjectCondition<T> {
   String describe(T object);
 
   default String message(T object) {
-    return describe(object) + " " + description();
+    return describe(object) + " should have " + description();
   }
 
   default CheckResult result(T object, boolean met, @Nullable Object actualValue) {

--- a/src/main/java/com/codeborne/selenide/ObjectCondition.java
+++ b/src/main/java/com/codeborne/selenide/ObjectCondition.java
@@ -9,7 +9,13 @@ import static com.codeborne.selenide.CheckResult.rejected;
 public interface ObjectCondition<T> {
   String description();
 
-  String negativeDescription();
+  /**
+   * @deprecated not used anymore. Just remove it.
+   */
+  @Deprecated(forRemoval = true)
+  default String negativeDescription() {
+    return description();
+  }
 
   CheckResult check(T object);
 

--- a/src/main/java/com/codeborne/selenide/ObjectCondition.java
+++ b/src/main/java/com/codeborne/selenide/ObjectCondition.java
@@ -30,4 +30,7 @@ public interface ObjectCondition<T> {
     return new ExplainedObjectCondition<>(this, message);
   }
 
+  default ObjectCondition<T> or(ObjectCondition<T> alternative) {
+    return new Or<>(this, alternative);
+  }
 }

--- a/src/main/java/com/codeborne/selenide/Or.java
+++ b/src/main/java/com/codeborne/selenide/Or.java
@@ -23,7 +23,7 @@ class Or<T> implements ObjectCondition<T> {
 
   @Override
   public String negativeDescription() {
-    return "not(%s)".formatted(description());
+    return description();
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/Or.java
+++ b/src/main/java/com/codeborne/selenide/Or.java
@@ -22,11 +22,6 @@ class Or<T> implements ObjectCondition<T> {
   }
 
   @Override
-  public String negativeDescription() {
-    return description();
-  }
-
-  @Override
   public CheckResult check(T object) {
     List<CheckResult> results = new ArrayList<>();
     for (ObjectCondition<T> c : List.of(first, second)) {

--- a/src/main/java/com/codeborne/selenide/Or.java
+++ b/src/main/java/com/codeborne/selenide/Or.java
@@ -1,0 +1,55 @@
+package com.codeborne.selenide;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.codeborne.selenide.CheckResult.Verdict.ACCEPT;
+import static com.codeborne.selenide.CheckResult.Verdict.REJECT;
+import static java.util.stream.Collectors.joining;
+
+class Or<T> implements ObjectCondition<T> {
+  private final ObjectCondition<T> first;
+  private final ObjectCondition<T> second;
+
+  Or(ObjectCondition<T> first, ObjectCondition<T> second) {
+    this.first = first;
+    this.second = second;
+  }
+
+  @Override
+  public String description() {
+    return "%s or %s".formatted(first.description(), second.description());
+  }
+
+  @Override
+  public String negativeDescription() {
+    return "not(%s)".formatted(description());
+  }
+
+  @Override
+  public CheckResult check(T object) {
+    List<CheckResult> results = new ArrayList<>();
+    for (ObjectCondition<T> c : List.of(first, second)) {
+      CheckResult check = c.check(object);
+      if (check.verdict() == ACCEPT) {
+        return check;
+      }
+      else {
+        results.add(check);
+      }
+    }
+
+    String actualValues = results.stream().map(check -> String.valueOf(check.actualValue())).collect(joining(", "));
+    return new CheckResult(REJECT, actualValues);
+  }
+
+  @Override
+  public String expectedValue() {
+    return "%s or %s".formatted(first.expectedValue(), second.expectedValue());
+  }
+
+  @Override
+  public String describe(T object) {
+    return first.describe(object);
+  }
+}

--- a/src/main/java/com/codeborne/selenide/conditions/ExplainedObjectCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/ExplainedObjectCondition.java
@@ -19,11 +19,6 @@ public class ExplainedObjectCondition<T> implements ObjectCondition<T> {
   }
 
   @Override
-  public String negativeDescription() {
-    return delegate.negativeDescription() + " (because " + message + ")";
-  }
-
-  @Override
   public CheckResult check(T object) {
     return delegate.check(object);
   }

--- a/src/main/java/com/codeborne/selenide/conditions/clipboard/Content.java
+++ b/src/main/java/com/codeborne/selenide/conditions/clipboard/Content.java
@@ -13,12 +13,12 @@ public class Content implements ObjectCondition<Clipboard> {
 
   @Override
   public String description() {
-    return String.format("should have content '%s'", expectedContent);
+    return String.format("content '%s'", expectedContent);
   }
 
   @Override
   public String negativeDescription() {
-    return String.format("should not have content '%s'", expectedContent);
+    return String.format("content '%s'", expectedContent);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/clipboard/Content.java
+++ b/src/main/java/com/codeborne/selenide/conditions/clipboard/Content.java
@@ -17,11 +17,6 @@ public class Content implements ObjectCondition<Clipboard> {
   }
 
   @Override
-  public String negativeDescription() {
-    return String.format("content '%s'", expectedContent);
-  }
-
-  @Override
   public CheckResult check(Clipboard clipboard) {
     String clipboardText = clipboard.getText();
     return result(clipboard, clipboardText.equals(expectedContent), clipboardText);

--- a/src/main/java/com/codeborne/selenide/conditions/cookiestore/CookieWithName.java
+++ b/src/main/java/com/codeborne/selenide/conditions/cookiestore/CookieWithName.java
@@ -18,11 +18,6 @@ public class CookieWithName implements ObjectCondition<CookieStore> {
   }
 
   @Override
-  public String negativeDescription() {
-    return delegate.negativeDescription();
-  }
-
-  @Override
   @Nullable
   public String expectedValue() {
     return delegate.expectedValue();

--- a/src/main/java/com/codeborne/selenide/conditions/cookiestore/CookieWithNameAndValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/cookiestore/CookieWithNameAndValue.java
@@ -18,11 +18,6 @@ public class CookieWithNameAndValue implements ObjectCondition<CookieStore> {
   }
 
   @Override
-  public String negativeDescription() {
-    return delegate.negativeDescription();
-  }
-
-  @Override
   @Nullable
   public String expectedValue() {
     return delegate.expectedValue();

--- a/src/main/java/com/codeborne/selenide/conditions/localstorage/Item.java
+++ b/src/main/java/com/codeborne/selenide/conditions/localstorage/Item.java
@@ -16,11 +16,6 @@ public class Item implements ObjectCondition<LocalStorage> {
     return String.format("item '%s'", item);
   }
 
-  @Override
-  public String negativeDescription() {
-    return String.format("item '%s'", item);
-  }
-
   private String actualValue(LocalStorage localStorage) {
     return localStorage.getItems().toString();
   }

--- a/src/main/java/com/codeborne/selenide/conditions/localstorage/Item.java
+++ b/src/main/java/com/codeborne/selenide/conditions/localstorage/Item.java
@@ -13,12 +13,12 @@ public class Item implements ObjectCondition<LocalStorage> {
 
   @Override
   public String description() {
-    return String.format("should have item '%s'", item);
+    return String.format("item '%s'", item);
   }
 
   @Override
   public String negativeDescription() {
-    return String.format("should not have item '%s'", item);
+    return String.format("item '%s'", item);
   }
 
   private String actualValue(LocalStorage localStorage) {

--- a/src/main/java/com/codeborne/selenide/conditions/localstorage/ItemWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/localstorage/ItemWithValue.java
@@ -20,11 +20,6 @@ public class ItemWithValue implements ObjectCondition<LocalStorage> {
     return String.format("item '%s' with value '%s'", item, value);
   }
 
-  @Override
-  public String negativeDescription() {
-    return String.format("item '%s' with value '%s'", item, value);
-  }
-
   private String actualValue(LocalStorage localStorage) {
     return localStorage.getItems().toString();
   }

--- a/src/main/java/com/codeborne/selenide/conditions/localstorage/ItemWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/localstorage/ItemWithValue.java
@@ -17,12 +17,12 @@ public class ItemWithValue implements ObjectCondition<LocalStorage> {
 
   @Override
   public String description() {
-    return String.format("should have item '%s' with value '%s'", item, value);
+    return String.format("item '%s' with value '%s'", item, value);
   }
 
   @Override
   public String negativeDescription() {
-    return String.format("should not have item '%s' with value '%s'", item, value);
+    return String.format("item '%s' with value '%s'", item, value);
   }
 
   private String actualValue(LocalStorage localStorage) {

--- a/src/main/java/com/codeborne/selenide/conditions/sessionstorage/Item.java
+++ b/src/main/java/com/codeborne/selenide/conditions/sessionstorage/Item.java
@@ -17,11 +17,6 @@ public class Item implements ObjectCondition<SessionStorage> {
     return String.format("item '%s'", item);
   }
 
-  @Override
-  public String negativeDescription() {
-    return String.format("item '%s'", item);
-  }
-
   private String actualValue(SessionStorage sessionStorage) {
     return sessionStorage.getItems().toString();
   }

--- a/src/main/java/com/codeborne/selenide/conditions/sessionstorage/Item.java
+++ b/src/main/java/com/codeborne/selenide/conditions/sessionstorage/Item.java
@@ -14,12 +14,12 @@ public class Item implements ObjectCondition<SessionStorage> {
 
   @Override
   public String description() {
-    return String.format("should have item '%s'", item);
+    return String.format("item '%s'", item);
   }
 
   @Override
   public String negativeDescription() {
-    return String.format("should not have item '%s'", item);
+    return String.format("item '%s'", item);
   }
 
   private String actualValue(SessionStorage sessionStorage) {

--- a/src/main/java/com/codeborne/selenide/conditions/sessionstorage/ItemWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/sessionstorage/ItemWithValue.java
@@ -21,11 +21,6 @@ public class ItemWithValue implements ObjectCondition<SessionStorage> {
     return String.format("item '%s' with value '%s'", item, value);
   }
 
-  @Override
-  public String negativeDescription() {
-    return String.format("item '%s' with value '%s'", item, value);
-  }
-
   private String actualValue(SessionStorage sessionStorage) {
     return sessionStorage.getItems().toString();
   }

--- a/src/main/java/com/codeborne/selenide/conditions/sessionstorage/ItemWithValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/sessionstorage/ItemWithValue.java
@@ -18,12 +18,12 @@ public class ItemWithValue implements ObjectCondition<SessionStorage> {
 
   @Override
   public String description() {
-    return String.format("should have item '%s' with value '%s'", item, value);
+    return String.format("item '%s' with value '%s'", item, value);
   }
 
   @Override
   public String negativeDescription() {
-    return String.format("should not have item '%s' with value '%s'", item, value);
+    return String.format("item '%s' with value '%s'", item, value);
   }
 
   private String actualValue(SessionStorage sessionStorage) {

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithName.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithName.java
@@ -19,11 +19,6 @@ public class CookieWithName implements ObjectCondition<WebDriver> {
   }
 
   @Override
-  public String negativeDescription() {
-    return String.format("cookie with name \"%s\"", expectedName);
-  }
-
-  @Override
   public CheckResult check(WebDriver webDriver) {
     Cookie cookie = webDriver.manage().getCookieNamed(expectedName);
     return result(webDriver, cookie != null, actualValue(webDriver));

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithName.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithName.java
@@ -15,12 +15,12 @@ public class CookieWithName implements ObjectCondition<WebDriver> {
 
   @Override
   public String description() {
-    return String.format("should have a cookie with name \"%s\"", expectedName);
+    return String.format("cookie with name \"%s\"", expectedName);
   }
 
   @Override
   public String negativeDescription() {
-    return String.format("should not have cookie with name \"%s\"", expectedName);
+    return String.format("cookie with name \"%s\"", expectedName);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithNameAndValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithNameAndValue.java
@@ -19,12 +19,12 @@ public class CookieWithNameAndValue implements ObjectCondition<WebDriver> {
 
   @Override
   public String description() {
-    return String.format("should have a cookie with name \"%s\" and value \"%s\"", name, value);
+    return String.format("cookie with name \"%s\" and value \"%s\"", name, value);
   }
 
   @Override
   public String negativeDescription() {
-    return String.format("should not have cookie with name \"%s\" and value \"%s\"", name, value);
+    return String.format("cookie with name \"%s\" and value \"%s\"", name, value);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithNameAndValue.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CookieWithNameAndValue.java
@@ -23,11 +23,6 @@ public class CookieWithNameAndValue implements ObjectCondition<WebDriver> {
   }
 
   @Override
-  public String negativeDescription() {
-    return String.format("cookie with name \"%s\" and value \"%s\"", name, value);
-  }
-
-  @Override
   public CheckResult check(WebDriver webDriver) {
     Cookie cookie = webDriver.manage().getCookieNamed(name);
     boolean met = cookie != null && Objects.equals(cookie.getValue(), value);

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameCondition.java
@@ -18,12 +18,12 @@ public abstract class CurrentFrameCondition implements ObjectCondition<WebDriver
 
   @Override
   public String description() {
-    return "should have url " + name + expectedUrl;
+    return name + " " + expectedUrl;
   }
 
   @Override
   public String negativeDescription() {
-    return "should not have url " + name + expectedUrl;
+    return name + " " + expectedUrl;
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameCondition.java
@@ -22,11 +22,6 @@ public abstract class CurrentFrameCondition implements ObjectCondition<WebDriver
   }
 
   @Override
-  public String negativeDescription() {
-    return name + " " + expectedUrl;
-  }
-
-  @Override
   public String expectedValue() {
     return expectedUrl;
   }

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameUrl.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameUrl.java
@@ -2,7 +2,7 @@ package com.codeborne.selenide.conditions.webdriver;
 
 public class CurrentFrameUrl extends CurrentFrameCondition {
   public CurrentFrameUrl(String expectedUrl) {
-    super("", expectedUrl);
+    super("url", expectedUrl);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameUrlContaining.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameUrlContaining.java
@@ -2,7 +2,7 @@ package com.codeborne.selenide.conditions.webdriver;
 
 public class CurrentFrameUrlContaining extends CurrentFrameCondition {
   public CurrentFrameUrlContaining(String expectedUrl) {
-    super("containing ", expectedUrl);
+    super("url containing", expectedUrl);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameUrlStartingWith.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/CurrentFrameUrlStartingWith.java
@@ -2,7 +2,7 @@ package com.codeborne.selenide.conditions.webdriver;
 
 public class CurrentFrameUrlStartingWith extends CurrentFrameCondition {
   public CurrentFrameUrlStartingWith(String expectedUrl) {
-    super("starting with ", expectedUrl);
+    super("url starting with", expectedUrl);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfWindows.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfWindows.java
@@ -17,11 +17,6 @@ public class NumberOfWindows implements ObjectCondition<WebDriver> {
   }
 
   @Override
-  public String negativeDescription() {
-    return expectedNumberOfWindows + " window(s)";
-  }
-
-  @Override
   public CheckResult check(WebDriver webDriver) {
     int count = webDriver.getWindowHandles().size();
     return result(webDriver, count == expectedNumberOfWindows, String.valueOf(count));

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfWindows.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/NumberOfWindows.java
@@ -13,12 +13,12 @@ public class NumberOfWindows implements ObjectCondition<WebDriver> {
 
   @Override
   public String description() {
-    return "should have " + expectedNumberOfWindows + " window(s)";
+    return expectedNumberOfWindows + " window(s)";
   }
 
   @Override
   public String negativeDescription() {
-    return "should not have " + expectedNumberOfWindows + " window(s)";
+    return expectedNumberOfWindows + " window(s)";
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/Title.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/Title.java
@@ -25,11 +25,6 @@ public class Title implements ObjectCondition<WebDriver> {
   }
 
   @Override
-  public String negativeDescription() {
-    return "title " + expectedTitle;
-  }
-
-  @Override
   public String describe(WebDriver webDriver) {
     return "Page";
   }

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/Title.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/Title.java
@@ -21,12 +21,12 @@ public class Title implements ObjectCondition<WebDriver> {
 
   @Override
   public String description() {
-    return "should have title " + expectedTitle;
+    return "title " + expectedTitle;
   }
 
   @Override
   public String negativeDescription() {
-    return "should not have title " + expectedTitle;
+    return "title " + expectedTitle;
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/Url.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/Url.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public class Url extends UrlCondition {
   public Url(String expectedUrl) {
-    super("", expectedUrl);
+    super("url", expectedUrl);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlCondition.java
@@ -25,11 +25,6 @@ public abstract class UrlCondition implements ObjectCondition<WebDriver> {
   }
 
   @Override
-  public String negativeDescription() {
-    return name + " " + expectedUrl;
-  }
-
-  @Override
   public String describe(WebDriver webDriver) {
     return "webdriver";
   }

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlCondition.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlCondition.java
@@ -21,12 +21,12 @@ public abstract class UrlCondition implements ObjectCondition<WebDriver> {
 
   @Override
   public String description() {
-    return "should have url " + name + expectedUrl;
+    return name + " " + expectedUrl;
   }
 
   @Override
   public String negativeDescription() {
-    return "should not have url " + name + expectedUrl;
+    return name + " " + expectedUrl;
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlContaining.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlContaining.java
@@ -13,11 +13,6 @@ public class UrlContaining extends UrlCondition {
   }
 
   @Override
-  public String negativeDescription() {
-    return description();
-  }
-
-  @Override
   public boolean test(@Nullable String url) {
     return url != null && url.contains(expectedUrl);
   }

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlContaining.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlContaining.java
@@ -4,7 +4,17 @@ import org.jspecify.annotations.Nullable;
 
 public class UrlContaining extends UrlCondition {
   public UrlContaining(String expectedUrl) {
-    super("containing ", expectedUrl);
+    super("url containing", expectedUrl);
+  }
+
+  @Override
+  public String description() {
+    return "url containing \"%s\"".formatted(expectedUrl);
+  }
+
+  @Override
+  public String negativeDescription() {
+    return description();
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlStartingWith.java
+++ b/src/main/java/com/codeborne/selenide/conditions/webdriver/UrlStartingWith.java
@@ -4,7 +4,7 @@ import org.jspecify.annotations.Nullable;
 
 public class UrlStartingWith extends UrlCondition {
   public UrlStartingWith(String expectedUrl) {
-    super("starting with ", expectedUrl);
+    super("url starting with", expectedUrl);
   }
 
   @Override

--- a/src/main/java/com/codeborne/selenide/ex/ConditionMetError.java
+++ b/src/main/java/com/codeborne/selenide/ex/ConditionMetError.java
@@ -8,7 +8,7 @@ public class ConditionMetError extends ObjectConditionError {
   public <T> ConditionMetError(ObjectCondition<T> condition, T subject,
                                @Nullable CheckResult checkResult, @Nullable Exception cause) {
     super(
-      condition.describe(subject) + " " + condition.negativeDescription(),
+      condition.describe(subject) + " should not have " + condition.negativeDescription(),
       condition.expectedValue(),
       checkResult == null ? null : checkResult.getActualValue(),
       cause

--- a/src/main/java/com/codeborne/selenide/ex/ConditionMetError.java
+++ b/src/main/java/com/codeborne/selenide/ex/ConditionMetError.java
@@ -8,7 +8,7 @@ public class ConditionMetError extends ObjectConditionError {
   public <T> ConditionMetError(ObjectCondition<T> condition, T subject,
                                @Nullable CheckResult checkResult, @Nullable Exception cause) {
     super(
-      condition.describe(subject) + " should not have " + condition.negativeDescription(),
+      condition.describe(subject) + " should not have " + condition.description(),
       condition.expectedValue(),
       checkResult == null ? null : checkResult.getActualValue(),
       cause

--- a/src/main/java/com/codeborne/selenide/ex/ConditionNotMetError.java
+++ b/src/main/java/com/codeborne/selenide/ex/ConditionNotMetError.java
@@ -8,7 +8,7 @@ public class ConditionNotMetError extends ObjectConditionError {
   public <T> ConditionNotMetError(ObjectCondition<T> condition, T subject,
                                   @Nullable CheckResult checkResult, @Nullable Exception cause) {
     super(
-      condition.describe(subject) + " " + condition.description(),
+      condition.describe(subject) + " should have " + condition.description(),
       condition.expectedValue(),
       checkResult == null ? null : checkResult.getActualValue(),
       cause

--- a/src/main/java/com/codeborne/selenide/impl/Waiter.java
+++ b/src/main/java/com/codeborne/selenide/impl/Waiter.java
@@ -71,7 +71,7 @@ public class Waiter {
   }
 
   private <T> void waitWhile(Driver driver, T subject, ObjectCondition<T> condition, long timeout, long pollingInterval) {
-    SelenideLog log = SelenideLogger.beginStep(subject.toString(), "should not have " + condition.negativeDescription());
+    SelenideLog log = SelenideLogger.beginStep(subject.toString(), "should not have " + condition.description());
     CheckResult result = null;
     Exception error = null;
     for (long start = currentTimeMillis(); !isTimeoutExceeded(timeout, start); ) {

--- a/src/main/java/com/codeborne/selenide/impl/Waiter.java
+++ b/src/main/java/com/codeborne/selenide/impl/Waiter.java
@@ -39,7 +39,7 @@ public class Waiter {
   }
 
   private <T> void wait(Driver driver, T subject, ObjectCondition<T> condition, long timeout, long pollingInterval) {
-    SelenideLog log = SelenideLogger.beginStep(condition.describe(subject), condition.description());
+    SelenideLog log = SelenideLogger.beginStep(condition.describe(subject), "should have " + condition.description());
     CheckResult result = null;
     Exception error = null;
     for (long start = currentTimeMillis(); !isTimeoutExceeded(timeout, start); ) {
@@ -71,7 +71,7 @@ public class Waiter {
   }
 
   private <T> void waitWhile(Driver driver, T subject, ObjectCondition<T> condition, long timeout, long pollingInterval) {
-    SelenideLog log = SelenideLogger.beginStep(subject.toString(), condition.negativeDescription());
+    SelenideLog log = SelenideLogger.beginStep(subject.toString(), "should not have " + condition.negativeDescription());
     CheckResult result = null;
     Exception error = null;
     for (long start = currentTimeMillis(); !isTimeoutExceeded(timeout, start); ) {

--- a/src/test/java/integration/AnimationTest.java
+++ b/src/test/java/integration/AnimationTest.java
@@ -1,12 +1,12 @@
 package integration;
 
-import com.codeborne.selenide.WebDriverConditions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.codeborne.selenide.Condition.animated;
 import static com.codeborne.selenide.Selectors.byText;
+import static com.codeborne.selenide.WebDriverConditions.numberOfWindows;
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -36,7 +36,7 @@ final class AnimationTest extends ITest {
   void shouldFailIfTabIsNotActive() {
     $(byText("New tab")).click();
     $("#move-box").click();
-    driver().webdriver().shouldHave(WebDriverConditions.numberOfWindows(2));
+    driver().webdriver().shouldHave(numberOfWindows(2));
     if (driver().browser().isFirefox()) {
       // for some reason Firefox is not immediately stop calling requestAnimationFrame(callback)
       pause(2000);

--- a/src/test/java/integration/OrTest.java
+++ b/src/test/java/integration/OrTest.java
@@ -34,7 +34,7 @@ class OrTest extends ITest {
     setTimeout(2);
     assertThatThrownBy(() -> driver().webdriver().shouldHave(url("foo:foo").or(url("bar:bar"))))
       .isInstanceOf(UIAssertionError.class)
-      .hasMessageStartingWith("webdriver should have url foo:foo or should have url bar:bar") // TODO improve wording
+      .hasMessageStartingWith("webdriver should have url foo:foo or url bar:bar")
       .hasMessageContaining("Actual value: about:blank" + testName())
       .hasMessageContaining("Screenshot:")
       .hasMessageContaining("Page source:")
@@ -46,7 +46,7 @@ class OrTest extends ITest {
     setTimeout(3);
     assertThatThrownBy(() -> driver().webdriver().shouldNotHave(url("foo:foo").or(urlStartingWith("about:blank"))))
       .isInstanceOf(UIAssertionError.class)
-      .hasMessageStartingWith("webdriver not(should have url foo:foo or should have url starting with about:blank)") // TODO fix wording
+      .hasMessageStartingWith("webdriver should not have url foo:foo or url starting with about:blank")
       .hasMessageContaining("Actual value: about:blank" + testName())
       .hasMessageContaining("Screenshot:")
       .hasMessageContaining("Page source:")

--- a/src/test/java/integration/OrTest.java
+++ b/src/test/java/integration/OrTest.java
@@ -1,0 +1,55 @@
+package integration;
+
+import com.codeborne.selenide.ex.UIAssertionError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.WebDriverConditions.url;
+import static com.codeborne.selenide.WebDriverConditions.urlStartingWith;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrTest extends ITest {
+  @BeforeEach
+  void setUp() {
+    driver().open("about:blank" + testName());
+  }
+
+  @Test
+  void positive_first() {
+    driver().webdriver().shouldHave(urlStartingWith("about:blank").or(url("bar")));
+  }
+
+  @Test
+  void positive_second() {
+    driver().webdriver().shouldHave(url("foo").or(urlStartingWith("about:blank")));
+  }
+
+  @Test
+  void positive_composite() {
+    driver().webdriver().shouldHave(url("foo").or(url("bar")).or(urlStartingWith("about:blank")));
+  }
+
+  @Test
+  void errorMessage() {
+    setTimeout(2);
+    assertThatThrownBy(() -> driver().webdriver().shouldHave(url("foo:foo").or(url("bar:bar"))))
+      .isInstanceOf(UIAssertionError.class)
+      .hasMessageStartingWith("webdriver should have url foo:foo or should have url bar:bar") // TODO improve wording
+      .hasMessageContaining("Actual value: about:blank" + testName())
+      .hasMessageContaining("Screenshot:")
+      .hasMessageContaining("Page source:")
+      .hasMessageContaining("Timeout: 2ms");
+  }
+
+  @Test
+  void errorMessage_negative() {
+    setTimeout(3);
+    assertThatThrownBy(() -> driver().webdriver().shouldNotHave(url("foo:foo").or(urlStartingWith("about:blank"))))
+      .isInstanceOf(UIAssertionError.class)
+      .hasMessageStartingWith("webdriver not(should have url foo:foo or should have url starting with about:blank)") // TODO fix wording
+      .hasMessageContaining("Actual value: about:blank" + testName())
+      .hasMessageContaining("Screenshot:")
+      .hasMessageContaining("Page source:")
+      .hasMessageContaining("Timeout: 3ms");
+  }
+}

--- a/statics/src/test/java/integration/BrowserPositionTest.java
+++ b/statics/src/test/java/integration/BrowserPositionTest.java
@@ -23,6 +23,7 @@ final class BrowserPositionTest extends IntegrationTest {
   @Test
   void ableToSetBrowserPosition() {
     Configuration.browserPosition = "30x60";
+    Configuration.browserSize = "100x100";
 
     openFile("start_page.html");
 

--- a/statics/src/test/java/integration/CookieStoreTest.java
+++ b/statics/src/test/java/integration/CookieStoreTest.java
@@ -78,7 +78,7 @@ final class CookieStoreTest extends IntegrationTest {
       cookies().shouldHave(cookie("foo"), ofMillis(10))
     )
       .isInstanceOf(ConditionNotMetError.class)
-      .hasMessageStartingWith("cookieStore should have a cookie with name \"foo\"")
+      .hasMessageStartingWith("cookieStore should have cookie with name \"foo\"")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
       .hasMessageContaining("Timeout: 10ms");
@@ -93,7 +93,7 @@ final class CookieStoreTest extends IntegrationTest {
       cookies().shouldHave(cookie(NAME, "wrong value"))
     )
       .isInstanceOf(ConditionNotMetError.class)
-      .hasMessageStartingWith("cookieStore should have a cookie with name \"%s\" and value \"wrong value\"".formatted(NAME))
+      .hasMessageStartingWith("cookieStore should have cookie with name \"%s\" and value \"wrong value\"".formatted(NAME))
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
       .hasMessageContaining("Timeout: 1ms");

--- a/statics/src/test/java/integration/DefaultClipboardTest.java
+++ b/statics/src/test/java/integration/DefaultClipboardTest.java
@@ -9,6 +9,7 @@ import static com.codeborne.selenide.ClipboardConditions.content;
 import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.visible;
+import static com.codeborne.selenide.Configuration.timeout;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.clipboard;
 import static java.time.Duration.ofMillis;
@@ -54,17 +55,51 @@ public class DefaultClipboardTest extends IntegrationTest {
   public void errorMessage_negativeCase() {
     $("#button-copy-text").shouldBe(visible, enabled).click();
     assertThatThrownBy(() ->
-      clipboard().shouldNotHave(content("Hello World"), ofMillis(300))
+      clipboard().shouldNotHave(content("Hello World"), ofMillis(3))
     )
       .isInstanceOf(ConditionMetError.class)
       .hasMessageStartingWith("clipboard should not have content 'Hello World'")
       .hasMessageContaining("Actual value: Hello World")
-      .hasMessageContaining("Timeout: 300ms");
+      .hasMessageContaining("Timeout: 3ms");
   }
 
   @Test
   public void checkSetValue() {
     clipboard().setText("111");
     assertThat(clipboard().getText()).isEqualTo("111");
+  }
+
+  @Test
+  public void or() {
+    clipboard().setText("hello, world");
+    clipboard().shouldHave(content("aaa").or(content("hello, world")));
+    clipboard().shouldHave(content("hello, world").or(content("bbb")));
+    clipboard().shouldHave(content("aaa").or(content("bbb").or(content("hello, world"))));
+  }
+
+  @Test
+  void or_errorMessage() {
+    timeout = 2;
+    clipboard().setText("hello, world");
+    assertThatThrownBy(() -> clipboard().shouldHave(content("aaa").or(content("bbb"))))
+      .isInstanceOf(ConditionNotMetError.class)
+      .hasMessageStartingWith("clipboard should have content 'aaa' or content 'bbb'")
+      .hasMessageContaining("Actual value: hello, world")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source:")
+      .hasMessageContaining("Timeout: 2ms");
+  }
+
+  @Test
+  void or_negative_errorMessage() {
+    timeout = 2;
+    clipboard().setText("hello, world");
+    assertThatThrownBy(() -> clipboard().shouldNotHave(content("good bye, world").or(content("hello, world"))))
+      .isInstanceOf(ConditionMetError.class)
+      .hasMessageStartingWith("clipboard should not have content 'good bye, world' or content 'hello, world'")
+      .hasMessageContaining("Actual value: hello, world")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source:")
+      .hasMessageContaining("Timeout: 2ms");
   }
 }

--- a/statics/src/test/java/integration/LocalStorageTest.java
+++ b/statics/src/test/java/integration/LocalStorageTest.java
@@ -175,11 +175,6 @@ final class LocalStorageTest extends IntegrationTest {
       }
 
       @Override
-      public String negativeDescription() {
-        return String.format("all items containing '%s'", expectedValue);
-      }
-
-      @Override
       public CheckResult check(LocalStorage localStorage) {
         return localStorage.getItems().values().stream()
           .allMatch(value -> value.contains(expectedValue)) ?

--- a/statics/src/test/java/integration/LocalStorageTest.java
+++ b/statics/src/test/java/integration/LocalStorageTest.java
@@ -171,12 +171,12 @@ final class LocalStorageTest extends IntegrationTest {
     return new ObjectCondition<>() {
       @Override
       public String description() {
-        return String.format("should have all items containing '%s'", expectedValue);
+        return String.format("all items containing '%s'", expectedValue);
       }
 
       @Override
       public String negativeDescription() {
-        return String.format("should not have all items containing '%s'", expectedValue);
+        return String.format("all items containing '%s'", expectedValue);
       }
 
       @Override

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -110,6 +110,19 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
+  void errorMessageForWrongUrlContaining() {
+    assertThatThrownBy(() ->
+      webdriver().shouldHave(urlContaining("oogle.ee/"), ofMillis(2))
+    )
+      .isInstanceOf(ConditionNotMetError.class)
+      .hasMessageStartingWith("webdriver should have url containing \"oogle.ee/\"")
+      .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 2ms");
+  }
+
+  @Test
   void errorMessageForWrongUrlStartingWith() {
     assertThatThrownBy(() ->
                          webdriver().shouldHave(urlStartingWith("https://google.ee/"), ofMillis(10))
@@ -164,6 +177,19 @@ final class WebDriverConditionsTest extends IntegrationTest {
   }
 
   @Test
+  void errorMessageForWrongCurrentFrameUrlContaining() {
+    assertThatThrownBy(() ->
+                         webdriver().shouldHave(currentFrameUrlContaining("oogle.ee"), ofMillis(3))
+    )
+      .isInstanceOf(ConditionNotMetError.class)
+      .hasMessageStartingWith("current frame should have url containing oogle.ee")
+      .hasMessageContaining("Actual value: " + baseUrl + "/page_with_frames_with_delays.html")
+      .hasMessageContaining("Screenshot: ")
+      .hasMessageContaining("Page source: ")
+      .hasMessageContaining("Timeout: 3ms");
+  }
+
+  @Test
   void checkNumberOfOpenWindows() {
     openFile("page_with_tabs.html");
 
@@ -203,20 +229,27 @@ final class WebDriverConditionsTest extends IntegrationTest {
   @Test
   void errorMessageForWrongTitle() {
     assertThatThrownBy(() ->
-                         webdriver().shouldHave(title("Selenide-test-page"), ofMillis(10))
+                         webdriver().shouldHave(title("Selenide-test-page"), ofMillis(3))
     )
       .isInstanceOf(ConditionNotMetError.class)
-      .hasMessageContaining("Actual value: Test::frames with delays");
+      .hasMessageStartingWith("Page should have title Selenide-test-page")
+      .hasMessageContaining("Actual value: Test::frames with delays")
+      .hasMessageContaining("Screenshot:")
+      .hasMessageContaining("Page source:")
+      .hasMessageContaining("Timeout: 3ms");
   }
 
   @Test
   void errorMessageWhenWebdriverShouldNotHaveTitle() {
     assertThatThrownBy(() ->
-                         webdriver().shouldNotHave(title("Test::frames with delays"), ofMillis(10))
+                         webdriver().shouldNotHave(title("Test::frames with delays"), ofMillis(2))
     )
       .isInstanceOf(ConditionMetError.class)
       .hasMessageStartingWith("Page should not have title Test::frames with delays")
-      .hasMessageContaining("Actual value: Test::frames with delays");
+      .hasMessageContaining("Actual value: Test::frames with delays")
+      .hasMessageContaining("Screenshot:")
+      .hasMessageContaining("Page source:")
+      .hasMessageContaining("Timeout: 2ms");
   }
 
   @Test
@@ -230,12 +263,12 @@ final class WebDriverConditionsTest extends IntegrationTest {
     return new ObjectCondition<>() {
       @Override
       public String description() {
-        return "should have a cookie with name '" + expectedCookieName + "'";
+        return "cookie with name '" + expectedCookieName + "'";
       }
 
       @Override
       public String negativeDescription() {
-        return "should not have a cookie with name '" + expectedCookieName + "'";
+        return "cookie with name '" + expectedCookieName + "'";
       }
 
       @Override
@@ -277,7 +310,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
     $("#button-put").click();
     assertThatThrownBy(() -> webdriver().shouldHave(cookie("WRONG_COOKIE")))
       .isInstanceOf(ConditionNotMetError.class)
-      .hasMessageStartingWith("webdriver should have a cookie with name \"WRONG_COOKIE\"")
+      .hasMessageStartingWith("webdriver should have cookie with name \"WRONG_COOKIE\"")
       .hasMessageContaining("Actual value: Available cookies: [TEST_COOKIE=AF33892F98ABC39A")
       .hasMessageContaining("Screenshot: ")
       .hasMessageContaining("Page source: ")
@@ -299,7 +332,7 @@ final class WebDriverConditionsTest extends IntegrationTest {
     $("#button-put").click();
     assertThatThrownBy(() -> webdriver().shouldHave(cookie("WRONG_COOKIE", VALUE)))
       .isInstanceOf(ConditionNotMetError.class)
-      .hasMessageStartingWith("webdriver should have a cookie with name \"WRONG_COOKIE\" and value \"AF33892F98ABC39A\"")
+      .hasMessageStartingWith("webdriver should have cookie with name \"WRONG_COOKIE\" and value \"AF33892F98ABC39A\"")
       .hasMessageContaining("Actual value: Available cookies: [TEST_COOKIE=AF33892F98ABC39A");
   }
 

--- a/statics/src/test/java/integration/WebDriverConditionsTest.java
+++ b/statics/src/test/java/integration/WebDriverConditionsTest.java
@@ -267,11 +267,6 @@ final class WebDriverConditionsTest extends IntegrationTest {
       }
 
       @Override
-      public String negativeDescription() {
-        return "cookie with name '" + expectedCookieName + "'";
-      }
-
-      @Override
       public CheckResult check(WebDriver webdriver) {
         return webdriver.manage().getCookieNamed(expectedCookieName) != null ?
           accepted(actualValue(webdriver)) :


### PR DESCRIPTION
This allows checks with multiple acceptable values, e.g.

* `webdriver().shouldHave(url("a").or(url("b")))`
* `clipboard.shouldHave(content("a").or(content("b")))`
* etc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added condition combinator support for `or`, including improved “first or second” diagnostics.
- **Improvements**
  - Standardized human-readable assertion descriptions across URLs, cookies, titles, frames, storage items, and window counts.
  - Refined positive/negative failure messaging and Selenide step text.
  - Updated clipboard assertions to allow an expected value or an empty clipboard when appropriate.
- **Tests**
  - Expanded/adjusted integration tests and expected error-message/timeout text to match the new messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->