### PR TITLE
Harden selenide-cli: fix daemon/protocol bugs, wire CI, close spawn race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,7 @@ jobs:
             ]
           - name: 'others'
             projects: [
+              ':modules:cli',
               ':modules:junit4',
               ':modules:clear-with-shortcut',
               ':modules:appium',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 7.18.0 (unreleased)
-* add Selenide CLI (`selenide-cli`): a command-line tool over a background browser daemon that records actions and generates Selenide Java; also published to npm as `selenide-cli`
+* add Selenide CLI (`selenide-cli`): a command-line tool over a background browser daemon that records actions and generates Selenide Java; also published to npm as `@selenide/cli`
 
 ## 7.17.0 (12.07.2026)
 * #3359 Add "byRole" locator - find elements by ARIA role (#3336)

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -20,11 +20,11 @@ runs one command, prints the result, and exits. Every successful command is reco
 
 ## Install (npm)
 
-Published on npm: [selenide-cli](https://www.npmjs.com/package/selenide-cli).
+Published on npm: [@selenide/cli](https://www.npmjs.com/package/@selenide/cli).
 
 ```bash
-npm install -g selenide-cli
-selenide --version          # -> selenide-cli 7.17.0
+npm install -g @selenide/cli
+selenide --version          # -> selenide-cli 7.18.0
 ```
 
 Requirements: **JDK 17+** on your `PATH` (`java -version`) and a browser (Chrome/Firefox/Edge) —
@@ -50,7 +50,7 @@ sudo chmod +x /usr/local/bin/selenide
 ```
 
 Without a launcher, replace `selenide` with `java -jar modules/cli/build/libs/selenide-cli-*.jar`
-(the shaded jar is versioned, e.g. `selenide-cli-7.17.0.jar`).
+(the shaded jar is versioned, e.g. `selenide-cli-7.18.0.jar`).
 
 ## Quick start
 

--- a/modules/cli/npm/README.md
+++ b/modules/cli/npm/README.md
@@ -32,7 +32,7 @@ sudo chmod +x /usr/local/bin/selenide
 ```
 
 Without a launcher, replace `selenide` with `java -jar modules/cli/build/libs/selenide-cli-*.jar`
-(the shaded jar is versioned, e.g. `selenide-cli-7.17.0.jar`).
+(the shaded jar is versioned, e.g. `selenide-cli-7.18.0.jar`).
 
 ## Quick start
 

--- a/modules/cli/npm/bin/selenide.js
+++ b/modules/cli/npm/bin/selenide.js
@@ -13,8 +13,12 @@ if (!jar) {
   process.exit(1);
 }
 
+// An explicit path (as opposed to a bare command) isn't resolved against PATHEXT by
+// spawnSync/CreateProcess on Windows, so a correctly-set JAVA_HOME would otherwise fail with
+// ENOENT - misreported below as "Java is required", which is backwards.
+const javaExecutable = process.platform === 'win32' ? 'java.exe' : 'java';
 const javaBin = process.env.JAVA_HOME
-  ? path.join(process.env.JAVA_HOME, 'bin', 'java')
+  ? path.join(process.env.JAVA_HOME, 'bin', javaExecutable)
   : 'java';
 
 const result = spawnSync(javaBin, ['-jar', path.join(jarDir, jar), ...process.argv.slice(2)], {

--- a/modules/cli/npm/package.json
+++ b/modules/cli/npm/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "selenide-cli",
-  "version": "7.17.0",
+  "name": "@selenide/cli",
+  "version": "7.18.0",
   "description": "Command-line browser automation & Selenide Java codegen over a background daemon.",
   "bin": { "selenide": "bin/selenide.js" },
   "files": ["bin/", "jar/", "README.md"],
@@ -8,5 +8,6 @@
   "keywords": ["selenide", "selenium", "webdriver", "browser", "automation", "codegen", "cli"],
   "license": "MIT",
   "repository": { "type": "git", "url": "git+https://github.com/selenide/selenide.git" },
-  "homepage": "https://selenide.org"
+  "homepage": "https://selenide.org",
+  "publishConfig": { "access": "public" }
 }

--- a/modules/cli/src/doc/build-and-npm-deploy.md
+++ b/modules/cli/src/doc/build-and-npm-deploy.md
@@ -3,7 +3,7 @@
 The Selenide CLI is a Java tool: it builds to a single self-contained ("fat") JAR
 (`selenide-cli-<version>.jar`) that acts as both the client and the background daemon. There is no
 Node.js code in the CLI itself — the npm package is a thin **launcher** that ships (or downloads)
-that JAR and spawns `java -jar …`. This keeps `npm install -g selenide-cli` giving users a `selenide`
+that JAR and spawns `java -jar …`. This keeps `npm install -g @selenide/cli` giving users a `selenide`
 command without them cloning the repo or dealing with Gradle.
 
 - [1. Build the CLI locally](#1-build-the-cli-locally)
@@ -31,7 +31,7 @@ command without them cloning the repo or dealing with Gradle.
 java -jar modules/cli/build/libs/selenide-cli-*.jar --version
 ```
 
-The JAR is versioned to match the Selenide release (e.g. `selenide-cli-7.17.0.jar`).
+The JAR is versioned to match the Selenide release (e.g. `selenide-cli-7.18.0.jar`).
 
 ### Run it locally
 
@@ -99,8 +99,8 @@ modules/cli/npm/
 
 ```json
 {
-  "name": "selenide-cli",
-  "version": "7.17.0",
+  "name": "@selenide/cli",
+  "version": "7.18.0",
   "description": "Command-line browser automation & Selenide Java codegen over a background daemon.",
   "bin": { "selenide": "bin/selenide.js" },
   "files": ["bin/", "jar/", "README.md"],
@@ -108,12 +108,16 @@ modules/cli/npm/
   "keywords": ["selenide", "selenium", "webdriver", "browser", "automation", "codegen", "cli"],
   "license": "MIT",
   "repository": { "type": "git", "url": "https://github.com/selenide/selenide.git" },
-  "homepage": "https://selenide.org"
+  "homepage": "https://selenide.org",
+  "publishConfig": { "access": "public" }
 }
 ```
 
-Keep `version` in lockstep with the Gradle `version` in `build.gradle` (currently `7.17.0`), so
-`selenide-cli@X` on npm always ships `selenide-cli-X.jar`.
+Keep `version` in lockstep with the Gradle `version` in `build.gradle` (set to `7.18.0` right before
+that release is cut), so
+`@selenide/cli@X` on npm always ships `selenide-cli-X.jar`. `publishConfig.access: "public"` is
+required for a scoped package (`@selenide/...`) to publish publicly instead of defaulting to
+private, which requires a paid npm org plan.
 
 ### `bin/selenide.js` — the launcher
 
@@ -184,31 +188,32 @@ and `package.json` — nothing else.
 
 ```bash
 cd modules/cli/npm
-npm pack                                  # -> selenide-cli-<version>.tgz
+npm pack                                  # -> selenide-cli-<version>.tgz (npm strips "@"/"/" from scoped names)
 npm install -g ./selenide-cli-*.tgz
 selenide --version                        # should print: selenide-cli <version>
 selenide open --headless https://selenide.org && selenide close
-npm uninstall -g selenide-cli
+npm uninstall -g @selenide/cli
 ```
 
 ---
 
 ## 3. Publish to npm
 
-Prerequisites: an npm account with publish rights to the package name, and `npm login` done.
+Prerequisites: membership in the `@selenide` npm org (or publish rights granted on the package),
+and `npm login` done.
 
 ```bash
 cd modules/cli/npm
 
 # 1. make sure version matches the Gradle build version
-node -e "console.log(require('./package.json').version)"   # e.g. 7.17.0
+node -e "console.log(require('./package.json').version)"   # e.g. 7.18.0
 
 # 2. rebuild + refresh the bundled JAR (see step 2)
 (cd ../../.. && ./gradlew :modules:cli:shadowJar)
 mkdir -p jar && rm -f jar/*.jar && cp ../build/libs/selenide-cli-*.jar jar/
 cp ../README.md README.md
 
-# 3. publish (public scope-less package)
+# 3. publish (scoped packages default to private, so --access public is required)
 npm publish --access public
 ```
 
@@ -238,19 +243,28 @@ Notes:
 - Publishing is an outward-facing action; only run `npm publish` when the maintainer has explicitly
   asked to release.
 
-> **Status:** `selenide-cli@7.17.0` is published — https://www.npmjs.com/package/selenide-cli
->
-> ⚠️ This was published **for testing purposes** under a personal npm account (`sbielievitniev`),
-> not by the Selenide org. If the Selenide maintainers want to own the `selenide-cli` name under the
-> Selenide org/team on npm, the current owner will remove (unpublish) this package so it can be
-> re-published from the official account.
+### The old unscoped `selenide-cli` package
+
+The CLI was originally published for testing purposes as `selenide-cli` (unscoped) under a personal
+npm account. It's now deprecated in favor of the official `@selenide/cli`, the same move already
+made for the MCP server (`selenide-mcp` → `@selenide/mcp`). The deprecated package's source is
+`selenide-cli-legacy/` at the repo root — a thin shim whose `index.js` prints a deprecation notice
+to stderr and then `require()`s `@selenide/cli/bin/selenide.js` directly (its only dependency is
+`@selenide/cli`, so a plain `npm publish` from that directory picks up whatever version range is
+declared there). Publish/update it the same way as any other npm package once `@selenide/cli` itself
+is live:
+
+```bash
+cd selenide-cli-legacy
+npm publish   # unscoped package, no --access flag needed
+```
 
 ---
 
 ## 4. Install & use (end users)
 
 ```bash
-npm install -g selenide-cli      # requires JDK 17+ on PATH
+npm install -g @selenide/cli      # requires JDK 17+ on PATH
 selenide --version
 ```
 

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/CliConfig.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/CliConfig.java
@@ -45,10 +45,10 @@ final class CliConfig {
       config.baseUrl(value(arg));
     }
     else if (arg.startsWith("--timeout=")) {
-      config.timeout(Long.parseLong(value(arg)));
+      config.timeout(longValue(arg));
     }
     else if (arg.startsWith("--polling-interval=")) {
-      config.pollingInterval(Long.parseLong(value(arg)));
+      config.pollingInterval(longValue(arg));
     }
     else if (arg.startsWith("--remote=")) {
       config.remote(value(arg));
@@ -60,7 +60,7 @@ final class CliConfig {
       config.pageLoadStrategy(value(arg));
     }
     else if (arg.startsWith("--page-load-timeout=")) {
-      config.pageLoadTimeout(Long.parseLong(value(arg)));
+      config.pageLoadTimeout(longValue(arg));
     }
     else if (arg.startsWith("--reports-folder=")) {
       config.reportsFolder(value(arg));
@@ -72,5 +72,15 @@ final class CliConfig {
 
   private static String value(String arg) {
     return arg.substring(arg.indexOf('=') + 1);
+  }
+
+  private static long longValue(String arg) {
+    String value = value(arg);
+    try {
+      return Long.parseLong(value);
+    }
+    catch (NumberFormatException e) {
+      throw new IllegalArgumentException("invalid value for '" + arg.substring(0, arg.indexOf('=')) + "': '" + value + "'");
+    }
   }
 }

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/Daemon.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/Daemon.java
@@ -26,7 +26,8 @@ final class Daemon {
     // can ever intercept in any language; narrowing that residual gap further would need a
     // handshake in the wire protocol itself, which isn't worth the added complexity for a same-user,
     // localhost-only, single-daemon CLI tool.
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> SessionStore.delete(session), "selenide-cli-cleanup"));
+    Thread cleanupHook = new Thread(() -> SessionStore.delete(session), "selenide-cli-cleanup");
+    Runtime.getRuntime().addShutdownHook(cleanupHook);
     try (ServerSocket server = new ServerSocket()) {
       server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
       SessionStore.writePort(session, server.getLocalPort());
@@ -42,6 +43,19 @@ final class Daemon {
     }
     catch (IOException e) {
       throw new UncheckedIOException(e);
+    }
+    finally {
+      removeShutdownHookIfNotAlreadyShuttingDown(cleanupHook);
+    }
+  }
+
+  private static void removeShutdownHookIfNotAlreadyShuttingDown(Thread cleanupHook) {
+    try {
+      Runtime.getRuntime().removeShutdownHook(cleanupHook);
+    }
+    catch (IllegalStateException e) {
+      // The JVM is already shutting down (the hook itself is what's about to run, or already ran);
+      // nothing to undo.
     }
   }
 

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/Daemon.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/Daemon.java
@@ -26,26 +26,28 @@ final class Daemon {
     // can ever intercept in any language; narrowing that residual gap further would need a
     // handshake in the wire protocol itself, which isn't worth the added complexity for a same-user,
     // localhost-only, single-daemon CLI tool.
-    Thread cleanupHook = new Thread(() -> SessionStore.delete(session), "selenide-cli-cleanup");
-    Runtime.getRuntime().addShutdownHook(cleanupHook);
     try (ServerSocket server = new ServerSocket()) {
       server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
-      SessionStore.writePort(session, server.getLocalPort());
+      int port = server.getLocalPort();
+      SessionStore.writePort(session, port);
+      // Deletes only if the session's port file still points at this daemon's own port, so a
+      // delayed hook (or the safety-net cleanup below) can never delete a *replacement* daemon's
+      // record - one that started for the same session while this one was busy shutting down.
+      Thread cleanupHook = new Thread(() -> SessionStore.deleteIfOwnedBy(session, port), "selenide-cli-cleanup");
+      Runtime.getRuntime().addShutdownHook(cleanupHook);
       try {
         acceptLoop(server, executor);
       }
       finally {
-        SessionStore.delete(session);
+        SessionStore.deleteIfOwnedBy(session, port);
         // Safety net for abnormal exits (e.g. accept() failing) where serveOne() never got a chance
         // to shut down the executor itself; harmless to call again after a graceful "close".
         executor.shutdown();
+        removeShutdownHookIfNotAlreadyShuttingDown(cleanupHook);
       }
     }
     catch (IOException e) {
       throw new UncheckedIOException(e);
-    }
-    finally {
-      removeShutdownHookIfNotAlreadyShuttingDown(cleanupHook);
     }
   }
 

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/Daemon.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/Daemon.java
@@ -19,6 +19,14 @@ final class Daemon {
   }
 
   static void run(String session, CommandExecutor executor) {
+    // isAlive()/sendTo() only prove a TCP connect to the recorded port succeeds, not that the
+    // listener is still this session's daemon - if the process dies without deleting its port file
+    // (e.g. SIGTERM, Ctrl-C), a later process could in theory bind that same freed ephemeral port.
+    // A shutdown hook closes that window for every termination path except SIGKILL, which no process
+    // can ever intercept in any language; narrowing that residual gap further would need a
+    // handshake in the wire protocol itself, which isn't worth the added complexity for a same-user,
+    // localhost-only, single-daemon CLI tool.
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> SessionStore.delete(session), "selenide-cli-cleanup"));
     try (ServerSocket server = new ServerSocket()) {
       server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
       SessionStore.writePort(session, server.getLocalPort());
@@ -27,6 +35,8 @@ final class Daemon {
       }
       finally {
         SessionStore.delete(session);
+        // Safety net for abnormal exits (e.g. accept() failing) where serveOne() never got a chance
+        // to shut down the executor itself; harmless to call again after a graceful "close".
         executor.shutdown();
       }
     }
@@ -45,17 +55,33 @@ final class Daemon {
    * @return true when the served command asked the daemon to stop.
    */
   private static boolean serveOne(ServerSocket server, CommandExecutor executor) throws IOException {
-    // accept() failures propagate and stop the loop; per-connection IO errors are swallowed below.
+    // accept()/readRequest() failures propagate and stop the loop; a disconnect while reading a
+    // request means no command ran, so it's safe to just keep serving other clients.
     Socket accepted = server.accept();
     try (Socket socket = accepted) {
       List<String> args = Protocol.readRequest(socket.getInputStream());
       CommandExecutor.Result result = safeExecute(executor, args);
-      Protocol.writeResponse(socket.getOutputStream(), result.ok(), result.shutdown(), result.output());
+      if (result.shutdown()) {
+        // Shut down before acknowledging it, so a caller can never observe "closed" success before
+        // the browser has actually finished tearing down.
+        executor.shutdown();
+      }
+      writeResponseQuietly(socket, result);
       return result.shutdown();
     }
     catch (IOException e) {
-      // A client disconnected mid-command; keep serving other clients.
       return false;
+    }
+  }
+
+  private static void writeResponseQuietly(Socket socket, CommandExecutor.Result result) {
+    try {
+      Protocol.writeResponse(socket.getOutputStream(), result.ok(), result.shutdown(), result.output());
+    }
+    catch (IOException e) {
+      // The client disconnected while we were writing the response. The command already ran, so
+      // its shutdown intent (if any) - already applied above - must not be lost just because the
+      // client never received the acknowledgement.
     }
   }
 

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/DaemonClient.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/DaemonClient.java
@@ -6,11 +6,17 @@ import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalInt;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
 
 /**
  * The thin, per-invocation CLI client. Resolves the session's daemon (auto-spawning one for
@@ -39,14 +45,69 @@ final class DaemonClient {
       return 1;
     }
     if (!isAlive(session)) {
-      SessionStore.delete(session);
-      spawnDaemon(flagsOf(args));
-      if (!waitUntilReady()) {
-        err.println("Timed out starting the browser daemon. See " + SessionStore.logFile(session));
+      String failure = spawnDaemonIfNotAlreadyRunning(flagsOf(args));
+      if (failure != null) {
+        err.println(failure);
         return 1;
       }
     }
     return sendTo(session, List.of("open", url));
+  }
+
+  /**
+   * Ensures a daemon is running for this session, guarding the check-then-spawn sequence with a
+   * per-session file lock (held across separate OS processes, unlike an in-JVM lock) so two
+   * concurrent {@code open} invocations for the same session - e.g. a retried CI step - can't each
+   * spawn their own daemon and orphan one of the resulting browsers.
+   *
+   * @return an error message if the daemon could not be started, or null on success.
+   */
+  private String spawnDaemonIfNotAlreadyRunning(List<String> configFlags) {
+    try {
+      Files.createDirectories(SessionStore.dir());
+      try (FileChannel lockChannel = FileChannel.open(SessionStore.lockFile(session), CREATE, WRITE)) {
+        FileLock lock = acquireLock(lockChannel);
+        try {
+          if (isAlive(session)) {
+            // A concurrent `open` already spawned it while we were waiting for the lock.
+            return null;
+          }
+          SessionStore.delete(session);
+          Process daemonProcess = spawnDaemon(configFlags);
+          return waitUntilReady(daemonProcess) ? null : daemonFailureMessage(daemonProcess);
+        }
+        finally {
+          lock.release();
+        }
+      }
+    }
+    catch (IOException e) {
+      return "Could not spawn the browser daemon: " + e.getMessage();
+    }
+  }
+
+  private static FileLock acquireLock(FileChannel channel) throws IOException {
+    while (true) {
+      try {
+        FileLock lock = channel.tryLock();
+        if (lock != null) {
+          return lock;
+        }
+      }
+      catch (OverlappingFileLockException e) {
+        // Another thread in this same JVM holds it. Real usage never hits this branch (each
+        // `selenide open` invocation is a separate process), but keeps this safe for in-process
+        // callers too (e.g. tests).
+      }
+      sleep(POLL_INTERVAL_MS);
+    }
+  }
+
+  private String daemonFailureMessage(Process daemonProcess) {
+    String logFile = "See " + SessionStore.logFile(session);
+    return daemonProcess.isAlive()
+      ? "Timed out starting the browser daemon. " + logFile
+      : "The browser daemon exited immediately (exit code " + daemonProcess.exitValue() + "). " + logFile;
   }
 
   /** Any other command against an already-running session. */
@@ -70,13 +131,20 @@ final class DaemonClient {
   }
 
   int closeAll() {
+    int failures = 0;
     for (String name : SessionStore.sessions()) {
       if (isAlive(name)) {
-        sendTo(name, List.of("close"));
+        if (sendTo(name, List.of("close")) != 0) {
+          failures++;
+        }
       }
       else {
         SessionStore.delete(name);
       }
+    }
+    if (failures > 0) {
+      err.println("failed to close " + failures + " session(s); see above for details");
+      return 1;
     }
     out.println("closed all sessions");
     return 0;
@@ -119,18 +187,23 @@ final class DaemonClient {
     return socket;
   }
 
-  private boolean waitUntilReady() {
+  private boolean waitUntilReady(Process daemonProcess) {
     long deadline = System.currentTimeMillis() + SPAWN_TIMEOUT_MS;
     while (System.currentTimeMillis() < deadline) {
       if (isAlive(session)) {
         return true;
+      }
+      if (!daemonProcess.isAlive()) {
+        // The daemon subprocess crashed on startup (e.g. a bad config flag) - no point polling
+        // for the rest of the timeout.
+        return false;
       }
       sleep(POLL_INTERVAL_MS);
     }
     return isAlive(session);
   }
 
-  private void spawnDaemon(List<String> configFlags) {
+  private Process spawnDaemon(List<String> configFlags) {
     List<String> command = new ArrayList<>();
     command.add(javaBinary());
     command.add("-cp");
@@ -140,11 +213,10 @@ final class DaemonClient {
     command.add("--session=" + session);
     command.addAll(configFlags);
     try {
-      Files.createDirectories(SessionStore.dir());
       ProcessBuilder builder = new ProcessBuilder(command);
       builder.redirectErrorStream(true);
       builder.redirectOutput(SessionStore.logFile(session).toFile());
-      builder.start();
+      return builder.start();
     }
     catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -152,7 +224,16 @@ final class DaemonClient {
   }
 
   private static String javaBinary() {
-    return Path.of(System.getProperty("java.home"), "bin", "java").toString();
+    return javaBinary(System.getProperty("java.home"), System.getProperty("os.name", ""));
+  }
+
+  // ProcessBuilder/CreateProcess doesn't apply PATHEXT resolution to an explicit path on Windows,
+  // so the extension-less name must be spelled out there. Takes javaHome/osName as parameters
+  // (instead of reading system properties directly) so both branches are unit-testable regardless
+  // of the OS actually running the tests.
+  static String javaBinary(String javaHome, String osName) {
+    String executable = osName.toLowerCase().contains("win") ? "java.exe" : "java";
+    return Path.of(javaHome, "bin", executable).toString();
   }
 
   private static String firstPositional(List<String> args) {

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/DaemonClient.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/DaemonClient.java
@@ -2,7 +2,6 @@ package com.codeborne.selenide.cli;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -203,7 +202,7 @@ final class DaemonClient {
     return isAlive(session);
   }
 
-  private Process spawnDaemon(List<String> configFlags) {
+  private Process spawnDaemon(List<String> configFlags) throws IOException {
     List<String> command = new ArrayList<>();
     command.add(javaBinary());
     command.add("-cp");
@@ -212,15 +211,10 @@ final class DaemonClient {
     command.add("__daemon");
     command.add("--session=" + session);
     command.addAll(configFlags);
-    try {
-      ProcessBuilder builder = new ProcessBuilder(command);
-      builder.redirectErrorStream(true);
-      builder.redirectOutput(SessionStore.logFile(session).toFile());
-      return builder.start();
-    }
-    catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    ProcessBuilder builder = new ProcessBuilder(command);
+    builder.redirectErrorStream(true);
+    builder.redirectOutput(SessionStore.logFile(session).toFile());
+    return builder.start();
   }
 
   private static String javaBinary() {

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/Protocol.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/Protocol.java
@@ -2,6 +2,7 @@ package com.codeborne.selenide.cli;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -14,9 +15,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Wire framing between the CLI client and the daemon over a loopback socket.
  *
  * <p>Request = the command tokens (client argv). Response = a status plus a (possibly large,
- * e.g. generated code) UTF-8 text payload.
+ * e.g. generated code) UTF-8 text payload. Every string is framed as {@code int byteLength} +
+ * raw UTF-8 bytes, so - unlike {@link DataOutputStream#writeUTF}, whose modified-UTF-8 encoding
+ * is capped at 65535 bytes - there is no cap on argument or payload size besides {@link
+ * #MAX_FRAME_BYTES}.
  */
 final class Protocol {
+  private static final int MAX_ARGS = 10_000;
+  private static final int MAX_FRAME_BYTES = 16 * 1024 * 1024;
+
   record Response(boolean ok, boolean shutdown, String text) {
   }
 
@@ -27,7 +34,7 @@ final class Protocol {
     DataOutputStream data = new DataOutputStream(out);
     data.writeInt(args.size());
     for (String arg : args) {
-      data.writeUTF(arg);
+      writeFrame(data, arg);
     }
     data.flush();
   }
@@ -35,9 +42,12 @@ final class Protocol {
   static List<String> readRequest(InputStream in) throws IOException {
     DataInputStream data = new DataInputStream(in);
     int count = data.readInt();
-    List<String> args = new ArrayList<>(Math.max(0, count));
+    if (count < 0 || count > MAX_ARGS) {
+      throw new IOException("invalid request: implausible argument count " + count);
+    }
+    List<String> args = new ArrayList<>(count);
     for (int i = 0; i < count; i++) {
-      args.add(data.readUTF());
+      args.add(readFrame(data));
     }
     return args;
   }
@@ -46,9 +56,7 @@ final class Protocol {
     DataOutputStream data = new DataOutputStream(out);
     data.writeBoolean(ok);
     data.writeBoolean(shutdown);
-    byte[] bytes = text.getBytes(UTF_8);
-    data.writeInt(bytes.length);
-    data.write(bytes);
+    writeFrame(data, text);
     data.flush();
   }
 
@@ -56,8 +64,24 @@ final class Protocol {
     DataInputStream data = new DataInputStream(in);
     boolean ok = data.readBoolean();
     boolean shutdown = data.readBoolean();
+    return new Response(ok, shutdown, readFrame(data));
+  }
+
+  private static void writeFrame(DataOutputStream data, String text) throws IOException {
+    byte[] bytes = text.getBytes(UTF_8);
+    data.writeInt(bytes.length);
+    data.write(bytes);
+  }
+
+  private static String readFrame(DataInputStream data) throws IOException {
     int length = data.readInt();
+    if (length < 0 || length > MAX_FRAME_BYTES) {
+      throw new IOException("invalid frame: implausible length " + length);
+    }
     byte[] bytes = data.readNBytes(length);
-    return new Response(ok, shutdown, new String(bytes, UTF_8));
+    if (bytes.length != length) {
+      throw new EOFException("truncated frame: expected " + length + " bytes, got only " + bytes.length);
+    }
+    return new String(bytes, UTF_8);
   }
 }

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/Protocol.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/Protocol.java
@@ -31,6 +31,9 @@ final class Protocol {
   }
 
   static void writeRequest(OutputStream out, List<String> args) throws IOException {
+    if (args.size() > MAX_ARGS) {
+      throw new IOException("invalid request: implausible argument count " + args.size());
+    }
     DataOutputStream data = new DataOutputStream(out);
     data.writeInt(args.size());
     for (String arg : args) {
@@ -69,6 +72,9 @@ final class Protocol {
 
   private static void writeFrame(DataOutputStream data, String text) throws IOException {
     byte[] bytes = text.getBytes(UTF_8);
+    if (bytes.length > MAX_FRAME_BYTES) {
+      throw new IOException("invalid frame: implausible length " + bytes.length);
+    }
     data.writeInt(bytes.length);
     data.write(bytes);
   }

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SessionStore.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SessionStore.java
@@ -30,6 +30,11 @@ final class SessionStore {
     return sessionFile(session, ".log");
   }
 
+  /** Guards the check-then-spawn sequence in DaemonClient.open() against concurrent invocations. */
+  static Path lockFile(String session) {
+    return sessionFile(session, ".lock");
+  }
+
   private static Path portFile(String session) {
     return sessionFile(session, PORT_SUFFIX);
   }

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SessionStore.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SessionStore.java
@@ -81,6 +81,17 @@ final class SessionStore {
     }
   }
 
+  /**
+   * Like {@link #delete(String)}, but only if the session's port file still records {@code
+   * ownPort} - i.e. only if it still refers to the daemon calling this, not to some other daemon
+   * that has since started for the same session (e.g. while this one was busy shutting down).
+   */
+  static void deleteIfOwnedBy(String session, int ownPort) {
+    if (readPort(session).equals(OptionalInt.of(ownPort))) {
+      delete(session);
+    }
+  }
+
   static List<String> sessions() {
     if (!Files.isDirectory(dir())) {
       return List.of();

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/CliConfigTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/CliConfigTest.java
@@ -4,6 +4,7 @@ import com.codeborne.selenide.SelenideConfig;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CliConfigTest {
   @Test
@@ -37,5 +38,27 @@ class CliConfigTest {
   void ignoresPositionalUrlAndUnknownFlags() {
     SelenideConfig config = CliConfig.toConfig(new String[]{"https://example.com", "--browser=edge"});
     assertThat(config.browser()).isEqualTo("edge");
+  }
+
+  @Test
+  void reportsAClearErrorForAnInvalidTimeoutValue() {
+    assertThatThrownBy(() -> CliConfig.toConfig(new String[]{"--timeout=5ooo"}))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("--timeout")
+      .hasMessageContaining("5ooo");
+  }
+
+  @Test
+  void reportsAClearErrorForAnInvalidPollingIntervalValue() {
+    assertThatThrownBy(() -> CliConfig.toConfig(new String[]{"--polling-interval=abc"}))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("--polling-interval");
+  }
+
+  @Test
+  void reportsAClearErrorForAnInvalidPageLoadTimeoutValue() {
+    assertThatThrownBy(() -> CliConfig.toConfig(new String[]{"--page-load-timeout=abc"}))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("--page-load-timeout");
   }
 }

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/DaemonClientTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/DaemonClientTest.java
@@ -1,0 +1,69 @@
+package com.codeborne.selenide.cli;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises DaemonClient.open() against a real spawned {@code __daemon} subprocess (no browser
+ * involved - an invalid config flag crashes the subprocess before it ever touches Selenium), to
+ * verify that crash is reported quickly instead of only after the full spawn timeout.
+ *
+ * <p>Declares a write lock on the "user.home" system property so JUnit serializes this class
+ * against other test classes that read or write it, instead of racing on that JVM-wide property
+ * across concurrently-run test classes (see gradle/tests.gradle).
+ */
+@ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ_WRITE)
+class DaemonClientTest {
+  @TempDir
+  Path home;
+
+  private String originalHome;
+
+  @BeforeEach
+  void redirectHome() {
+    originalHome = System.getProperty("user.home");
+    System.setProperty("user.home", home.toString());
+  }
+
+  @AfterEach
+  void restoreHome() {
+    System.setProperty("user.home", originalHome);
+  }
+
+  @Test
+  void reportsABadConfigFlagQuicklyInsteadOfWaitingTheFullSpawnTimeout() {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    DaemonClient client = new DaemonClient("bad-flag-session", new PrintStream(out, true, UTF_8), new PrintStream(err, true, UTF_8));
+
+    long start = System.currentTimeMillis();
+    int exitCode = client.open(List.of("--timeout=5ooo", "https://example.com"));
+    long elapsed = System.currentTimeMillis() - start;
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(err.toString(UTF_8)).contains("exited immediately");
+    // The full spawn timeout is 20s; a bad flag should be detected in well under that.
+    assertThat(elapsed).isLessThan(15_000L);
+  }
+
+  @Test
+  void javaBinaryAppendsExeOnlyOnWindows() {
+    String javaHome = "some-jdk-home";
+    assertThat(DaemonClient.javaBinary(javaHome, "Linux")).isEqualTo(Path.of(javaHome, "bin", "java").toString());
+    assertThat(DaemonClient.javaBinary(javaHome, "Mac OS X")).isEqualTo(Path.of(javaHome, "bin", "java").toString());
+    assertThat(DaemonClient.javaBinary(javaHome, "Windows 11")).isEqualTo(Path.of(javaHome, "bin", "java.exe").toString());
+  }
+}

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/DaemonRoundTripTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/DaemonRoundTripTest.java
@@ -4,11 +4,20 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.OptionalInt;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,7 +25,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Exercises the client ↔ daemon round-trip over real loopback sockets with a fake executor
  * (no browser). Points {@code user.home} at a temp dir so session files stay isolated.
+ *
+ * <p>Declares a write lock on the "user.home" system property so JUnit serializes this class
+ * against other test classes that read or write it, instead of racing on that JVM-wide property
+ * across concurrently-run test classes (see gradle/tests.gradle).
  */
+@ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ_WRITE)
 class DaemonRoundTripTest {
   @TempDir
   Path home;
@@ -55,9 +69,11 @@ class DaemonRoundTripTest {
     assertThat(err.toString(UTF_8)).contains("bad");
 
     assertThat(client.command(List.of("close"))).isZero();
+    // The browser must already be shut down by the time the client sees success - not merely
+    // scheduled to shut down once the daemon thread eventually unwinds.
+    assertThat(executor.shutdownCalled).isTrue();
     daemon.join(3000);
     assertThat(daemon.isAlive()).isFalse();
-    assertThat(executor.shutdownCalled).isTrue();
     assertThat(SessionStore.readPort("t")).isEmpty();
 
     err.reset();
@@ -65,12 +81,97 @@ class DaemonRoundTripTest {
     assertThat(err.toString(UTF_8)).contains("No open session");
   }
 
+  @Test
+  void shutdownIntentSurvivesClientDisconnectingBeforeReadingTheResponse() throws Exception {
+    FakeExecutor executor = new FakeExecutor();
+    Thread daemon = new Thread(() -> Daemon.run("t2", executor), "daemon-under-test-2");
+    daemon.setDaemon(true);
+    daemon.start();
+    awaitPort("t2");
+
+    OptionalInt port = SessionStore.readPort("t2");
+    assertThat(port).isPresent();
+    try (Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), port.getAsInt()), 500);
+      Protocol.writeRequest(socket.getOutputStream(), List.of("close"));
+      // Disconnect immediately instead of reading the response, simulating a client that goes away
+      // while the daemon is (or is about to start) writing its acknowledgement.
+    }
+
+    daemon.join(3000);
+    assertThat(daemon.isAlive()).isFalse();
+    assertThat(executor.shutdownCalled).isTrue();
+  }
+
+  @Test
+  void closeAllReportsFailureWhenASessionFailsToClose() throws Exception {
+    FakeExecutor healthyExecutor = new FakeExecutor();
+    Thread healthyDaemon = new Thread(() -> Daemon.run("healthy", healthyExecutor), "daemon-healthy");
+    healthyDaemon.setDaemon(true);
+    healthyDaemon.start();
+    awaitPort("healthy");
+
+    try (ServerSocket brokenServer = new ServerSocket()) {
+      brokenServer.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+      SessionStore.writePort("broken", brokenServer.getLocalPort());
+      Thread brokenDaemon = new Thread(() -> respondWithFailure(brokenServer), "daemon-broken");
+      brokenDaemon.setDaemon(true);
+      brokenDaemon.start();
+
+      // A port file pointing at a port nothing listens on anymore, i.e. a stale/dead session.
+      int deadPort;
+      try (ServerSocket temp = new ServerSocket()) {
+        temp.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        deadPort = temp.getLocalPort();
+      }
+      SessionStore.writePort("stale", deadPort);
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      ByteArrayOutputStream err = new ByteArrayOutputStream();
+      PrintStream outStream = new PrintStream(out, true, UTF_8);
+      PrintStream errStream = new PrintStream(err, true, UTF_8);
+      DaemonClient client = new DaemonClient("irrelevant-for-closeAll", outStream, errStream);
+
+      assertThat(client.closeAll()).isEqualTo(1);
+      assertThat(err.toString(UTF_8)).contains("failed to close 1 session(s)");
+      assertThat(SessionStore.readPort("stale")).isEmpty();
+
+      healthyDaemon.join(3000);
+      assertThat(healthyDaemon.isAlive()).isFalse();
+      brokenDaemon.join(3000);
+    }
+  }
+
+  /**
+   * Accepts connections until it sees a real request, responding to it with a failure - and
+   * ignoring earlier connections that disconnect without sending anything, since closeAll() probes
+   * liveness (connect, then immediately disconnect) before it sends the actual "close" request.
+   */
+  private static void respondWithFailure(ServerSocket server) {
+    while (!server.isClosed()) {
+      try (Socket socket = server.accept()) {
+        List<String> request = Protocol.readRequest(socket.getInputStream());
+        if (!request.isEmpty()) {
+          Protocol.writeResponse(socket.getOutputStream(), false, false, "boom");
+          return;
+        }
+      }
+      catch (IOException e) {
+        // A liveness probe (or the server socket closing at test teardown); keep looping.
+      }
+    }
+  }
+
   private static void awaitPort() throws InterruptedException {
+    awaitPort("t");
+  }
+
+  private static void awaitPort(String session) throws InterruptedException {
     long deadline = System.currentTimeMillis() + 5000;
-    while (System.currentTimeMillis() < deadline && SessionStore.readPort("t").isEmpty()) {
+    while (System.currentTimeMillis() < deadline && SessionStore.readPort(session).isEmpty()) {
       Thread.sleep(50);
     }
-    assertThat(SessionStore.readPort("t")).isPresent();
+    assertThat(SessionStore.readPort(session)).isPresent();
   }
 
   private static final class FakeExecutor implements CommandExecutor {

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/ProtocolTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/ProtocolTest.java
@@ -4,10 +4,14 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ProtocolTest {
   @Test
@@ -18,6 +22,55 @@ class ProtocolTest {
     List<String> got = Protocol.readRequest(new ByteArrayInputStream(buffer.toByteArray()));
 
     assertThat(got).containsExactly("setValue", "#q", "hello world");
+  }
+
+  @Test
+  void requestArgumentCanExceedTheOldWriteUtf64kCap() throws IOException {
+    String longValue = "x".repeat(100_000);
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    Protocol.writeRequest(buffer, List.of("setValue", "#q", longValue));
+
+    List<String> got = Protocol.readRequest(new ByteArrayInputStream(buffer.toByteArray()));
+
+    assertThat(got).containsExactly("setValue", "#q", longValue);
+  }
+
+  @Test
+  void rejectsImplausiblyLargeArgumentCount() {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    DataOutputStream data = new DataOutputStream(buffer);
+    assertThatThrownBy(() -> {
+      data.writeInt(Integer.MAX_VALUE);
+      data.flush();
+      Protocol.readRequest(new ByteArrayInputStream(buffer.toByteArray()));
+    }).isInstanceOf(IOException.class).hasMessageContaining("argument count");
+  }
+
+  @Test
+  void rejectsImplausiblyLargeFrameLength() {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    DataOutputStream data = new DataOutputStream(buffer);
+    assertThatThrownBy(() -> {
+      data.writeBoolean(true);
+      data.writeBoolean(false);
+      data.writeInt(Integer.MAX_VALUE);
+      data.flush();
+      Protocol.readResponse(new ByteArrayInputStream(buffer.toByteArray()));
+    }).isInstanceOf(IOException.class).hasMessageContaining("length");
+  }
+
+  @Test
+  void rejectsATruncatedFrame() {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    DataOutputStream data = new DataOutputStream(buffer);
+    assertThatThrownBy(() -> {
+      data.writeBoolean(true);
+      data.writeBoolean(false);
+      data.writeInt(10);
+      data.write("short".getBytes(UTF_8));
+      data.flush();
+      Protocol.readResponse(new ByteArrayInputStream(buffer.toByteArray()));
+    }).isInstanceOf(EOFException.class).hasMessageContaining("truncated");
   }
 
   @Test

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/ProtocolTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/ProtocolTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -57,6 +58,25 @@ class ProtocolTest {
       data.flush();
       Protocol.readResponse(new ByteArrayInputStream(buffer.toByteArray()));
     }).isInstanceOf(IOException.class).hasMessageContaining("length");
+  }
+
+  @Test
+  void writeRequestRejectsImplausiblyLargeArgumentCount() {
+    List<String> tooManyArgs = new ArrayList<>();
+    for (int i = 0; i <= 10_000; i++) {
+      tooManyArgs.add("arg");
+    }
+    assertThatThrownBy(() -> Protocol.writeRequest(new ByteArrayOutputStream(), tooManyArgs))
+      .isInstanceOf(IOException.class)
+      .hasMessageContaining("argument count");
+  }
+
+  @Test
+  void writeResponseRejectsAnOversizedFrame() {
+    String tooLong = "x".repeat(16 * 1024 * 1024 + 1);
+    assertThatThrownBy(() -> Protocol.writeResponse(new ByteArrayOutputStream(), true, false, tooLong))
+      .isInstanceOf(IOException.class)
+      .hasMessageContaining("length");
   }
 
   @Test

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SessionStoreTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SessionStoreTest.java
@@ -1,6 +1,9 @@
 package com.codeborne.selenide.cli;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -10,6 +13,13 @@ import java.util.OptionalInt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/**
+ * SessionStore.dir() depends on the "user.home" system property, which DaemonRoundTripTest and
+ * DaemonClientTest temporarily redirect - since Gradle runs test classes concurrently (see
+ * gradle/tests.gradle), this class must declare a read lock on it so JUnit serializes it against
+ * those writers instead of racing on the JVM-wide property.
+ */
+@ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ)
 class SessionStoreTest {
   @Test
   void writesAndReadsPortForPlainSessionName() {

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SessionStoreTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SessionStoreTest.java
@@ -56,6 +56,32 @@ class SessionStoreTest {
   }
 
   @Test
+  void deleteIfOwnedByRemovesTheRecordWhenThePortMatches() {
+    String session = "unit-test-" + System.nanoTime();
+    SessionStore.writePort(session, 12345);
+
+    SessionStore.deleteIfOwnedBy(session, 12345);
+
+    assertThat(SessionStore.readPort(session)).isEmpty();
+  }
+
+  @Test
+  void deleteIfOwnedByLeavesAReplacementRecordAlone() {
+    String session = "unit-test-" + System.nanoTime();
+    try {
+      SessionStore.writePort(session, 111); // the "old" daemon's port
+      SessionStore.writePort(session, 222); // a "replacement" daemon has since taken over
+
+      SessionStore.deleteIfOwnedBy(session, 111); // the old daemon's delayed cleanup
+
+      assertThat(SessionStore.readPort(session)).isEqualTo(OptionalInt.of(222));
+    }
+    finally {
+      SessionStore.delete(session);
+    }
+  }
+
+  @Test
   void readPortReturnsEmptyForUnknownSession() {
     assertThat(SessionStore.readPort("unknown-session-" + System.nanoTime())).isEqualTo(OptionalInt.empty());
   }

--- a/modules/cli/src/test/java/integration/SelenideCliConcurrentOpenTest.java
+++ b/modules/cli/src/test/java/integration/SelenideCliConcurrentOpenTest.java
@@ -9,10 +9,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +35,10 @@ class SelenideCliConcurrentOpenTest {
     String session = "race-" + System.nanoTime();
     String url = page.toUri().toString();
 
+    // A daemon from a preceding test can still be in the middle of exiting when this one starts, so
+    // count new children relative to this baseline rather than asserting on the raw total.
+    Set<Long> childrenBeforeThisTest = ProcessHandle.current().children().map(ProcessHandle::pid).collect(Collectors.toSet());
+
     ExecutorService pool = Executors.newFixedThreadPool(2);
     try {
       List<Future<Integer>> futures = new ArrayList<>();
@@ -43,10 +49,13 @@ class SelenideCliConcurrentOpenTest {
         assertThat(future.get(30, TimeUnit.SECONDS)).isZero();
       }
 
-      // This test doesn't spawn any other child process, so any live child of this JVM must be the
-      // daemon - checking parent/child structure (always visible to a process for its own children)
+      // This test doesn't spawn any other child process itself, so exactly one *new* child of this
+      // JVM - checking parent/child structure, always visible to a process for its own children,
       // rather than matching each child's command line, which some CI environments don't expose.
-      assertThat(ProcessHandle.current().children()).hasSize(1);
+      long newChildren = ProcessHandle.current().children()
+        .filter(p -> !childrenBeforeThisTest.contains(p.pid()))
+        .count();
+      assertThat(newChildren).isEqualTo(1);
     }
     finally {
       cli("-s", session, "close");

--- a/modules/cli/src/test/java/integration/SelenideCliConcurrentOpenTest.java
+++ b/modules/cli/src/test/java/integration/SelenideCliConcurrentOpenTest.java
@@ -1,0 +1,68 @@
+package integration;
+
+import com.codeborne.selenide.cli.SelenideCli;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for a race between concurrent {@code open} invocations for the same session:
+ * without a lock guarding the check-then-spawn sequence in DaemonClient, two racing {@code open}
+ * calls (e.g. a retried CI step) could each spawn their own daemon, orphaning one browser process
+ * forever.
+ *
+ * <p>Runs under a browser task, like SelenideCliIntegrationTest.
+ */
+class SelenideCliConcurrentOpenTest {
+  @Test
+  void concurrentOpenCallsForTheSameSessionSpawnOnlyOneDaemon() throws Exception {
+    Path page = Files.createTempFile("selenide-cli-race", ".html");
+    Files.writeString(page, "<html><body>race</body></html>", UTF_8);
+    String session = "race-" + System.nanoTime();
+    String url = page.toUri().toString();
+
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      List<Future<Integer>> futures = new ArrayList<>();
+      for (int i = 0; i < 2; i++) {
+        futures.add(pool.submit(() -> cli("-s", session, "open", "--headless", "--browser=chrome", url)));
+      }
+      for (Future<Integer> future : futures) {
+        assertThat(future.get(30, TimeUnit.SECONDS)).isZero();
+      }
+
+      assertThat(daemonProcessCountFor(session)).isEqualTo(1);
+    }
+    finally {
+      cli("-s", session, "close");
+      Files.deleteIfExists(page);
+      pool.shutdown();
+    }
+  }
+
+  private static long daemonProcessCountFor(String session) {
+    String marker = "--session=" + session;
+    return ProcessHandle.allProcesses()
+      .filter(p -> p.info().arguments().map(args -> Arrays.asList(args).contains(marker)).orElse(false))
+      .count();
+  }
+
+  private static int cli(String... args) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    return SelenideCli.run(new ArrayList<>(List.of(args)), new PrintStream(out, true, UTF_8), new PrintStream(err, true, UTF_8));
+  }
+}

--- a/modules/cli/src/test/java/integration/SelenideCliConcurrentOpenTest.java
+++ b/modules/cli/src/test/java/integration/SelenideCliConcurrentOpenTest.java
@@ -8,7 +8,6 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -44,20 +43,16 @@ class SelenideCliConcurrentOpenTest {
         assertThat(future.get(30, TimeUnit.SECONDS)).isZero();
       }
 
-      assertThat(daemonProcessCountFor(session)).isEqualTo(1);
+      // This test doesn't spawn any other child process, so any live child of this JVM must be the
+      // daemon - checking parent/child structure (always visible to a process for its own children)
+      // rather than matching each child's command line, which some CI environments don't expose.
+      assertThat(ProcessHandle.current().children()).hasSize(1);
     }
     finally {
       cli("-s", session, "close");
       Files.deleteIfExists(page);
       pool.shutdown();
     }
-  }
-
-  private static long daemonProcessCountFor(String session) {
-    String marker = "--session=" + session;
-    return ProcessHandle.allProcesses()
-      .filter(p -> p.info().arguments().map(args -> Arrays.asList(args).contains(marker)).orElse(false))
-      .count();
   }
 
   private static int cli(String... args) {

--- a/modules/cli/src/test/java/integration/SelenideCliSigtermCleanupTest.java
+++ b/modules/cli/src/test/java/integration/SelenideCliSigtermCleanupTest.java
@@ -8,7 +8,6 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -37,9 +36,11 @@ class SelenideCliSigtermCleanupTest {
       assertThat(cli("-s", session, "open", "--headless", "--browser=chrome", url)).isZero();
       assertThat(portFile).exists();
 
-      ProcessHandle daemonProcess = ProcessHandle.allProcesses()
-        .filter(p -> p.info().arguments().map(args -> Arrays.asList(args).contains("--session=" + session)).orElse(false))
-        .findFirst()
+      // This test doesn't spawn any other child process, so the (only) live child of this JVM must
+      // be the daemon - checking parent/child structure (always visible to a process for its own
+      // children) rather than matching the child's command line, which some CI environments don't
+      // expose.
+      ProcessHandle daemonProcess = ProcessHandle.current().children().findFirst()
         .orElseThrow(() -> new AssertionError("daemon process for session '" + session + "' not found"));
 
       daemonProcess.destroy(); // SIGTERM - NOT `selenide close`

--- a/modules/cli/src/test/java/integration/SelenideCliSigtermCleanupTest.java
+++ b/modules/cli/src/test/java/integration/SelenideCliSigtermCleanupTest.java
@@ -1,0 +1,65 @@
+package integration;
+
+import com.codeborne.selenide.cli.SelenideCli;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for a residual risk in DaemonClient.isAlive(): it only proves a TCP connect to
+ * the recorded port succeeds, not that the listener is still this session's daemon. If a daemon
+ * died without deleting its port file, a later process could in theory bind that same freed
+ * ephemeral port. Daemon.run() registers a JVM shutdown hook precisely to close that window for
+ * every termination path except SIGKILL (which no process can ever intercept) - this verifies the
+ * hook actually deletes the port file when the daemon is sent SIGTERM, e.g. `kill <pid>` (as
+ * opposed to `selenide close`, which the other integration test already covers).
+ */
+class SelenideCliSigtermCleanupTest {
+  @Test
+  void sigtermCleansUpTheSessionPortFile() throws Exception {
+    Path page = Files.createTempFile("selenide-cli-sigterm", ".html");
+    Files.writeString(page, "<html><body>bye</body></html>", UTF_8);
+    String session = "sigterm-" + System.nanoTime();
+    String url = page.toUri().toString();
+    Path portFile = Path.of(System.getProperty("user.home"), ".selenide-cli", session + ".port");
+
+    try {
+      assertThat(cli("-s", session, "open", "--headless", "--browser=chrome", url)).isZero();
+      assertThat(portFile).exists();
+
+      ProcessHandle daemonProcess = ProcessHandle.allProcesses()
+        .filter(p -> p.info().arguments().map(args -> Arrays.asList(args).contains("--session=" + session)).orElse(false))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("daemon process for session '" + session + "' not found"));
+
+      daemonProcess.destroy(); // SIGTERM - NOT `selenide close`
+      daemonProcess.onExit().get(10, TimeUnit.SECONDS);
+
+      long deadline = System.currentTimeMillis() + 5000;
+      while (System.currentTimeMillis() < deadline && Files.exists(portFile)) {
+        Thread.sleep(50);
+      }
+      assertThat(portFile).doesNotExist();
+    }
+    finally {
+      Files.deleteIfExists(page);
+      Files.deleteIfExists(portFile);
+    }
+  }
+
+  private static int cli(String... args) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ByteArrayOutputStream err = new ByteArrayOutputStream();
+    return SelenideCli.run(new ArrayList<>(List.of(args)), new PrintStream(out, true, UTF_8), new PrintStream(err, true, UTF_8));
+  }
+}

--- a/selenide-cli-legacy/README.md
+++ b/selenide-cli-legacy/README.md
@@ -1,0 +1,14 @@
+# selenide-cli (deprecated)
+
+This package has moved to [`@selenide/cli`](https://www.npmjs.com/package/@selenide/cli).
+
+`selenide-cli` still works — it's a thin shim that forwards to `@selenide/cli` — but new installs
+should point at the scoped package name directly:
+
+```bash
+npm install -g @selenide/cli
+selenide open --headless https://selenide.org
+```
+
+See the [Selenide CLI docs](https://github.com/selenide/selenide/blob/main/modules/cli/README.md)
+for full usage.

--- a/selenide-cli-legacy/index.js
+++ b/selenide-cli-legacy/index.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+process.stderr.write('[selenide-cli] This package has moved to "@selenide/cli". ' +
+  'Please run "npm install -g @selenide/cli" instead.\n');
+
+require('@selenide/cli/bin/selenide.js');

--- a/selenide-cli-legacy/package.json
+++ b/selenide-cli-legacy/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "selenide-cli",
+  "version": "7.18.0",
+  "description": "DEPRECATED — moved to @selenide/cli. This package forwards to the new scoped package.",
+  "bin": {
+    "selenide": "index.js"
+  },
+  "keywords": [
+    "selenide",
+    "selenium",
+    "webdriver",
+    "browser",
+    "automation",
+    "codegen",
+    "cli",
+    "deprecated"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/selenide/selenide.git"
+  },
+  "homepage": "https://selenide.org",
+  "engines": {
+    "node": ">=16"
+  },
+  "dependencies": {
+    "@selenide/cli": "^7.18.0"
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #3380 (selenide-cli module). Fixes issues surfaced by an internal code review that weren't merge blockers for the initial PR, plus the "Module :modules:cli has integration tests but isn't referenced in test.yml" CI wiring gap.

- **CI wiring**: `:modules:cli` had integration tests (`SelenideCliIntegrationTest`) but was never added to `test.yml`'s browser-test matrix, so `verify-browser-test-coverage` was failing and the tests silently never ran in CI. Added it to the `others` project group.
- **Daemon.java**: the browser now shuts down *before* the "close" response is acknowledged (previously a caller could observe success while the browser was still tearing down), and a client disconnecting while the response is being written no longer swallows the command's shutdown intent (it's applied before the write is even attempted now).
- **Protocol.java**: removed the 65535-byte `writeUTF` cap on args/payloads (was crashing on longer pasted values with a misleading "could not reach session" error); added validation against implausible frame lengths/argument counts; truncated responses (daemon dying mid-write) now raise a clear `EOFException` instead of silently returning partial data.
- **CliConfig.java**: a bad numeric flag (e.g. `--timeout=5ooo`) now raises a clear error instead of a raw `NumberFormatException`; `DaemonClient` also detects the daemon subprocess exiting immediately instead of waiting out the full 20s spawn timeout before reporting failure.
- **DaemonClient.closeAll()**: no longer reports "closed all sessions" when a session actually failed to close.
- **Windows**: `selenide.js` and `DaemonClient.javaBinary()` now append `.exe` on Windows, since a correctly-set `JAVA_HOME` was otherwise breaking daemon spawning (`ProcessBuilder`/`CreateProcess` doesn't apply `PATHEXT` resolution to an explicit path).
- **Spawn race**: `DaemonClient.open()` now guards its check-then-spawn sequence with a per-session file lock (held across OS processes) so two concurrent `open` calls for the same session - e.g. a retried CI step - can't each spawn their own daemon and orphan a browser.
- **Stale port files**: `Daemon.run()` registers a JVM shutdown hook to delete the session's port file on SIGTERM/Ctrl-C, narrowing (not fully closing - SIGKILL can't be intercepted by any process) the window where a stale port file could in theory point at a since-reused ephemeral port.

## Test plan

- [x] `./gradlew :modules:cli:check` - unit tests, Checkstyle, SpotBugs all green (ran 4x with `--rerun-tasks` to rule out flakiness)
- [x] `./gradlew :modules:cli:chrome_headless` - all 3 integration tests pass, including two new regression tests:
  - `SelenideCliConcurrentOpenTest` - two concurrent `open` calls for the same session spawn exactly one daemon process
  - `SelenideCliSigtermCleanupTest` - SIGTERM to the daemon cleans up its port file
- [x] `./gradlew :modules:mcp:check` - `McpCliParityTest` still passes (untouched, but shares test infra)
- [x] `./gradlew check` (full repo) and `./gradlew javadocForSite` - both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the scoped npm package `@selenide/cli` version 7.18.0.
  * Added a compatibility package to support migration from `selenide-cli`.

* **Bug Fixes**
  * Improved Windows CLI launches when using `JAVA_HOME`.
  * Prevented duplicate daemon processes and improved cleanup after shutdown or termination.
  * Added clearer errors for invalid options, daemon failures, and incomplete messages.
  * Improved resilience when clients disconnect unexpectedly.

* **Improvements**
  * Enhanced UTF-8 communication and validation for large messages.
  * Expanded browser test coverage for Chrome and Firefox.
  * Updated CLI installation and usage documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->