### PR TITLE
#2757 Follow-up cleanups for MHTML page source (post #3363)

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumScreenSourceExtractor.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumScreenSourceExtractor.java
@@ -12,7 +12,7 @@ public class AppiumScreenSourceExtractor extends WebPageSourceExtractor {
   @Override
   protected File createFile(Config config, WebDriver webDriver, String fileName) {
     return isMobile(webDriver) ?
-      new File(config.reportsFolder(), fileName + ".xml") :
+      createFileWithExtension(config, fileName, "xml") :
       super.createFile(config, webDriver, fileName);
   }
 }

--- a/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumScreenSourceExtractorTest.java
+++ b/modules/appium/src/test/java/com/codeborne/selenide/appium/AppiumScreenSourceExtractorTest.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AppiumScreenSourceExtractorTest {
   private final Config config = new SelenideConfig().reportsFolder("foo");
@@ -24,6 +25,14 @@ class AppiumScreenSourceExtractorTest {
   void shouldUseXMLFileExtension_forMobileDriver(AppiumDriver driver) {
     File sourceFile = extractor.createFile(config, driver, "test123");
     assertThat(sourceFile.getName()).isEqualTo("test123.xml");
+  }
+
+  @ParameterizedTest
+  @MethodSource("mobileDrivers")
+  void rejectsPathTraversalInFileName_forMobileDriver(AppiumDriver driver) {
+    assertThatThrownBy(() -> extractor.createFile(config, driver, "../../outside"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Invalid file name: ../../outside");
   }
 
   @ParameterizedTest

--- a/src/main/java/com/codeborne/selenide/Browser.java
+++ b/src/main/java/com/codeborne/selenide/Browser.java
@@ -1,5 +1,8 @@
 package com.codeborne.selenide;
 
+import org.openqa.selenium.HasCapabilities;
+import org.openqa.selenium.WebDriver;
+
 import static com.codeborne.selenide.Browsers.CHROME;
 import static com.codeborne.selenide.Browsers.EDGE;
 import static com.codeborne.selenide.Browsers.FIREFOX;
@@ -26,6 +29,11 @@ public class Browser {
 
   public boolean isChromium() {
     return isChrome() || isEdge();
+  }
+
+  public static boolean isChromium(WebDriver driver) {
+    return driver instanceof HasCapabilities hasCapabilities &&
+      new Browser(hasCapabilities.getCapabilities().getBrowserName(), false).isChromium();
   }
 
   public boolean isFirefox() {

--- a/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
+++ b/src/main/java/com/codeborne/selenide/impl/DownloadFileWithCdp.java
@@ -11,7 +11,6 @@ import com.codeborne.selenide.files.DownloadAction;
 import com.codeborne.selenide.files.DownloadedFile;
 import com.codeborne.selenide.files.FileFilter;
 import org.jspecify.annotations.Nullable;
-import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.devtools.DevTools;
@@ -149,7 +148,7 @@ public class DownloadFileWithCdp {
         "The browser you selected \"%s\" doesn't support Chrome Devtools protocol".formatted(driver.browser().name));
     }
 
-    if (!isChromium(webDriver)) {
+    if (!com.codeborne.selenide.Browser.isChromium(webDriver)) {
       throw new IllegalArgumentException(
         "The browser you selected \"%s\" is not Chromium browser".formatted(driver.browser().name));
     }
@@ -158,11 +157,6 @@ public class DownloadFileWithCdp {
     devTools.createSessionIfThereIsNotOne(webDriver.getWindowHandle());
     devTools.send(Page.enable(Optional.empty()));
     return devTools;
-  }
-
-  private boolean isChromium(WebDriver webDriver) {
-    return webDriver instanceof HasCapabilities hasCapabilities &&
-      new com.codeborne.selenide.Browser(hasCapabilities.getCapabilities().getBrowserName(), false).isChromium();
   }
 
   private void prepareDownloadWithCdp(Driver driver, DevTools devTools,

--- a/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
@@ -5,7 +5,6 @@ import com.codeborne.selenide.Config;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Alert;
-import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
@@ -35,12 +34,13 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
 
   @CanIgnoreReturnValue
   private File extract(Config config, WebDriver driver, String fileName, boolean retryIfAlert) {
+    File pageSource = createFile(config, driver, fileName);
     try {
-      return doExtract(config, driver, fileName);
+      return doExtract(config, driver, fileName, pageSource);
     }
     catch (UnhandledAlertException e) {
       if (retryIfAlert) {
-        return retryingExtractionOnAlert(config, driver, fileName, e);
+        return retryingExtractionOnAlert(config, driver, fileName, pageSource, e);
       }
       else {
         printOnce("savePageSourceToFile", e);
@@ -48,31 +48,28 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
     catch (WebDriverException e) {
       log.warn("Failed to save page source to {}", fileName, e);
-      File pageSource = createFile(config, driver, fileName);
       writeToFile(e.toString(), pageSource);
       return pageSource;
     }
     catch (RuntimeException e) {
       log.error("Failed to save page source to {}", fileName, e);
-      File pageSource = createFile(config, driver, fileName);
       writeToFile(e.toString(), pageSource);
       return pageSource;
     }
-    return createFile(config, driver, fileName);
+    return pageSource;
   }
 
-  private File doExtract(Config config, WebDriver driver, String fileName) {
+  private File doExtract(Config config, WebDriver driver, String fileName, File pageSource) {
     if (config.savePageSourceWithResources()) {
       @Nullable String mhtml = extractMhtml(driver);
       if (mhtml != null) {
-        File pageSource = createFileWithExtension(config, fileName, "mhtml");
-        writeToFile(mhtml, pageSource);
-        attachmentHandler.attach(pageSource);
-        return pageSource;
+        File mhtmlFile = createFileWithExtension(config, fileName, "mhtml");
+        writeToFile(mhtml, mhtmlFile);
+        attachmentHandler.attach(mhtmlFile);
+        return mhtmlFile;
       }
     }
 
-    File pageSource = createFile(config, driver, fileName);
     String source = driver.getPageSource();
     if (source == null) {
       log.error("Failed to save page source to {}: page source is <null>", fileName);
@@ -87,7 +84,7 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
 
   @Nullable
   private String extractMhtml(WebDriver driver) {
-    if (!(driver instanceof HasCdp hasCdp) || !isChromium(driver)) {
+    if (!(driver instanceof HasCdp hasCdp) || !Browser.isChromium(driver)) {
       return null;
     }
     try {
@@ -102,11 +99,6 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
       log.warn("Failed to save page as MHTML, will fallback to plain HTML: {}", e.toString());
     }
     return null;
-  }
-
-  private boolean isChromium(WebDriver driver) {
-    return driver instanceof HasCapabilities hasCapabilities &&
-      new Browser(hasCapabilities.getCapabilities().getBrowserName(), false).isChromium();
   }
 
   protected File createFile(Config config, WebDriver driver, String fileName) {
@@ -136,7 +128,7 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
   }
 
-  private File retryingExtractionOnAlert(Config config, WebDriver driver, String fileName, Exception e) {
+  private File retryingExtractionOnAlert(Config config, WebDriver driver, String fileName, File pageSource, Exception e) {
     try {
       Alert alert = driver.switchTo().alert();
       log.error("{}: {}", e, alert.getText());
@@ -145,7 +137,7 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
     catch (Exception unableToCloseAlert) {
       log.error("Failed to close alert", unableToCloseAlert);
-      return createFile(config, driver, fileName);
+      return pageSource;
     }
   }
 }

--- a/src/test/java/com/codeborne/selenide/BrowserTest.java
+++ b/src/test/java/com/codeborne/selenide/BrowserTest.java
@@ -1,6 +1,11 @@
 package com.codeborne.selenide;
 
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.HasCapabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.WebDriver;
+
+import java.util.Map;
 
 import static com.codeborne.selenide.Browsers.CHROME;
 import static com.codeborne.selenide.Browsers.EDGE;
@@ -8,6 +13,8 @@ import static com.codeborne.selenide.Browsers.FIREFOX;
 import static com.codeborne.selenide.Browsers.IE;
 import static com.codeborne.selenide.Browsers.INTERNET_EXPLORER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 final class BrowserTest {
   @Test
@@ -30,6 +37,28 @@ final class BrowserTest {
   @Test
   void edgeNameFromCapabilitiesTest() {
     assertThat(new Browser("MicrosoftEdge", false).isChromium()).isTrue();
+  }
+
+  @Test
+  void detectsChromiumFromWebDriverCapabilities() {
+    assertThat(Browser.isChromium(driverWithBrowserName(CHROME))).isTrue();
+    assertThat(Browser.isChromium(driverWithBrowserName(EDGE))).isTrue();
+    assertThat(Browser.isChromium(driverWithBrowserName(FIREFOX))).isFalse();
+  }
+
+  @Test
+  void isNotChromium_whenDriverDoesNotExposeCapabilities() {
+    WebDriver driver = mock(WebDriver.class);
+    assertThat(Browser.isChromium(driver)).isFalse();
+  }
+
+  private interface CapableWebDriver extends WebDriver, HasCapabilities {
+  }
+
+  private static WebDriver driverWithBrowserName(String browserName) {
+    CapableWebDriver driver = mock(CapableWebDriver.class);
+    when(driver.getCapabilities()).thenReturn(new MutableCapabilities(Map.of("browserName", browserName)));
+    return driver;
   }
 
   @Test

--- a/src/test/java/com/codeborne/selenide/BrowserTest.java
+++ b/src/test/java/com/codeborne/selenide/BrowserTest.java
@@ -48,7 +48,7 @@ final class BrowserTest {
 
   @Test
   void isNotChromium_whenDriverDoesNotExposeCapabilities() {
-    WebDriver driver = mock(WebDriver.class);
+    WebDriver driver = mock();
     assertThat(Browser.isChromium(driver)).isFalse();
   }
 
@@ -56,7 +56,7 @@ final class BrowserTest {
   }
 
   private static WebDriver driverWithBrowserName(String browserName) {
-    CapableWebDriver driver = mock(CapableWebDriver.class);
+    CapableWebDriver driver = mock();
     when(driver.getCapabilities()).thenReturn(new MutableCapabilities(Map.of("browserName", browserName)));
     return driver;
   }

--- a/src/test/java/com/codeborne/selenide/impl/FileHelperTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/FileHelperTest.java
@@ -4,13 +4,35 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
 
+import static com.codeborne.selenide.impl.FileHelper.deleteFolderIfEmpty;
+import static org.apache.commons.io.FileUtils.touch;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class FileHelperTest {
   @TempDir
   File reportsFolder;
+
+  @Test
+  void deletesFolderIfItIsEmpty(@TempDir File folder) {
+    assertThat(folder).exists();
+
+    deleteFolderIfEmpty(folder);
+
+    assertThat(folder).doesNotExist();
+  }
+
+  @Test
+  void ignoresFolderWhichContainsFiles(@TempDir File folder) throws IOException {
+    touch(new File(folder, "file1"));
+
+    deleteFolderIfEmpty(folder);
+
+    assertThat(folder).exists();
+    assertThat(new File(folder, "file1")).exists();
+  }
 
   @Test
   void fileInFolder_allowsSubdirectories() {


### PR DESCRIPTION
## Summary

Follow-up to #3363, addressing findings from its code review:

- **Security fix**: `AppiumScreenSourceExtractor.createFile()` built the mobile `.xml` file path directly instead of going through `FileHelper.fileInFolder()`, so the path-traversal guard added in #3363 never applied to Appium/mobile page sources. Now routed through the same validated helper, with a regression test.
- **Test coverage**: restores the two `FileHelper.deleteFolderIfEmpty()` unit tests that were dropped in #3363 while adding the new `fileInFolder()` tests. That method is unrelated to the MHTML feature and is still used by `BrowserDownloadsFolder`.
- **De-duplication**: `WebPageSourceExtractor` had its own private `isChromium(WebDriver)` that was byte-for-byte identical to one already in `DownloadFileWithCdp`. Extracted a shared `Browser.isChromium(WebDriver)` and updated both call sites to use it.
- **Robustness**: `WebPageSourceExtractor.extract()`'s `WebDriverException`/`RuntimeException` handlers used to call `createFile()` again to build the fallback file. If the original failure was itself the path-validation `IllegalArgumentException` from `createFile()`, that second call could re-throw the same exception from inside the catch block, silently skipping the intended "write error info to file" fallback. The fallback file is now built once per `extract()` call (same as before #3363) and reused everywhere it's needed.

No behavior changes for the happy paths added in #3363 (MHTML capture, HTML fallback, path-traversal rejection) — verified by the existing `WebPageSourceExtractorTest` and `FileHelperTest` suites, which still pass unmodified.

## Test plan

- [x] `./gradlew check` (full project: unit tests, checkstyle, spotbugs)
- [x] `./gradlew javadocForSite`
- [x] New: `AppiumScreenSourceExtractorTest#rejectsPathTraversalInFileName_forMobileDriver`
- [x] New: `BrowserTest#detectsChromiumFromWebDriverCapabilities`, `#isNotChromium_whenDriverDoesNotExposeCapabilities`
- [x] Restored: `FileHelperTest#deletesFolderIfItIsEmpty`, `#ignoresFolderWhichContainsFiles`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser detection for Chromium-based browsers, including Chrome and Edge.
* **Bug Fixes**
  * Improved page-source file handling during extraction failures and alert retries.
  * Added protection against path-traversal input when creating Appium screen-source files.
  * Improved cleanup of empty temporary folders while preserving folders containing files.
* **Compatibility**
  * Drivers without browser capabilities are handled safely without being identified as Chromium.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->