### PR TITLE
#3413 Add tests and docs for appium tap-offset fix

### DIFF
--- a/modules/appium/README.md
+++ b/modules/appium/README.md
@@ -72,9 +72,11 @@ SelenideAppium.openIOSDeepLink("mydemoapprn://product-details/1");
    $(AppiumBy.xpath(".//*[@text='Views']")).tap(); //perform native event tap
    $(AppiumBy.xpath(".//*[@text='Views']")).doubleTap(); //perform native event double tap
    $(AppiumBy.xpath(".//*[@text='Views']")).click(tapWithOffset(100, -60)) //perform tap with offset from center of the element
+   $(AppiumBy.xpath(".//*[@text='Views']")).click(doubleTapWithOffset(100, -60)) //perform double tap with offset from center of the element
    $(AppiumBy.xpath(".//*[@text='People Names']")).click(longPress());
    $(AppiumBy.xpath(".//*[@text='People Names']")).click(longPressFor(ofSeconds(5)));
    $(AppiumBy.xpath(".//*[@text='People Names']")).tap(longPressFor(ofSeconds(4)));
+   $(AppiumBy.xpath(".//*[@text='People Names']")).click(longPressWithOffsetFor(ofSeconds(5), 100, -60)); //perform long press with offset from center of the element
 ```
 
 4. Drag and drop

--- a/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
+++ b/modules/appium/src/main/java/com/codeborne/selenide/appium/commands/AppiumClick.java
@@ -64,9 +64,9 @@ public class AppiumClick extends Click {
   }
 
   private void performDoubleTap(Driver driver, WebElement webElement, AppiumClickOptions appiumClickOptions) {
-    Point location = getCenter(webElement);
+    Point center = getCenter(webElement);
     PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, FINGER_1);
-    Sequence doubleTapSequence = getSequenceToPerformTap(finger, location, appiumClickOptions.offsetX(), appiumClickOptions.offsetY())
+    Sequence doubleTapSequence = getSequenceToPerformTap(finger, center, appiumClickOptions.offsetX(), appiumClickOptions.offsetY())
       .addAction(new Pause(finger, ofMillis(40)))
       .addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()))
       .addAction(new Pause(finger, ofMillis(200)))
@@ -75,11 +75,11 @@ public class AppiumClick extends Click {
   }
 
   private void performLongPress(Driver driver, WebElement webElement, AppiumClickOptions appiumClickOptions) {
-    Point location = getCenter(webElement);
+    Point center = getCenter(webElement);
     PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, FINGER_1);
     Sequence doubleTapSequence = new Sequence(finger, 1)
       .addAction(finger.createPointerMove(ofMillis(0), PointerInput.Origin.viewport(),
-        location.getX() + appiumClickOptions.offsetX(), location.getY() + appiumClickOptions.offsetY()))
+        center.getX() + appiumClickOptions.offsetX(), center.getY() + appiumClickOptions.offsetY()))
       .addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()))
       .addAction(new Pause(finger, appiumClickOptions.longPressHoldDuration()))
       .addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));
@@ -88,9 +88,9 @@ public class AppiumClick extends Click {
 
   private void performTapWithOffset(Driver driver, WebElement webElement, AppiumClickOptions appiumClickOptions) {
     PointerInput finger = new PointerInput(PointerInput.Kind.TOUCH, FINGER_1);
-    Point location = getCenter(webElement);
+    Point center = getCenter(webElement);
 
-    Sequence tapSequence = getSequenceToPerformTap(finger, location, appiumClickOptions.offsetX(), appiumClickOptions.offsetY());
+    Sequence tapSequence = getSequenceToPerformTap(finger, center, appiumClickOptions.offsetX(), appiumClickOptions.offsetY());
     perform(driver, tapSequence);
   }
 
@@ -100,10 +100,10 @@ public class AppiumClick extends Click {
     appiumDriver.perform(singletonList(sequence));
   }
 
-  private Sequence getSequenceToPerformTap(PointerInput finger, Point location, int offsetX, int offsetY) {
+  private Sequence getSequenceToPerformTap(PointerInput finger, Point center, int offsetX, int offsetY) {
     return new Sequence(finger, 1)
       .addAction(finger.createPointerMove(ofMillis(0),
-        PointerInput.Origin.viewport(), location.getX() + offsetX, location.getY() + offsetY))
+        PointerInput.Origin.viewport(), center.getX() + offsetX, center.getY() + offsetY))
       .addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()))
       .addAction(new Pause(finger, ofMillis(200)))
       .addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()));

--- a/modules/appium/src/test/java/it/mobile/android/AndroidClickOptionsTest.java
+++ b/modules/appium/src/test/java/it/mobile/android/AndroidClickOptionsTest.java
@@ -1,6 +1,7 @@
 package it.mobile.android;
 
 import com.codeborne.selenide.Configuration;
+import com.codeborne.selenide.SelenideElement;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 
@@ -13,7 +14,9 @@ import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.appium.AppiumClickOptions.doubleTap;
+import static com.codeborne.selenide.appium.AppiumClickOptions.doubleTapWithOffset;
 import static com.codeborne.selenide.appium.AppiumClickOptions.longPressFor;
+import static com.codeborne.selenide.appium.AppiumClickOptions.longPressWithOffsetFor;
 import static com.codeborne.selenide.appium.AppiumClickOptions.tap;
 import static com.codeborne.selenide.appium.AppiumClickOptions.tapWithOffset;
 import static com.codeborne.selenide.appium.SelenideAppium.$;
@@ -49,10 +52,35 @@ class AndroidClickOptionsTest extends BaseApiDemosTest {
   }
 
   @Test
+  void androidLongPressWithOffset() {
+    $(By.xpath(".//*[@text='Views']")).click();
+    $(By.xpath(".//*[@text='Expandable Lists']")).click();
+    $(By.xpath(".//*[@text='1. Custom Adapter']")).click();
+    // Offset is close to the right edge of the element - it should still land on it if the base point is the
+    // element's center (as it should be), but would miss it entirely if the base point were the top-left corner.
+    SelenideElement peopleNames = $(By.xpath(".//*[@text='People Names']")).shouldBe(visible);
+    int offsetX = peopleNames.getSize().getWidth() / 2 - 5;
+    peopleNames.click(longPressWithOffsetFor(Duration.ofSeconds(4), offsetX, 0));
+    $(By.xpath(".//*[@text='Sample menu']")).shouldBe(visible);
+  }
+
+  @Test
   void androidDoubleTap() {
     $(By.xpath(".//*[@text='Views']")).click();
     $(By.xpath(".//*[@text='TextSwitcher']")).scrollTo().click();
     $(By.xpath("//android.widget.Button")).click(doubleTap());
+    $(By.xpath("(.//android.widget.TextView)[2]")).shouldHave(text("2"));
+  }
+
+  @Test
+  void androidDoubleTapWithOffset() {
+    $(By.xpath(".//*[@text='Views']")).click();
+    $(By.xpath(".//*[@text='TextSwitcher']")).scrollTo().click();
+    // Same reasoning as androidLongPressWithOffset: an offset close to the button's edge only lands on the
+    // button if it's computed from the button's center.
+    SelenideElement button = $(By.xpath("//android.widget.Button")).shouldBe(visible);
+    int offsetX = button.getSize().getWidth() / 2 - 5;
+    button.click(doubleTapWithOffset(offsetX, 0));
     $(By.xpath("(.//android.widget.TextView)[2]")).shouldHave(text("2"));
   }
 


### PR DESCRIPTION
## Proposed changes

Follow-up to #3415 (which fixed #3413 by making `performDoubleTap`/`performLongPress` use the element's center instead of its top-left corner). That PR was merged without the checklist items for tests and docs, so this PR fills those in:

- Add `androidDoubleTapWithOffset` / `androidLongPressWithOffset` integration tests. Each computes an offset close to the target element's edge, so the tap only lands on the element if it's based on the element's **center** — with the old corner-based bug, the same offset would miss the element entirely. This is a regression test for the #3413 fix itself, not just the new offset methods.
- Document `doubleTapWithOffset` and `longPressWithOffsetFor` in `modules/appium/README.md`, matching how `tapWithOffset` was already documented.
- Rename the local variable `location` (holding the element's center point since #3415) to `center` in `AppiumClick`, to avoid the same naming confusion that partly motivated the original bug report.

## Checklist
- [x] Checkstyle and compilation pass locally (`./gradlew :modules:appium:checkstyleMain :modules:appium:checkstyleTest :modules:appium:compileTestJava`)
- [ ] New integration tests require a running Android emulator to execute — not run in this environment, please verify with `./gradlew :modules:appium:android --tests "it.mobile.android.AndroidClickOptionsTest"` before merging
- [x] Documentation updated (README)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added examples for double-tap and long-press actions with positional offsets in the Appium documentation.
  * Added coverage for offset-based Android interactions, including long-press and double-tap actions.

* **Tests**
  * Verified that offset interactions produce the expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->