### PR TITLE
Make selenide-cli discoverable by AI agents

### DIFF
--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -42,14 +42,16 @@ Any agent that can run shell commands can drive `selenide-cli` cold — `selenid
 self-documenting, and every command's grammar is discoverable from there. Two ways to give an agent
 richer, pre-loaded context on top of that:
 
-- **Claude Code** — the npm package bundles a [Skill](skills/selenide-cli/SKILL.md)
-  (`skills/selenide-cli/`) with the full command grammar, selectors and codegen conventions. Copy it
-  into your project so Claude Code picks it up automatically:
+- **Claude Code, or any agent that reads a project-local `.agents/skills/`** — the CLI bundles a
+  [Skill](skills/selenide-cli/SKILL.md) (full command grammar, selectors, codegen conventions) inside
+  its own jar, so installing it is one command, no path-guessing into `node_modules` required:
   ```bash
-  mkdir -p .claude/skills
-  cp -r "$(npm root -g)/@selenide/cli/skills/selenide-cli" .claude/skills/
-  # (local install: use ./node_modules/@selenide/cli/skills/selenide-cli instead)
+  selenide install --skills           # -> .claude/skills/selenide-cli/
+  selenide install --skills=agents    # -> .agents/skills/selenide-cli/
+  selenide install --skills --global  # installs into $HOME instead of the current project
   ```
+  If an already-installed copy drifts from the version bundled in your current `selenide-cli`
+  (e.g. after upgrading), the CLI prints a warning on stderr telling you to re-run `install`.
 - **Other agents that read `AGENTS.md`** (Codex CLI, Amp, and others) — add a section pointing at the
   CLI, e.g.:
   ```markdown
@@ -107,6 +109,7 @@ Lifecycle:
 | `close` | close the browser and stop the daemon |
 | `list` | list sessions (`running` / `stale`) |
 | `close-all` | close every session |
+| `install --skills[=agents] [--global]` | install the bundled skill into `.claude/skills` (default) or `.agents/skills` |
 
 Recorded actions (each appends to the generated code):
 

--- a/modules/cli/README.md
+++ b/modules/cli/README.md
@@ -36,6 +36,39 @@ Troubleshooting:
 - `command not found: selenide` → add npm's global bin dir to `PATH`:
   `export PATH="$(npm prefix -g)/bin:$PATH"`.
 
+## Using with AI coding agents
+
+Any agent that can run shell commands can drive `selenide-cli` cold — `selenide --help` is
+self-documenting, and every command's grammar is discoverable from there. Two ways to give an agent
+richer, pre-loaded context on top of that:
+
+- **Claude Code** — the npm package bundles a [Skill](skills/selenide-cli/SKILL.md)
+  (`skills/selenide-cli/`) with the full command grammar, selectors and codegen conventions. Copy it
+  into your project so Claude Code picks it up automatically:
+  ```bash
+  mkdir -p .claude/skills
+  cp -r "$(npm root -g)/@selenide/cli/skills/selenide-cli" .claude/skills/
+  # (local install: use ./node_modules/@selenide/cli/skills/selenide-cli instead)
+  ```
+- **Other agents that read `AGENTS.md`** (Codex CLI, Amp, and others) — add a section pointing at the
+  CLI, e.g.:
+  ```markdown
+  ## Browser automation & Selenide codegen
+
+  Use `selenide-cli` (`npm install -g @selenide/cli`; requires JDK 17+ on PATH) to drive a real
+  browser and record a Selenide Java test as you go:
+
+      selenide open <url>
+      selenide click "<selector>"
+      selenide setValue "<selector>" "<text>"
+      selenide should "<selector>" visible
+      selenide code      # print the generated Selenide Java
+      selenide close
+
+  Selectors: CSS by default; `text=<text>` for byText; `xpath=<expr>` (or a leading `//`) for byXpath.
+  Run `selenide --help` or `selenide <command> --help` for the full reference.
+  ```
+
 ## Build & requirements
 
 - JDK 17+; a browser (Chrome/Firefox/Edge). Selenium Manager downloads the driver automatically.
@@ -91,7 +124,7 @@ screenshot [name]
 
 Codegen (not recorded): `code`, `save <file>`, `undo`, `reset`.
 
-Full grammar and generated-Java mapping: [../../.github/skills/selenide-cli/references/commands.md](skills/selenide-cli/references/commands.md).
+Full grammar and generated-Java mapping: [skills/selenide-cli/references/commands.md](skills/selenide-cli/references/commands.md).
 
 ## Selectors & conditions
 

--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -6,6 +6,15 @@ ext {
   artifactId = 'selenide-cli'
 }
 
+// Bundles skills/selenide-cli/** (SKILL.md + references) onto the classpath as
+// /selenide-cli/**, so `selenide install --skills` can extract it at runtime regardless of
+// whether the jar was obtained via npm or Maven Central.
+sourceSets {
+  main {
+    resources.srcDir 'skills'
+  }
+}
+
 dependencies {
   implementation project(':modules:core')
   runtimeOnly("org.slf4j:slf4j-simple:$slf4jVersion")

--- a/modules/cli/npm/.gitignore
+++ b/modules/cli/npm/.gitignore
@@ -1,4 +1,6 @@
 # The fat JAR is a build artifact — copied in at pack time, not committed.
 jar/*.jar
+# Copied from ../skills at pack time — source of truth lives there, not committed here.
+skills/
 # npm pack output
 *.tgz

--- a/modules/cli/npm/package.json
+++ b/modules/cli/npm/package.json
@@ -3,7 +3,7 @@
   "version": "7.18.0",
   "description": "Command-line browser automation & Selenide Java codegen over a background daemon.",
   "bin": { "selenide": "bin/selenide.js" },
-  "files": ["bin/", "jar/", "README.md"],
+  "files": ["bin/", "jar/", "skills/", "README.md"],
   "engines": { "node": ">=16" },
   "keywords": ["selenide", "selenium", "webdriver", "browser", "automation", "codegen", "cli"],
   "license": "MIT",

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
@@ -6,6 +6,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -45,6 +46,9 @@ public final class SelenideCli {
     "  -v, --version            print version",
     "  -h, --help               print this help");
 
+  /** Commands handled daemon-side (via {@link SelenideExecutor}) but outside {@link CommandInterpreter}. */
+  private static final Set<String> META_COMMANDS = Set.of("close", "code", "save", "undo", "reset");
+
   private SelenideCli() {
   }
 
@@ -60,6 +64,10 @@ public final class SelenideCli {
     }
     String command = args.get(0);
     List<String> rest = args.subList(1, args.size());
+    if (hasHelpFlag(rest)) {
+      USAGE.forEach(out::println);
+      return 0;
+    }
     return switch (command) {
       case "__daemon" -> {
         runDaemon(session, rest);
@@ -75,8 +83,23 @@ public final class SelenideCli {
         yield 0;
       }
       case "close-all" -> new DaemonClient(session, out, err).closeAll();
-      default -> new DaemonClient(session, out, err).command(args);
+      default -> {
+        if (!isKnownCommand(command)) {
+          err.println("Unknown command: '" + command + "'. Run 'selenide --help' to see commands.");
+          yield 1;
+        }
+        yield new DaemonClient(session, out, err).command(args);
+      }
     };
+  }
+
+  private static boolean hasHelpFlag(List<String> args) {
+    return args.contains("--help") || args.contains("-h");
+  }
+
+  private static boolean isKnownCommand(String command) {
+    String normalized = command.toLowerCase(Locale.ROOT);
+    return META_COMMANDS.contains(normalized) || CommandInterpreter.commandNames().contains(normalized);
   }
 
   private static void runDaemon(String session, List<String> configFlags) {

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
@@ -62,7 +62,8 @@ public final class SelenideCli {
   public static int run(List<String> args, PrintStream out, PrintStream err) {
     String session = extractSession(args);
     String command = args.isEmpty() ? "" : args.get(0);
-    if (!command.equals("install") && !command.equals("__daemon")) {
+    String normalizedCommand = command.toLowerCase(Locale.ROOT);
+    if (!normalizedCommand.equals("install") && !normalizedCommand.equals("__daemon")) {
       SkillInstaller.warnIfStale(err);
     }
     if (args.isEmpty() || isHelp(command) || hasHelpFlag(args)) {

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
@@ -75,7 +75,7 @@ public final class SelenideCli {
 
   private static int dispatch(String command, List<String> rest, List<String> args, String session,
                                PrintStream out, PrintStream err) {
-    return switch (command) {
+    return switch (command.toLowerCase(Locale.ROOT)) {
       case "__daemon" -> {
         runDaemon(session, rest);
         yield 0;

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
@@ -39,6 +39,9 @@ public final class SelenideCli {
     "",
     "Codegen:  code (print generated Java), save <file>, undo, reset",
     "",
+    "AI agents:  install --skills[=agents] [--global]   install the bundled skill into",
+    "  .claude/skills (default) or .agents/skills (--skills=agents); --global targets $HOME",
+    "",
     "open options:  --browser=<name> --headless --browser-size=<WxH> --base-url=<url>",
     "  --timeout=<ms> --remote=<url> --reports-folder=<dir>  (see references/configuration)",
     "",
@@ -58,16 +61,20 @@ public final class SelenideCli {
 
   public static int run(List<String> args, PrintStream out, PrintStream err) {
     String session = extractSession(args);
-    if (args.isEmpty() || isHelp(args.get(0))) {
+    String command = args.isEmpty() ? "" : args.get(0);
+    if (!command.equals("install") && !command.equals("__daemon")) {
+      SkillInstaller.warnIfStale(err);
+    }
+    if (args.isEmpty() || isHelp(command) || hasHelpFlag(args)) {
       USAGE.forEach(out::println);
       return 0;
     }
-    String command = args.get(0);
     List<String> rest = args.subList(1, args.size());
-    if (hasHelpFlag(rest)) {
-      USAGE.forEach(out::println);
-      return 0;
-    }
+    return dispatch(command, rest, args, session, out, err);
+  }
+
+  private static int dispatch(String command, List<String> rest, List<String> args, String session,
+                               PrintStream out, PrintStream err) {
     return switch (command) {
       case "__daemon" -> {
         runDaemon(session, rest);
@@ -77,20 +84,23 @@ public final class SelenideCli {
         out.println("selenide-cli " + version());
         yield 0;
       }
+      case "install" -> SkillInstaller.install(rest, out, err);
       case "open" -> new DaemonClient(session, out, err).open(rest);
       case "list" -> {
         new DaemonClient(session, out, err).list();
         yield 0;
       }
       case "close-all" -> new DaemonClient(session, out, err).closeAll();
-      default -> {
-        if (!isKnownCommand(command)) {
-          err.println("Unknown command: '" + command + "'. Run 'selenide --help' to see commands.");
-          yield 1;
-        }
-        yield new DaemonClient(session, out, err).command(args);
-      }
+      default -> runAction(command, args, session, out, err);
     };
+  }
+
+  private static int runAction(String command, List<String> args, String session, PrintStream out, PrintStream err) {
+    if (!isKnownCommand(command)) {
+      err.println("Unknown command: '" + command + "'. Run 'selenide --help' to see commands.");
+      return 1;
+    }
+    return new DaemonClient(session, out, err).command(args);
   }
 
   private static boolean hasHelpFlag(List<String> args) {

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SelenideCli.java
@@ -66,7 +66,7 @@ public final class SelenideCli {
     if (!normalizedCommand.equals("install") && !normalizedCommand.equals("__daemon")) {
       SkillInstaller.warnIfStale(err);
     }
-    if (args.isEmpty() || isHelp(command) || hasHelpFlag(args)) {
+    if (args.isEmpty() || isHelp(normalizedCommand) || hasHelpFlag(args)) {
       USAGE.forEach(out::println);
       return 0;
     }

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SkillInstaller.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SkillInstaller.java
@@ -1,0 +1,171 @@
+package com.codeborne.selenide.cli;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Installs the bundled {@code selenide-cli} Agent Skill (SKILL.md + references, embedded on the
+ * classpath at build time from {@code modules/cli/skills/}) into a project's - or the user's home -
+ * {@code .claude/skills/} or {@code .agents/skills/} directory, and warns when an already-installed
+ * copy has drifted from the version bundled in the currently running CLI. Mirrors the
+ * {@code playwright-cli install --skills[=agents]} convention.
+ */
+final class SkillInstaller {
+  private static final String SKILL_NAME = "selenide-cli";
+  private static final List<String> AGENT_DIRS = List.of("claude", "agents");
+  private static final List<String> SKILL_FILES = List.of(
+    "SKILL.md",
+    "references/build-and-run.md",
+    "references/codegen.md",
+    "references/commands.md",
+    "references/configuration.md",
+    "references/scripting.md",
+    "references/selectors.md");
+
+  private SkillInstaller() {
+  }
+
+  static int install(List<String> args, PrintStream out, PrintStream err) {
+    return install(args, out, err, cwd(), homeDir());
+  }
+
+  static int install(List<String> args, PrintStream out, PrintStream err, Path cwd, Path home) {
+    Flags flags = Flags.parse(args);
+    if (flags.skills() == null) {
+      err.println("Usage: selenide install --skills[=agents] [--global]");
+      return 1;
+    }
+    if (!AGENT_DIRS.contains(flags.skills())) {
+      err.println("Unknown --skills value: '" + flags.skills() + "'. Use --skills or --skills=agents.");
+      return 1;
+    }
+    Path base = flags.global() ? home : cwd;
+    Path destDir = base.resolve("." + flags.skills()).resolve("skills").resolve(SKILL_NAME);
+    try {
+      copySkill(destDir);
+    }
+    catch (IOException e) {
+      err.println("Could not install skill: " + e.getMessage());
+      return 1;
+    }
+    out.println("Installed " + SKILL_NAME + " skill to " + (flags.global() ? destDir : cwd.relativize(destDir)));
+    return 0;
+  }
+
+  static void warnIfStale(PrintStream err) {
+    warnIfStale(err, cwd());
+  }
+
+  static void warnIfStale(PrintStream err, Path cwd) {
+    String bundled = readBundledSkill();
+    if (bundled == null) {
+      return;
+    }
+    for (String agent : AGENT_DIRS) {
+      Path installedDir = cwd.resolve("." + agent).resolve("skills").resolve(SKILL_NAME);
+      String installed = readFile(installedDir.resolve("SKILL.md"));
+      if (installed != null && !installed.equals(bundled)) {
+        err.print(staleWarning(cwd, agent, installedDir));
+      }
+    }
+  }
+
+  private static String staleWarning(Path cwd, String agent, Path installedDir) {
+    String installCommand = "selenide install --skills" + (agent.equals("agents") ? "=agents" : "");
+    return frame(List.of(
+      "The " + SKILL_NAME + " skill at '" + cwd.relativize(installedDir) + "'",
+      "does not match the tool version.",
+      "",
+      "Run `" + installCommand + "`",
+      "to install the up-to-date skill."));
+  }
+
+  private static void copySkill(Path destDir) throws IOException {
+    for (String relativePath : SKILL_FILES) {
+      Path dest = destDir.resolve(relativePath);
+      Files.createDirectories(dest.getParent());
+      try (InputStream in = bundledResource(relativePath)) {
+        Files.copy(in, dest, StandardCopyOption.REPLACE_EXISTING);
+      }
+    }
+  }
+
+  private static InputStream bundledResource(String relativePath) throws IOException {
+    InputStream in = SkillInstaller.class.getResourceAsStream("/" + SKILL_NAME + "/" + relativePath);
+    if (in == null) {
+      throw new IOException("bundled skill resource not found: " + relativePath);
+    }
+    return in;
+  }
+
+  private static String readBundledSkill() {
+    try (InputStream in = bundledResource("SKILL.md")) {
+      return normalize(new String(in.readAllBytes(), UTF_8));
+    }
+    catch (IOException e) {
+      return null;
+    }
+  }
+
+  private static String readFile(Path file) {
+    if (!Files.isRegularFile(file)) {
+      return null;
+    }
+    try {
+      return normalize(Files.readString(file, UTF_8));
+    }
+    catch (IOException e) {
+      return null;
+    }
+  }
+
+  private static String normalize(String text) {
+    return text.replace("\r\n", "\n");
+  }
+
+  private static String frame(List<String> lines) {
+    int width = lines.stream().mapToInt(String::length).max().orElse(0);
+    String horizontal = "═".repeat(width + 2);
+    StringBuilder result = new StringBuilder();
+    result.append('╔').append(horizontal).append('╗').append('\n');
+    for (String line : lines) {
+      result.append("║ ").append(line).append(" ".repeat(width - line.length())).append(" ║").append('\n');
+    }
+    result.append('╚').append(horizontal).append('╝').append('\n');
+    return result.toString();
+  }
+
+  private static Path cwd() {
+    return Path.of("").toAbsolutePath();
+  }
+
+  private static Path homeDir() {
+    return Path.of(System.getProperty("user.home"));
+  }
+
+  private record Flags(String skills, boolean global) {
+    static Flags parse(List<String> args) {
+      String skills = null;
+      boolean global = false;
+      for (String arg : args) {
+        if (arg.equals("--skills")) {
+          skills = "claude";
+        }
+        else if (arg.startsWith("--skills=")) {
+          skills = arg.substring("--skills=".length());
+        }
+        else if (arg.equals("--global") || arg.equals("-g")) {
+          global = true;
+        }
+      }
+      return new Flags(skills, global);
+    }
+  }
+}

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SkillInstaller.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SkillInstaller.java
@@ -65,9 +65,12 @@ final class SkillInstaller {
   }
 
   static void warnIfStale(PrintStream err, Path cwd, Path home) {
+    boolean cwdIsHome = cwd.equals(home);
     for (String agent : AGENT_DIRS) {
       warnIfStaleAt(err, cwd, agent, false);
-      warnIfStaleAt(err, home, agent, true);
+      if (!cwdIsHome) {
+        warnIfStaleAt(err, home, agent, true);
+      }
     }
   }
 

--- a/modules/cli/src/main/java/com/codeborne/selenide/cli/SkillInstaller.java
+++ b/modules/cli/src/main/java/com/codeborne/selenide/cli/SkillInstaller.java
@@ -19,9 +19,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 final class SkillInstaller {
   private static final String SKILL_NAME = "selenide-cli";
+  private static final String SKILL_MD = "SKILL.md";
   private static final List<String> AGENT_DIRS = List.of("claude", "agents");
   private static final List<String> SKILL_FILES = List.of(
-    "SKILL.md",
+    SKILL_MD,
     "references/build-and-run.md",
     "references/codegen.md",
     "references/commands.md",
@@ -60,27 +61,44 @@ final class SkillInstaller {
   }
 
   static void warnIfStale(PrintStream err) {
-    warnIfStale(err, cwd());
+    warnIfStale(err, cwd(), homeDir());
   }
 
-  static void warnIfStale(PrintStream err, Path cwd) {
-    String bundled = readBundledSkill();
-    if (bundled == null) {
+  static void warnIfStale(PrintStream err, Path cwd, Path home) {
+    for (String agent : AGENT_DIRS) {
+      warnIfStaleAt(err, cwd, agent, false);
+      warnIfStaleAt(err, home, agent, true);
+    }
+  }
+
+  private static void warnIfStaleAt(PrintStream err, Path base, String agent, boolean global) {
+    Path installedDir = base.resolve("." + agent).resolve("skills").resolve(SKILL_NAME);
+    if (!hasDrifted(installedDir)) {
       return;
     }
-    for (String agent : AGENT_DIRS) {
-      Path installedDir = cwd.resolve("." + agent).resolve("skills").resolve(SKILL_NAME);
-      String installed = readFile(installedDir.resolve("SKILL.md"));
-      if (installed != null && !installed.equals(bundled)) {
-        err.print(staleWarning(cwd, agent, installedDir));
-      }
-    }
+    Path shown = global ? installedDir : base.relativize(installedDir);
+    err.print(staleWarning(shown, agent, global));
   }
 
-  private static String staleWarning(Path cwd, String agent, Path installedDir) {
-    String installCommand = "selenide install --skills" + (agent.equals("agents") ? "=agents" : "");
+  /** True if {@code installedDir} holds a copy of the skill and any of its files differs from the bundled one. */
+  private static boolean hasDrifted(Path installedDir) {
+    if (!Files.isRegularFile(installedDir.resolve(SKILL_MD))) {
+      return false;
+    }
+    for (String relativePath : SKILL_FILES) {
+      String bundled = readBundledFile(relativePath);
+      String installed = readFile(installedDir.resolve(relativePath));
+      if (bundled == null || !bundled.equals(installed)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String staleWarning(Path shown, String agent, boolean global) {
+    String installCommand = "selenide install --skills" + (agent.equals("agents") ? "=agents" : "") + (global ? " --global" : "");
     return frame(List.of(
-      "The " + SKILL_NAME + " skill at '" + cwd.relativize(installedDir) + "'",
+      "The " + SKILL_NAME + " skill at '" + shown + "'",
       "does not match the tool version.",
       "",
       "Run `" + installCommand + "`",
@@ -105,8 +123,8 @@ final class SkillInstaller {
     return in;
   }
 
-  private static String readBundledSkill() {
-    try (InputStream in = bundledResource("SKILL.md")) {
+  private static String readBundledFile(String relativePath) {
+    try (InputStream in = bundledResource(relativePath)) {
       return normalize(new String(in.readAllBytes(), UTF_8));
     }
     catch (IOException e) {

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
@@ -149,6 +149,15 @@ class SelenideCliTest {
   }
 
   @Test
+  void mixedCaseHelpAliasPrintsUsageInsteadOfUnknownCommand() {
+    int exitCode = SelenideCli.run(List.of("HELP"), out, err);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(outBuffer.toString(UTF_8)).contains("Selenide CLI");
+    assertThat(errBuffer.toString(UTF_8)).doesNotContain("Unknown command");
+  }
+
+  @Test
   void mixedCaseInstallIsDispatchedToSkillInstaller() {
     int exitCode = SelenideCli.run(List.of("INSTALL"), out, err);
 

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
@@ -105,4 +105,53 @@ class SelenideCliTest {
     assertThat(exitCode).isEqualTo(1);
     assertThat(errBuffer.toString(UTF_8)).contains("No open session 'default'");
   }
+
+  @Test
+  void mixedCaseOpenReachesTheOpenHandlerInsteadOfTheDaemonCommandPath() {
+    // "open" is also a CommandInterpreter action name, so a case mismatch used to slip past the
+    // known-command check but miss the case-sensitive switch, silently landing in the generic
+    // DaemonClient.command() path instead of DaemonClient.open() (which alone knows how to spawn
+    // a daemon). No URL given, so this only exercises dispatch, not a real daemon spawn.
+    int exitCode = SelenideCli.run(List.of("OPEN"), out, err);
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(errBuffer.toString(UTF_8))
+      .contains("Usage: selenide open <url> [options]")
+      .doesNotContain("No open session");
+  }
+
+  @Test
+  void mixedCaseListIsDispatchedToTheListHandler() {
+    int exitCode = SelenideCli.run(List.of("LIST"), out, err);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(outBuffer.toString(UTF_8)).contains("No sessions.");
+    assertThat(errBuffer.toString(UTF_8)).doesNotContain("Unknown command");
+  }
+
+  @Test
+  void mixedCaseCloseAllIsDispatchedToTheCloseAllHandler() {
+    int exitCode = SelenideCli.run(List.of("CLOSE-ALL"), out, err);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(outBuffer.toString(UTF_8)).contains("closed all sessions");
+    assertThat(errBuffer.toString(UTF_8)).doesNotContain("Unknown command");
+  }
+
+  @Test
+  void mixedCaseVersionIsDispatchedToTheVersionHandler() {
+    int exitCode = SelenideCli.run(List.of("VERSION"), out, err);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(outBuffer.toString(UTF_8)).contains("selenide-cli");
+    assertThat(errBuffer.toString(UTF_8)).doesNotContain("Unknown command");
+  }
+
+  @Test
+  void mixedCaseInstallIsDispatchedToSkillInstaller() {
+    int exitCode = SelenideCli.run(List.of("INSTALL"), out, err);
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(errBuffer.toString(UTF_8)).contains("Usage: selenide install --skills[=agents]");
+  }
 }

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
@@ -89,6 +89,16 @@ class SelenideCliTest {
   }
 
   @Test
+  void installCommandIsDispatchedToSkillInstallerNotTheDaemon() {
+    // No --skills flag, so this only exercises argument validation - no filesystem writes into
+    // this test's real working directory (see SkillInstallerTest for the actual install/copy logic).
+    int exitCode = SelenideCli.run(List.of("install"), out, err);
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(errBuffer.toString(UTF_8)).contains("Usage: selenide install --skills[=agents]");
+  }
+
+  @Test
   void commandNameMatchingIsCaseInsensitive() {
     int exitCode = SelenideCli.run(List.of("SetValue", "#email", "a@b.com"), out, err);
 

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.parallel.Resources;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -153,5 +154,22 @@ class SelenideCliTest {
 
     assertThat(exitCode).isEqualTo(1);
     assertThat(errBuffer.toString(UTF_8)).contains("Usage: selenide install --skills[=agents]");
+  }
+
+  @Test
+  void mixedCaseInstallDoesNotNagAboutTheStaleSkillItIsAboutToReplace() throws Exception {
+    // The stale-skill guard used to compare the un-normalized command ("INSTALL" != "install"), so
+    // it fired even for the command about to fix that exact staleness. Planting the stale copy
+    // under the redirected home (--global target) - never the real ~/.claude - to reproduce it.
+    Path skillMd = home.resolve(".claude/skills/selenide-cli/SKILL.md");
+    Files.createDirectories(skillMd.getParent());
+    Files.writeString(skillMd, "stale content, deliberately does not match the bundled SKILL.md");
+
+    int exitCode = SelenideCli.run(List.of("INSTALL"), out, err);
+
+    assertThat(exitCode).isEqualTo(1); // still errors: no --skills flag given
+    assertThat(errBuffer.toString(UTF_8))
+      .contains("Usage: selenide install --skills[=agents]")
+      .doesNotContain("does not match the tool version");
   }
 }

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SelenideCliTest.java
@@ -1,0 +1,98 @@
+package com.codeborne.selenide.cli;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every one of these commands has no daemon running for its session, so any behaviour beyond
+ * "print usage" or "unknown command" would mean it fell through to {@link DaemonClient}.
+ *
+ * <p>Declares a write lock on the "user.home" system property so JUnit serializes this class
+ * against other test classes that read or write it, instead of racing on that JVM-wide property
+ * across concurrently-run test classes (see gradle/tests.gradle).
+ */
+@ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ_WRITE)
+class SelenideCliTest {
+  @TempDir
+  Path home;
+
+  private String originalHome;
+  private final ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
+  private final PrintStream out = new PrintStream(outBuffer, true, UTF_8);
+  private final PrintStream err = new PrintStream(errBuffer, true, UTF_8);
+
+  @BeforeEach
+  void redirectHome() {
+    originalHome = System.getProperty("user.home");
+    System.setProperty("user.home", home.toString());
+  }
+
+  @AfterEach
+  void restoreHome() {
+    System.setProperty("user.home", originalHome);
+  }
+
+  @Test
+  void printsUsageWhenCalledWithNoArgs() {
+    int exitCode = SelenideCli.run(List.of(), out, err);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(outBuffer.toString(UTF_8)).contains("Selenide CLI", "Lifecycle:", "Actions (recorded):");
+  }
+
+  @Test
+  void helpFlagOnAKnownCommandPrintsUsageInsteadOfContactingTheDaemon() {
+    int exitCode = SelenideCli.run(List.of("should", "--help"), out, err);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(outBuffer.toString(UTF_8)).contains("Selenide CLI");
+    assertThat(errBuffer.toString(UTF_8)).doesNotContain("No open session");
+  }
+
+  @Test
+  void shortHelpFlagOnOpenPrintsUsageInsteadOfARequiredUrlError() {
+    int exitCode = SelenideCli.run(List.of("open", "-h"), out, err);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(outBuffer.toString(UTF_8)).contains("Selenide CLI");
+    assertThat(errBuffer.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  void unknownCommandIsRejectedWithoutContactingTheDaemon() {
+    int exitCode = SelenideCli.run(List.of("bogus", "#selector"), out, err);
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(errBuffer.toString(UTF_8)).contains("Unknown command: 'bogus'").contains("selenide --help");
+  }
+
+  @Test
+  void knownCommandWithNoRunningDaemonStillReportsNoOpenSession() {
+    int exitCode = SelenideCli.run(List.of("should", "#msg", "visible"), out, err);
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(errBuffer.toString(UTF_8)).contains("No open session 'default'");
+  }
+
+  @Test
+  void commandNameMatchingIsCaseInsensitive() {
+    int exitCode = SelenideCli.run(List.of("SetValue", "#email", "a@b.com"), out, err);
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(errBuffer.toString(UTF_8)).contains("No open session 'default'");
+  }
+}

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SkillInstallerTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SkillInstallerTest.java
@@ -76,7 +76,7 @@ class SkillInstallerTest {
 
   @Test
   void doesNotWarnWhenNoSkillIsInstalled() {
-    SkillInstaller.warnIfStale(err, cwd);
+    SkillInstaller.warnIfStale(err, cwd, home);
 
     assertThat(errBuffer.toString(UTF_8)).isEmpty();
   }
@@ -85,7 +85,7 @@ class SkillInstallerTest {
   void doesNotWarnRightAfterInstalling() {
     SkillInstaller.install(List.of("--skills"), out, err, cwd, home);
 
-    SkillInstaller.warnIfStale(err, cwd);
+    SkillInstaller.warnIfStale(err, cwd, home);
 
     assertThat(errBuffer.toString(UTF_8)).isEmpty();
   }
@@ -96,11 +96,36 @@ class SkillInstallerTest {
     Path skillMd = cwd.resolve(".claude/skills/selenide-cli/SKILL.md");
     Files.writeString(skillMd, Files.readString(skillMd, UTF_8) + "\nstale edit");
 
-    SkillInstaller.warnIfStale(err, cwd);
+    SkillInstaller.warnIfStale(err, cwd, home);
 
     assertThat(errBuffer.toString(UTF_8))
       .contains("does not match the tool version")
       .contains("selenide install --skills")
       .contains(".claude/skills/selenide-cli");
+  }
+
+  @Test
+  void warnsWhenAReferenceFileDriftedEvenIfSkillMdDidNot() throws Exception {
+    SkillInstaller.install(List.of("--skills"), out, err, cwd, home);
+    Path commandsMd = cwd.resolve(".claude/skills/selenide-cli/references/commands.md");
+    Files.writeString(commandsMd, Files.readString(commandsMd, UTF_8) + "\nstale edit");
+
+    SkillInstaller.warnIfStale(err, cwd, home);
+
+    assertThat(errBuffer.toString(UTF_8)).contains("does not match the tool version");
+  }
+
+  @Test
+  void warnsAboutAStaleGlobalInstallWithAGlobalReinstallHint() throws Exception {
+    SkillInstaller.install(List.of("--skills=agents", "--global"), out, err, cwd, home);
+    Path skillMd = home.resolve(".agents/skills/selenide-cli/SKILL.md");
+    Files.writeString(skillMd, Files.readString(skillMd, UTF_8) + "\nstale edit");
+
+    SkillInstaller.warnIfStale(err, cwd, home);
+
+    assertThat(errBuffer.toString(UTF_8))
+      .contains("does not match the tool version")
+      .contains("selenide install --skills=agents --global")
+      .contains(home.resolve(".agents/skills/selenide-cli").toString());
   }
 }

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SkillInstallerTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SkillInstallerTest.java
@@ -1,0 +1,106 @@
+package com.codeborne.selenide.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises install/warnIfStale through the testable overloads that take explicit cwd/home paths,
+ * so nothing here ever touches the real filesystem outside a {@link TempDir} (unlike the real
+ * {@code user.home}-based entry points, which are exercised only manually / in the CLI itself).
+ */
+class SkillInstallerTest {
+  @TempDir
+  Path cwd;
+  @TempDir
+  Path home;
+
+  private final ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
+  private final PrintStream out = new PrintStream(outBuffer, true, UTF_8);
+  private final PrintStream err = new PrintStream(errBuffer, true, UTF_8);
+
+  @Test
+  void requiresTheSkillsFlag() {
+    int exitCode = SkillInstaller.install(List.of(), out, err, cwd, home);
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(errBuffer.toString(UTF_8)).contains("Usage: selenide install --skills[=agents]");
+  }
+
+  @Test
+  void rejectsAnUnknownSkillsValue() {
+    int exitCode = SkillInstaller.install(List.of("--skills=cursor"), out, err, cwd, home);
+
+    assertThat(exitCode).isEqualTo(1);
+    assertThat(errBuffer.toString(UTF_8)).contains("Unknown --skills value: 'cursor'");
+  }
+
+  @Test
+  void installsIntoDotClaudeSkillsByDefault() throws Exception {
+    int exitCode = SkillInstaller.install(List.of("--skills"), out, err, cwd, home);
+
+    assertThat(exitCode).isEqualTo(0);
+    Path skillMd = cwd.resolve(".claude/skills/selenide-cli/SKILL.md");
+    assertThat(skillMd).exists();
+    assertThat(Files.readString(skillMd, UTF_8)).contains("name: selenide-cli");
+    assertThat(cwd.resolve(".claude/skills/selenide-cli/references/commands.md")).exists();
+    assertThat(outBuffer.toString(UTF_8)).contains("Installed selenide-cli skill to");
+  }
+
+  @Test
+  void installsIntoDotAgentsSkillsWhenRequested() {
+    int exitCode = SkillInstaller.install(List.of("--skills=agents"), out, err, cwd, home);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(cwd.resolve(".agents/skills/selenide-cli/SKILL.md")).exists();
+    assertThat(cwd.resolve(".claude/skills/selenide-cli/SKILL.md")).doesNotExist();
+  }
+
+  @Test
+  void globalFlagTargetsHomeInsteadOfCwd() {
+    int exitCode = SkillInstaller.install(List.of("--skills", "--global"), out, err, cwd, home);
+
+    assertThat(exitCode).isEqualTo(0);
+    assertThat(home.resolve(".claude/skills/selenide-cli/SKILL.md")).exists();
+    assertThat(cwd.resolve(".claude/skills/selenide-cli")).doesNotExist();
+  }
+
+  @Test
+  void doesNotWarnWhenNoSkillIsInstalled() {
+    SkillInstaller.warnIfStale(err, cwd);
+
+    assertThat(errBuffer.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  void doesNotWarnRightAfterInstalling() {
+    SkillInstaller.install(List.of("--skills"), out, err, cwd, home);
+
+    SkillInstaller.warnIfStale(err, cwd);
+
+    assertThat(errBuffer.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  void warnsWhenTheInstalledSkillDriftedFromTheBundledVersion() throws Exception {
+    SkillInstaller.install(List.of("--skills"), out, err, cwd, home);
+    Path skillMd = cwd.resolve(".claude/skills/selenide-cli/SKILL.md");
+    Files.writeString(skillMd, Files.readString(skillMd, UTF_8) + "\nstale edit");
+
+    SkillInstaller.warnIfStale(err, cwd);
+
+    assertThat(errBuffer.toString(UTF_8))
+      .contains("does not match the tool version")
+      .contains("selenide install --skills")
+      .contains(".claude/skills/selenide-cli");
+  }
+}

--- a/modules/cli/src/test/java/com/codeborne/selenide/cli/SkillInstallerTest.java
+++ b/modules/cli/src/test/java/com/codeborne/selenide/cli/SkillInstallerTest.java
@@ -101,7 +101,7 @@ class SkillInstallerTest {
     assertThat(errBuffer.toString(UTF_8))
       .contains("does not match the tool version")
       .contains("selenide install --skills")
-      .contains(".claude/skills/selenide-cli");
+      .contains(Path.of(".claude", "skills", "selenide-cli").toString());
   }
 
   @Test
@@ -113,6 +113,21 @@ class SkillInstallerTest {
     SkillInstaller.warnIfStale(err, cwd, home);
 
     assertThat(errBuffer.toString(UTF_8)).contains("does not match the tool version");
+  }
+
+  @Test
+  void doesNotDoubleWarnWhenCwdAndHomeAreTheSameDirectory() throws Exception {
+    // e.g. running the CLI with the home directory as cwd - cwd and home resolve to one real
+    // install, not two, so it must be reported (and re-installed) exactly once, as project-local.
+    SkillInstaller.install(List.of("--skills"), out, err, cwd, cwd);
+    Path skillMd = cwd.resolve(".claude/skills/selenide-cli/SKILL.md");
+    Files.writeString(skillMd, Files.readString(skillMd, UTF_8) + "\nstale edit");
+
+    SkillInstaller.warnIfStale(err, cwd, cwd);
+
+    String warnings = errBuffer.toString(UTF_8);
+    assertThat(warnings.split("does not match the tool version", -1)).hasSize(2);
+    assertThat(warnings).contains("selenide install --skills").doesNotContain("--global");
   }
 
   @Test

--- a/release
+++ b/release
@@ -32,13 +32,18 @@ fi
 
 echo "Releasing version: ${version}"
 
-./gradlew clean check javadocForSite
+# Build everything
+./gradlew clean check javadocForSite :modules:cli:shadowJar
+rm -f modules/cli/npm/jar/*.jar
+cp modules/cli/build/libs/selenide-cli-*.jar modules/cli/npm/jar/
+rm -rf modules/cli/npm/skills
+cp -r modules/cli/skills modules/cli/npm/skills
+
+# Publish JARs
 ./gradlew publishToMavenLocal
 ./gradlew publishToMavenCentral --no-parallel --info
 
-git tag -a "v${version}" -m "released selenide ${version}"
-git push origin --tags
-
+# Publish javadoc on site
 rm -fr "../selenide-web/static/javadoc/current/*"
 cp -r build/javadoc-for-site/. ../selenide-web/static/javadoc/current/
 cd ../selenide-web || exit 2
@@ -47,6 +52,7 @@ git commit -m "publish javadoc for Selenide ${version}"
 git push
 cd - || exit 3
 
+# Publish NPM modules
 npm login
 
 cd mcp-server
@@ -58,4 +64,13 @@ npm publish -i
 npm deprecate selenide-mcp@"*" "selenide-mcp has moved to @selenide/mcp. Please update your config to use @selenide/mcp instead."
 cd -
 
+cd modules/cli/npm
+npm version "$version" --no-git-tag-version
+npm publish --access public -i
+cd -
+
 npm logout
+
+# Add git tag
+git tag -a "v${version}" -m "released selenide ${version}"
+git push origin --tags


### PR DESCRIPTION
## Summary
- Ships the `selenide-cli` Claude Code Skill (`modules/cli/skills/selenide-cli/`) inside the `@selenide/cli` npm package (previously only lived in this repo, so npm-installed users had no way to get it), and documents wiring the CLI into Claude Code or any `AGENTS.md`-reading agent in `modules/cli/README.md`.
- Fixes `selenide <cmd> --help` and unrecognized/mistyped commands: with no daemon running, both used to fall through to a confusing "No open session" error instead of showing usage or naming the actual problem — common when an agent (or new user) explores the CLI cold, before ever running `open`.
- Adds `selenide install --skills[=agents] [--global]`, mirroring `playwright-cli`'s actual mechanism (verified against its published npm package): an explicit install subcommand instead of a postinstall script, plus a staleness warning on every other invocation when an installed skill copy has drifted from the running CLI's bundled version. The skill is now bundled as a classpath resource (`modules/cli/skills/` wired in as a Gradle resources srcDir), so `install` works identically whether the CLI came from npm or a bare `java -jar` from Maven Central.

## Test plan
- [x] `./gradlew :modules:cli:check` — unit tests (incl. `SelenideCliTest`, `SkillInstallerTest`), checkstyle, spotbugs all pass
- [x] `npm pack --dry-run` in `modules/cli/npm` confirms `skills/selenide-cli/**` is included in the published tarball
- [x] Confirmed `skills/selenide-cli/**` is embedded in the shadow jar (`unzip -l`)
- [x] Manual smoke test against the built jar: `should --help`, `open -h`, `bogus` (unknown command), `install --skills`/`--skills=agents`/`--global`, and the staleness warning all print the right thing
- [x] `./gradlew javadocForSite` still builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CLI support for installing Selenide skills for AI coding agents in project-local or global locations.
  - Added outdated-skill warnings and reinstall guidance.
  - Improved help handling, case-insensitive commands, and unknown-command errors.
  - Included skills in the published CLI package.

- **Documentation**
  - Expanded CLI documentation with installation options and version-drift guidance.
  - Updated the grammar reference link.

- **Release**
  - Improved automation for building, packaging, publishing, and tagging CLI artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->