### PR TITLE
bugfix: close webdriver that has been opened inside `inNewBrowser` with a custom config

### DIFF
--- a/statics/src/main/java/com/codeborne/selenide/WebDriverThreadLocalContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverThreadLocalContainer.java
@@ -215,51 +215,41 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
   @Override
   public void using(WebDriver driver, @Nullable SelenideProxyServer proxy, @Nullable DownloadsFolder downloadsFolder, Runnable lambda) {
     DownloadsFolder folder = downloadsFolder != null ? downloadsFolder : new SharedDownloadsFolder(config.downloadsFolder());
-    using(new WebDriverInstance(config, driver, proxy, folder), lambda);
+    using(new WebDriverInstance(config, driver, proxy, folder), lambda, false);
   }
 
-  private Optional<WebDriverInstance> using(WebDriverInstance webDriverInstance, Runnable lambda) {
+  private void using(WebDriverInstance webDriverInstance, Runnable lambda, boolean closeCurrentBrowserInLambda) {
     var previous = getCurrentThreadDriver();
     setWebDriver(webDriverInstance);
-    Optional<WebDriverInstance> latestOpenedBrowserInLambda;
+
     try {
       lambda.run();
     }
     finally {
-      latestOpenedBrowserInLambda = getCurrentThreadDriver();
+      if (closeCurrentBrowserInLambda) {
+        getCurrentThreadDriver().ifPresent(wd -> {
+          WebdriversRegistry.unregister(wd);
+          wd.dispose();
+        });
+      }
       resetWebDriver();
       previous.ifPresent(prev -> {
         setWebDriver(prev);
         config.set(prev.config());
       });
     }
-    return latestOpenedBrowserInLambda;
   }
 
   @Override
   public void inNewBrowser(Runnable lambda) {
     var newBrowser = createDriver();
-    try {
-      Optional<WebDriverInstance> latestOpenedBrowserInLambda = using(newBrowser, lambda);
-      latestOpenedBrowserInLambda.ifPresent(wd -> {
-        WebdriversRegistry.unregister(wd);
-        wd.dispose();
-      });
-    }
-    finally {
-      newBrowser.dispose();
-    }
+    using(newBrowser, lambda, true);
   }
 
   @Override
   public void inNewBrowser(Config config, Runnable lambda) {
     var newBrowser = createDriver(config);
-    try {
-      using(newBrowser, lambda);
-    }
-    finally {
-      newBrowser.dispose();
-    }
+    using(newBrowser, lambda, true);
   }
 
   @Override

--- a/statics/src/main/java/com/codeborne/selenide/WebDriverThreadLocalContainer.java
+++ b/statics/src/main/java/com/codeborne/selenide/WebDriverThreadLocalContainer.java
@@ -218,26 +218,33 @@ public class WebDriverThreadLocalContainer implements WebDriverContainer {
     using(new WebDriverInstance(config, driver, proxy, folder), lambda);
   }
 
-  private void using(WebDriverInstance webDriverInstance, Runnable lambda) {
+  private Optional<WebDriverInstance> using(WebDriverInstance webDriverInstance, Runnable lambda) {
     var previous = getCurrentThreadDriver();
     setWebDriver(webDriverInstance);
+    Optional<WebDriverInstance> latestOpenedBrowserInLambda;
     try {
       lambda.run();
     }
     finally {
+      latestOpenedBrowserInLambda = getCurrentThreadDriver();
       resetWebDriver();
       previous.ifPresent(prev -> {
         setWebDriver(prev);
         config.set(prev.config());
       });
     }
+    return latestOpenedBrowserInLambda;
   }
 
   @Override
   public void inNewBrowser(Runnable lambda) {
     var newBrowser = createDriver();
     try {
-      using(newBrowser, lambda);
+      Optional<WebDriverInstance> latestOpenedBrowserInLambda = using(newBrowser, lambda);
+      latestOpenedBrowserInLambda.ifPresent(wd -> {
+        WebdriversRegistry.unregister(wd);
+        wd.dispose();
+      });
     }
     finally {
       newBrowser.dispose();

--- a/statics/src/test/java/integration/ConfigPerBrowserTest.java
+++ b/statics/src/test/java/integration/ConfigPerBrowserTest.java
@@ -2,6 +2,7 @@ package integration;
 
 import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.SelenideElement;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ConfigPerBrowserTest extends IntegrationTest {
   private static final SelenideElement h1 = $("h1");
+  private WebDriver webDriverOpenedDuringTest;
 
   @BeforeEach
   @AfterEach
@@ -36,15 +38,14 @@ public class ConfigPerBrowserTest extends IntegrationTest {
     open("/page_with_images.html" + testName());
     h1.shouldHave(text("Images"));
     assertSizeGreaterThan(500, 400);
-    WebDriver webDriver = getWebDriver();
+    webDriverOpenedDuringTest = getWebDriver();
 
     open("/page_with_uploads.html" + testName(), config().browserSize("500x400"));
     h1.shouldHave(text("File uploads"));
     assertSize(500, 400);
 
-    assertThatThrownBy(webDriver::getTitle)
-      .as("The first webdriver should be already closed as a result of `open(url, config)`")
-      .isInstanceOf(NoSuchSessionException.class);
+    assertBrowserClosed(webDriverOpenedDuringTest,
+      "The first webdriver should be already closed as a result of `open(url, config)`");
   }
 
   @Test
@@ -63,7 +64,10 @@ public class ConfigPerBrowserTest extends IntegrationTest {
       h1.shouldHave(text("File uploads"));
       assertSize(500, 400);
       webdriver().shouldNotHave(cookie("bober", "kurwa"));
+      webDriverOpenedDuringTest = getWebDriver();
     });
+
+    assertBrowserClosed(webDriverOpenedDuringTest, "Webdriver should be closed in the end of `inNewBrowser`");
 
     h1.shouldHave(text("Images"));
     open("/page_with_images.html" + testName(), originalConfig);
@@ -81,7 +85,9 @@ public class ConfigPerBrowserTest extends IntegrationTest {
       SelenideConfig anotherConfig = new SelenideConfig().baseUrl(getBaseUrl());
       open("/page_with_uploads.html" + testName(), anotherConfig);
       h1.shouldHave(text("File uploads"));
+      webDriverOpenedDuringTest = getWebDriver();
     });
+    assertBrowserClosed(webDriverOpenedDuringTest, "Webdriver should be closed in the end of `inNewBrowser`");
 
     h1.shouldHave(text("Images"));
     open("/page_with_images.html" + testName(), originalConfig);
@@ -97,5 +103,12 @@ public class ConfigPerBrowserTest extends IntegrationTest {
     Dimension size = getWebDriver().manage().window().getSize();
     assertThat(size.getWidth()).isGreaterThan(width);
     assertThat(size.getHeight()).isGreaterThan(height);
+  }
+
+  private void assertBrowserClosed(@Nullable WebDriver webDriver, String explanation) {
+    assertThat(webDriver).isNotNull();
+    assertThatThrownBy(() -> webDriver.getTitle())
+      .as(explanation)
+      .isInstanceOf(NoSuchSessionException.class);
   }
 }

--- a/statics/src/test/java/integration/ConfigPerBrowserTest.java
+++ b/statics/src/test/java/integration/ConfigPerBrowserTest.java
@@ -2,6 +2,7 @@ package integration;
 
 import com.codeborne.selenide.SelenideConfig;
 import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.ex.ElementShould;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,8 @@ import org.openqa.selenium.Cookie;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.WebDriver;
+
+import java.time.Duration;
 
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Configuration.config;
@@ -25,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ConfigPerBrowserTest extends IntegrationTest {
   private static final SelenideElement h1 = $("h1");
-  private WebDriver webDriverOpenedDuringTest;
+  private @Nullable WebDriver webDriverOpenedDuringTest;
 
   @BeforeEach
   @AfterEach
@@ -87,6 +90,30 @@ public class ConfigPerBrowserTest extends IntegrationTest {
       h1.shouldHave(text("File uploads"));
       webDriverOpenedDuringTest = getWebDriver();
     });
+    assertBrowserClosed(webDriverOpenedDuringTest, "Webdriver should be closed in the end of `inNewBrowser`");
+
+    h1.shouldHave(text("Images"));
+    open("/page_with_images.html" + testName(), originalConfig);
+    h1.shouldHave(text("Images"));
+  }
+
+  @Test
+  public void inNewBrowser_withCustomConfigInside_shouldBeClosed_evenIfLambdaFailed() {
+    SelenideConfig originalConfig = new SelenideConfig().baseUrl(getBaseUrl());
+    open("/page_with_images.html" + testName(), originalConfig);
+    h1.shouldHave(text("Images"));
+
+    assertThatThrownBy(() -> {
+      inNewBrowser(() -> {
+        SelenideConfig anotherConfig = new SelenideConfig().baseUrl(getBaseUrl());
+        open("/page_with_uploads.html" + testName(), anotherConfig);
+        webDriverOpenedDuringTest = getWebDriver();
+        h1.shouldHave(text("Wrong header!"), Duration.ofMillis(1));
+      });
+    })
+      .isInstanceOf(ElementShould.class)
+      .hasMessageStartingWith("Element should have text \"Wrong header!\" {h1}");
+
     assertBrowserClosed(webDriverOpenedDuringTest, "Webdriver should be closed in the end of `inNewBrowser`");
 
     h1.shouldHave(text("Images"));

--- a/statics/src/test/java/integration/CustomWebdriverTest.java
+++ b/statics/src/test/java/integration/CustomWebdriverTest.java
@@ -53,6 +53,7 @@ final class CustomWebdriverTest extends IntegrationTest {
     });
 
     assertThat(WebDriverRunner.hasWebDriverStarted()).isFalse();
+    assertThat(browser1.getCurrentUrl()).contains("page_with_selects_without_jquery.html");
 
     using(browser2, () -> {
       openFile("file_upload_form.html");
@@ -61,6 +62,7 @@ final class CustomWebdriverTest extends IntegrationTest {
     });
 
     assertThat(WebDriverRunner.hasWebDriverStarted()).isFalse();
+    assertThat(browser2.getCurrentUrl()).contains("file_upload_form.html");
 
     using(browser1, () -> {
       $("h1").shouldBe(visible).shouldHave(text("Page with selects"));
@@ -68,6 +70,7 @@ final class CustomWebdriverTest extends IntegrationTest {
     });
 
     assertThat(WebDriverRunner.hasWebDriverStarted()).isFalse();
+    assertThat(browser1.getCurrentUrl()).contains("page_with_selects_without_jquery.html");
 
     using(browser2, () -> {
       $("h1").shouldBe(visible).shouldHave(text("File upload form"));
@@ -75,6 +78,7 @@ final class CustomWebdriverTest extends IntegrationTest {
     });
 
     assertThat(WebDriverRunner.hasWebDriverStarted()).isFalse();
+    assertThat(browser2.getCurrentUrl()).contains("file_upload_form.html");
   }
 
   @Test


### PR DESCRIPTION
The problem:

After test `integration.ConfigPerBrowserTest.inNewBrowser_withCustomConfigInside`, one browser was still opened (left unclosed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup behavior for temporary browsers, ensuring the currently active browser instance is disposed correctly after each scoped run.
  * More reliably preserved browser/config context when switching between custom webdrivers.
* **Tests**
  * Strengthened integration tests to capture and verify that each browser session is closed after `inNewBrowser(...)`/`open(...)` flows, including when a lambda fails.
  * Expanded webdriver switching tests with additional assertions for the expected page URL after each switch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->