### PR TITLE
fix appium long press and double tap (#3413)

### DIFF
--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumClickOptions.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/AppiumClickOptions.java
@@ -32,15 +32,23 @@ public class AppiumClickOptions extends ClickOptions {
   }
 
   public static AppiumClickOptions doubleTap() {
-    return new AppiumClickOptions(AppiumClickMethod.DOUBLE_TAP, 0, 0, ZERO);
+    return doubleTapWithOffset(0, 0);
+  }
+
+  public static AppiumClickOptions doubleTapWithOffset(int xOffset, int yOffset) {
+    return new AppiumClickOptions(AppiumClickMethod.DOUBLE_TAP, xOffset, yOffset, ZERO);
   }
 
   public static AppiumClickOptions longPress() {
-    return new AppiumClickOptions(AppiumClickMethod.LONG_PRESS, 0, 0, DEFAULT_LONG_PRESS_DURATION);
+    return longPressFor(DEFAULT_LONG_PRESS_DURATION);
   }
 
   public static AppiumClickOptions longPressFor(Duration longPressHoldDuration) {
-    return new AppiumClickOptions(AppiumClickMethod.LONG_PRESS, 0, 0, longPressHoldDuration);
+    return longPressWithOffsetFor(longPressHoldDuration, 0, 0);
+  }
+
+  public static AppiumClickOptions longPressWithOffsetFor(Duration longPressHoldDuration, int xOffset, int yOffset) {
+    return new AppiumClickOptions(AppiumClickMethod.LONG_PRESS, xOffset, yOffset, longPressHoldDuration);
   }
 
   public AppiumClickMethod appiumClickMethod() {

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
@@ -56,18 +56,17 @@ public class AppiumClick extends Click {
 
   protected void click(Driver driver, WebElement webElement, AppiumClickOptions appiumClickOptions) {
     switch (appiumClickOptions.appiumClickMethod()) {
-      case TAP_WITH_OFFSET -> performTapWithOffset(driver, webElement, appiumClickOptions.offsetX(), appiumClickOptions.offsetY());
-      case TAP -> performTapWithOffset(driver, webElement, 0, 0);
-      case DOUBLE_TAP -> performDoubleTap(driver, webElement);
+      case TAP_WITH_OFFSET, TAP -> performTapWithOffset(driver, webElement, appiumClickOptions);
+      case DOUBLE_TAP -> performDoubleTap(driver, webElement, appiumClickOptions);
       case LONG_PRESS -> performLongPress(driver, webElement, appiumClickOptions);
       default -> throw new IllegalArgumentException("Unknown click option: " + appiumClickOptions.appiumClickMethod());
     }
   }
 
-  private void performDoubleTap(Driver driver, WebElement webElement) {
-    Point size = webElement.getLocation();
+  private void performDoubleTap(Driver driver, WebElement webElement, AppiumClickOptions appiumClickOptions) {
+    Point location = getCenter(webElement);
     PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, FINGER_1);
-    Sequence doubleTapSequence = getSequenceToPerformTap(finger, size, 0, 0)
+    Sequence doubleTapSequence = getSequenceToPerformTap(finger, location, appiumClickOptions.offsetX(), appiumClickOptions.offsetY())
       .addAction(new Pause(finger, ofMillis(40)))
       .addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()))
       .addAction(new Pause(finger, ofMillis(200)))
@@ -76,22 +75,22 @@ public class AppiumClick extends Click {
   }
 
   private void performLongPress(Driver driver, WebElement webElement, AppiumClickOptions appiumClickOptions) {
-    Point size = webElement.getLocation();
+    Point location = getCenter(webElement);
     PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, FINGER_1);
     Sequence doubleTapSequence = new Sequence(finger, 1)
-      .addAction(finger.createPointerMove(ofMillis(0),
-        PointerInput.Origin.viewport(), size.getX(), size.getY()))
+      .addAction(finger.createPointerMove(ofMillis(0), PointerInput.Origin.viewport(),
+        location.getX() + appiumClickOptions.offsetX(), location.getY() + appiumClickOptions.offsetY()))
       .addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()))
       .addAction(new Pause(finger, appiumClickOptions.longPressHoldDuration()))
       .addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
     perform(driver, doubleTapSequence);
   }
 
-  private void performTapWithOffset(Driver driver, WebElement webElement, int offsetX, int offsetY) {
+  private void performTapWithOffset(Driver driver, WebElement webElement, AppiumClickOptions appiumClickOptions) {
     PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, FINGER_1);
-    Point size = getCenter(webElement);
+    Point location = getCenter(webElement);
 
-    Sequence tapSequence = getSequenceToPerformTap(finger, size, offsetX, offsetY);
+    Sequence tapSequence = getSequenceToPerformTap(finger, location, appiumClickOptions.offsetX(), appiumClickOptions.offsetY());
     perform(driver, tapSequence);
   }
 
@@ -101,10 +100,10 @@ public class AppiumClick extends Click {
     appiumDriver.perform(singletonList(sequence));
   }
 
-  private Sequence getSequenceToPerformTap(PointerInput finger, Point size, int offsetX, int offsetY) {
+  private Sequence getSequenceToPerformTap(PointerInput finger, Point location, int offsetX, int offsetY) {
     return new Sequence(finger, 1)
       .addAction(finger.createPointerMove(ofMillis(0),
-        PointerInput.Origin.viewport(), size.getX() + offsetX, size.getY() + offsetY))
+        PointerInput.Origin.viewport(), location.getX() + offsetX, location.getY() + offsetY))
       .addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()))
       .addAction(new Pause(finger, ofMillis(200)))
       .addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));


### PR DESCRIPTION
## Proposed changes

- fix https://github.com/selenide/selenide/issues/3413
- added offset option to long press and double tap

## Checklist
- [x] Checkstyle and unit tests are passed locally with my changes by running `gradlew check chrome_headless firefox_headless` command
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Tests work `gradlew :modules:appium:android --tests "it.mobile.android.AndroidClickOptionsTest"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for offset-based double-tap and long-press gestures.
  - Mobile tap, double-tap, and long-press actions now use the element center as the default location.
  - Double-tap gestures now support custom horizontal and vertical offsets.

- **Bug Fixes**
  - Improved consistency between standard and offset-based tap actions while preserving existing default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->