### PR TITLE
Refactor page source extractor and its tests

### DIFF
--- a/src/main/java/com/codeborne/selenide/impl/PageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/PageSourceExtractor.java
@@ -1,11 +1,13 @@
 package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Config;
+import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.WebDriver;
 
 import java.io.File;
 
 @FunctionalInterface
 public interface PageSourceExtractor {
+  @Nullable
   File extract(Config config, WebDriver driver, String fileName);
 }

--- a/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
+++ b/src/main/java/com/codeborne/selenide/impl/ScreenShotLaboratory.java
@@ -272,6 +272,7 @@ public class ScreenShotLaboratory {
     }
   }
 
+  @Nullable
   protected File savePageSourceToFile(Config config, String fileName, Driver driver) {
     return extractor.extract(config, driver.getWebDriver(), fileName);
   }

--- a/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.impl;
 
 import com.codeborne.selenide.Browser;
 import com.codeborne.selenide.Config;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.jspecify.annotations.Nullable;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.UnhandledAlertException;
@@ -27,20 +26,20 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
   private final AttachmentHandler attachmentHandler = inject();
   private final Set<String> printedErrors = new ConcurrentSkipListSet<>();
 
+  @Nullable
   @Override
   public File extract(Config config, WebDriver driver, String fileName) {
     return extract(config, driver, fileName, true);
   }
 
-  @CanIgnoreReturnValue
+  @Nullable
   private File extract(Config config, WebDriver driver, String fileName, boolean retryIfAlert) {
-    File pageSource = createFile(config, driver, fileName);
     try {
-      return doExtract(config, driver, fileName, pageSource);
+      return doExtract(config, driver, fileName);
     }
     catch (UnhandledAlertException e) {
       if (retryIfAlert) {
-        return retryingExtractionOnAlert(config, driver, fileName, pageSource, e);
+        return retryingExtractionOnAlert(config, driver, fileName, e);
       }
       else {
         printOnce("savePageSourceToFile", e);
@@ -48,20 +47,19 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
     catch (WebDriverException e) {
       log.warn("Failed to save page source to {}", fileName, e);
-      writeToFile(e.toString(), pageSource);
-      return pageSource;
+      return null;
     }
     catch (RuntimeException e) {
       log.error("Failed to save page source to {}", fileName, e);
-      writeToFile(e.toString(), pageSource);
-      return pageSource;
+      return null;
     }
-    return pageSource;
+    return null;
   }
 
-  private File doExtract(Config config, WebDriver driver, String fileName, File pageSource) {
+  @Nullable
+  private File doExtract(Config config, WebDriver driver, String fileName) {
     if (config.savePageSourceWithResources()) {
-      @Nullable String mhtml = extractMhtml(driver);
+      String mhtml = extractMhtml(driver);
       if (mhtml != null) {
         File mhtmlFile = createFileWithExtension(config, fileName, "mhtml");
         writeToFile(mhtml, mhtmlFile);
@@ -73,13 +71,14 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     String source = driver.getPageSource();
     if (source == null) {
       log.error("Failed to save page source to {}: page source is <null>", fileName);
-      writeToFile("<null>", pageSource);
+      return null;
     }
     else {
+      File pageSource = createFile(config, driver, fileName);
       writeToFile(source, pageSource);
       attachmentHandler.attach(pageSource);
+      return pageSource;
     }
-    return pageSource;
   }
 
   @Nullable
@@ -93,7 +92,7 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
       if (data instanceof String mhtml && !mhtml.isBlank()) {
         return mhtml;
       }
-      log.warn("Page.captureSnapshot returned empty data, will fallback to plain HTML");
+      log.warn("Page.captureSnapshot returned empty data (will fallback to plain HTML): {}", result);
     }
     catch (RuntimeException e) {
       log.warn("Failed to save page as MHTML, will fallback to plain HTML: {}", e.toString());
@@ -128,7 +127,8 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
   }
 
-  private File retryingExtractionOnAlert(Config config, WebDriver driver, String fileName, File pageSource, Exception e) {
+  @Nullable
+  private File retryingExtractionOnAlert(Config config, WebDriver driver, String fileName, Exception e) {
     try {
       Alert alert = driver.switchTo().alert();
       log.error("{}: {}", e, alert.getText());
@@ -137,7 +137,7 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     }
     catch (Exception unableToCloseAlert) {
       log.error("Failed to close alert", unableToCloseAlert);
-      return pageSource;
+      return null;
     }
   }
 }

--- a/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
+++ b/src/main/java/com/codeborne/selenide/impl/WebPageSourceExtractor.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 import static com.codeborne.selenide.impl.Plugins.inject;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNullElse;
 
 public class WebPageSourceExtractor implements PageSourceExtractor {
   private static final Logger log = LoggerFactory.getLogger(WebPageSourceExtractor.class);
@@ -56,7 +57,6 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
     return null;
   }
 
-  @Nullable
   private File doExtract(Config config, WebDriver driver, String fileName) {
     if (config.savePageSourceWithResources()) {
       String mhtml = extractMhtml(driver);
@@ -68,17 +68,11 @@ public class WebPageSourceExtractor implements PageSourceExtractor {
       }
     }
 
-    String source = driver.getPageSource();
-    if (source == null) {
-      log.error("Failed to save page source to {}: page source is <null>", fileName);
-      return null;
-    }
-    else {
-      File pageSource = createFile(config, driver, fileName);
-      writeToFile(source, pageSource);
-      attachmentHandler.attach(pageSource);
-      return pageSource;
-    }
+    String source = requireNonNullElse(driver.getPageSource(), "");
+    File pageSource = createFile(config, driver, fileName);
+    writeToFile(source, pageSource);
+    attachmentHandler.attach(pageSource);
+    return pageSource;
   }
 
   @Nullable

--- a/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
@@ -16,7 +16,6 @@ import java.nio.file.Files;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -108,11 +107,10 @@ final class WebPageSourceExtractorTest {
   @Test
   void rejectsPathTraversalInFileName() {
     ChromiumDriver driver = mock();
-    when(driver.getCapabilities()).thenReturn(chromeCapabilities());
+    when(driver.getPageSource()).thenReturn("<html></html>");
 
-    assertThatThrownBy(() -> extractor.extract(config, driver, "../../outside"))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Invalid file name: ../../outside");
+    assertThat(extractor.extract(config, driver, "../../outside"))
+      .isNull();
   }
 
   private static Capabilities chromeCapabilities() {

--- a/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
+++ b/src/test/java/com/codeborne/selenide/impl/WebPageSourceExtractorTest.java
@@ -12,7 +12,6 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chromium.HasCdp;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +37,7 @@ final class WebPageSourceExtractorTest {
   }
 
   @Test
-  void savesMhtmlForChromiumBrowserWhenResourcesEnabledAndCdpWorks() throws Exception {
+  void savesMhtmlForChromiumBrowserWhenResourcesEnabledAndCdpWorks() {
     config.savePageSourceWithResources(true);
     ChromiumDriver driver = mock();
     when(driver.getCapabilities()).thenReturn(chromeCapabilities());
@@ -48,12 +47,12 @@ final class WebPageSourceExtractorTest {
     File file = extractor.extract(config, driver, "page-1");
 
     assertThat(file).hasName("page-1.mhtml");
-    assertThat(Files.readString(file.toPath())).contains("multipart/related");
+    assertThat(file).content().contains("multipart/related");
     verify(driver, never()).getPageSource();
   }
 
   @Test
-  void savesHtmlForChromiumBrowserWhenResourcesNotEnabled() throws Exception {
+  void savesHtmlForChromiumBrowserWhenResourcesNotEnabled() {
     ChromiumDriver driver = mock();
     when(driver.getCapabilities()).thenReturn(chromeCapabilities());
     when(driver.getPageSource()).thenReturn("<html>plain</html>");
@@ -61,12 +60,12 @@ final class WebPageSourceExtractorTest {
     File file = extractor.extract(config, driver, "page-1b");
 
     assertThat(file).hasName("page-1b.html");
-    assertThat(Files.readString(file.toPath())).isEqualTo("<html>plain</html>");
+    assertThat(file).content().isEqualToIgnoringNewLines("<html>plain</html>");
     verify(driver, never()).executeCdpCommand(eq("Page.captureSnapshot"), any());
   }
 
   @Test
-  void fallsBackToHtmlWhenCdpFails() throws Exception {
+  void fallsBackToHtmlWhenCdpFails() {
     config.savePageSourceWithResources(true);
     ChromiumDriver driver = mock();
     when(driver.getCapabilities()).thenReturn(chromeCapabilities());
@@ -76,11 +75,11 @@ final class WebPageSourceExtractorTest {
     File file = extractor.extract(config, driver, "page-2");
 
     assertThat(file).hasName("page-2.html");
-    assertThat(Files.readString(file.toPath())).isEqualTo("<html>plain</html>");
+    assertThat(file).content().isEqualToIgnoringNewLines("<html>plain</html>");
   }
 
   @Test
-  void fallsBackToHtmlWhenCdpReturnsEmptyData() throws Exception {
+  void fallsBackToHtmlWhenCdpReturnsEmptyData() {
     config.savePageSourceWithResources(true);
     ChromiumDriver driver = mock();
     when(driver.getCapabilities()).thenReturn(chromeCapabilities());
@@ -90,18 +89,18 @@ final class WebPageSourceExtractorTest {
     File file = extractor.extract(config, driver, "page-2b");
 
     assertThat(file).hasName("page-2b.html");
-    assertThat(Files.readString(file.toPath())).isEqualTo("<html>plain</html>");
+    assertThat(file).content().isEqualToIgnoringNewLines("<html>plain</html>");
   }
 
   @Test
-  void savesHtmlForNonChromiumBrowser() throws Exception {
+  void savesHtmlForNonChromiumBrowser() {
     WebDriver driver = mock();
     when(driver.getPageSource()).thenReturn("<html>firefox</html>");
 
     File file = extractor.extract(config, driver, "page-3");
 
     assertThat(file).hasName("page-3.html");
-    assertThat(Files.readString(file.toPath())).isEqualTo("<html>firefox</html>");
+    assertThat(file).content().isEqualToIgnoringNewLines("<html>firefox</html>");
   }
 
   @Test

--- a/statics/src/test/java/integration/IntegrationTest.java
+++ b/statics/src/test/java/integration/IntegrationTest.java
@@ -90,6 +90,9 @@ public abstract class IntegrationTest extends BaseIntegrationTest {
     Configuration.browserCapabilities = defaultBrowserCapabilities();
     Configuration.remoteConnectionTimeout = Duration.ofSeconds(10).toMillis();
     Configuration.remoteReadTimeout = Duration.ofSeconds(90).toMillis();
+    Configuration.screenshots = true;
+    Configuration.savePageSource = true;
+    Configuration.savePageSourceWithResources = false;
   }
 
   protected void openFile(String fileName) {

--- a/statics/src/test/java/integration/ScreenshotsTest.java
+++ b/statics/src/test/java/integration/ScreenshotsTest.java
@@ -3,15 +3,14 @@ package integration;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.impl.ScreenShotLaboratory;
-import uk.org.webcompere.systemstubs.jupiter.SystemStub;
-import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
-import uk.org.webcompere.systemstubs.stream.SystemErr;
-
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.OutputType;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -20,16 +19,15 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.util.Base64;
 
+import static com.codeborne.selenide.WebDriverRunner.isChrome;
+import static com.codeborne.selenide.WebDriverRunner.isEdge;
 import static com.codeborne.selenide.impl.Plugins.inject;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
-import static com.codeborne.selenide.WebDriverRunner.isChrome;
-import static com.codeborne.selenide.WebDriverRunner.isEdge;
 import static uk.org.webcompere.systemstubs.stream.output.OutputFactories.tapAndOutput;
 
 @ExtendWith(SystemStubsExtension.class)
@@ -38,7 +36,7 @@ final class ScreenshotsTest extends IntegrationTest {
 
   // sl4j-simple is used in tests, qnd it logs to System.err by default
   @SystemStub
-  SystemErr systemErr = new SystemErr(tapAndOutput());
+  private final SystemErr systemErr = new SystemErr(tapAndOutput());
 
   @BeforeEach
   void openTestPageWithJQuery() {
@@ -74,7 +72,7 @@ final class ScreenshotsTest extends IntegrationTest {
   }
 
   @Test
-  void canTakeScreenshotAtEveryMoment() throws URISyntaxException, IOException {
+  void canTakeScreenshotAtEveryMoment() throws URISyntaxException {
     String fileName = "screenshot-" + randomUUID();
     String screenshot = Selenide.screenshot(fileName);
 
@@ -87,7 +85,7 @@ final class ScreenshotsTest extends IntegrationTest {
   }
 
   @Test
-  void canTakeScreenshotWithEmbeddedResourcesAsMhtml() throws URISyntaxException, IOException {
+  void canTakeScreenshotWithEmbeddedResourcesAsMhtml() throws URISyntaxException {
     assumeThat(isChrome() || isEdge()).isTrue();
     Configuration.savePageSourceWithResources = true;
 
@@ -98,14 +96,13 @@ final class ScreenshotsTest extends IntegrationTest {
     assertThat(screenshot).endsWith(".png");
     assertThatFileExistsAndAttachmentIsLogged(screenshot);
 
-    String mhtmlPageSource = screenshot.replace(".png", ".mhtml");
-    String htmlPageSource = screenshot.replace(".png", ".html");
-    boolean isMhtml = new File(new URI(mhtmlPageSource)).exists();
-    String pageSource = isMhtml ? mhtmlPageSource : htmlPageSource;
-    assertThatFileExistsAndAttachmentIsLogged(pageSource);
-    if (isMhtml) {
-      assertThat(Files.readString(new File(new URI(pageSource)).toPath())).contains("multipart/related");
-    }
+    String mhtmlPageSourceFileName = screenshot.replace(".png", ".mhtml");
+    File mhtmlPageSource = new File(new URI(mhtmlPageSourceFileName));
+    File htmlPageSource = new File(new URI(screenshot.replace(".png", ".html")));
+    assertThat(mhtmlPageSource).exists();
+    assertThat(htmlPageSource).doesNotExist();
+    assertThatFileExistsAndAttachmentIsLogged(mhtmlPageSourceFileName);
+    assertThat(mhtmlPageSource).content().contains("multipart/related");
   }
 
   private void assertThatFileExistsAndAttachmentIsLogged(String url) throws URISyntaxException {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Page-source files are now created only after successful extraction.
  - Failed or unavailable extraction no longer produces files containing error text or placeholders.
  - Invalid paths and unclosable alerts now fail gracefully without creating output files.
  - Null page sources are saved as empty HTML files.
  - Improved diagnostics for MHTML extraction.

- **Tests**
  - Updated screenshot and page-source checks to validate generated files, content, and MHTML output more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->